### PR TITLE
fix(gh): Goo to SpeckleBase and SpeckleStream conversion

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Speckle.IGH_Goo.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Speckle.IGH_Goo.cs
@@ -56,9 +56,23 @@ namespace ConnectorGrasshopper.Extras
 
     public override bool CastFrom(object source)
     {
-      var @base = (source as GH_SpeckleBase)?.Value;
-      if (@base == null)
+      Base @base = null;
+      if (source is Base _base)
+      {
+        @base = _base;
+      }
+      else if (source is GH_SpeckleBase speckleBase)
+      {
+        @base = speckleBase.Value;
+      }
+      else if (source is GH_Goo<Base> goo)
+      {
+        @base = goo.Value;
+      }
+      
+      if (source == null)
         return false;
+      
       Value = @base;
       return true;
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleBaseParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleBaseParam.cs
@@ -22,5 +22,6 @@ namespace ConnectorGrasshopper.Extras
         {
             
         }
+        
     }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStreamParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStreamParam.cs
@@ -98,6 +98,11 @@ namespace ConnectorGrasshopper.Extras
         }
       }
 
+      if (source is StreamWrapper strWrapper)
+      {
+        Value = strWrapper;
+        return true;
+      }
       var stream = (source as GH_SpeckleStream)?.Value;
       if (stream == null) return false;
       Value = stream;


### PR DESCRIPTION
Fixes #216 

Main cause was a missing case check on the `CastFrom` methods in our `SpeckleBaseParam` and `GH_SpeckleStream` classes.