### PR TITLE
Fixes #101: Alert user if no default account is set, or no account is found.

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/AccountsNode/Accounts.cs
+++ b/ConnectorDynamo/ConnectorDynamo/AccountsNode/Accounts.cs
@@ -101,15 +101,17 @@ namespace Speckle.ConnectorDynamo.AccountsNode
     internal void RestoreSelection()
     {
       AccountList = new ObservableCollection<Account>(AccountManager.GetAccounts());
-
-        if (!string.IsNullOrEmpty(SelectedAccountId))
-        {
-          SelectedAccount = AccountList.FirstOrDefault(x => x.id == SelectedAccountId);
-        }
-        else
-        {
-          SelectedAccount = AccountList.FirstOrDefault(x => x.isDefault);
-        }
+      if (AccountList.Count == 0)
+      {
+        Warning("No accounts found. Please use the Speckle Manager to manage your accounts on this computer.");
+        SelectedAccount = null;
+        SelectedAccountId = "";
+        return;
+      }
+      
+      SelectedAccount = !string.IsNullOrEmpty(SelectedAccountId) 
+        ? AccountList.FirstOrDefault(x => x.id == SelectedAccountId) 
+        : AccountList.FirstOrDefault(x => x.isDefault);
     }
 
     internal void SelectionChanged(Account account)

--- a/ConnectorDynamo/ConnectorDynamo/AccountsNode/AccountsViewCustomization.cs
+++ b/ConnectorDynamo/ConnectorDynamo/AccountsNode/AccountsViewCustomization.cs
@@ -1,4 +1,5 @@
-﻿using Dynamo.Configuration;
+﻿using System;
+using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Models;
 using Dynamo.Scheduler;
@@ -34,6 +35,14 @@ namespace Speckle.ConnectorDynamo.AccountsNode
       ui.DataContext = model;
       ui.Loaded += Loaded;
       ui.AccountsComboBox.SelectionChanged += SelectionChanged;
+      ui.AccountsComboBox.DropDownOpened += AccountsComboBoxOnDropDownOpened;
+
+    }
+
+    private void AccountsComboBoxOnDropDownOpened(object sender, EventArgs e)
+    {
+      accountsNode.ClearErrorsAndWarnings();
+      accountsNode.RestoreSelection();
     }
 
     private void Loaded(object o, RoutedEventArgs a)

--- a/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStream.cs
+++ b/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStream.cs
@@ -122,15 +122,17 @@ namespace Speckle.ConnectorDynamo.CreateStreamNode
     internal void RestoreSelection()
     {
       AccountList = new ObservableCollection<Account>(AccountManager.GetAccounts());
+      if (AccountList.Count == 0)
+      {
+        Warning("No accounts found. Please use the Speckle Manager to manage your accounts on this computer.");
+        SelectedAccount = null;
+        SelectedAccountId = "";
+        return;
+      }
 
-      if (!string.IsNullOrEmpty(SelectedAccountId))
-      {
-        SelectedAccount = AccountList.FirstOrDefault(x => x.id == SelectedAccountId);
-      }
-      else
-      {
-        SelectedAccount = AccountList.FirstOrDefault(x => x.isDefault);
-      }
+      SelectedAccount = !string.IsNullOrEmpty(SelectedAccountId) 
+        ? AccountList.FirstOrDefault(x => x.id == SelectedAccountId) 
+        : AccountList.FirstOrDefault(x => x.isDefault);
     }
 
     internal void DoCreateStream()

--- a/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStreamViewCustomization.cs
+++ b/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStreamViewCustomization.cs
@@ -1,4 +1,5 @@
-﻿using Dynamo.Configuration;
+﻿using System;
+using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Models;
 using Dynamo.Scheduler;
@@ -33,6 +34,13 @@ namespace Speckle.ConnectorDynamo.CreateStreamNode
       ui.DataContext = model;
       ui.Loaded += Loaded;
       ui.CreateStreamButton.Click += CreateStreamButtonClick;
+      ui.AccountsComboBox.DropDownOpened += AccountsComboBoxOnDropDownOpened;
+    }
+
+    private void AccountsComboBoxOnDropDownOpened(object sender, EventArgs e)
+    {
+      accountsNode.ClearErrorsAndWarnings();
+      accountsNode.RestoreSelection();
     }
 
     private void Loaded(object o, RoutedEventArgs a)

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Account.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Account.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Autodesk.DesignScript.Runtime;
 using Dynamo.Graph.Nodes;
@@ -15,7 +16,8 @@ namespace Speckle.ConnectorDynamo.Functions
     [IsVisibleInDynamoLibrary(false)]
     public static Core.Credentials.Account GetById(string id)
     {
-      return AccountManager.GetAccounts().FirstOrDefault(x => x.id == id);
+      var acc =  AccountManager.GetAccounts().FirstOrDefault(x => x.id == id);
+      return acc;
     }
 
     /// <summary>
@@ -26,7 +28,11 @@ namespace Speckle.ConnectorDynamo.Functions
     public static Dictionary<string, object> Details(Core.Credentials.Account account)
     {
       Tracker.TrackPageview(Tracker.ACCOUNT_DETAILS);
-
+      if(account == null)
+      {
+        
+        Utils.HandleApiExeption(new WarningException("Provided account was invalid."));
+      }
       return new Dictionary<string, object>
       {
         {"id", account.id},

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
@@ -213,6 +213,12 @@ namespace Speckle.ConnectorDynamo.Functions
 
       if (account == null)
         account = AccountManager.GetDefaultAccount();
+      
+      if(account == null)
+      {
+        Utils.HandleApiExeption(new Exception("No accounts found. Please use the Speckle Manager to manage your accounts on this computer."));
+      }
+
 
       var client = new Client(account);
       var streamWrappers = new List<StreamWrapper>();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.ListAccounts.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.ListAccounts.cs
@@ -48,6 +48,15 @@ namespace ConnectorGrasshopper.Accounts
       var accounts = AccountManager.GetAccounts();
       var defaultAccount = AccountManager.GetDefaultAccount();
       int index = 0, defaultAccountIndex = 0;
+
+      if(accounts.ToList().Count == 0)
+      {
+        ListItems.Add(new GH_ValueListItem("No accounts where found on this machine. Right-click for more options.",""));
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No accounts found. Please use the Speckle Manager to manage your accounts on this computer.");
+        SelectItem(0);
+        return;
+      }
+
       foreach (var account in accounts)
       {
         if (defaultAccount != null && account.id == defaultAccount.id)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
@@ -102,7 +102,11 @@ namespace ConnectorGrasshopper.Streams
                 var account = item.Value.AccountId == null
                   ? AccountManager.GetDefaultAccount()
                   : AccountManager.GetAccounts().FirstOrDefault(a => a.id == item.Value.AccountId);
-
+                if (account == null)
+                {
+                  AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Could not find default account in this machine. Use the Speckle Manager to add an account.");
+                  return;
+                }
                 var client = new Client(account);
                 
                 var task = client.StreamGet(item.Value?.StreamId);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
@@ -60,6 +60,12 @@ namespace ConnectorGrasshopper.Streams
         ? AccountManager.GetDefaultAccount()
         : AccountManager.GetAccounts().FirstOrDefault(a => a.id == accountId);
 
+      if(account == null)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Could not find default account in this machine. Use the Speckle Manager to add an account.");
+        return;
+      }
+
       Params.Input[1].AddVolatileData(new GH_Path(0), 0, account.id);
 
       if (error != null)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
@@ -69,6 +69,12 @@ namespace ConnectorGrasshopper.Streams
           return;
         }
 
+        if (account == null)
+        {
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Could not find default account in this machine. Use the Speckle Manager to add an account.");
+          return;
+        }
+
         Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.id);
 
         Task.Run(async () =>

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
@@ -77,7 +77,12 @@ namespace ConnectorGrasshopper.Streams
                       ? AccountManager.GetDefaultAccount()
                       : AccountManager.GetAccounts().FirstOrDefault(a => a.id == streamWrapper.AccountId);
 
-          
+          if (account == null)
+          {
+            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Could not find the specified account in this machine. Use the Speckle Manager to add an account, or modify the input stream with your credentials.");
+            return;
+          }
+
           var client = new Client(account);
           var input = new StreamUpdateInput();
           try


### PR DESCRIPTION
Handled cases for Dynamo and GH nodes. For consistency, all account nodes, and any other node that may use the default account automatically, will display a warning directing the user to the Speckle Manager.

Fixes #101 