### PR TITLE
Models cleanup: Line, point, vector and controlPoint

### DIFF
--- a/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
+++ b/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Xaml.Behaviors;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 using Speckle.DesktopUI.Streams.Dialogs.FilterViews;
 using Stylet;
 

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using MaterialDesignThemes.Wpf;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -53,7 +53,7 @@ namespace Objects.Converter.Dynamo
     public DS.Point PointToNative(Point pt)
     {
       var point = DS.Point.ByCoordinates(
-        ScaleToNative(pt.value[0], pt.units), ScaleToNative(pt.value[1], pt.units), ScaleToNative(pt.value[2], pt.units));
+        ScaleToNative(pt.x, pt.units), ScaleToNative(pt.y, pt.units), ScaleToNative(pt.z, pt.units));
 
       return point.SetDynamoProperties<DS.Point>(GetDynamicMembersFromBase(pt));
     }
@@ -113,9 +113,9 @@ namespace Objects.Converter.Dynamo
     public DS.Vector VectorToNative(Vector vc)
     {
       return DS.Vector.ByCoordinates(
-        ScaleToNative(vc.value[0], vc.units),
-        ScaleToNative(vc.value[1], vc.units),
-        ScaleToNative(vc.value[2], vc.units));
+        ScaleToNative(vc.x, vc.units),
+        ScaleToNative(vc.y, vc.units),
+        ScaleToNative(vc.z, vc.units));
     }
 
     /// <summary>
@@ -202,11 +202,14 @@ namespace Objects.Converter.Dynamo
     /// <returns></returns>
     public DS.Line LineToNative(Line line)
     {
-      var pts = ArrayToPointList(line.value, line.units);
-      var ln = DS.Line.ByStartPointEndPoint(pts[0], pts[1]);
-
-      pts.ForEach(pt => pt.Dispose());
-
+      var ptStart = PointToNative(line.start);
+      var ptEnd = PointToNative(line.end);
+     
+      var ln = DS.Line.ByStartPointEndPoint(ptStart,ptEnd);
+      
+      ptStart.Dispose();
+      ptEnd.Dispose();
+      
       return ln.SetDynamoProperties<DS.Line>(GetDynamicMembersFromBase(line));
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -155,7 +155,7 @@ namespace Objects.Converter.Revit
 
       // NOTE: Only try generic method assignment if there is no existing render material from conversions;
       // we might want to try later on to capture it more intelligently from inside conversion routines.
-      if (returnObject["renderMaterial"] == null)
+      if (returnObject != null && returnObject["renderMaterial"] == null)
       {
         var material = GetElementRenderMaterial(@object as DB.Element);
         returnObject["renderMaterial"] = material;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -90,6 +90,7 @@ namespace Objects.Converter.Revit
         new List<Parameter>()
         );
       GetAllRevitParamsAndIds(speckleAc, revitAc);
+      speckleAc["type"] = revitAc.Name;
       return speckleAc;
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -42,7 +42,7 @@ namespace Objects.Converter.Revit
 
     public XYZ PointToNative(Point pt)
     {
-      var revitPoint = new XYZ(ScaleToNative(pt.value[0], pt.units), ScaleToNative(pt.value[1], pt.units), ScaleToNative(pt.value[2], pt.units));
+      var revitPoint = new XYZ(ScaleToNative(pt.x, pt.units), ScaleToNative(pt.y, pt.units), ScaleToNative(pt.z, pt.units));
       var intPt = ToInternalCoordinates(revitPoint);
       return intPt;
     }
@@ -50,12 +50,13 @@ namespace Objects.Converter.Revit
     public Point PointToSpeckle(XYZ pt)
     {
       var extPt = ToExternalCoordinates(pt);
-      return new Point(ScaleToSpeckle(extPt.X), ScaleToSpeckle(extPt.Y), ScaleToSpeckle(extPt.Z), ModelUnits);
+      var pointToSpeckle = new Point(ScaleToSpeckle(extPt.X), ScaleToSpeckle(extPt.Y), ScaleToSpeckle(extPt.Z), ModelUnits);
+      return pointToSpeckle;
     }
 
     public XYZ VectorToNative(Vector pt)
     {
-      var revitVector = new XYZ(ScaleToNative(pt.value[0], pt.units), ScaleToNative(pt.value[1], pt.units), ScaleToNative(pt.value[2], pt.units));
+      var revitVector = new XYZ(ScaleToNative(pt.x, pt.units), ScaleToNative(pt.y, pt.units), ScaleToNative(pt.z, pt.units));
       var intV = ToInternalCoordinates(revitVector);
       return intV;
     }
@@ -78,15 +79,16 @@ namespace Objects.Converter.Revit
     public DB.Line LineToNative(Line line)
     {
       return DB.Line.CreateBound(
-        new XYZ(ScaleToNative(line.value[0], line.units), ScaleToNative(line.value[1], line.units), ScaleToNative(line.value[2], line.units)),
-        new XYZ(ScaleToNative(line.value[3], line.units), ScaleToNative(line.value[4], line.units), ScaleToNative(line.value[5], line.units)));
+        PointToNative(line.start),
+        PointToNative(line.end));
     }
 
     public Line LineToSpeckle(DB.Line line)
     {
-      var l = new Line() { value = new List<double>(), units = ModelUnits };
-      l.value.AddRange(PointToSpeckle(line.GetEndPoint(0)).value);
-      l.value.AddRange(PointToSpeckle(line.GetEndPoint(1)).value);
+      var l = new Line { units = ModelUnits };
+      l.start = PointToSpeckle(line.GetEndPoint(0));
+      l.end = PointToSpeckle(line.GetEndPoint(1));
+      
       l.length = line.Length;
       return l;
     }
@@ -196,7 +198,7 @@ namespace Objects.Converter.Revit
       var points = new List<double>();
       foreach (var p in revitCurve.CtrlPoints)
       {
-        points.AddRange(PointToSpeckle(p).value);
+        points.AddRange(new List<double>{ScaleToSpeckle(p.X),ScaleToSpeckle(p.Y),ScaleToSpeckle(p.Z)});
       }
 
       Curve speckleCurve = new Curve();
@@ -374,13 +376,13 @@ namespace Objects.Converter.Revit
 
         for (var i = 1; i < pts.Count; i++)
         {
-          var speckleLine = new Line(new double[] { pts[i - 1].value[0], pts[i - 1].value[1], pts[i - 1].value[2], pts[i].value[0], pts[i].value[1], pts[i].value[2] }, polyline.units);
+          var speckleLine = new Line(new double[] { pts[i - 1].x, pts[i - 1].y, pts[i - 1].z, pts[i].x, pts[i].y, pts[i].z }, polyline.units);
           curveArray.Append(LineToNative(speckleLine));
         }
 
         if (polyline.closed)
         {
-          var speckleLine = new Line(new double[] { pts[pts.Count - 1].value[0], pts[pts.Count - 1].value[1], pts[pts.Count - 1].value[2], pts[0].value[0], pts[0].value[1], pts[0].value[2] }, polyline.units);
+          var speckleLine = new Line(new double[] { pts[pts.Count - 1].x, pts[pts.Count - 1].y, pts[pts.Count - 1].z, pts[0].x, pts[0].y, pts[0].z }, polyline.units);
           curveArray.Append(LineToNative(speckleLine));
         }
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
@@ -116,7 +116,7 @@ namespace Objects.Converter.Revit
         if (!(bool)elem["isSlanted"] || IsVertical(curve))
         {
           var baseLine = elem["baseLine"] as Line;
-          var point = new Point(baseLine.value[0], baseLine.value[1], baseLine.value[3] - (double) offset, ModelUnits);
+          var point = new Point(baseLine.start.x, baseLine.start.y, baseLine.start.z - (double) offset, ModelUnits);
 
           return PointToNative(point);
         }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
@@ -84,11 +84,11 @@ namespace Objects.Converter.Revit
         //2 points: bottom left and top right
         var btmLeft = PointToSpeckle(revitOpening.BoundaryRect[0]);
         var topRight = PointToSpeckle(revitOpening.BoundaryRect[1]);
-        poly.value.AddRange(btmLeft.value);
-        poly.value.AddRange(new Point(btmLeft.value[0], btmLeft.value[1], topRight.value[2], ModelUnits).value);
-        poly.value.AddRange(topRight.value);
-        poly.value.AddRange(new Point(topRight.value[0], topRight.value[1], btmLeft.value[2], ModelUnits).value);
-        poly.value.AddRange(btmLeft.value);
+        poly.value.AddRange(btmLeft.ToList());
+        poly.value.AddRange(new Point(btmLeft.x, btmLeft.y, topRight.z, ModelUnits).ToList());
+        poly.value.AddRange(topRight.ToList());
+        poly.value.AddRange(new Point(topRight.x, topRight.y, btmLeft.z, ModelUnits).ToList());
+        poly.value.AddRange(btmLeft.ToList());
         poly.units = ModelUnits;
         speckleOpening.outline = poly;
       }
@@ -123,7 +123,7 @@ namespace Objects.Converter.Revit
         speckleOpening.outline = poly;
       }
 
-      //speckleOpening.type = revitOpening.Name;
+      speckleOpening["type"] = revitOpening.Name;
 
       GetAllRevitParamsAndIds(speckleOpening, revitOpening, new List<string> { "WALL_BASE_CONSTRAINT", "WALL_HEIGHT_TYPE", "WALL_USER_HEIGHT_PARAM" });
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -107,9 +107,9 @@ namespace Objects.Converter.RhinoGh
     public Rhino.Geometry.Point PointToNative(Point pt)
     {
       var myPoint = new Rhino.Geometry.Point(new Point3d(
-        ScaleToNative(pt.value[0], pt.units),
-        ScaleToNative(pt.value[1], pt.units),
-        ScaleToNative(pt.value[2], pt.units)));
+        ScaleToNative(pt.x, pt.units),
+        ScaleToNative(pt.y, pt.units),
+        ScaleToNative(pt.z, pt.units)));
 
       return myPoint;
     }
@@ -128,9 +128,9 @@ namespace Objects.Converter.RhinoGh
     public Vector3d VectorToNative(Vector pt)
     {
       return new Vector3d(
-        ScaleToNative(pt.value[0], pt.units),
-        ScaleToNative(pt.value[1], pt.units),
-        ScaleToNative(pt.value[2], pt.units));
+        ScaleToNative(pt.x, pt.units),
+        ScaleToNative(pt.y, pt.units),
+        ScaleToNative(pt.z, pt.units));
     }
 
     // Interval
@@ -201,8 +201,7 @@ namespace Objects.Converter.RhinoGh
     // Back again only to LINECURVES because we hate grasshopper and its dealings with rhinocommon
     public LineCurve LineToNative(Line line)
     {
-      var pts = PointListToNative(line.value, line.units);
-      var myLine = new LineCurve(pts[0], pts[1]);
+      var myLine = new LineCurve(PointToNative(line.start).Location, PointToNative(line.end).Location);
       if (line.domain != null)
         myLine.Domain = IntervalToNative(line.domain);
 

--- a/Objects/Objects/Geometry/ControlPoint.cs
+++ b/Objects/Objects/Geometry/ControlPoint.cs
@@ -1,9 +1,27 @@
-﻿using Speckle.Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
   public class ControlPoint : Point, IHasBoundingBox
   {
+    /// <summary>
+    /// OBSOLETE - This is just here for backwards compatibility.
+    /// You should not use this for anything. Access coordinates using X,Y,Z and weight fields.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    private List<double> value
+    {
+      get { return null; }
+      set
+      {
+        x = value[0];
+        y = value[1];
+        z = value[2];
+        weight = value.Count > 3 ? value[3] : 1;
+      }
+    }
+    
     public ControlPoint()
     {
 
@@ -11,16 +29,15 @@ namespace Objects.Geometry
 
     public ControlPoint(double x, double y, double z, string units, string applicationId = null) : base(x, y, z, units, applicationId)
     {
-      value.Add(1); //w = 1
+      this.weight = 1;
     }
 
     public ControlPoint(double x, double y, double z, double w, string units, string applicationId = null) : base(x, y, z, units, applicationId)
     {
-      value.Add(w);
+      this.weight = w;
     }
 
-    [JsonIgnore]
-    public double weight => value[3];
+    public double weight { get; set; }
 
     public override string ToString() => $"{{{x},{y},{z},{weight}}}";
   }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -5,40 +5,70 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Speckle.Newtonsoft.Json;
+using Speckle.Core.Logging;
 
 namespace Objects.Geometry
 {
   public class Line : Base, ICurve, IHasBoundingBox
   {
-    public List<double> value { get; set; }
+    /// <summary>
+    /// OBSOLETE - This is just here for backwards compatibility.
+    /// You should not use this for anything. Access coordinates using start and end point.
+    /// </summary>
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public List<double> value
+    {
+      get
+      {
+        return null;
+      }
+      set
+      {
+        start = new Point(value[0], value[1], value[2]);
+        end = new Point(value[3], value[4], value[5]);
+      } 
+    }
+    
     public Interval domain { get; set; }
 
     public Box bbox { get; set; }
 
     public double area { get; set; }
     public double length { get; set; }
-
+    
+    public Point start { get; set; }
+    public Point end { get; set; }
     public Line() { }
 
     public Line(double x, double y, double z = 0, string units = Units.Meters, string applicationId = null)
     {
-      this.value = new List<double>() { x, y, z };
+      this.start = new Point(x, y, z);
+      this.end = null;
       this.applicationId = applicationId;
       this.units = units;
     }
 
     public Line(Point start, Point end, string units = Units.Meters, string applicationId = null)
     {
-      this.value = start.value.Concat(end.value).ToList();
+      this.start = start;
+      this.end = end;
       this.applicationId = applicationId;
       this.units = units;
     }
 
     public Line(IEnumerable<double> coordinatesArray, string units = Units.Meters, string applicationId = null)
     {
-      this.value = coordinatesArray.ToList();
+      var enumerable = coordinatesArray.ToList();
+      if (enumerable.Count < 6)
+        throw new SpeckleException("Line from coordinate array requires 6 coordinates.");
+      this.start = new Point(enumerable[0], enumerable[1], enumerable[2], units, applicationId);
+      this.end = new Point(enumerable[3], enumerable[4], enumerable[5], units, applicationId);
       this.applicationId = applicationId;
       this.units = units;
     }
+
+    public List<double> ToList() => start.ToList().Concat(end.ToList()).ToList();
   }
 }

--- a/Objects/Objects/Geometry/Point.cs
+++ b/Objects/Objects/Geometry/Point.cs
@@ -7,52 +7,48 @@ namespace Objects.Geometry
 {
   public class Point : Base, IHasBoundingBox
   {
-    public List<double> value { get; set; }
+    /// <summary>
+    /// OBSOLETE - This is just here for backwards compatibility.
+    /// You should not use this for anything. Access coordinates using X,Y,Z fields.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public List<double> value
+    {
+      get { return null; }
+      set
+      {
+        x = value[0];
+        y = value[1];
+        z = value.Count > 2 ? value[2] : 0;
+      }
+    }
 
     public Box bbox { get; set; }
 
-    public Point() { }
+    public Point()
+    {
+    }
 
     public Point(double x, double y, double z, string units = Units.Meters, string applicationId = null)
     {
-      this.value = new List<double>() { x, y, z };
+      this.value = new List<double>() {x, y, z};
       this.applicationId = applicationId;
       this.units = units;
     }
 
     public Point(double x, double y, string units = Units.Meters, string applicationId = null)
     {
-      this.value = new List<double>() { x, y, 0 };
+      this.value = new List<double>() {x, y, 0};
       this.applicationId = applicationId;
       this.units = units;
     }
 
-    [JsonIgnore]
-    public double x
-    {
-      get
-      {
-        return value[0];
-      }
-    }
+    public double x { get; set; }
 
-    [JsonIgnore]
-    public double y
-    {
-      get
-      {
-        return value[1];
-      }
-    }
+    public double y { get; set; }
 
-    [JsonIgnore]
-    public double z
-    {
-      get
-      {
-        return value[2];
-      }
-    }
-
+    public double z { get; set; }
+    
+    public List<double> ToList() => new List<double>() {x, y, z};
   }
 }

--- a/Objects/Objects/Geometry/Vector.cs
+++ b/Objects/Objects/Geometry/Vector.cs
@@ -3,29 +3,66 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
   public class Vector : Base, IHasBoundingBox
   {
-    public List<double> value { get; set; }
-    
+    /// <summary>
+    /// OBSOLETE - This is just here for backwards compatibility.
+    /// You should not use this for anything. Access coordinates using X,Y,Z fields.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public List<double> value
+    {
+      get { return null; }
+      set
+      {
+        x = value[0];
+        y = value[1];
+        z = value.Count > 2 ? value[2] : 0;
+      }
+    }
+
     public Box bbox { get; set; }
 
     public Vector() { }
 
     public Vector(double x, double y, string units = Units.Meters, string applicationId = null)
     {
-      this.value = new List<double>() { x, y, 0 };
+      this.x = x;
+      this.y = y;
+      this.z = 0;
       this.applicationId = applicationId;
       this.units = units;
     }
 
     public Vector(double x, double y, double z, string units = Units.Meters, string applicationId = null)
     {
-      this.value = new List<double>() { x, y, z };
+      this.x = x;
+      this.y = y;
+      this.z = z;
       this.applicationId = applicationId;
       this.units = units;
+    }
+
+    public double x
+    {
+      get;
+      set;
+    }
+    
+    public double y
+    {
+      get;
+      set;
+    }
+    
+    public double z
+    {
+      get;
+      set;
     }
   }
 }


### PR DESCRIPTION
`Line`, `Point`, `Vector` and `ControlPoint` were all storing the coordinates in a list of doubles named `value`.

`value` field is now obsolete, but instead of deleting it I modified it to populate the desired fields when setting int.

Tested serialization/deserialization of old and new serialized formats and both work correctly.

Fixed a minor issue in Revit regarding a null check when setting materials in the converter.

Fixes #86 