### PR TITLE
🌀 Refresh stream cards when the stream is modified elsewhere

### DIFF
--- a/DesktopUI/DesktopUI/DesktopUI.csproj
+++ b/DesktopUI/DesktopUI/DesktopUI.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Utils\Helpers.cs" />
     <Compile Include="Utils\StreamDialogBase.cs" />
     <Compile Include="Utils\StreamState.cs" />
+    <Compile Include="Utils\StreamState.Events.cs" />
     <Compile Include="Utils\ViewModelFactories.cs" />
     <Compile Include="Utils\RelayCommand.cs" />
     <Compile Include="Utils\SelectionFilter.cs" />

--- a/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
@@ -272,7 +272,7 @@
             <local:BindingProxy x:Key="Proxy" Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
           </Button.Resources>
           <Button.ContextMenu>
-            <ContextMenu FontSize="12" ItemsSource="{Binding CommitContextMenuItems, Mode=OneWay}">
+            <ContextMenu FontSize="12" ItemsSource="{Binding CommitContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
               <ContextMenu.ItemTemplate>
                 <DataTemplate>
                   <StackPanel>

--- a/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
@@ -59,7 +59,7 @@
             <local:BindingProxy x:Key="Proxy" Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
           </Button.Resources>
           <Button.ContextMenu>
-            <ContextMenu FontSize="12" ItemsSource="{Binding BranchContextMenuItems, Mode=OneWay}">
+            <ContextMenu FontSize="12" ItemsSource="{Binding BranchContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
               <ContextMenu.ItemTemplate>
                 <DataTemplate DataType="re">
                   <Grid Background="Transparent" ToolTip="{Binding Tooltip}">
@@ -408,7 +408,7 @@
                         Command="{s:Action ShowStreamInfo}"
                         CommandParameter="{Binding}"
                         ToolTip="Open stream details page.">
-                        <TextBlock FontSize="20" Text="{Binding Stream.name}" />
+                        <TextBlock FontSize="20" Text="{Binding Stream.name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                       </Hyperlink>
                     </TextBlock>
                   </WrapPanel>

--- a/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
@@ -110,7 +110,11 @@ namespace Speckle.DesktopUI.Streams
       await DialogHost.Show(view, "RootDialogHost");
     }
 
-    public async void Send(StreamState state) => state.Send();
+    public async void Send(StreamState state)
+    {
+      state.Send();
+      StreamList.Refresh();
+    }
 
     public async void Receive(StreamState state) => state.Receive();
 

--- a/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
@@ -110,11 +110,7 @@ namespace Speckle.DesktopUI.Streams
       await DialogHost.Show(view, "RootDialogHost");
     }
 
-    public async void Send(StreamState state)
-    {
-      state.Send();
-      StreamList.Refresh();
-    }
+    public async void Send(StreamState state) => state.Send();
 
     public async void Receive(StreamState state) => state.Receive();
 

--- a/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
+++ b/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Windows.Controls;
-using Speckle.Core.Logging;
+using Newtonsoft.Json;
 using Stylet;
 
 namespace Speckle.DesktopUI.Utils
 {
+
   public interface ISelectionFilter
   {
     string Name { get; set; }
@@ -64,12 +63,11 @@ namespace Speckle.DesktopUI.Utils
 
   public class PropertySelectionFilter : ISelectionFilter
   {
-    public string Type => typeof(ListSelectionFilter).ToString();
+    public string Type => typeof(PropertySelectionFilter).ToString();
 
     public string Name { get; set; }
     public string Icon { get; set; }
     public string Description { get; set; }
-
 
     public List<string> Selection { get; set; } = new List<string>();
 
@@ -148,8 +146,31 @@ namespace Speckle.DesktopUI.Utils
     {
       ListItem = null;
       ListItems.Remove(name);
-      if (SearchQuery != null && !name.Contains(SearchQuery)) return;
+      if (SearchQuery != null && !name.Contains(SearchQuery))return;
       SearchResults.Add(name);
+    }
+  }
+
+  public class SelectionFilterConverter : JsonConverter
+  {
+    public override bool CanConvert(Type objectType)
+    {
+      return objectType == typeof(ISelectionFilter);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+      ISelectionFilter filter;
+      filter = serializer.Deserialize<ListSelectionFilter>(reader) ?? (ISelectionFilter)serializer.Deserialize<PropertySelectionFilter>(reader);
+      if (filter != null)
+        return filter;
+
+      throw new NotSupportedException($"Type {objectType} unrecognised and could not be deserialised.");
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+      serializer.Serialize(writer, value);
     }
   }
 }

--- a/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
+++ b/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
@@ -160,12 +160,9 @@ namespace Speckle.DesktopUI.Utils
 
     public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
     {
-      ISelectionFilter filter;
-      filter = serializer.Deserialize<ListSelectionFilter>(reader) ?? (ISelectionFilter)serializer.Deserialize<PropertySelectionFilter>(reader);
-      if (filter != null)
-        return filter;
+      var filter = serializer.Deserialize<ListSelectionFilter>(reader) ?? (ISelectionFilter)serializer.Deserialize<PropertySelectionFilter>(reader);
 
-      throw new NotSupportedException($"Type {objectType} unrecognised and could not be deserialised.");
+      return filter;
     }
 
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Speckle.Core.Api.SubscriptionModels;
+using Speckle.Core.Models;
+using Stylet;
+
+namespace Speckle.DesktopUI.Utils
+{
+  public partial class StreamState : PropertyChangedBase, IHandle<UpdateSelectionCountEvent>
+  {
+    public async Task<bool> RefreshStream()
+    {
+      try
+      {
+        var updatedStream = await Client.StreamGet(Stream.id);
+        Stream.name = updatedStream.name;
+        Stream.description = updatedStream.description;
+        Branches = updatedStream.branches.items;
+        NotifyOfPropertyChange(nameof(Stream));
+      }
+      catch ( Exception )
+      {
+        return false;
+      }
+
+      return true;
+    }
+
+    #region Selection events
+
+    public void SetObjectSelection()
+    {
+      var objIds = Globals.HostBindings.GetSelectedObjects();
+      if ( objIds == null || objIds.Count == 0 )
+      {
+        Globals.Notify("Could not get object selection.");
+        return;
+      }
+
+      Objects = objIds.Select(id => new Base {applicationId = id}).ToList();
+
+      Globals.Notify("Object selection set.");
+      Filter = null;
+    }
+
+    public void AddObjectSelection()
+    {
+      var objIds = Globals.HostBindings.GetSelectedObjects();
+      if ( objIds == null || objIds.Count == 0 )
+      {
+        Globals.Notify("Could not get object selection.");
+        return;
+      }
+
+      objIds.ForEach(id =>
+      {
+        if ( Objects.FirstOrDefault(b => b.applicationId == id) == null )
+        {
+          Objects.Add(new Base {applicationId = id});
+        }
+      });
+
+      Globals.Notify("Object added.");
+      Filter = null;
+    }
+
+    public void RemoveObjectSelection()
+    {
+      var objIds = Globals.HostBindings.GetSelectedObjects();
+      if ( objIds == null || objIds.Count == 0 )
+      {
+        Globals.Notify("Could not get object selection.");
+        return;
+      }
+
+      var filtered = Objects.Where(o => objIds.IndexOf(o.applicationId) == -1).ToList();
+
+      if ( filtered.Count == Objects.Count )
+      {
+        Globals.Notify("No objects removed.");
+        return;
+      }
+
+      Globals.Notify($"{Objects.Count - filtered.Count} objects removed.");
+      Objects = filtered;
+    }
+
+    public void ClearObjectSelection()
+    {
+      Objects = new List<Base>();
+      Filter = null;
+      Globals.Notify($"Selection cleared.");
+    }
+
+    public void Handle(UpdateSelectionCountEvent message)
+    {
+      SelectionCount = message.SelectionCount;
+    }
+
+    #endregion
+
+    #region subscriptions
+
+    private void HandleStreamUpdated(object sender, StreamInfo info)
+    {
+      Stream.name = info.name;
+      Stream.description = info.description;
+      NotifyOfPropertyChange(nameof(Stream));
+    }
+
+    private async void HandleCommitCreated(object sender, CommitInfo info)
+    {
+      var updatedStream = await Client.StreamGet(Stream.id);
+      Branches = updatedStream.branches.items;
+
+      if ( IsSenderCard ) return;
+
+      var binfo = Branches.FirstOrDefault(b => b.name == info.branchName);
+      var cinfo = binfo.commits.items.FirstOrDefault(c => c.id == info.id);
+
+      if ( Branch.name == info.branchName )
+      {
+        Branch = binfo;
+      }
+
+      ServerUpdateSummary = $"{cinfo.authorName} sent new data on branch {info.branchName}: {info.message}";
+      ServerUpdates = true;
+    }
+
+    private void HandleCommitUpdated(object sender, CommitInfo info)
+    {
+      var branch = Stream.branches.items.FirstOrDefault(b => b.name == info.branchName);
+      var commit = branch?.commits.items.FirstOrDefault(c => c.id == info.id);
+      if ( commit == null )
+      {
+        // something went wrong, but notify the user there were changes anyway
+        // ((look like this sub isn't returning a branch name?))
+        ServerUpdates = true;
+        return;
+      }
+
+      commit.message = info.message;
+      NotifyOfPropertyChange(nameof(Stream));
+    }
+
+    private async void HandleBranchCreated(object sender, BranchInfo info)
+    {
+      var updatedStream = await Client.StreamGet(Stream.id);
+      Branches = updatedStream.branches.items;
+    }
+
+    private void HandleBranchUpdated(object sender, BranchInfo info)
+    {
+      var branch = Branches.FirstOrDefault(b => b.id == info.id);
+      if ( branch == null ) return;
+      branch.name = info.name;
+      branch.description = info.description;
+      NotifyOfPropertyChange(nameof(BranchContextMenuItems));
+    }
+
+    private void HandleBranchDeleted(object sender, BranchInfo info)
+    {
+      var branch = Branches.FirstOrDefault(b => b.id == info.id);
+      if ( branch == null ) return;
+      Stream.branches.items.Remove(branch);
+      NotifyOfPropertyChange(nameof(BranchContextMenuItems));
+    }
+
+    #endregion
+  }
+}

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -586,7 +586,6 @@ namespace Speckle.DesktopUI.Utils
       CancellationTokenSource = new CancellationTokenSource();
 
       await Task.Run(() => Globals.Repo.ConvertAndSend(this));
-      await RefreshStream();
 
       ShowProgressBar = false;
       Progress.ResetProgress();
@@ -744,13 +743,11 @@ namespace Speckle.DesktopUI.Utils
 
     private async void HandleCommitCreated(object sender, CommitInfo info)
     {
-      if (IsSenderCard)
-      {
-        return;
-      }
-
       var updatedStream = await Client.StreamGet(Stream.id);
       Branches = updatedStream.branches.items;
+
+      if (IsReceiverCard) return;
+
 
       var binfo = Branches.FirstOrDefault(b => b.name == info.branchName);
       var cinfo = binfo.commits.items.FirstOrDefault(c => c.id == info.id);
@@ -760,10 +757,7 @@ namespace Speckle.DesktopUI.Utils
         Branch = binfo;
       }
 
-      NotifyOfPropertyChange(nameof(CommitContextMenuItems));
-
       ServerUpdateSummary = $"{cinfo.authorName} sent new data on branch {info.branchName}: {info.message}";
-
       ServerUpdates = true;
     }
 

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -25,6 +25,7 @@ namespace Speckle.DesktopUI.Utils
   public partial class StreamState : PropertyChangedBase, IHandle<UpdateSelectionCountEvent>
   {
     private Client _client;
+
     public Client Client
     {
       get => _client;
@@ -217,6 +218,7 @@ namespace Speckle.DesktopUI.Utils
     }
 
     private ISelectionFilter _filter;
+
     [JsonProperty]
     public ISelectionFilter Filter
     {
@@ -457,7 +459,7 @@ namespace Speckle.DesktopUI.Utils
     public StreamState(string accountId)
     {
       var account = AccountManager.GetAccounts().FirstOrDefault(a => a.id == accountId) ??
-                    AccountManager.GetAccounts().FirstOrDefault(a => a.serverInfo.url == ServerUrl);
+        AccountManager.GetAccounts().FirstOrDefault(a => a.serverInfo.url == ServerUrl);
       if (account == null)
       {
         // TODO : Notify error!
@@ -533,14 +535,14 @@ namespace Speckle.DesktopUI.Utils
         });
         Branch = Stream.branches.items.Last();
 
-        NotifyOfPropertyChange(nameof(BranchContextMenuItem));
         Globals.Notify($"Created branch {Branch.name} and switched to it.");
         return;
       }
 
       Branch = branch;
       Globals.Notify($"Switched active branch to {Branch.name}.");
-      NotifyOfPropertyChange(nameof(BranchContextMenuItem));
+
+      NotifyOfPropertyChange(nameof(CommitContextMenuItems));
       Globals.HostBindings.PersistAndUpdateStreamInFile(this);
     }
 
@@ -636,6 +638,7 @@ namespace Speckle.DesktopUI.Utils
     public void SwapState()
     {
       IsSenderCard = !IsSenderCard;
+      NotifyOfPropertyChange(nameof(CommitContextMenuItems));
       Globals.HostBindings.PersistAndUpdateStreamInFile(this);
     }
 
@@ -721,7 +724,7 @@ namespace Speckle.DesktopUI.Utils
 
     #endregion
 
-    #region application events 
+    #region application events
 
     private void HandleStreamUpdated(object sender, StreamInfo info)
     {
@@ -752,6 +755,8 @@ namespace Speckle.DesktopUI.Utils
       {
         Branch = binfo;
       }
+
+      NotifyOfPropertyChange(nameof(CommitContextMenuItems));
 
       ServerUpdateSummary = $"{cinfo.authorName} sent new data on branch {info.branchName}: {info.message}";
 
@@ -814,7 +819,6 @@ namespace Speckle.DesktopUI.Utils
     }
 
     #endregion
-
   }
 
   /// <summary>
@@ -833,7 +837,6 @@ namespace Speckle.DesktopUI.Utils
       public Branch Branch { get; set; }
     }
   }
-
 
   /// <summary>
   /// Class used for handling actions around the context menu of the commit switcher (receiver).

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -586,6 +586,7 @@ namespace Speckle.DesktopUI.Utils
       CancellationTokenSource = new CancellationTokenSource();
 
       await Task.Run(() => Globals.Repo.ConvertAndSend(this));
+      await RefreshStream();
 
       ShowProgressBar = false;
       Progress.ResetProgress();
@@ -810,8 +811,10 @@ namespace Speckle.DesktopUI.Utils
       try
       {
         var updatedStream = await Client.StreamGet(Stream.id);
-        Stream = updatedStream;
+        Stream.name = updatedStream.name;
+        Stream.description = updatedStream.description;
         Branches = updatedStream.branches.items;
+        NotifyOfPropertyChange(nameof(Stream));
       }
       catch (Exception)
       {

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -7,7 +7,6 @@ using System.Windows.Input;
 using MaterialDesignThemes.Wpf;
 using Newtonsoft.Json;
 using Speckle.Core.Api;
-using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
@@ -22,7 +21,7 @@ namespace Speckle.DesktopUI.Utils
   /// account information so a `Client` can be recreated.
   /// </summary>
   [JsonObject(MemberSerialization.OptIn)]
-  public partial class StreamState : PropertyChangedBase, IHandle<UpdateSelectionCountEvent>
+  public partial class StreamState : PropertyChangedBase
   {
     private Client _client;
 
@@ -655,167 +654,6 @@ namespace Speckle.DesktopUI.Utils
     {
       Errors.Clear();
       ShowErrors = false;
-    }
-
-    #endregion
-
-    #region Selection events
-
-    public void SetObjectSelection()
-    {
-      var objIds = Globals.HostBindings.GetSelectedObjects();
-      if (objIds == null || objIds.Count == 0)
-      {
-        Globals.Notify("Could not get object selection.");
-        return;
-      }
-
-      Objects = objIds.Select(id => new Base { applicationId = id }).ToList();
-
-      Globals.Notify("Object selection set.");
-      Filter = null;
-    }
-
-    public void AddObjectSelection()
-    {
-      var objIds = Globals.HostBindings.GetSelectedObjects();
-      if (objIds == null || objIds.Count == 0)
-      {
-        Globals.Notify("Could not get object selection.");
-        return;
-      }
-
-      objIds.ForEach(id =>
-      {
-        if (Objects.FirstOrDefault(b => b.applicationId == id) == null)
-        {
-          Objects.Add(new Base { applicationId = id });
-        }
-      });
-
-      Globals.Notify("Object added.");
-      Filter = null;
-    }
-
-    public void RemoveObjectSelection()
-    {
-      var objIds = Globals.HostBindings.GetSelectedObjects();
-      if (objIds == null || objIds.Count == 0)
-      {
-        Globals.Notify("Could not get object selection.");
-        return;
-      }
-
-      var filtered = Objects.Where(o => objIds.IndexOf(o.applicationId) == -1).ToList();
-
-      if (filtered.Count == Objects.Count)
-      {
-        Globals.Notify("No objects removed.");
-        return;
-      }
-
-      Globals.Notify($"{Objects.Count - filtered.Count} objects removed.");
-      Objects = filtered;
-    }
-
-    public void ClearObjectSelection()
-    {
-      Objects = new List<Base>();
-      Filter = null;
-      Globals.Notify($"Selection cleared.");
-    }
-
-    #endregion
-
-    #region application events
-
-    private void HandleStreamUpdated(object sender, StreamInfo info)
-    {
-      Stream.name = info.name;
-      Stream.description = info.description;
-      NotifyOfPropertyChange(nameof(Stream));
-    }
-
-    public void Handle(UpdateSelectionCountEvent message)
-    {
-      SelectionCount = message.SelectionCount;
-    }
-
-    private async void HandleCommitCreated(object sender, CommitInfo info)
-    {
-      var updatedStream = await Client.StreamGet(Stream.id);
-      Branches = updatedStream.branches.items;
-
-      if (IsReceiverCard) return;
-
-
-      var binfo = Branches.FirstOrDefault(b => b.name == info.branchName);
-      var cinfo = binfo.commits.items.FirstOrDefault(c => c.id == info.id);
-
-      if (Branch.name == info.branchName)
-      {
-        Branch = binfo;
-      }
-
-      ServerUpdateSummary = $"{cinfo.authorName} sent new data on branch {info.branchName}: {info.message}";
-      ServerUpdates = true;
-    }
-
-    private void HandleCommitUpdated(object sender, CommitInfo info)
-    {
-      var branch = Stream.branches.items.FirstOrDefault(b => b.name == info.branchName);
-      var commit = branch?.commits.items.FirstOrDefault(c => c.id == info.id);
-      if (commit == null)
-      {
-        // something went wrong, but notify the user there were changes anyway
-        // ((look like this sub isn't returning a branch name?))
-        ServerUpdates = true;
-        return;
-      }
-
-      commit.message = info.message;
-      NotifyOfPropertyChange(nameof(Stream));
-    }
-
-    private async void HandleBranchCreated(object sender, BranchInfo info)
-    {
-      var updatedStream = await Client.StreamGet(Stream.id);
-      Branches = updatedStream.branches.items;
-    }
-
-    private void HandleBranchUpdated(object sender, BranchInfo info)
-    {
-      var branch = Branches.FirstOrDefault(b => b.id == info.id);
-      if (branch == null)return;
-      branch.name = info.name;
-      branch.description = info.description;
-      NotifyOfPropertyChange(nameof(BranchContextMenuItems));
-    }
-
-    private void HandleBranchDeleted(object sender, BranchInfo info)
-    {
-      var branch = Branches.FirstOrDefault(b => b.id == info.id);
-      if (branch == null)return;
-      Stream.branches.items.Remove(branch);
-      NotifyOfPropertyChange(nameof(BranchContextMenuItems));
-    }
-
-    public async Task<bool> RefreshStream()
-    {
-      try
-      {
-        var updatedStream = await Client.StreamGet(Stream.id);
-        Stream.name = updatedStream.name;
-        Stream.description = updatedStream.description;
-        Branches = updatedStream.branches.items;
-        NotifyOfPropertyChange(nameof(Stream));
-      }
-      catch (Exception)
-      {
-        return false;
-      }
-
-      return true;
     }
 
     #endregion

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -220,6 +220,7 @@ namespace Speckle.DesktopUI.Utils
     private ISelectionFilter _filter;
 
     [JsonProperty]
+    [JsonConverter(typeof(SelectionFilterConverter))]
     public ISelectionFilter Filter
     {
       get => _filter;
@@ -475,6 +476,8 @@ namespace Speckle.DesktopUI.Utils
       {
         return;
       }
+      // refresh after deserialisation
+      Task.Run(() => RefreshStream());
 
       Client.SubscribeStreamUpdated(Stream.id);
       Client.SubscribeCommitCreated(Stream.id);


### PR DESCRIPTION
This resolves the issue of streams not being refreshed when a document with a saved stream is reopened and the stream is deserialised. The stream is now refreshed upon initialisation after being deserialised.

An issue regarding deserialisation of selection filters has also been resolved with a json converter.

This also resolves other issues with the branches / commits:
- commits and branches now update consistently including when they have been edited from the web, from another connector, or from the document itself (previously branches and commits would not update if you were modifying the stream from the document itself - they would only update if the stream was modified elsewhere)
- a bug with the commit list compiling commits from different branches has been squashed
- branch subscriptions are now handled so the branch / commit lists will update consistently 

This closes #124 