### PR TITLE
fix(core): return collaborator avatar in gql ops

### DIFF
--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -157,6 +157,7 @@ namespace Speckle.Core.Api
                           id
                           name
                           role
+                          avatar
                         }},
                         branches (limit: {branchesLimit}){{
                           totalCount,
@@ -238,7 +239,8 @@ namespace Speckle.Core.Api
                             collaborators {{
                               id,
                               name,
-                              role
+                              role,
+                              avatar
                             }}
                           }}
                         }}


### PR DESCRIPTION
added collaborator avatar field to `StreamGet` and `StreamsGet` queries so they appear correctly in desktop ui

previously, they weren't showing up on the Stream Details page