### PR TITLE
GH: Temporary fix for "green cables" issue.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -541,6 +541,17 @@ namespace ConnectorGrasshopper.Ops
     {
     }
 
+    private bool _selected;
+    public override bool Selected
+    {
+      get {
+        return _selected;
+      }
+      set {
+        Owner.Params.ToList().ForEach(p => p.Attributes.Selected = value);
+        _selected = value;
+      }
+    }
     protected override void Layout()
     {
       base.Layout();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -555,10 +555,22 @@ namespace ConnectorGrasshopper.Ops
 
   public class SendComponentAttributes : GH_ComponentAttributes
   {
+    private bool _selected;
     Rectangle ButtonBounds { get; set; }
 
     public SendComponentAttributes(GH_Component owner) : base(owner)
     {
+    }
+
+    public override bool Selected
+    {
+      get {
+         return _selected;
+      }
+      set {
+        Owner.Params.ToList().ForEach(p => p.Attributes.Selected = value);
+         _selected = value;
+      }
     }
 
     protected override void Layout()


### PR DESCRIPTION
The issue was related with overriding `GH_ComponentAttributes`. It appears inheriting from this class does not do all the magic one would have expected it to.

I'll leave the issue open and contact the McNeel guys to see if this is a bug or we're just missing something.