### PR TITLE
fix(gh): Fixed initial state on receiver

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -122,7 +122,7 @@ namespace ConnectorGrasshopper.Ops
       var streamInputIndex = pManager.AddGenericParameter("Stream", "S",
         "The Speckle Stream to receive data from. You can also input the Stream ID or it's URL as text.",
         GH_ParamAccess.tree);
-      pManager[streamInputIndex].Optional = true;
+      //pManager[streamInputIndex].Optional = true;
     }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)


### PR DESCRIPTION
Issue was due to receiver input being optional. Enforcing input now prevents the component from running and ending up in an `expired` state.

![Screenshot 2021-01-07 at 12 13 01](https://user-images.githubusercontent.com/2316535/103886670-26e05880-50e2-11eb-813b-9363466542a7.png)

Fixes #169 