### PR TITLE
🏷 Update Commit Models & Populate New Props in Connectors

### DIFF
--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Autodesk.DesignScript.Runtime;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
+using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
@@ -58,7 +59,9 @@ namespace Speckle.ConnectorDynamo.Functions
            streamId = streams[i].StreamId,
            branchName = branchName,
            objectId = objectId,
-           message = message
+           message = message,
+           sourceApplication = Applications.Dynamo,
+           parents = new List<string>() {streams[i].CommitId}
          }).Result;
 
           responses.Add(res);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -466,6 +466,7 @@ namespace ConnectorGrasshopper.Ops
               message = message,
               objectId = BaseId,
               streamId = ((ServerTransport)transport).StreamId,
+              sourceApplication = Applications.Grasshopper
             };
 
             // Check to see if we have a previous commit; if so set it.
@@ -473,7 +474,7 @@ namespace ConnectorGrasshopper.Ops
               c.ServerUrl == client.ServerUrl && c.StreamId == ((ServerTransport)transport).StreamId);
             if (prevCommit != null)
             {
-              commitCreateInput.previousCommitIds = new List<string>() { prevCommit.CommitId };
+              commitCreateInput.parents = new List<string>() { prevCommit.CommitId };
             }
 
             var commitId = await client.CommitCreate(CancellationToken, commitCreateInput);

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -164,10 +164,11 @@ namespace Speckle.ConnectorRevit.UI
         streamId = streamId,
         objectId = objectId,
         branchName = state.Branch.name,
-        message = state.CommitMessage != null ? state.CommitMessage : $"Sent {convertedCount} objects from {ConnectorRevitUtils.RevitAppName}."
+        message = state.CommitMessage != null ? state.CommitMessage : $"Sent {convertedCount} objects from {ConnectorRevitUtils.RevitAppName}.",
+        sourceApplication = ConnectorRevitUtils.RevitAppName,
       };
 
-      if (state.PreviousCommitId != null) { actualCommit.previousCommitIds = new List<string>() { state.PreviousCommitId }; }
+      if (state.PreviousCommitId != null) { actualCommit.parents = new List<string>() { state.PreviousCommitId }; }
 
       try
       {

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -172,12 +172,13 @@ namespace Speckle.ConnectorRevit.UI
 
       try
       {
-        var res = await client.CommitCreate(actualCommit);
+        var commitId = await client.CommitCreate(actualCommit);
 
         var updatedStream = await client.StreamGet(streamId);
         state.Branches = updatedStream.branches.items;
         state.Stream.name = updatedStream.name;
         state.Stream.description = updatedStream.description;
+        state.PreviousCommitId = commitId;
 
         WriteStateToFile();
         RaiseNotification($"{convertedCount} objects sent to Speckle 🚀");

--- a/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -481,10 +481,11 @@ namespace SpeckleRhino
         streamId = streamId,
         objectId = commitObjId,
         branchName = state.Branch.name,
-        message = state.CommitMessage != null ? state.CommitMessage : $"Pushed {objCount} elements from Rhino."
+        message = state.CommitMessage != null ? state.CommitMessage : $"Pushed {objCount} elements from Rhino.",
+        sourceApplication = Applications.Rhino
       };
 
-      if (state.PreviousCommitId != null) { actualCommit.previousCommitIds = new List<string>() { state.PreviousCommitId }; }
+      if (state.PreviousCommitId != null) { actualCommit.parents = new List<string>() { state.PreviousCommitId }; }
 
       try
       {

--- a/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -489,12 +489,13 @@ namespace SpeckleRhino
 
       try
       {
-        var res = await client.CommitCreate(actualCommit);
+        var commitId = await client.CommitCreate(actualCommit);
 
         var updatedStream = await client.StreamGet(streamId);
         state.Branches = updatedStream.branches.items;
         state.Stream.name = updatedStream.name;
         state.Stream.description = updatedStream.description;
+        state.PreviousCommitId = commitId;
 
         PersistAndUpdateStreamInFile(state);
         RaiseNotification($"{objCount} objects sent to {state.Stream.name}.");

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -170,9 +170,12 @@ namespace Speckle.Core.Api
                             items {{
                               id,
                               referencedObject,
+                              totalChildrenCount,
+                              sourceApplication,
                               message,
                               authorName,
                               authorId,
+                              parents,
                               createdAt
                             }}
                           }}
@@ -636,9 +639,12 @@ namespace Speckle.Core.Api
                             items {{
                               id,
                               referencedObject,
+                              sourceApplication,
+                              totalChildrenCount,
                               message,
                               authorName,
                               authorId,
+                              parents,
                               createdAt
                             }}
                           }}
@@ -782,8 +788,11 @@ namespace Speckle.Core.Api
                         commit(id: $commitId){{
                           id,
                           message,
+                          sourceApplication,
+                          totalChildrenCount,
                           referencedObject,
                           createdAt,
+                          parents,
                           authorName
                         }}                       
                       }}

--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -60,6 +60,11 @@ namespace Speckle.Core.Api
     public string branchName { get; set; }
     public string objectId { get; set; }
     public string message { get; set; }
+    public string sourceApplication { get; set; }
+    public string totalChildrenCount { get; set; }
+    public List<string> parents { get; set; }
+
+    [Obsolete("Please use the parents property. This property will be removed in later versions")]
     public List<string> previousCommitIds { get; set; }
   }
 
@@ -145,8 +150,11 @@ namespace Speckle.Core.Api
     public string authorId { get; set; }
     public string authorAvatar { get; set; }
     public string createdAt { get; set; }
+    public string sourceApplication { get; set; }
 
     public string referencedObject { get; set; }
+    public int totalChildrenCount { get; set; }
+    public List<string> parents { get; set; }
 
     public override string ToString()
     {
@@ -163,7 +171,6 @@ namespace Speckle.Core.Api
     public string createdAt { get; set; }
   }
 
-
   public class Branch
   {
     public string id { get; set; }
@@ -176,7 +183,6 @@ namespace Speckle.Core.Api
       return $"Branch ({name} | {id})";
     }
   }
-
 
   public class Streams
   {

--- a/Core/Core/Api/GraphQL/SubscriptionModels.cs
+++ b/Core/Core/Api/GraphQL/SubscriptionModels.cs
@@ -67,9 +67,13 @@ namespace Speckle.Core.Api.SubscriptionModels
     public string objectId { get; set; }
     public string authorId { get; set; }
     public string message { get; set; }
-    public string[] previousCommitIds { get; set; }
-    
-    
+    public string sourceApplication { get; set; }
+    public int totalChildrenCount { get; set; }
+    public string[ ] parents { get; set; }
+
+    [Obsolete("Please use the parents property. This property will be removed in later versions")]
+    public string[ ] previousCommitIds { get; set; }
+
   }
 
   public class CommitCreatedResult


### PR DESCRIPTION
- adds `sourceApplication`, `totalChildrenCount`, and `parents` to core commit models
- depreciates `previousCommitIds`
- populates `sourceApplication` and `parents` in grasshopper, dynamo, rhino, and revit connectors

![image](https://user-images.githubusercontent.com/7717434/104313048-5ff83e80-54cf-11eb-9bea-db18e5865892.png)

closes #162 