### PR TITLE
👌 Show user if there are no local accounts

### DIFF
--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -106,7 +106,7 @@ namespace Speckle.Core.Credentials
         var firstAccount = GetAccounts().FirstOrDefault();
         if (firstAccount == null)
         {
-          Log.CaptureAndThrow(new SpeckleException("No Speckle accounts found. Visit the Speckle web app to create one."), level: Sentry.Protocol.SentryLevel.Info);
+          Log.CaptureException(new SpeckleException("No Speckle accounts found. Visit the Speckle web app to create one."), level: Sentry.Protocol.SentryLevel.Info);
         }
         return firstAccount;
       }

--- a/DesktopUI/DesktopUI/Accounts/AccountsRepository.cs
+++ b/DesktopUI/DesktopUI/Accounts/AccountsRepository.cs
@@ -5,14 +5,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Speckle.Core.Credentials;
+using Stylet;
 
 namespace Speckle.DesktopUI.Accounts
 {
   public class AccountsRepository
   {
-    public ObservableCollection<Account> LoadAccounts()
+    public BindableCollection<Account> LoadAccounts()
     {
-      return new ObservableCollection<Account>(AccountManager.GetAccounts());
+      return new BindableCollection<Account>(AccountManager.GetAccounts());
     }
 
     public Account GetDefault()

--- a/DesktopUI/DesktopUI/RootView.xaml
+++ b/DesktopUI/DesktopUI/RootView.xaml
@@ -1,34 +1,37 @@
-﻿<Window
-  x:Class="Speckle.DesktopUI.RootView"
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-  xmlns:local="clr-namespace:Speckle.DesktopUI"
-  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
-  xmlns:s="https://github.com/canton7/Stylet"
-  xmlns:utils="clr-namespace:Speckle.DesktopUI.Utils"
-  xmlns:stylet="clr-namespace:Stylet;assembly=Stylet"
-  Closing="{s:Action OnClosing}"
-  Title="Speckle"
-  Width="450"
-  Height="800"
-  MinWidth="400"
-  MinHeight="300"
-  Background="{DynamicResource MaterialDesignPaper}"
-  FontFamily="{md:MaterialDesignFont}"
-  Icon="Resources/s2block.ico"
-  TextElement.FontSize="13"
-  TextElement.FontWeight="Normal"
-  TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-  TextOptions.TextFormattingMode="Ideal"
-  TextOptions.TextRenderingMode="Auto"
-  Topmost="{Binding IsPinned, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-  mc:Ignorable="d">
+﻿<Window x:Class="Speckle.DesktopUI.RootView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:local="clr-namespace:Speckle.DesktopUI"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:s="https://github.com/canton7/Stylet"
+        xmlns:stylet="clr-namespace:Stylet;assembly=Stylet"
+        xmlns:utils="clr-namespace:Speckle.DesktopUI.Utils"
+        x:Name="RootWindow"
+        Title="Speckle"
+        Width="450"
+        Height="800"
+        MinWidth="400"
+        MinHeight="300"
+        Background="{DynamicResource MaterialDesignPaper}"
+        Closing="{s:Action OnClosing}"
+        FontFamily="{md:MaterialDesignFont}"
+        Icon="Resources/s2block.ico"
+        TextElement.FontSize="13"
+        TextElement.FontWeight="Normal"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextOptions.TextFormattingMode="Ideal"
+        TextOptions.TextRenderingMode="Auto"
+        Topmost="{Binding IsPinned, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+        mc:Ignorable="d">
   <Window.Resources>
     <utils:StringToUpperConverter x:Key="StringToUpperConverter" />
   </Window.Resources>
-  <md:DialogHost DialogTheme="Inherit" CloseOnClickAway="True" Identifier="RootDialogHost" Style="{StaticResource MaterialDesignEmbeddedDialogHost}">
+  <md:DialogHost CloseOnClickAway="True"
+                 DialogTheme="Inherit"
+                 Identifier="RootDialogHost"
+                 Style="{StaticResource MaterialDesignEmbeddedDialogHost}">
     <md:DrawerHost IsLeftDrawerOpen="{Binding ElementName=MenuToggleButton, Path=IsChecked}">
       <!--#region Left Navigation Drawer-->
       <md:DrawerHost.LeftDrawerContent>
@@ -40,38 +43,37 @@
             <RowDefinition Height="Auto" />
           </Grid.RowDefinitions>
 
-          <ToggleButton
-            Grid.Row="0"
-            Margin="16"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Top"
-            IsChecked="{Binding ElementName=MenuToggleButton, Path=IsChecked, Mode=TwoWay}"
-            Style="{StaticResource MaterialDesignHamburgerToggleButton}" />
+          <ToggleButton Grid.Row="0"
+                        Margin="16"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        IsChecked="{Binding ElementName=MenuToggleButton, Path=IsChecked, Mode=TwoWay}"
+                        Style="{StaticResource MaterialDesignHamburgerToggleButton}" />
 
           <!--  Main Navigation  -->
-          <ListBox
-            x:Name="NavDrawerListBox"
-            Grid.Row="2"
-            Margin="0,0,0,16"
-            DockPanel.Dock="Top"
-            ItemsSource="{Binding Items}"
-            PreviewMouseLeftButtonUp="UIElement_OnPreviewMouseLeftButtonUp"
-            SelectedItem="{Binding ActiveItem}">
+          <ListBox x:Name="NavDrawerListBox"
+                   Grid.Row="2"
+                   Margin="0,0,0,16"
+                   DockPanel.Dock="Top"
+                   ItemsSource="{Binding Items}"
+                   PreviewMouseLeftButtonUp="UIElement_OnPreviewMouseLeftButtonUp"
+                   SelectedItem="{Binding ActiveItem}">
             <ListBox.Resources>
-              <Style BasedOn="{StaticResource MaterialDesignScrollBarMinimal}" TargetType="ScrollBar" />
+              <Style BasedOn="{StaticResource MaterialDesignScrollBarMinimal}"
+                     TargetType="ScrollBar" />
             </ListBox.Resources>
             <ListBox.ItemTemplate>
               <DataTemplate DataType="stylet:IScreen">
-                <TextBlock Margin="32,0,32,0" Text="{Binding DisplayName}" />
+                <TextBlock Margin="32,0,32,0"
+                           Text="{Binding DisplayName}" />
               </DataTemplate>
             </ListBox.ItemTemplate>
           </ListBox>
 
           <!--  Bottom Section  -->
-          <StackPanel
-            Grid.Row="3"
-            VerticalAlignment="Bottom"
-            Orientation="Vertical">
+          <StackPanel Grid.Row="3"
+                      VerticalAlignment="Bottom"
+                      Orientation="Vertical">
             <Separator Margin="0,8" />
             <!--  Dark Mode 😎  -->
 
@@ -81,22 +83,19 @@
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
 
-              <TextBlock
-                Grid.Column="0"
-                Margin="32,8,0,8"
-                Text="Dark Mode" />
-              <StackPanel
-                Grid.Column="1"
-                Margin="0,8,24,8"
-                Orientation="Horizontal">
+              <TextBlock Grid.Column="0"
+                         Margin="32,8,0,8"
+                         Text="Dark Mode" />
+              <StackPanel Grid.Column="1"
+                          Margin="0,8,24,8"
+                          Orientation="Horizontal">
                 <TextBlock Margin="0,0,8,0">
                   <md:PackIcon Kind="WhiteBalanceSunny" />
                 </TextBlock>
                 <!--  TODO figure out why this isn't changing the theme  -->
-                <ToggleButton
-                  x:Name="DarkModeToggleButton"
-                  Command="{s:Action ToggleTheme}"
-                  IsChecked="{Binding DarkMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <ToggleButton x:Name="DarkModeToggleButton"
+                              Command="{s:Action ToggleTheme}"
+                              IsChecked="{Binding DarkMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <TextBlock Margin="8,0,0,0">
                   <md:PackIcon Kind="NightSky" />
                 </TextBlock>
@@ -110,38 +109,38 @@
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
 
-              <TextBlock
-                Grid.Column="0"
-                Margin="32,8,0,8"
-                Text="Pin Window" />
-              <StackPanel
-                Grid.Column="1"
-                Margin="0,8,24,8"
-                Orientation="Horizontal">
+              <TextBlock Grid.Column="0"
+                         Margin="32,8,0,8"
+                         Text="Pin Window" />
+              <StackPanel Grid.Column="1"
+                          Margin="0,8,24,8"
+                          Orientation="Horizontal">
                 <TextBlock Margin="0,0,8,0">
-                  <md:PackIcon Kind="Pin" RenderTransformOrigin=".5,.5">
+                  <md:PackIcon Kind="Pin"
+                               RenderTransformOrigin=".5,.5">
                     <md:PackIcon.RenderTransform>
                       <RotateTransform Angle="45" />
                     </md:PackIcon.RenderTransform>
                   </md:PackIcon>
                 </TextBlock>
-                <ToggleButton x:Name="PinWindowToggleButton" IsChecked="{Binding IsPinned, Mode=TwoWay}" />
+                <ToggleButton x:Name="PinWindowToggleButton"
+                              IsChecked="{Binding IsPinned, Mode=TwoWay}" />
                 <TextBlock Margin="8,0,0,0">
                   <md:PackIcon Kind="Pin" />
                 </TextBlock>
               </StackPanel>
             </Grid>
 
-            <TextBlock Margin="32,8" Text="Help link" />
+            <TextBlock Margin="32,8"
+                       Text="Help link" />
             <Separator Margin="0,8" />
-            <TextBlock
-              Margin="0,16,0,24"
-              HorizontalAlignment="Center"
-              FontSize="12"
-              Foreground="Gray"
-              Style="{StaticResource MaterialDesignCaptionTextBlock}"
-              Text="Speckle version 2.😮"
-              TextWrapping="Wrap" />
+            <TextBlock Margin="0,16,0,24"
+                       HorizontalAlignment="Center"
+                       FontSize="12"
+                       Foreground="Gray"
+                       Style="{StaticResource MaterialDesignCaptionTextBlock}"
+                       Text="Speckle version 2.😮"
+                       TextWrapping="Wrap" />
           </StackPanel>
 
         </Grid>
@@ -151,40 +150,39 @@
       <DockPanel x:Name="TopLevelDockPanel">
 
         <!--#region Top Menu Bar-->
-        <md:ColorZone
-          Padding="16"
-          Panel.ZIndex="5"
-          Background="{DynamicResource MaterialDesignCardBackground}"
-          md:ShadowAssist.ShadowDepth="Depth2"
-          DockPanel.Dock="Top" >
+        <md:ColorZone Padding="16"
+                      Panel.ZIndex="2"
+                      md:ShadowAssist.ShadowDepth="Depth0"
+                      Background="{DynamicResource MaterialDesignCardBackground}"
+                      DockPanel.Dock="Top">
           <DockPanel>
-            <ToggleButton
-              x:Name="MenuToggleButton"
-              Click="MenuToggleButton_OnClick"
-              IsChecked="False"
-              Style="{StaticResource MaterialDesignHamburgerToggleButton}" />
+            <ToggleButton x:Name="MenuToggleButton"
+                          Click="MenuToggleButton_OnClick"
+                          IsChecked="False"
+                          Style="{StaticResource MaterialDesignHamburgerToggleButton}" />
 
-            <StackPanel Margin="16,0,0,0" Orientation="Horizontal">
-              <TextBlock
-                VerticalAlignment="Center"
-                FontSize="26"
-                Style="{StaticResource MaterialDesignHeadline3TextBlock}"
-                Text="SPECKLE" />
-              <TextBlock
-                VerticalAlignment="Center"
-                FontSize="26"
-                Style="{StaticResource MaterialDesignHeadline2TextBlock}"
-                Text="{Binding HostName, Converter={StaticResource StringToUpperConverter}}" />
+            <StackPanel Margin="16,0,0,0"
+                        Orientation="Horizontal">
+              <TextBlock VerticalAlignment="Center"
+                         FontSize="26"
+                         Style="{StaticResource MaterialDesignHeadline3TextBlock}"
+                         Text="SPECKLE" />
+              <TextBlock VerticalAlignment="Center"
+                         FontSize="26"
+                         Style="{StaticResource MaterialDesignHeadline2TextBlock}"
+                         Text="{Binding HostName, Converter={StaticResource StringToUpperConverter}}" />
             </StackPanel>
           </DockPanel>
         </md:ColorZone>
         <!--#endregion-->
 
-        <Grid x:Name="MainContent" Margin="0 12">
+        <Grid x:Name="MainContent"
+              Margin="0">
 
           <!--  Page Content  -->
           <ContentControl s:View.Model="{Binding ActiveItem}" />
-          <md:Snackbar x:Name="MainWindowSnackbar" MessageQueue="{Binding Notifications}" />
+          <md:Snackbar x:Name="MainWindowSnackbar"
+                       MessageQueue="{Binding Notifications}" />
         </Grid>
       </DockPanel>
 

--- a/DesktopUI/DesktopUI/RootViewModel.cs
+++ b/DesktopUI/DesktopUI/RootViewModel.cs
@@ -102,6 +102,7 @@ namespace Speckle.DesktopUI
       e.Cancel = true;
       // refocusing window with `.Show()` should be handled by individual connectors
       // can be accessed through `Application.Current.MainWindow.Show()`
+      // TODO maybe change this to be a notify icon? http://www.hardcodet.net/wpf-notifyicon
       sender.Hide();
     }
   }

--- a/DesktopUI/DesktopUI/Settings/SettingsView.xaml
+++ b/DesktopUI/DesktopUI/Settings/SettingsView.xaml
@@ -144,22 +144,12 @@
           Height="40"
           Margin="0,16,0,8"
           HorizontalAlignment="Stretch"
-          Command="{x:Static md:DialogHost.OpenDialogCommand}"
+          Command="{s:Action OpenHelpLink}"
+          CommandParameter="speckle://account"
           Content="Manage Accounts"
+          ToolTip="Open the Speckle Manager"
           Foreground="#FFfafafa"
           Style="{StaticResource SoftFlatMidBgButton}">
-          <Button.CommandParameter>
-            <StackPanel Margin="24">
-              <TextBlock Margin="0,8" Text="👻 this doesn't work yet..." />
-              <Button
-                Margin="0,12,0,0"
-                HorizontalAlignment="Center"
-                Command="{x:Static md:DialogHost.CloseDialogCommand}"
-                Content="CANCEL"
-                IsCancel="True"
-                Style="{StaticResource SoftFlatButton}" />
-            </StackPanel>
-          </Button.CommandParameter>
         </Button>
 
         <Separator Margin="0,8" />

--- a/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
@@ -12,7 +12,7 @@ using Stylet;
 namespace Speckle.DesktopUI.Streams
 {
   public class AllStreamsViewModel : Screen, IHandle<StreamAddedEvent>, IHandle<StreamUpdatedEvent>, IHandle<
-    StreamRemovedEvent>, IHandle<ApplicationEvent>
+    StreamRemovedEvent>, IHandle<ApplicationEvent>, IHandle<ReloadRequestedEvent>
   {
     private readonly IViewManager _viewManager;
     private readonly IStreamViewModelFactory _streamViewModelFactory;
@@ -36,11 +36,8 @@ namespace Speckle.DesktopUI.Streams
       _dialogFactory = dialogFactory;
       _bindings = bindings;
 
-      _streamList = new BindableCollection<StreamState>(_bindings.GetFileContext());
-#if DEBUG
-      if ( _streamList.Count == 0 )
-        _streamList = _repo.LoadTestStreams();
-#endif
+      StreamList = LoadStreams();
+
       _events.Subscribe(this);
     }
 
@@ -66,6 +63,15 @@ namespace Speckle.DesktopUI.Streams
     {
       get => _selectedBranch;
       set => SetAndNotify(ref _selectedBranch, value);
+    }
+
+    private BindableCollection<StreamState> LoadStreams()
+    {
+      var streams = new BindableCollection<StreamState>(_bindings.GetFileContext());
+      if ( streams.Count == 0 )
+        streams = _repo.LoadTestStreams();
+
+      return streams;
     }
 
     public void ShowStreamInfo(StreamState state)
@@ -195,6 +201,11 @@ namespace Speckle.DesktopUI.Streams
         default:
           return;
       }
+    }
+
+    public void Handle(ReloadRequestedEvent message)
+    {
+      StreamList = LoadStreams();
     }
   }
 }

--- a/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
@@ -48,7 +48,6 @@ namespace Speckle.DesktopUI.Streams
     private BindableCollection<StreamState> _streamList;
     private Stream _selectedStream;
     private Branch _selectedBranch;
-
     private CancellationTokenSource _cancellationToken = new CancellationTokenSource();
 
     public BindableCollection<StreamState> StreamList

--- a/DesktopUI/DesktopUI/Streams/StreamsHomeView.xaml
+++ b/DesktopUI/DesktopUI/Streams/StreamsHomeView.xaml
@@ -1,18 +1,67 @@
-﻿<UserControl
-  x:Class="Speckle.DesktopUI.Streams.StreamsHomeView"
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-  xmlns:local="clr-namespace:Speckle.DesktopUI.Streams"
-  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
-  xmlns:s="https://github.com/canton7/Stylet"
-  d:DesignHeight="450"
-  d:DesignWidth="600"
-  mc:Ignorable="d">
+﻿<UserControl x:Class="Speckle.DesktopUI.Streams.StreamsHomeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Speckle.DesktopUI.Streams"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:s="https://github.com/canton7/Stylet"
+             d:DesignHeight="450"
+             d:DesignWidth="600"
+             mc:Ignorable="d">
   <UserControl.Resources />
 
-  <Grid>
-    <ContentControl s:View.Model="{Binding ActiveItem}" />
+  <Grid x:Name="StreamsHomeRootGrid">
+
+    <ContentControl Grid.Row="0"
+                    Margin="0,12"
+                    s:View.Model="{Binding ActiveItem}" />
+
+    <Grid Grid.Row="0"
+          Visibility="{Binding Accounts, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"
+          ZIndex="10">
+      <md:Card MaxWidth="500"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"
+               md:ShadowAssist.ShadowDepth="Depth0"
+               UniformCornerRadius="6">
+        <StackPanel Margin="24,36">
+          <TextBlock FontSize="20"
+                     Style="{StaticResource MaterialDesignHeadline4TextBlock}"
+                     Text="No local accounts found" />
+          <TextBlock Margin="0,12"
+                     FontSize="14"
+                     Text="In order to use Speckle on desktop, you need to install the Speckle Manager. This will allow you to manage you local accounts and keep track of your connectors and kits."
+                     TextWrapping="Wrap" />
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="0"
+                    Width="150"
+                    Margin="8"
+                    Command="{s:Action OpenManagerLink}"
+                    Content="GET MANAGER"
+                    Style="{StaticResource SoftFlatMidBgButton}"
+                    ToolTip="Find the download link to the manager here" />
+            <Button Grid.Column="1"
+                    Width="150"
+                    Margin="8"
+                    Command="{s:Action ReloadAccounts}"
+                    Content="RELOAD"
+                    Style="{StaticResource SoftFlatMidBgButton}"
+                    ToolTip="Try loading local accounts again. If successful, the app will restart." />
+          </Grid>
+        </StackPanel>
+      </md:Card>
+    </Grid>
+    <Grid Grid.Row="0"
+          Visibility="{Binding Accounts, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}"
+          ZIndex="5">
+      <Border Height="5000"
+              Background="{DynamicResource MaterialDesignToolBarBackground}"
+              Opacity="0.9" />
+    </Grid>
   </Grid>
 </UserControl>

--- a/DesktopUI/DesktopUI/Streams/StreamsHomeViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamsHomeViewModel.cs
@@ -12,14 +12,16 @@ namespace Speckle.DesktopUI.Streams
   public class StreamsHomeViewModel : Conductor<IScreen>.StackNavigation
   {
     private IViewModelFactory _viewModelFactory;
+    private readonly IEventAggregator _events;
     private AccountsRepository _accountsRepo;
     private ConnectorBindings _bindings;
 
-    public StreamsHomeViewModel(IViewModelFactory viewModelFactory,
+    public StreamsHomeViewModel(IViewModelFactory viewModelFactory, IEventAggregator events,
       AccountsRepository accountsRepo, ConnectorBindings bindings)
     {
       DisplayName = "Home";
       _viewModelFactory = viewModelFactory;
+      _events = events;
       _accountsRepo = accountsRepo;
       _bindings = bindings;
       _accounts = _accountsRepo.LoadAccounts();
@@ -30,6 +32,7 @@ namespace Speckle.DesktopUI.Streams
     }
 
     private  BindableCollection<Account> _accounts;
+
     public BindableCollection<Account> Accounts
     {
       get => _accounts;
@@ -46,11 +49,11 @@ namespace Speckle.DesktopUI.Streams
       Accounts = _accountsRepo.LoadAccounts();
       if ( Accounts.Any() )
       {
-        // just restart the app - easier than doing an events hokey pokey to get test streams reloaded
-        System.Diagnostics.Process.Start(Application.ResourceAssembly.Location);
-        Application.Current.Shutdown();
+        _events.PublishOnUIThread(new ReloadRequestedEvent());
+        _bindings.RaiseNotification($"Success! You have {Accounts.Count} local accounts.");
         return;
       }
+
       _bindings.RaiseNotification("Sorry, no local accounts were found 😢");
     }
   }

--- a/DesktopUI/DesktopUI/Streams/StreamsHomeViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamsHomeViewModel.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Linq;
+using System.Windows;
+using MaterialDesignThemes.Wpf;
+using Speckle.Core.Credentials;
+using Speckle.DesktopUI.Accounts;
 using Speckle.DesktopUI.Utils;
 using Stylet;
 
@@ -7,14 +12,46 @@ namespace Speckle.DesktopUI.Streams
   public class StreamsHomeViewModel : Conductor<IScreen>.StackNavigation
   {
     private IViewModelFactory _viewModelFactory;
-    public StreamsHomeViewModel(IViewModelFactory viewModelFactory)
+    private AccountsRepository _accountsRepo;
+    private ConnectorBindings _bindings;
+
+    public StreamsHomeViewModel(IViewModelFactory viewModelFactory,
+      AccountsRepository accountsRepo, ConnectorBindings bindings)
     {
       DisplayName = "Home";
       _viewModelFactory = viewModelFactory;
+      _accountsRepo = accountsRepo;
+      _bindings = bindings;
+      _accounts = _accountsRepo.LoadAccounts();
 
       var item = _viewModelFactory.CreateAllStreamsViewModel();
 
       ActivateItem(item);
+    }
+
+    private  BindableCollection<Account> _accounts;
+    public BindableCollection<Account> Accounts
+    {
+      get => _accounts;
+      set => SetAndNotify(ref _accounts, value);
+    }
+
+    public void OpenManagerLink()
+    {
+      Link.OpenInBrowser("https://github.com/specklesystems/speckle-sharp/tree/master/DesktopUI#accounts");
+    }
+
+    public void ReloadAccounts()
+    {
+      Accounts = _accountsRepo.LoadAccounts();
+      if ( Accounts.Any() )
+      {
+        // just restart the app - easier than doing an events hokey pokey to get test streams reloaded
+        System.Diagnostics.Process.Start(Application.ResourceAssembly.Location);
+        Application.Current.Shutdown();
+        return;
+      }
+      _bindings.RaiseNotification("Sorry, no local accounts were found 😢");
     }
   }
 }

--- a/DesktopUI/DesktopUI/Streams/StreamsRepository.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamsRepository.cs
@@ -136,8 +136,9 @@ namespace Speckle.DesktopUI.Streams
       };
 
       #endregion
-
-      var client = new Client(AccountManager.GetDefaultAccount());
+      var client = AccountManager.GetDefaultAccount() != null
+        ? new Client(AccountManager.GetDefaultAccount())
+        : new Client();
       foreach ( var stream in testStreams )
       {
         collection.Add(new StreamState(client, stream));
@@ -180,8 +181,9 @@ namespace Speckle.DesktopUI.Streams
       }
       catch ( Exception e )
       {
-        if (e is HttpRequestException)
-          _bindings.RaiseNotification($"Sorry, we could not connect to the server: {state.Client.ServerUrl}. Please ensure the server is online.");
+        if ( e is HttpRequestException )
+          _bindings.RaiseNotification(
+            $"Sorry, we could not connect to the server: {state.Client.ServerUrl}. Please ensure the server is online.");
         Log.CaptureException(e);
         return null;
       }

--- a/DesktopUI/DesktopUI/Utils/Events.cs
+++ b/DesktopUI/DesktopUI/Utils/Events.cs
@@ -18,6 +18,10 @@ namespace Speckle.DesktopUI.Utils
   {
   }
 
+  public class ReloadRequestedEvent : EventBase
+  {
+  }
+
   public class StreamAddedEvent : EventBase
   {
     public StreamState NewStream { get; set; }

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -45,14 +45,14 @@ namespace Speckle.DesktopUI.Utils
       Client = new Client(account);
     }
 
-    private  Client _client;
+    private Client _client;
 
     public Client Client
     {
       get => _client;
       set
       {
-        if (value.AccountId == null) return;
+        if ( value.AccountId == null ) return;
         _client = value;
         AccountId = Client.AccountId;
         ServerUrl = Client.ServerUrl;
@@ -76,7 +76,7 @@ namespace Speckle.DesktopUI.Utils
       }
     }
 
-    private  ISelectionFilter _filter;
+    private ISelectionFilter _filter;
 
     public ISelectionFilter Filter
     {
@@ -138,8 +138,7 @@ namespace Speckle.DesktopUI.Utils
 
     internal void Initialise()
     {
-      if (Stream == null) return;
-      if (Client?.AccountId == null) return;
+      if ( Stream == null || Client?.AccountId == null ) return;
 
       Client.SubscribeStreamUpdated(Stream.id);
       Client.SubscribeCommitCreated(Stream.id);
@@ -161,7 +160,7 @@ namespace Speckle.DesktopUI.Utils
 
     private void HandleCommitCreated(object sender, CommitInfo info)
     {
-      if (LatestCommit().id == info.id) return;
+      if ( LatestCommit().id == info.id ) return;
       ServerUpdates = true;
     }
 
@@ -176,6 +175,7 @@ namespace Speckle.DesktopUI.Utils
         ServerUpdates = true;
         return;
       }
+
       commit.message = info.message;
       NotifyOfPropertyChange(nameof(Stream));
     }
@@ -188,6 +188,7 @@ namespace Speckle.DesktopUI.Utils
         Log.CaptureException(new SpeckleException($"Could not find branch {branchName} on stream {Stream.id}"));
         return null;
       }
+
       var commits = branch.commits.items;
       return commits.Any() ? commits[ 0 ] : null;
     }

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -52,6 +52,7 @@ namespace Speckle.DesktopUI.Utils
       get => _client;
       set
       {
+        if (value.AccountId == null) return;
         _client = value;
         AccountId = Client.AccountId;
         ServerUrl = Client.ServerUrl;
@@ -138,6 +139,7 @@ namespace Speckle.DesktopUI.Utils
     internal void Initialise()
     {
       if (Stream == null) return;
+      if (Client?.AccountId == null) return;
 
       Client.SubscribeStreamUpdated(Stream.id);
       Client.SubscribeCommitCreated(Stream.id);


### PR DESCRIPTION
This adds an overlay to the DesktopUI home page if there are no local accounts on the machine. This is likely caused by not having installed manager, so the overlay directs the user to download the manager and try again.

![no accounts found overlay](https://user-images.githubusercontent.com/7717434/98154507-ca3ba400-1ecc-11eb-9789-2a1f50a63f4a.png)

This includes a small change in core: `AccountManager` was using `CaptureAndThrow` when no default account was found. I assume the intended behaviour was to `CaptureException` but allow it to continue and return null, so I have made this change. 
