### PR TITLE
🌳  DYN/GH: Support for branch url's in Sender/Receiver

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
+++ b/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
@@ -113,6 +113,10 @@
       <Project>{3f02e475-e777-4dfd-8ae9-8065edd092dc}</Project>
       <Name>Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Core\Transports\ServerTransport\ServerTransport.csproj">
+      <Project>{82f74946-6c04-4ae3-bfb9-f09e68cdfe12}</Project>
+      <Name>ServerTransport</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ConnectorDynamoExtension\ConnectorDynamoExtension.csproj">
       <Project>{b494fd40-5e59-4d5e-87b0-80aac8bdcd5a}</Project>
       <Name>ConnectorDynamoExtension</Name>

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -187,7 +187,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
     [DNJ.JsonConstructor]
     private Receive(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
     {
-      if (inPorts.Count() == 2)
+      if (inPorts.Count() == 1)
       {
         //blocker: https://github.com/DynamoDS/Dynamo/issues/11118
         //inPorts.ElementAt(1).DefaultValue = endPortDefaultValue;
@@ -204,7 +204,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
 
       ArgumentLacing = LacingStrategy.Disabled;
 
-      this.PropertyChanged += HandlePropertyChanged;
+      PropertyChanged += HandlePropertyChanged;
     }
 
     /// <summary>

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using Dynamo.Utilities;
 using Speckle.Core.Api;
 using Speckle.Core.Models;
+using Speckle.Core.Transports;
 
 namespace Speckle.ConnectorDynamo.SendNode
 {
@@ -47,8 +48,8 @@ namespace Speckle.ConnectorDynamo.SendNode
 
     //cached inputs
     private object _data { get; set; }
-    private List<StreamWrapper> _streams { get; set; }
-    private List<string> _branchNames { get; set; }
+    private List<ITransport> _streams { get; set; }
+    private Dictionary<ITransport, string> _branchNames { get; set; }
     private string _commitMessage { get; set; }
 
     #endregion
@@ -176,23 +177,18 @@ namespace Speckle.ConnectorDynamo.SendNode
 
     private void AddInputs()
     {
-      StringNode defaultBranchValue = new StringNode();
-      StringNode defaultMessageValue = new StringNode();
-
-      defaultBranchValue.Value = "main";
-      defaultMessageValue.Value = "Automatic commit from Dynamo";
+      var defaultMessageValue = new StringNode {Value = "Automatic commit from Dynamo"};
 
       InPorts.Add(new PortModel(PortType.Input, this, new PortData("data", "The data to send")));
       InPorts.Add(new PortModel(PortType.Input, this, new PortData("stream", "The stream or streams to send to")));
-      InPorts.Add(new PortModel(PortType.Input, this,
-        new PortData("branchName", "The branch you want your commit associated with.", defaultBranchValue)));
       InPorts.Add(new PortModel(PortType.Input, this,
         new PortData("message", "Commit message. If left blank, one will be generated for you.", defaultMessageValue)));
     }
 
     private void AddOutputs()
     {
-      OutPorts.Add(new PortModel(PortType.Output, this, new PortData("stream", "Stream or streams pointing to the created commit")));
+      OutPorts.Add(new PortModel(PortType.Output, this,
+        new PortData("stream", "Stream or streams pointing to the created commit")));
     }
 
 
@@ -240,7 +236,7 @@ namespace Speckle.ConnectorDynamo.SendNode
 
         void ProgressAction(ConcurrentDictionary<string, int> dict)
         {
-          var val = (double)dict.Values.Average() / totalCount;
+          var val = (double) dict.Values.Average() / totalCount;
           Message = val.ToString("0%");
           Progress = val * 100;
         }
@@ -266,12 +262,7 @@ namespace Speckle.ConnectorDynamo.SendNode
 
         if (!hasErrors && commitIds != null)
         {
-          for (int i = 0; i < _streams.Count; i++)
-          {
-            _streams[i].CommitId = commitIds[i];
-          }
-
-          _outputInfo = string.Join("|", _streams.Select(x => x.ToString()));
+          _outputInfo = string.Join("|", commitIds.Select(x => x.ToString()));
           Message = "";
         }
       }
@@ -336,45 +327,51 @@ namespace Speckle.ConnectorDynamo.SendNode
         return;
       }
 
-      //this port accepts:
-      //a stream wrapper, a url, a list of stream wrappers or a list of urls
-      try
+      Dictionary<ITransport, string> TryConvertInputToTransport(object o)
       {
-        _streams = new List<StreamWrapper>();
-        var inputStream = GetInputAs<object>(engine, 1);
-        switch (inputStream)
+        var defaultBranch = "main";
+        var transports = new Dictionary<ITransport, string>();
+        switch (o)
         {
           case StreamWrapper s:
-            _streams.Add(new StreamWrapper(s.StreamId, s.AccountId, s.ServerUrl));
+            var wrapperTransport = new ServerTransport(s.GetAccount(), s.StreamId);
+            var branch = s.BranchName ?? defaultBranch;
+            transports.Add(wrapperTransport, branch);
             break;
           case string s:
-            _streams.Add(new StreamWrapper(s));
+            var streamWrapper = new StreamWrapper(s);
+            var transport = new ServerTransport(streamWrapper.GetAccount(), streamWrapper.StreamId);
+            var b = streamWrapper.BranchName ?? defaultBranch;
+            transports.Add(transport, b);
+            break;
+          case ITransport t:
+            transports.Add(t, defaultBranch);
             break;
           case List<object> s:
-            try
-            {
-              var ss = s.Cast<StreamWrapper>();
-              _streams.AddRange(ss.Select(x => new StreamWrapper(x.StreamId, x.AccountId, x.ServerUrl)));
-              break;
-            }
-            catch
-            {
-              //ignored
-            }
-
-            try
-            {
-              var ss = s.Cast<string>();
-              _streams.AddRange(ss.Select(x => new StreamWrapper(x)));
-              break;
-            }
-            catch
-            {
-              //ignored
-            }
-
+            transports = s
+              .Select(TryConvertInputToTransport)
+              .Aggregate(transports, (current, t) => new List<Dictionary<ITransport, string>> {current, t}
+                .SelectMany(dict => dict)
+                .ToDictionary(pair => pair.Key, pair => pair.Value));
+            break;
+          default:
+            Warning("Input was neither a transport nor a stream.");
             break;
         }
+
+        return transports;
+      }
+
+      try
+      {
+        _streams = new List<ITransport>();
+
+        //this port accepts:
+        //a stream wrapper, a url, a list of stream wrappers or a list of urls
+        var inputTransport = GetInputAs<object>(engine, 1);
+        var transportsDict = TryConvertInputToTransport(inputTransport);
+        _streams = transportsDict.Keys.ToList();
+        _branchNames = transportsDict;
       }
       catch
       {
@@ -388,40 +385,10 @@ namespace Speckle.ConnectorDynamo.SendNode
         return;
       }
 
-      //get branch name/s
-      if (InPorts[2].Connectors.Any())
-      {
-        try
-        {
-          _branchNames = new List<string>();
-          var branch = GetInputAs<object>(engine, 2);
-          switch (branch)
-          {
-            case string b:
-              _branchNames.Add(b);
-              break;
-            case List<string> b:
-              _branchNames.AddRange(b);
-              break;
-          }
-
-          if (_streams.Count != _branchNames.Count)
-          {
-            Message = "Branch count is invalid, will use `main`";
-            _branchNames = null;
-          }
-        }
-        catch
-        {
-          Message = "Branch name is invalid, will use `main`";
-          _branchNames = null;
-        }
-      }
-
       try
       {
         _commitMessage =
-          InPorts[3].Connectors.Any()
+          InPorts[2].Connectors.Any()
             ? GetInputAs<string>(engine, 3)
             : ""; //IsConnected not working because has default value
       }
@@ -442,7 +409,7 @@ namespace Speckle.ConnectorDynamo.SendNode
       {
         //_objectCount is updated when the RecurseInput function loops through the data, not ideal but it works
         //if we're dealing with a single Base (preconverted obj) use GetTotalChildrenCount to count its children
-        _objectCount = (int)@base.GetTotalChildrenCount();
+        _objectCount = (int) @base.GetTotalChildrenCount();
         //exclude wrapper obj.... this is a bit of a hack...
         if (_objectCount > 1) _objectCount--;
       }
@@ -466,7 +433,7 @@ namespace Speckle.ConnectorDynamo.SendNode
       var data = inputMirror.GetData();
       var value = RecurseInput(data, count);
 
-      return (T)value;
+      return (T) value;
     }
 
     private object RecurseInput(MirrorData data, bool count)
@@ -555,9 +522,9 @@ namespace Speckle.ConnectorDynamo.SendNode
 
       var dataFunctionCall = AstFactory.BuildFunctionCall(
         new Func<string, object>(Functions.Functions.SendData),
-        new List<AssociativeNode> { AstFactory.BuildStringNode(_outputInfo) });
+        new List<AssociativeNode> {AstFactory.BuildStringNode(_outputInfo)});
 
-      return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), dataFunctionCall) };
+      return new[] {AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), dataFunctionCall)};
     }
 
     #endregion

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -141,7 +141,7 @@ namespace Speckle.ConnectorDynamo.SendNode
     [DNJ.JsonConstructor]
     private Send(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
     {
-      if (inPorts.Count() == 4)
+      if (inPorts.Count() == 3)
       {
         //blocker: https://github.com/DynamoDS/Dynamo/issues/11118
         //inPorts.ElementAt(1).DefaultValue = endPortDefaultValue;

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -44,7 +44,7 @@ namespace Speckle.ConnectorDynamo.Functions
         // Only create commits on ServerTransport instances (for now)
         if (!(t is ServerTransport serverTransport))
         {
-          commitWrappers.Add(t + objectId);
+          //commitWrappers.Add(t + objectId);
           continue;
         }
         var branchName = branchNames == null ? "main" : branchNames[t];

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -263,12 +263,23 @@ namespace ConnectorGrasshopper.Ops
       if (input is StreamWrapper wrapper)
       {
         newWrapper = wrapper;
+        inputType = GetStreamTypeMessage(newWrapper);
       }
       else if (input is string s)
       {
         newWrapper = new StreamWrapper(s);
+        inputType = GetStreamTypeMessage(newWrapper);
       }
+      
 
+      InputType = inputType;
+      Message = inputType;
+      HandleInputType(newWrapper);
+    }
+
+    private string GetStreamTypeMessage(StreamWrapper newWrapper)
+    {
+      string inputType = null;
       switch (newWrapper?.Type)
       {
         case StreamWrapperType.Undefined:
@@ -284,10 +295,7 @@ namespace ConnectorGrasshopper.Ops
           inputType = "Branch";
           break;
       }
-
-      InputType = inputType;
-      Message = inputType;
-      HandleInputType(newWrapper);
+      return inputType;
     }
 
     public void HandleInputType(StreamWrapper wrapper)

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -11,6 +11,24 @@ namespace Speckle.Core.Credentials
     public string CommitId { get; set; }
     public string BranchName { get; set; } // To be used later! 
 
+    /// <summary>
+    /// Determines if the current stream wrapper contains a valid stream.
+    /// </summary>
+    public bool IsValid => Type != StreamWrapperType.Undefined;
+    
+    public StreamWrapperType Type
+    {
+      // Quick solution to determine whether a wrapper points to a branch, commit or stream.
+      get
+      {
+        if (!string.IsNullOrEmpty(BranchName)) return StreamWrapperType.Branch;
+        if (!string.IsNullOrEmpty(CommitId)) return StreamWrapperType.Commit;
+        if (!string.IsNullOrEmpty(StreamId)) return StreamWrapperType.Stream;
+        // If we reach here, it means that the stream is invalid for some reason.
+        return StreamWrapperType.Undefined;
+      }
+    }
+    
     public StreamWrapper()
     {
     }
@@ -22,8 +40,8 @@ namespace Speckle.Core.Credentials
     /// <exception cref="Exception"></exception>
     public StreamWrapper(string streamUrl)
     {
-      Account account = null;
-      Uri uri = null;
+      Account account;
+      Uri uri;
       if (streamUrl.Contains("?u="))
       {
         uri = new Uri(streamUrl.Split(new string[] {"?u="}, StringSplitOptions.None)[0]);
@@ -142,5 +160,13 @@ namespace Speckle.Core.Credentials
     {
       return GetAccountForServer(AccountId);
     }
+  }
+  
+  public enum StreamWrapperType
+  {
+    Undefined,
+    Stream,
+    Commit,
+    Branch
   }
 }


### PR DESCRIPTION
`StreamWrapper` can now handle `commit`, `branch` and `stream` types.
GH/Dyn -> Both sender and receiver now support new improvements in StreamWrapper.

- Created a `Type` property on the `StreamWrapper` class to indicate what type of stream it is holding.
- Sender and receiver no longer have a `branch` input, it is deduced  automatically by introducing a branch/commit/stream url.
- Modified behaviour of sender to be same as in GH and Dyn: Sender supports streams and transports. Will only output commit for serverTransports/streams.

Fixes #167 