### PR TITLE
🏭 Core & Connectors: Rework StreamGet query and propagate to connectors

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -455,9 +455,9 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
         return;
       try
       {
-        var res = Client.StreamGet(Stream.StreamId).Result;
+        var branches = Client.StreamGetBranches(Stream.StreamId).Result;
         var branchName = string.IsNullOrEmpty(Stream.BranchName) ? "main" : Stream.BranchName;
-        var mainBranch = res.branches.items.FirstOrDefault(b => b.name == branchName);
+        var mainBranch = branches.FirstOrDefault(b => b.name == branchName);
         if (mainBranch == null || !mainBranch.commits.items.Any())
         {
           Message = "Empty Stream";

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -106,8 +106,8 @@ namespace Speckle.ConnectorDynamo.Functions
         if (string.IsNullOrEmpty(stream.CommitId))
         {
 
-          var res = client.StreamGet(cancellationToken, stream.StreamId).Result;
-          var mainBranch = res.branches.items.FirstOrDefault(b => b.name == stream.BranchName);
+          var branches = client.StreamGetBranches(cancellationToken, stream.StreamId).Result;
+          var mainBranch = branches.FirstOrDefault(b => b.name == stream.BranchName);
 
           if (mainBranch == null)
           {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -427,8 +427,8 @@ namespace ConnectorGrasshopper.Ops
         {
           try
           {
-            var stream = await client.StreamGet(InputWrapper.StreamId);
-            var mainBranch = stream.branches.items.FirstOrDefault(b => b.name == (InputWrapper.BranchName ?? "main"));
+            var branches = await client.StreamGetBranches(InputWrapper.StreamId);
+            var mainBranch = branches.FirstOrDefault(b => b.name == (InputWrapper.BranchName ?? "main"));
             myCommit = mainBranch.commits.items[0];
           }
           catch (Exception e)

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -108,10 +108,7 @@ namespace Speckle.ConnectorRevit.UI
 
       try
       {
-        var updatedStream = await state.Client.StreamGet(state.Stream.id);
-        state.Branches = await state.Client.StreamGetBranches(state.Stream.id);
-        state.Stream.name = updatedStream.name;
-        state.Stream.description = updatedStream.description;
+        await state.RefreshStream();
 
         WriteStateToFile();
       }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -109,7 +109,7 @@ namespace Speckle.ConnectorRevit.UI
       try
       {
         var updatedStream = await state.Client.StreamGet(state.Stream.id);
-        state.Branches = updatedStream.branches.items;
+        state.Branches = await state.Client.StreamGetBranches(state.Stream.id);
         state.Stream.name = updatedStream.name;
         state.Stream.description = updatedStream.description;
 

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -174,10 +174,7 @@ namespace Speckle.ConnectorRevit.UI
       {
         var commitId = await client.CommitCreate(actualCommit);
 
-        var updatedStream = await client.StreamGet(streamId);
-        state.Branches = await client.StreamGetBranches(streamId);
-        state.Stream.name = updatedStream.name;
-        state.Stream.description = updatedStream.description;
+        await state.RefreshStream();
         state.PreviousCommitId = commitId;
 
         WriteStateToFile();

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -175,7 +175,7 @@ namespace Speckle.ConnectorRevit.UI
         var commitId = await client.CommitCreate(actualCommit);
 
         var updatedStream = await client.StreamGet(streamId);
-        state.Branches = updatedStream.branches.items;
+        state.Branches = await client.StreamGetBranches(streamId);
         state.Stream.name = updatedStream.name;
         state.Stream.description = updatedStream.description;
         state.PreviousCommitId = commitId;

--- a/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -491,10 +491,7 @@ namespace SpeckleRhino
       {
         var commitId = await client.CommitCreate(actualCommit);
 
-        var updatedStream = await client.StreamGet(streamId);
-        state.Branches = await client.StreamGetBranches(streamId);
-        state.Stream.name = updatedStream.name;
-        state.Stream.description = updatedStream.description;
+        await state.RefreshStream();
         state.PreviousCommitId = commitId;
 
         PersistAndUpdateStreamInFile(state);

--- a/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -492,7 +492,7 @@ namespace SpeckleRhino
         var commitId = await client.CommitCreate(actualCommit);
 
         var updatedStream = await client.StreamGet(streamId);
-        state.Branches = updatedStream.branches.items;
+        state.Branches = await client.StreamGetBranches(streamId);
         state.Stream.name = updatedStream.name;
         state.Stream.description = updatedStream.description;
         state.PreviousCommitId = commitId;

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -120,7 +120,8 @@ namespace Speckle.Core.Api
     #region streams
 
     /// <summary>
-    /// Gets a stream by id, includes commits and branches
+    /// Gets a stream by id including basic branch info (id, name, description, and total commit count).
+    /// For detailed commit and branch info, use StreamGetCommits and StreamGetBranches respectively.
     /// </summary>
     /// <param name="id">Id of the stream to get</param>
     /// <param name="branchesLimit">Max number of branches to retrieve</param>
@@ -131,7 +132,8 @@ namespace Speckle.Core.Api
     }
 
     /// <summary>
-    /// Gets a stream by id, includes commits and branches
+    /// Gets a stream by id including basic branch info (id, name, description, and total commit count).
+    /// For detailed commit and branch info, use StreamGetCommits and StreamGetBranches respectively.
     /// </summary>
     /// <param name="id">Id of the stream to get</param>
     /// <param name="branchesLimit">Max number of branches to retrieve</param>
@@ -409,7 +411,7 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Deletes a stream.
     /// </summary>
-    /// <param name="id"></param>
+    /// <param name="id">Id of the stream to be deleted</param>
     /// <returns></returns>
     public Task<bool> StreamDelete(string id)
     {
@@ -419,7 +421,7 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Deletes a stream.
     /// </summary>
-    /// <param name="id"></param>
+    /// <param name="id">Id of the stream to be deleted</param>
     /// <returns></returns>
     public async Task<bool> StreamDelete(CancellationToken cancellationToken, string id)
     {
@@ -452,9 +454,9 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Grants permissions to a user on a given stream.
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="userId"></param>
-    /// <param name="role"></param>
+    /// <param name="streamId">Id of the stream to grant permissions to</param>
+    /// <param name="userId">Id of the user to grant permissions to</param>
+    /// <param name="role">Role to give the user on this stream</param>
     /// <returns></returns>
     public Task<bool> StreamGrantPermission(StreamGrantPermissionInput permissionInput)
     {
@@ -464,9 +466,9 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Grants permissions to a user on a given stream.
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="userId"></param>
-    /// <param name="role"></param>
+    /// <param name="streamId">Id of the stream to grant permissions to</param>
+    /// <param name="userId">Id of the user to grant permissions to</param>
+    /// <param name="role">Role to give the user on this stream</param>
     /// <returns></returns>
     public async Task<bool> StreamGrantPermission(CancellationToken cancellationToken, StreamGrantPermissionInput permissionInput)
     {
@@ -502,8 +504,8 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Revokes permissions of a user on a given stream.
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="userId"></param>
+    /// <param name="streamId">Id of the stream to revoke permissions from</param>
+    /// <param name="userId">Id of the user to revoke permissions from</param>
     /// <returns></returns>
     public Task<bool> StreamRevokePermission(StreamRevokePermissionInput permissionInput)
     {
@@ -513,8 +515,8 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Revokes permissions of a user on a given stream.
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="userId"></param>
+    /// <param name="streamId">Id of the stream to revoke permissions from</param>
+    /// <param name="userId">Id of the user to revoke permissions from</param>
     /// <returns></returns>
     public async Task<bool> StreamRevokePermission(CancellationToken cancellationToken, StreamRevokePermissionInput permissionInput)
     {
@@ -553,9 +555,9 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Get branches from a given stream
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="branchesLimit"></param>
-    /// <param name="commitsLimit"></param>
+    /// <param name="streamId">Id of the stream to get the branches from</param>
+    /// <param name="branchesLimit">Max number of branches to retrieve</param>
+    /// <param name="commitsLimit">Max number of commits to retrieve</param>
     /// <returns></returns>
     public Task<List<Branch>> StreamGetBranches(string streamId,  int branchesLimit = 10, int commitsLimit = 10)
     {
@@ -566,9 +568,9 @@ namespace Speckle.Core.Api
     /// Get branches from a given stream
     /// </summary>
     /// <param name="cancellationToken"></param>
-    /// <param name="streamId"></param>
-    /// <param name="branchesLimit"></param>
-    /// <param name="commitsLimit"></param>
+    /// <param name="streamId">Id of the stream to get the branches from</param>
+    /// <param name="branchesLimit">Max number of branches to retrieve</param>
+    /// <param name="commitsLimit">Max number of commits to retrieve</param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
     public async Task<List<Branch>> StreamGetBranches(CancellationToken cancellationToken, string streamId,
@@ -666,8 +668,8 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Gets a given branch from a stream.
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="branchName"></param>
+    /// <param name="streamId">Id of the stream to get the branch from</param>
+    /// <param name="branchName">Name of the branch to get</param>
     /// <returns></returns>
     public Task<Branch> BranchGet(string streamId, string branchName, int commitsLimit = 10)
     {
@@ -678,8 +680,8 @@ namespace Speckle.Core.Api
     /// Gets a given branch from a stream.
     /// </summary>
     /// <param name="cancellationToken"></param>
-    /// <param name="streamId"></param>
-    /// <param name="branchName"></param>
+    /// <param name="streamId">Id of the stream to get the branch from</param>
+    /// <param name="branchName">Name of the branch to get</param>
     /// <returns></returns>
     public async Task<Branch> BranchGet(CancellationToken cancellationToken, string streamId, string branchName, int commitsLimit = 10)
     {
@@ -823,8 +825,8 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Gets a given commit from a stream.
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="commitId"></param>
+    /// <param name="streamId">Id of the stream to get the commit from</param>
+    /// <param name="commitId">Id of the commit to get</param>
     /// <returns></returns>
     public Task<Commit> CommitGet(string streamId, string commitId)
     {
@@ -835,8 +837,8 @@ namespace Speckle.Core.Api
     /// Gets a given commit from a stream.
     /// </summary>
     /// <param name="cancellationToken"></param>
-    /// <param name="streamId"></param>
-    /// <param name="commitId"></param>
+    /// <param name="streamId">Id of the stream to get the commit from</param>
+    /// <param name="commitId">Id of the commit to get</param>
     /// <returns></returns>
     public async Task<Commit> CommitGet(CancellationToken cancellationToken, string streamId, string commitId)
     {
@@ -883,8 +885,8 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Gets the latest commits from a stream
     /// </summary>
-    /// <param name="streamId"></param>
-    /// <param name="limit"></param>
+    /// <param name="streamId">Id of the stream to get the commits from</param>
+    /// <param name="limit">Max number of commits to get</param>
     /// <returns></returns>
     public Task<List<Commit>> StreamGetCommits(string streamId, int limit = 10)
     {
@@ -895,8 +897,8 @@ namespace Speckle.Core.Api
     /// Gets the latest commits from a stream
     /// </summary>
     /// <param name="cancellationToken"></param>
-    /// <param name="streamId"></param>
-    /// <param name="limit"></param>
+    /// <param name="streamId">Id of the stream to get the commits from</param>
+    /// <param name="limit">Max number of commits to get</param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
     public async Task<List<Commit>> StreamGetCommits(CancellationToken cancellationToken, string streamId, int limit = 10)
@@ -1074,8 +1076,8 @@ namespace Speckle.Core.Api
     /// <summary>
     /// Gets a given object from a stream.
     /// </summary>
-    /// <param name="streamId"></param> 
-    /// <param name="objectId"></param>
+    /// <param name="streamId">Id of the stream to get the object from</param> 
+    /// <param name="objectId">Id of the object to get</param>
     /// <returns></returns>
     public Task<Object> ObjectGet(string streamId, string objectId)
     {
@@ -1086,8 +1088,8 @@ namespace Speckle.Core.Api
     /// Gets a given object from a stream.
     /// </summary>
     /// <param name="cancellationToken"></param>
-    /// <param name="streamId"></param>
-    /// <param name="objectId"></param>
+    /// <param name="streamId">Id of the stream to get the object from</param>
+    /// <param name="objectId">Id of the object to get</param>
     /// <returns></returns>
     public async Task<Object> ObjectGet(CancellationToken cancellationToken, string streamId, string objectId)
     {

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -124,11 +124,10 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="id">Id of the stream to get</param>
     /// <param name="branchesLimit">Max number of branches to retrieve</param>
-    /// <param name="commitsLimit">Max number of commits per branch to retrieve</param>
     /// <returns></returns>
-    public Task<Stream> StreamGet(string id, int branchesLimit = 10, int commitsLimit = 10)
+    public Task<Stream> StreamGet(string id, int branchesLimit = 10)
     {
-      return StreamGet(CancellationToken.None, id, branchesLimit, commitsLimit);
+      return StreamGet(CancellationToken.None, id, branchesLimit);
     }
 
     /// <summary>
@@ -136,9 +135,8 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="id">Id of the stream to get</param>
     /// <param name="branchesLimit">Max number of branches to retrieve</param>
-    /// <param name="commitsLimit">Max number of commits per branch to retrieve</param>
     /// <returns></returns>
-    public async Task<Stream> StreamGet(CancellationToken cancellationToken, string id, int branchesLimit = 10, int commitsLimit = 10)
+    public async Task<Stream> StreamGet(CancellationToken cancellationToken, string id, int branchesLimit = 10)
     {
       try
       {
@@ -162,26 +160,13 @@ namespace Speckle.Core.Api
                           totalCount,
                           cursor,
                           items {{
-                          id,
-                          name,
-                          description,
-                          commits (limit: {commitsLimit}) {{
-                            totalCount,
-                            cursor,
-                            items {{
-                              id,
-                              referencedObject,
-                              totalChildrenCount,
-                              sourceApplication,
-                              message,
-                              authorName,
-                              authorId,
-                              branchName,
-                              parents,
-                              createdAt
+                            id,
+                            name,
+                            description,
+                            commits {{
+                              totalCount
                             }}
                           }}
-                        }}
                         }}
                       }}
                     }}",

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -176,6 +176,7 @@ namespace Speckle.Core.Api
                               message,
                               authorName,
                               authorId,
+                              branchName,
                               parents,
                               createdAt
                             }}
@@ -609,6 +610,7 @@ namespace Speckle.Core.Api
                                 message
                                 authorName
                                 authorId
+                                branchName
                                 parents
                                 createdAt
                               }}
@@ -717,6 +719,7 @@ namespace Speckle.Core.Api
                               message,
                               authorName,
                               authorId,
+                              branchName,
                               parents,
                               createdAt
                             }}
@@ -864,6 +867,7 @@ namespace Speckle.Core.Api
                           sourceApplication,
                           totalChildrenCount,
                           referencedObject,
+                          branchName,
                           createdAt,
                           parents,
                           authorName
@@ -922,6 +926,7 @@ namespace Speckle.Core.Api
                           items {
                             id,
                             message,
+                            branchName,
                             sourceApplication,
                             totalChildrenCount,
                             referencedObject,

--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -151,6 +151,7 @@ namespace Speckle.Core.Api
   {
     public string id { get; set; }
     public string message { get; set; }
+    public string branchName { get; set; }
     public string authorName { get; set; }
     public string authorId { get; set; }
     public string authorAvatar { get; set; }

--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -107,6 +107,11 @@ namespace Speckle.Core.Api
     /// </summary>
     public Commit commit { get; set; }
 
+    /// <summary>
+    /// Set only in the case that you've requested this through <see cref="Client.StreamGetCommits(System.Threading.CancellationToken, string, int)"/>
+    /// </summary>
+    public Commits commits { get; set; }
+
     public Object @object { get; set; }
 
     public override string ToString()

--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -169,6 +169,15 @@ namespace TestsIntegration
       Assert.AreEqual("this is a sample branch", res.description);
     }
 
+    [Test, Order(43)]
+    public async Task StreamGetBranches()
+    {
+      var res = await myClient.StreamGetBranches(streamId);
+
+      Assert.NotNull(res);
+      Assert.AreEqual("sample-branch", res[0].name);
+    }
+
     #region commit
 
     [Test, Order(43)]
@@ -202,6 +211,15 @@ namespace TestsIntegration
 
       Assert.NotNull(res);
       Assert.AreEqual("MATT0E IS THE B3ST", res.message);
+    }
+
+    [Test, Order(45)]
+    public async Task StreamGetCommits()
+    {
+      var res = await myClient.StreamGetCommits(streamId);
+      
+      Assert.NotNull(res);
+      Assert.AreEqual(commitId, res[0].id);
     }
 
     #region object

--- a/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
@@ -25,14 +25,11 @@ namespace Speckle.DesktopUI.Streams
       _events = events;
       Bindings = bindings;
       FilterTabs = new BindableCollection<FilterTab>(Bindings.GetSelectionFilters().Select(f => new FilterTab(f)));
-      _streamsRepo = streamsRepo;
       _acctRepo = acctsRepo;
 
       SelectionCount = Bindings.GetSelectedObjects().Count;
       _events.Subscribe(this);
     }
-
-    private readonly StreamsRepository _streamsRepo;
 
     private readonly AccountsRepository _acctRepo;
 
@@ -200,7 +197,10 @@ namespace Speckle.DesktopUI.Streams
       var client = new Client(AccountToSendFrom);
       try
       {
-        var streamId = await _streamsRepo.CreateStream(StreamToCreate, AccountToSendFrom);
+        var streamId = await client.StreamCreate(new StreamCreateInput()
+        {
+          name = StreamToCreate.name, description = StreamToCreate.description, isPublic = StreamToCreate.isPublic
+        });
 
         if (Collaborators.Any())
         {
@@ -217,7 +217,7 @@ namespace Speckle.DesktopUI.Streams
           });
         }
 
-        StreamToCreate = await _streamsRepo.GetStream(streamId, AccountToSendFrom);
+        StreamToCreate = await client.StreamGet(streamId);
 
         StreamState = new StreamState(client, StreamToCreate);
         Bindings.AddNewStream(StreamState);

--- a/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
@@ -220,6 +220,7 @@ namespace Speckle.DesktopUI.Streams
         StreamToCreate = await client.StreamGet(streamId);
 
         StreamState = new StreamState(client, StreamToCreate);
+        StreamState.Branches = await client.StreamGetBranches(streamId);
         Bindings.AddNewStream(StreamState);
 
         _events.Publish(new StreamAddedEvent() { NewStream = StreamState });

--- a/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
@@ -252,6 +252,7 @@ namespace Speckle.DesktopUI.Streams
       StreamToCreate = await client.StreamGet(SelectedStream.id);
 
       StreamState = new StreamState(client, StreamToCreate);
+      StreamState.Branches = await client.StreamGetBranches(StreamState.Stream.id);
 
       StreamState.IsSenderCard = false; // Assume we're creating a receiver
 

--- a/DesktopUI/DesktopUI/Streams/StreamUpdateObjectsDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamUpdateObjectsDialogViewModel.cs
@@ -198,7 +198,7 @@ namespace Speckle.DesktopUI.Streams
         return;
       }
 
-      StreamState.Stream = await StreamState.Client.StreamGet(StreamState.Stream.id);
+      await StreamState.RefreshStream();
       Collaborators.Clear();
       _events.Publish(new StreamUpdatedEvent(StreamState.Stream));
       Notifications.Enqueue($"Added {success} collaborators to this stream");

--- a/DesktopUI/DesktopUI/Streams/StreamsRepository.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamsRepository.cs
@@ -14,39 +14,11 @@ namespace Speckle.DesktopUI.Streams
 {
   public class StreamsRepository
   {
-    private AccountsRepository _acctsRepo;
     private readonly ConnectorBindings _bindings;
 
-    public StreamsRepository(AccountsRepository acctsRepo, ConnectorBindings bindings)
+    public StreamsRepository(ConnectorBindings bindings)
     {
-      _acctsRepo = acctsRepo;
       _bindings = bindings;
-    }
-
-    public Branch GetMainBranch(List<Branch> branches)
-    {
-      Branch main = branches.Find(branch => branch.name == "main");
-      return main;
-    }
-
-    public Task<string> CreateStream(Stream stream, Account account)
-    {
-      var client = new Client(account);
-
-      var streamInput = new StreamCreateInput()
-      {
-        name = stream.name,
-        description = stream.description,
-        isPublic = stream.isPublic
-      };
-
-      return client.StreamCreate(streamInput);
-    }
-
-    public Task<Stream> GetStream(string streamId, Account account)
-    {
-      var client = new Client(account);
-      return client.StreamGet(streamId);
     }
 
     public async Task<StreamState> ConvertAndSend(StreamState state)

--- a/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
@@ -17,7 +17,7 @@ namespace Speckle.DesktopUI.Utils
         var updatedStream = await Client.StreamGet(Stream.id);
         Stream.name = updatedStream.name;
         Stream.description = updatedStream.description;
-        Branches = updatedStream.branches.items;
+        Branches = await Client.StreamGetBranches(Stream.id);
         NotifyOfPropertyChange(nameof(Stream));
       }
       catch (Exception)

--- a/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
@@ -112,8 +112,8 @@ namespace Speckle.DesktopUI.Utils
 
     private async void HandleCommitCreated(object sender, CommitInfo info)
     {
-      var updatedStream = await Client.StreamGet(Stream.id);
-      Branches = updatedStream.branches.items;
+      var updatedBranches = await Client.StreamGetBranches(Stream.id);
+      Branches = updatedBranches;
 
       if (IsSenderCard) return;
 
@@ -147,8 +147,8 @@ namespace Speckle.DesktopUI.Utils
 
     private async void HandleBranchCreated(object sender, BranchInfo info)
     {
-      var updatedStream = await Client.StreamGet(Stream.id);
-      Branches = updatedStream.branches.items;
+      var updatedBranches = await Client.StreamGetBranches(Stream.id);
+      Branches = updatedBranches;
     }
 
     private void HandleBranchUpdated(object sender, BranchInfo info)

--- a/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
@@ -17,6 +17,8 @@ namespace Speckle.DesktopUI.Utils
         var updatedStream = await Client.StreamGet(Stream.id);
         Stream.name = updatedStream.name;
         Stream.description = updatedStream.description;
+        Stream.isPublic = updatedStream.isPublic;
+        Stream.collaborators = updatedStream.collaborators;
         Branches = await Client.StreamGetBranches(Stream.id);
         NotifyOfPropertyChange(nameof(Stream));
       }
@@ -112,8 +114,7 @@ namespace Speckle.DesktopUI.Utils
 
     private async void HandleCommitCreated(object sender, CommitInfo info)
     {
-      var updatedBranches = await Client.StreamGetBranches(Stream.id);
-      Branches = updatedBranches;
+      Branches = await Client.StreamGetBranches(Stream.id);
 
       if (IsSenderCard) return;
 

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -119,6 +119,7 @@ namespace Speckle.DesktopUI.Utils
         }
 
         NotifyOfPropertyChange(nameof(BranchContextMenuItems));
+        NotifyOfPropertyChange(nameof(CommitContextMenuItems));
       }
     }
 
@@ -501,14 +502,7 @@ namespace Speckle.DesktopUI.Utils
       if (Branch == null)
       {
         var tempBranch = Stream.branches.items.FirstOrDefault(b => b.name == "main");
-        if (tempBranch == null)
-        {
-          Branch = Stream.branches.items[0];
-        }
-        else
-        {
-          Branch = tempBranch;
-        }
+        Branch = tempBranch ?? Stream.branches.items[0];
       }
 
       if (Branch.commits != null && Branch.commits.items != null && Branch.commits.items.Count != 0)


### PR DESCRIPTION
This breaks down the stream queries into:

`StreamGet`: returns the stream info and basic branch info (id, name, description, and total commit count)
`StreamGetCommits`: returns a list of the latest commits on a given stream
`CommitGet`: returns a commit via `streamId` and `commitId`
`StreamGetBranches`: returns a list of branches on a given stream _including_ commit info
`BranchGet`: returns a commit via `streamId` and `branchName`

The collection queries and the item queries are named with different convention to avoid accidental autocomplete of the wrong one 🙃 

In theory, this also propagates these changes to all the connectors. They should now be using a more specific query or a combination of queries (eg `StreamGet` + `StreamGetBranches`) to get what they need.

Bonus points: simplifies some desktopui bindings logic by using these new queries!

Closes #53 