### PR TITLE
fix(dynamo): removes objects.dll reference

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
+++ b/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
@@ -82,10 +82,6 @@
       <Project>{3f02e475-e777-4dfd-8ae9-8065edd092dc}</Project>
       <Name>Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Objects\Objects\Objects.csproj">
-      <Project>{1e11c8cc-f56d-4474-883c-f55e9614c417}</Project>
-      <Name>Objects</Name>
-    </ProjectReference>
     <ProjectReference Include="..\ConnectorDynamoExtension\ConnectorDynamoExtension.csproj">
       <Project>{b494fd40-5e59-4d5e-87b0-80aac8bdcd5a}</Project>
       <Name>ConnectorDynamoExtension</Name>


### PR DESCRIPTION
this was throwing off the GetConverterForApp func as it was looking inside the plugin folder rather than the kits folder.