### PR TITLE
GH: Receiver checks for new commits on file open

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -84,7 +84,7 @@ namespace ConnectorGrasshopper.Ops
               ResetApiClient(StreamWrapper);
 
               // Get last commit from the branch
-              var b = ApiClient.BranchGet(StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1).Result;
+              var b = ApiClient.BranchGet(BaseWorker.CancellationToken , StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1).Result;
 
               // Compare commit id's. If they don't match, notify user or fetch data if in auto mode
               if (b.commits.items[0].id != ReceivedCommitId)
@@ -379,9 +379,7 @@ namespace ConnectorGrasshopper.Ops
 
     private void CleanApiClient()
     {
-      if (ApiClient == null) return;
-      ApiClient.OnCommitCreated -= ApiClient_OnCommitCreated;
-      ApiClient.Dispose();
+      ApiClient?.Dispose();
     }
 
     private void ApiClient_OnCommitCreated(object sender, CommitInfo e)

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -36,7 +36,7 @@ namespace Speckle.Core.Api
             Log.CaptureAndThrow(new GraphQLException("Could not subscribe to commitCreated"), response.Errors);
 
           if (response.Data != null)
-            OnCommitCreated(this, response.Data.commitCreated);
+            OnCommitCreated?.Invoke(this, response.Data.commitCreated);
         });
 
       }


### PR DESCRIPTION
Fixes #92
Minor changes in the way the receiver works:
- Upon a document becoming active, receiver will compare it's receiving commit with the previous one (if exists), and handle notifications or fetching accordingly.
- When a document becomes inactive, any receivers in it will `Dispose` of the ApiClient to prevent subscription calls being called in the background.
- Same as above, but also when the receiver is removed from the document.
- Minor fix preventing a "Receive" operation when no objectID was present.
- Minor fix in Commit subscription: now checks if an event has been assigned before invoking `OnCommitCreated`