### PR TITLE
WIP: Dim/children count corrections

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/AccountsNode/Accounts.cs
+++ b/ConnectorDynamo/ConnectorDynamo/AccountsNode/Accounts.cs
@@ -100,13 +100,13 @@ namespace Speckle.ConnectorDynamo.AccountsNode
       }
 
       SelectedAccount = !string.IsNullOrEmpty(SelectedAccountId)
-        ? AccountList.FirstOrDefault(x => x.id == SelectedAccountId)
+        ? AccountList.FirstOrDefault(x => x.userInfo.id == SelectedAccountId)
         : AccountList.FirstOrDefault(x => x.isDefault);
     }
 
     internal void SelectionChanged(Account account)
     {
-      SelectedAccountId = account.id;
+      SelectedAccountId = account.userInfo.id;
       OnNodeModified(true);
     }
 

--- a/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStream.cs
+++ b/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStream.cs
@@ -143,9 +143,9 @@ namespace Speckle.ConnectorDynamo.CreateStreamNode
       {
         var res = client.StreamCreate(new StreamCreateInput()).Result;
 
-        Stream = new StreamWrapper(res, SelectedAccount.id, SelectedAccount.serverInfo.url);
+        Stream = new StreamWrapper(res, SelectedAccount.userInfo.id, SelectedAccount.serverInfo.url);
         CreateEnabled = false;
-        SelectedAccountId = SelectedAccount.id;
+        SelectedAccountId = SelectedAccount.userInfo.id;
 
         this.Name = "Stream Created";
         OnNodeModified(true);
@@ -163,7 +163,6 @@ namespace Speckle.ConnectorDynamo.CreateStreamNode
       }
 
     }
-
 
     #region overrides
 

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -50,7 +50,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       {
         if (_client == null && Stream != null)
         {
-          var account = Stream.GetAccount();
+          var account = Stream.GetAccount().Result;
           _client = new Client(account);
         }
 
@@ -401,7 +401,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       if (Stream == null)
         return;
 
-      var account = Stream.GetAccount();
+      var account = Stream.GetAccount().Result;
       Client = new Client(account);
       Client.SubscribeCommitCreated(Stream.StreamId);
       Client.OnCommitCreated += OnCommitChange;

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -370,8 +370,8 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
         return;
       }
 
-      if (newStream.Type != StreamWrapperType.Branch)
-        newStream.BranchName = "main";
+      //if (newStream.Type != StreamWrapperType.Branch)
+      //  newStream.BranchName = "main";
 
       //no need to re-subscribe. it's the same stream
       if (oldStream != null && newStream.ToString() == oldStream.ToString())
@@ -382,7 +382,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       ReceiveEnabled = true;
 
       //StreamWrapper points to a Stream
-      if (newStream.Type == StreamWrapperType.Commit)
+      if (newStream.Type == StreamWrapperType.Commit || newStream.Type == StreamWrapperType.Object) 
       {
         Name = "Receive Commit";
         AutoUpdate = false;

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -358,13 +358,13 @@ namespace Speckle.ConnectorDynamo.SendNode
         switch (o)
         {
           case StreamWrapper s:
-            var wrapperTransport = new ServerTransport(s.GetAccount(), s.StreamId);
+            var wrapperTransport = new ServerTransport(s.GetAccount().Result, s.StreamId);
             var branch = s.BranchName ?? defaultBranch;
             transports.Add(wrapperTransport, branch);
             break;
           case string s:
             var streamWrapper = new StreamWrapper(s);
-            var transport = new ServerTransport(streamWrapper.GetAccount(), streamWrapper.StreamId);
+            var transport = new ServerTransport(streamWrapper.GetAccount().Result, streamWrapper.StreamId);
             var b = streamWrapper.BranchName ?? defaultBranch;
             transports.Add(transport, b);
             break;

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Account.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Account.cs
@@ -35,7 +35,6 @@ namespace Speckle.ConnectorDynamo.Functions
       }
       return new Dictionary<string, object>
       {
-        {"id", account.id},
         {"isDefault", account.isDefault},
         {
           "serverInfo",

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -104,35 +104,51 @@ namespace Speckle.ConnectorDynamo.Functions
       stream.BranchName = string.IsNullOrEmpty(stream.BranchName) ? "main" : stream.BranchName;
 
       var client = new Client(account);
-      Commit commit;
-      try
+      Commit commit = null;
+      
+      if(stream.Type == StreamWrapperType.Stream || stream.Type == StreamWrapperType.Branch)
       {
-        if (string.IsNullOrEmpty(stream.CommitId))
+        List<Branch> branches;
+        try
         {
-
-          var branches = client.StreamGetBranches(cancellationToken, stream.StreamId).Result;
-          var mainBranch = branches.FirstOrDefault(b => b.name == stream.BranchName);
-
-          if (mainBranch == null)
-          {
-            Log.CaptureAndThrow(new Exception("No branch found with name " + stream.BranchName));
-          }
-
-          if (!mainBranch.commits.items.Any())
-            throw new Exception("No commits found.");
-
-          commit = mainBranch.commits.items[0];
+          branches = client.StreamGetBranches(cancellationToken, stream.StreamId).Result;
         }
-        else
+        catch (Exception ex)
+        {
+          Utils.HandleApiExeption(ex);
+          return null;
+        }
+
+        var branch = branches.FirstOrDefault(b => b.name == stream.BranchName);
+        if (branch == null)
+        {
+          Log.CaptureAndThrow(new Exception("No branch found with name " + stream.BranchName));
+        }
+
+        if (!branch.commits.items.Any())
+        {
+          throw new Exception("No commits found.");
+        }
+
+        commit = branch.commits.items[0];
+      } 
+      else if(stream.Type == StreamWrapperType.Commit)
+      {
+        try
         {
           commit = client.CommitGet(cancellationToken, stream.StreamId, stream.CommitId).Result;
         }
-      }
-      catch (Exception ex)
+        catch (Exception ex)
+        {
+          Utils.HandleApiExeption(ex);
+          return null;
+        }
+      } 
+      else if(stream.Type == StreamWrapperType.Object)
       {
-        Utils.HandleApiExeption(ex);
-        return null;
+        commit = new Commit() { referencedObject = stream.ObjectId, id = Guid.NewGuid().ToString() };
       }
+     
 
       if (commit == null)
       {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -100,7 +100,7 @@ namespace Speckle.ConnectorDynamo.Functions
       Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null,
       Action<int> onTotalChildrenCountKnown = null)
     {
-      var account = stream.GetAccount();
+      var account = stream.GetAccount().Result;
       stream.BranchName = string.IsNullOrEmpty(stream.BranchName) ? "main" : stream.BranchName;
 
       var client = new Client(account);

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
@@ -110,7 +110,7 @@ namespace Speckle.ConnectorDynamo.Functions
         return null;
       }
 
-      var wrapper = Utils.InputToStream(stream).First();
+      var wrapper = Utils.ParseWrapper(stream);
 
       if (wrapper == null)
       {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
@@ -99,13 +99,20 @@ namespace Speckle.ConnectorDynamo.Functions
     /// <param name="description">Description of the Stream</param>
     /// <param name="isPublic">True if the stream is to be publicly available</param>
     /// <returns name="stream">Updated Stream object</returns>
-    public static StreamWrapper Update(StreamWrapper stream,
+    public static StreamWrapper Update([DefaultArgument("null")] object stream,
       [DefaultArgument("null")] string name,
       [DefaultArgument("null")] string description, [DefaultArgument("null")] bool? isPublic)
     {
       Tracker.TrackPageview(Tracker.STREAM_UPDATE);
 
-      if (stream == null)
+      if(stream == null)
+      {
+        return null;
+      }
+
+      var wrapper = Utils.InputToStream(stream).First();
+
+      if (wrapper == null)
       {
         Core.Logging.Log.CaptureAndThrow(new Exception("Invalid stream."));
       }
@@ -113,11 +120,11 @@ namespace Speckle.ConnectorDynamo.Functions
       if (name == null && description == null && isPublic == null)
         return null;
 
-      var account = stream.GetAccount().Result;
+      var account = wrapper.GetAccount().Result;
 
       var client = new Client(account);
 
-      var input = new StreamUpdateInput { id = stream.StreamId };
+      var input = new StreamUpdateInput { id = wrapper.StreamId };
 
       if (name != null)
         input.name = name;
@@ -133,7 +140,7 @@ namespace Speckle.ConnectorDynamo.Functions
         var res = client.StreamUpdate(input).Result;
 
         if (res)
-          return stream;
+          return wrapper;
       }
       catch (Exception ex)
       {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
@@ -48,7 +48,7 @@ namespace Speckle.ConnectorDynamo.Functions
           if (account != null)
             accountToUse = account;
           else
-            accountToUse = s.GetAccount();
+            accountToUse = s.GetAccount().Result;
 
 
           var client = new Client(accountToUse);
@@ -113,7 +113,7 @@ namespace Speckle.ConnectorDynamo.Functions
       if (name == null && description == null && isPublic == null)
         return null;
 
-      var account = stream.GetAccount();
+      var account = stream.GetAccount().Result;
 
       var client = new Client(account);
 
@@ -172,7 +172,7 @@ namespace Speckle.ConnectorDynamo.Functions
 
       foreach (var streamWrapper in streams)
       {
-        var account = streamWrapper.GetAccount();
+        var account = streamWrapper.GetAccount().Result;
 
         var client = new Client(account);
 

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Utils.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Utils.cs
@@ -14,7 +14,7 @@ namespace Speckle.ConnectorDynamo.Functions
       try
       {
         //it's a list
-        var array = (input as ArrayList).ToArray();
+        var array = (input as ArrayList)?.ToArray();
 
         try
         {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Utils.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Utils.cs
@@ -9,6 +9,7 @@ namespace Speckle.ConnectorDynamo.Functions
   internal static class Utils
   {
 
+    //My god this function sucks. It took me 20 mins to understand. Why not one that simply deals with one stream wrapper, and then use linq to cast things around? 
     internal static List<StreamWrapper> InputToStream(object input)
     {
       try
@@ -46,7 +47,9 @@ namespace Speckle.ConnectorDynamo.Functions
         //single stream wrapper
         var sw = input as StreamWrapper;
         if (sw != null)
+        {
           return new List<StreamWrapper> { sw };
+        }
       }
       catch
       {
@@ -58,7 +61,9 @@ namespace Speckle.ConnectorDynamo.Functions
         //single url
         var s = input as string;
         if (!string.IsNullOrEmpty(s))
+        {
           return new List<StreamWrapper> { new StreamWrapper(s) };
+        }
       }
       catch
       {
@@ -68,15 +73,36 @@ namespace Speckle.ConnectorDynamo.Functions
       return null;
     }
 
+    internal static StreamWrapper ParseWrapper(object input)
+    {
+      if (input is StreamWrapper w)
+      {
+        return w;
+      }
+
+      if (input is string s)
+      {
+        return new StreamWrapper(s);
+      }
+
+      return null;
+    }
 
     internal static void HandleApiExeption(Exception ex)
     {
       if (ex.InnerException != null && ex.InnerException.InnerException != null)
+      {
         throw (ex.InnerException.InnerException);
+      }
+
       if (ex.InnerException != null)
+      {
         throw (ex.InnerException);
+      }
       else
+      {
         throw (ex);
+      }
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/AccountDetails.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/AccountDetails.cs
@@ -59,16 +59,16 @@ namespace ConnectorGrasshopper.Streams
       }
 
       var account = string.IsNullOrEmpty(accountId)  ? AccountManager.GetDefaultAccount()
-        : AccountManager.GetAccounts().FirstOrDefault(a => a.id == accountId);
+        : AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == accountId);
 
       if(account == null)
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Could not find default account in this machine. Use the Speckle Manager to add an account.");
         return;
       }
-      Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.id);
+      Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.userInfo.id);
 
-      DA.SetData(0, account.id);
+      //DA.SetData(0, account.id);
       DA.SetData(1, account.isDefault);
       DA.SetData(2, account.serverInfo.name);
       DA.SetData(3, account.serverInfo.company);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.AccountDetails.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.AccountDetails.cs
@@ -34,7 +34,6 @@ namespace ConnectorGrasshopper.Streams
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
-      pManager.AddTextParameter("ID", "ID", "Unique ID of the account.", GH_ParamAccess.item);
       pManager.AddBooleanParameter("isDefault", "D", "Determines if the account is the default of this machine.",
         GH_ParamAccess.item);
       pManager.AddTextParameter("Server name", "SN", "Name of the server.", GH_ParamAccess.item);
@@ -68,15 +67,14 @@ namespace ConnectorGrasshopper.Streams
       }
       Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.userInfo.id);
 
-      //DA.SetData(0, account.id);
-      DA.SetData(1, account.isDefault);
-      DA.SetData(2, account.serverInfo.name);
-      DA.SetData(3, account.serverInfo.company);
-      DA.SetData(4, account.serverInfo.url);
-      DA.SetData(5, account.userInfo.id);
-      DA.SetData(6, account.userInfo.name);
-      DA.SetData(7, account.userInfo.company);
-      DA.SetData(8, account.userInfo.email);
+      DA.SetData(0, account.isDefault);
+      DA.SetData(1, account.serverInfo.name);
+      DA.SetData(2, account.serverInfo.company);
+      DA.SetData(3, account.serverInfo.url);
+      DA.SetData(4, account.userInfo.id);
+      DA.SetData(5, account.userInfo.name);
+      DA.SetData(6, account.userInfo.company);
+      DA.SetData(7, account.userInfo.email);
     }
     
     protected override void BeforeSolveInstance()

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.ListAccounts.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.ListAccounts.cs
@@ -61,12 +61,12 @@ namespace ConnectorGrasshopper.Accounts
 
       foreach (var account in accounts)
       {
-        if (defaultAccount != null && account.id == defaultAccount.id)
+        if (defaultAccount != null && account.userInfo.id == defaultAccount.userInfo.id)
         {
           defaultAccountIndex = index;
         }
 
-        ListItems.Add(new GH_ValueListItem(account.ToString(), $"\"{account.id}\""));
+        ListItems.Add(new GH_ValueListItem(account.ToString(), $"\"{account.userInfo.id}\""));
         index++;
       }
 
@@ -103,7 +103,7 @@ namespace ConnectorGrasshopper.Accounts
     public override bool Write(GH_IWriter writer)
     {
       var selectedAccountId = SelectedItems[0].Expression.Trim(new char[] { '"' });
-      var selectedAccount = AccountManager.GetAccounts().FirstOrDefault(a => a.id == selectedAccountId);
+      var selectedAccount = AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == selectedAccountId);
       if (selectedAccount != null)
       {
         writer.SetString("selectedId", selectedAccountId);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -354,7 +354,7 @@ namespace ConnectorGrasshopper.Ops
 
     private void HandleInputType(StreamWrapper wrapper)
     {
-      if (wrapper.Type == StreamWrapperType.Commit)
+      if (wrapper.Type == StreamWrapperType.Commit || wrapper.Type == StreamWrapperType.Object)
       {
         AutoReceive = false;
         StreamWrapper = wrapper;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -42,7 +42,7 @@ namespace ConnectorGrasshopper.Ops
       SetDefaultKitAndConverter();
     }
 
-    private Client ApiClient { get; set; }
+    public Client ApiClient { get; set; }
 
     public bool AutoReceive { get; set; }
 
@@ -78,10 +78,10 @@ namespace ConnectorGrasshopper.Ops
         {
           // Will execute every time a document becomes active (from background or opening file.).
           if (StreamWrapper != null)
-            Task.Run(() =>
+            Task.Run(async () =>
             {
               // Ensure fresh instance of client.
-              ResetApiClient(StreamWrapper);
+              await ResetApiClient(StreamWrapper);
 
               // Get last commit from the branch
               var b = ApiClient.BranchGet(BaseWorker.CancellationToken , StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1).Result;
@@ -95,7 +95,7 @@ namespace ConnectorGrasshopper.Ops
         case GH_DocumentContext.Unloaded:
           // Will execute every time a document becomes inactive (in background or closing file.)
           //Correctly dispose of the client when changing documents to prevent subscription handlers being called in background.
-          CleanApiClient();
+          ApiClient?.Dispose();
           break;
       }
 
@@ -287,7 +287,8 @@ namespace ConnectorGrasshopper.Ops
 
     public override void RemovedFromDocument(GH_Document document)
     {
-      CleanApiClient();
+      //CleanApiClient();
+      ApiClient?.Dispose();
       base.RemovedFromDocument(document);
     }
 
@@ -362,27 +363,27 @@ namespace ConnectorGrasshopper.Ops
 
       if (wrapper.Type == StreamWrapperType.Branch)
       {
-        // TODO: 
+        // NOTE: Handled in do work
       }
 
       if (StreamWrapper != null && wrapper.StreamId == StreamWrapper.StreamId && !JustPastedIn) return;
 
       StreamWrapper = wrapper;
 
-      ResetApiClient(wrapper);
+      //ResetApiClient(wrapper);
+      Task.Run(async () =>
+      {
+        await ResetApiClient(wrapper);
+      });
     }
 
-    private void ResetApiClient(StreamWrapper wrapper)
-    {
-      CleanApiClient();
-      ApiClient = new Client(wrapper.GetAccount());
-      ApiClient.SubscribeCommitCreated(StreamWrapper.StreamId);
-      ApiClient.OnCommitCreated += ApiClient_OnCommitCreated;
-    }
-
-    private void CleanApiClient()
+    private async Task ResetApiClient(StreamWrapper wrapper)
     {
       ApiClient?.Dispose();
+      var acc = await wrapper.GetAccount();
+      ApiClient = new Client(acc);
+      ApiClient.SubscribeCommitCreated(StreamWrapper.StreamId);
+      ApiClient.OnCommitCreated += ApiClient_OnCommitCreated;
     }
 
     private void ApiClient_OnCommitCreated(object sender, CommitInfo e)
@@ -448,8 +449,8 @@ namespace ConnectorGrasshopper.Ops
           asyncParent.CancellationSources.ForEach(source => source.Cancel());
         };
 
-        var client = new Client(InputWrapper?.GetAccount());
-        var remoteTransport = new ServerTransport(InputWrapper?.GetAccount(), InputWrapper?.StreamId);
+        var client = new Client(InputWrapper?.GetAccount().Result);
+        var remoteTransport = new ServerTransport(InputWrapper?.GetAccount().Result, InputWrapper?.StreamId);
         remoteTransport.TransportName = "R";
 
         if (receiveComponent.JustPastedIn &&
@@ -682,6 +683,8 @@ namespace ConnectorGrasshopper.Ops
         Owner.OnDisplayExpired(true);
         return GH_ObjectResponse.Handled;
       }
+
+      // TODO: check if owner has null account/client, and call the reset thing SYNC 
 
       ((ReceiveComponent) Owner).CurrentComponentState = "primed_to_receive";
       Owner.ExpireSolution(true);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -365,10 +365,10 @@ namespace ConnectorGrasshopper.Ops
       {
         // NOTE: Handled in do work
       }
+      
+      StreamWrapper = wrapper;
 
       if (StreamWrapper != null && wrapper.StreamId == StreamWrapper.StreamId && !JustPastedIn) return;
-
-      StreamWrapper = wrapper;
 
       //ResetApiClient(wrapper);
       Task.Run(async () =>

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -343,6 +343,9 @@ namespace ConnectorGrasshopper.Ops
         case StreamWrapperType.Branch:
           inputType = "Branch";
           break;
+        case StreamWrapperType.Object:
+          inputType = "Object";
+          break;
       }
 
       return inputType;
@@ -491,6 +494,10 @@ namespace ConnectorGrasshopper.Ops
               Done();
               return;
             }
+          if(InputWrapper.ObjectId != null)
+          {
+            myCommit = new Commit() { referencedObject = InputWrapper.ObjectId };
+          }
           else
             try
             {
@@ -501,7 +508,7 @@ namespace ConnectorGrasshopper.Ops
             catch (Exception e)
             {
               RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,
-                "Could not get any commits from the stream's \"main\" branch."));
+                $"Could not get any commits from the stream's '{(InputWrapper.BranchName ?? "main")}' branch."));
               Done();
               return;
             }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -386,20 +386,17 @@ namespace ConnectorGrasshopper.Ops
               continue;
             }
 
-            var acc = sw.GetAccount();
-            if (acc == null)
+            Account acc;
+            try
             {
-              Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"Could not get an account for {sw}");
+              acc = sw.GetAccount().Result;
+            } catch(Exception e)
+            {
+              Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
               continue;
             }
-
-            if (!sw.ExistsInServer())
-            {
-              Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"The provided stream ID does not exist in the server.");
-              continue;
-
-            }
-              var serverTransport = new ServerTransport(acc, sw.StreamId) { TransportName = $"T{t}" };
+            
+            var serverTransport = new ServerTransport(acc, sw.StreamId) { TransportName = $"T{t}" };
             transportBranches.Add(serverTransport, sw.BranchName ?? "main");
             Transports.Add(serverTransport);
           }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -503,12 +503,8 @@ namespace ConnectorGrasshopper.Ops
 
               var commitId = await client.CommitCreate(CancellationToken, commitCreateInput);
 
-              OutputWrappers.Add(new StreamWrapper
-              {
-                StreamId = ((ServerTransport)transport).StreamId,
-                ServerUrl = client.ServerUrl,
-                CommitId = commitId
-              });
+              var wrapper = new StreamWrapper($"{client.Account.serverInfo.url}/streams/{((ServerTransport)transport).StreamId}/commits/{commitId}?u={client.Account.userInfo.id}");
+              OutputWrappers.Add(wrapper);
             }
             catch (Exception e)
             {
@@ -544,7 +540,6 @@ namespace ConnectorGrasshopper.Ops
       {
         ((SendComponent)Parent).JustPastedIn = false;
         DA.SetDataList(0, ((SendComponent)Parent).OutputWrappers);
-        //DA.SetData(1, ((SendComponent)Parent).BaseId);
         return;
       }
 
@@ -560,14 +555,12 @@ namespace ConnectorGrasshopper.Ops
       }
 
       DA.SetDataList(0, OutputWrappers);
-      //DA.SetData(1, BaseId);
-      //DA.SetData(2, new GH_SpeckleBase { Value = ObjectToSend });
 
       ((SendComponent)Parent).CurrentComponentState = "up_to_date";
-      ((SendComponent)Parent).OutputWrappers =
-        OutputWrappers; // ref the outputs in the parent too, so we can serialise them on write/read
-      ((SendComponent)Parent).BaseId =
-        BaseId; // ref the outputs in the parent too, so we can serialise them on write/read
+      ((SendComponent)Parent).OutputWrappers = OutputWrappers; // ref the outputs in the parent too, so we can serialise them on write/read
+
+      ((SendComponent)Parent).BaseId = BaseId; // ref the outputs in the parent too, so we can serialise them on write/read
+
       ((SendComponent)Parent).OverallProgress = 0;
 
       var hasWarnings = RuntimeMessages.Count > 0;
@@ -676,11 +669,6 @@ namespace ConnectorGrasshopper.Ops
             return GH_ObjectResponse.Handled;
           }
 
-          // if (((SendComponent)Owner).CurrentComponentState != "expired")
-          // {
-          //   return GH_ObjectResponse.Handled;
-          // }
-
           ((SendComponent)Owner).CurrentComponentState = "primed_to_send";
           Owner.ExpireSolution(true);
           return GH_ObjectResponse.Handled;
@@ -690,32 +678,5 @@ namespace ConnectorGrasshopper.Ops
       return base.RespondToMouseDown(sender, e);
     }
 
-    /*public override GH_ObjectResponse RespondToMouseDoubleClick(GH_Canvas sender, GH_CanvasMouseEvent e)
-    {
-      // Double clicking the send button, even if the state is up to date, will do a "force send"
-      if (e.Button == MouseButtons.Left)
-      {
-        if (((RectangleF)ButtonBounds).Contains(e.CanvasLocation))
-        {
-          if (((SendComponent)Owner).CurrentComponentState == "sending")
-          {
-            return GH_ObjectResponse.Handled;
-          }
-
-          if (((SendComponent)Owner).AutoSend)
-          {
-            ((SendComponent)Owner).AutoSend = false;
-            Owner.OnDisplayExpired(true);
-            return GH_ObjectResponse.Handled;
-          }
-
-          ((SendComponent)Owner).CurrentComponentState = "primed_to_send";
-          Owner.ExpireSolution(true);
-          return GH_ObjectResponse.Handled;
-        }
-      }
-
-      return base.RespondToMouseDown(sender, e);
-    }*/
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
@@ -80,7 +80,7 @@ namespace ConnectorGrasshopper.Streams
       }
       else
       {
-        account = AccountManager.GetAccounts().FirstOrDefault(a => a.id == accountId);
+        account = AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == accountId);
         if (account == null)
         {
           // Really last ditch effort - in case people delete accounts from the manager, and the selection dropdown is still using an outdated list.
@@ -89,7 +89,7 @@ namespace ConnectorGrasshopper.Streams
         }
       }
 
-      Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.id);
+      Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.userInfo.id);
 
       if (stream != null)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
@@ -101,7 +101,7 @@ namespace ConnectorGrasshopper.Streams
                 }
                 var account = item.Value.AccountId == null
                   ? AccountManager.GetDefaultAccount()
-                  : AccountManager.GetAccounts().FirstOrDefault(a => a.id == item.Value.AccountId);
+                  : AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == item.Value.AccountId);
                 if (account == null)
                 {
                   AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Could not find default account in this machine. Use the Speckle Manager to add an account.");

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
@@ -59,7 +59,7 @@ namespace ConnectorGrasshopper.Streams
       DA.GetData(0, ref ghIdWrapper);
       DA.GetData(1, ref accountId);
       var account = string.IsNullOrEmpty(accountId)  ? AccountManager.GetDefaultAccount()
-        : AccountManager.GetAccounts().FirstOrDefault(a => a.id == accountId);
+        : AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == accountId);
 
       var idWrapper = ghIdWrapper.Value;
       if(account == null)
@@ -68,7 +68,7 @@ namespace ConnectorGrasshopper.Streams
         return;
       }
 
-      Params.Input[1].AddVolatileData(new GH_Path(0), 0, account.id);
+      Params.Input[1].AddVolatileData(new GH_Path(0), 0, account.userInfo.id);
 
       if (error != null)
       {
@@ -96,7 +96,7 @@ namespace ConnectorGrasshopper.Streams
             //Exists?
             var client = new Client(account);
             var result = await client.StreamGet(idWrapper.StreamId);
-            stream = new StreamWrapper(result.id, account.id, account.serverInfo.url);
+            stream = new StreamWrapper(result.id, account.userInfo.id, account.serverInfo.url);
           }
           catch (Exception e)
           {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
@@ -58,6 +58,13 @@ namespace ConnectorGrasshopper.Streams
 
         DA.GetData(0, ref accountId);
         DA.GetData(1, ref limit); // Has default value so will never be empty.
+
+        if (limit > 50)
+        {
+          limit = 50;
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Max number of streams retrieved is 50.");
+        }
+
         var account = string.IsNullOrEmpty(accountId)  ? AccountManager.GetDefaultAccount()
           : AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == accountId);
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
@@ -59,7 +59,7 @@ namespace ConnectorGrasshopper.Streams
         DA.GetData(0, ref accountId);
         DA.GetData(1, ref limit); // Has default value so will never be empty.
         var account = string.IsNullOrEmpty(accountId)  ? AccountManager.GetDefaultAccount()
-          : AccountManager.GetAccounts().FirstOrDefault(a => a.id == accountId);
+          : AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == accountId);
 
         if (accountId == null)
         {
@@ -72,7 +72,7 @@ namespace ConnectorGrasshopper.Streams
           return;
         }
 
-        Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.id);
+        Params.Input[0].AddVolatileData(new GH_Path(0), 0, account.userInfo.id);
 
         Task.Run(async () =>
         {
@@ -82,7 +82,7 @@ namespace ConnectorGrasshopper.Streams
             // Save the result
             var result = await client.StreamsGet(limit);
             streams = result
-              .Select(stream => new StreamWrapper(stream.id, account.id, account.serverInfo.url))
+              .Select(stream => new StreamWrapper(stream.id, account.userInfo.id, account.serverInfo.url))
               .ToList();
           }
           catch (Exception e)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
@@ -75,7 +75,7 @@ namespace ConnectorGrasshopper.Streams
         {
           var account = streamWrapper.AccountId == null
                       ? AccountManager.GetDefaultAccount()
-                      : AccountManager.GetAccounts().FirstOrDefault(a => a.id == streamWrapper.AccountId);
+                      : AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == streamWrapper.AccountId);
 
           if (account == null)
           {

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -21,11 +21,6 @@ namespace Speckle.Core.Credentials
   {
     private static SQLiteTransport AccountStorage = new SQLiteTransport(scope: "Accounts");
 
-    // NOTE: These need to be coordinated with the server.
-    internal static string APPID = "connectors";
-    internal static string SECRET = "connectors";
-    internal static int PORT = 24707;
-
     /// <summary>
     /// Gets the basic information about a server. 
     /// </summary>

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -10,7 +10,8 @@ namespace Speckle.Core.Credentials
     public string ServerUrl { get; set; }
     public string StreamId { get; set; }
     public string CommitId { get; set; }
-    public string BranchName { get; set; } // To be used later! 
+    public string BranchName { get; set; } 
+    public string ObjectId { get; set; }
 
     /// <summary>
     /// Determines if the current stream wrapper contains a valid stream.
@@ -22,6 +23,7 @@ namespace Speckle.Core.Credentials
       // Quick solution to determine whether a wrapper points to a branch, commit or stream.
       get
       {
+        if (!string.IsNullOrEmpty(ObjectId)) return StreamWrapperType.Object;
         if (!string.IsNullOrEmpty(BranchName)) return StreamWrapperType.Branch;
         if (!string.IsNullOrEmpty(CommitId)) return StreamWrapperType.Commit;
         if (!string.IsNullOrEmpty(StreamId)) return StreamWrapperType.Stream;
@@ -143,7 +145,12 @@ namespace Speckle.Core.Credentials
           else if (uri.Segments[3].ToLowerInvariant() == "branches/")
           {
             StreamId = uri.Segments[2].Replace("/", "");
-            BranchName = uri.Segments[4].Replace("/", "");
+            BranchName = Uri.UnescapeDataString( uri.Segments[4].Replace("/", ""));
+          }
+          else if (uri.Segments[3].ToLowerInvariant() == "objects/")
+          {
+            StreamId = uri.Segments[2].Replace("/", "");
+            ObjectId = uri.Segments[4].Replace("/", "");
           }
           else
           {
@@ -220,6 +227,7 @@ namespace Speckle.Core.Credentials
     Undefined,
     Stream,
     Commit,
-    Branch
+    Branch,
+    Object
   }
 }

--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -1,12 +1,12 @@
-﻿using Speckle.Newtonsoft.Json;
-using Speckle.Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using Speckle.Core.Api;
 using Speckle.Core.Kits;
 using Speckle.Core.Transports;
+using Speckle.Newtonsoft.Json;
+using Speckle.Newtonsoft.Json.Linq;
 
 namespace Speckle.Core.Models
 {
@@ -73,24 +73,24 @@ namespace Speckle.Core.Models
       {
         var detachAttribute = prop.GetCustomAttribute<DetachProperty>(true);
         var chunkAttribute = prop.GetCustomAttribute<Chunkable>(true);
-        
+
         object value = prop.GetValue(@base);
 
         if (detachAttribute != null && detachAttribute.Detachable && chunkAttribute == null)
-        {  
+        {
           count += HandleObjectCount(value, parsed);
-        } 
+        }
         else if (detachAttribute != null && detachAttribute.Detachable && chunkAttribute != null)
         {
           // Simplified chunking count handling.
           var asList = value as IList;
-          if(asList!=null)
+          if (asList != null)
           {
             count += asList.Count / chunkAttribute.MaxObjCountPerChunk;
             continue;
           }
           var asArray = value as Array;
-          if(asArray!=null)
+          if (asArray != null)
           {
             count += asArray.Length / chunkAttribute.MaxObjCountPerChunk;
             continue;
@@ -99,11 +99,34 @@ namespace Speckle.Core.Models
       }
 
       var dynamicProps = @base.GetDynamicMembers();
+      var chunkSyntax = new System.Text.RegularExpressions.Regex(@"^@\((\d*)\)");
       foreach (var propName in dynamicProps)
       {
         if (!propName.StartsWith("@"))
         {
           continue;
+        }
+
+        // Simplfied dynamic prop chunking handling
+        if (chunkSyntax.IsMatch(propName))
+        {
+          int chunkSize = -1;
+          var match = chunkSyntax.Match(propName);
+          int.TryParse(match.Groups[match.Groups.Count - 1].Value, out chunkSize);
+          
+          var asList = @base[propName] as IList;
+          if(chunkSize != -1 && asList != null)
+          {
+            count += asList.Count / chunkSize;
+            continue;
+          }
+
+          var asArr = @base[propName] as Array;
+          if(chunkSize != -1 && asArr != null)
+          {
+            count += asArr.Length / chunkSize;
+            continue;
+          }
         }
 
         count += HandleObjectCount(@base[propName], parsed);

--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -72,10 +72,29 @@ namespace Speckle.Core.Models
       foreach (var prop in typedProps)
       {
         var detachAttribute = prop.GetCustomAttribute<DetachProperty>(true);
-        if (detachAttribute != null && detachAttribute.Detachable)
-        {
-          object value = prop.GetValue(@base);
+        var chunkAttribute = prop.GetCustomAttribute<Chunkable>(true);
+        
+        object value = prop.GetValue(@base);
+
+        if (detachAttribute != null && detachAttribute.Detachable && chunkAttribute == null)
+        {  
           count += HandleObjectCount(value, parsed);
+        } 
+        else if (detachAttribute != null && detachAttribute.Detachable && chunkAttribute != null)
+        {
+          // Simplified chunking count handling.
+          var asList = value as IList;
+          if(asList!=null)
+          {
+            count += asList.Count / chunkAttribute.MaxObjCountPerChunk;
+            continue;
+          }
+          var asArray = value as Array;
+          if(asArray!=null)
+          {
+            count += asArray.Length / chunkAttribute.MaxObjCountPerChunk;
+            continue;
+          }
         }
       }
 

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -355,6 +355,11 @@ namespace Speckle.Core.Serialisation
             continue;
           }
 
+          if(prop == "id")
+          {
+            continue;
+          }
+
           var property = contract.Properties.GetClosestMatchProperty(prop);
 
           // Ignore properties decorated with [JsonIgnore].

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Speckle.Core.Models;
+using Tests;
 
-namespace TestsUnit
+namespace Tests
 {
   [TestFixture]
   public class BaseTests
@@ -26,6 +28,63 @@ namespace TestsUnit
       // Trying to change a class member value will throw exceptions.
       //Assert.Throws<Exception>(() => { @base["speckle_type"] = "Testing"; });
       //Assert.Throws<Exception>(() => { @base["id"] = "Testing"; });
+    }
+
+    [Test]
+    public void CountDynamicChunkables()
+    {
+      int MAX_NUM = 3000;
+      var @base = new Base();
+      var customChunk = new List<double>();
+      var customChunkArr = new double[MAX_NUM];
+
+      for (int i = 0; i < MAX_NUM; i++)
+      {
+        customChunk.Add(i / 2);
+        customChunkArr[i] = i;
+      }
+
+      @base["@(1000)cc1"] = customChunk;
+      @base["@(1000)cc2"] = customChunkArr;
+
+      var num = @base.GetTotalChildrenCount();
+      Assert.AreEqual(MAX_NUM / 1000 * 2 + 1, num);
+    }
+
+    [Test]
+    public void CountTypedChunkables()
+    {
+      int MAX_NUM = 3000;
+      var @base = new SampleObject();
+      var customChunk = new List<double>();
+      var customChunkArr = new double[MAX_NUM];
+
+      for (int i = 0; i < MAX_NUM; i++)
+      {
+        customChunk.Add(i / 2);
+        customChunkArr[i] = i;
+      }
+
+      @base.list = customChunk;
+      @base.arr = customChunkArr;
+
+      var num = @base.GetTotalChildrenCount();
+      var actualNum = 1 + MAX_NUM / 300 + MAX_NUM / 1000;
+      Assert.AreEqual(actualNum, num);
+      var ttt = num;
+    }
+
+    public class SampleObject : Base
+    {
+      [Chunkable]
+      [DetachProperty]
+      public List<double> list { get; set; } = new List<double>();
+
+      [Chunkable(300)]
+      [DetachProperty]
+      public double[] arr { get; set; }
+
+      public SampleObject() { }
     }
   }
 }

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -71,7 +71,6 @@ namespace Tests
       var num = @base.GetTotalChildrenCount();
       var actualNum = 1 + MAX_NUM / 300 + MAX_NUM / 1000;
       Assert.AreEqual(actualNum, num);
-      var ttt = num;
     }
 
     public class SampleObject : Base

--- a/Core/Tests/Wrapper.cs
+++ b/Core/Tests/Wrapper.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+using Speckle.Core.Credentials;
+
+namespace Tests
+{
+  [TestFixture]
+  public class WrapperTests
+  {
+
+    [Test]
+    public void ParseStream()
+    {
+      var wrapper = new StreamWrapper("https://staging.speckle.dev/streams/a75ab4f10f");
+      Assert.AreEqual(StreamWrapperType.Stream, wrapper.Type);
+    }
+
+    [Test]
+    public void ParseBranch()
+    {
+      var wrapperCrazy = new StreamWrapper("https://staging.speckle.dev/streams/4c3ce1459c/branches/%F0%9F%8D%95%E2%AC%85%F0%9F%8C%9F%20you%20wat%3F");
+      Assert.AreEqual(wrapperCrazy.BranchName, "🍕⬅🌟 you wat?");
+      Assert.AreEqual(StreamWrapperType.Branch, wrapperCrazy.Type);
+
+      wrapperCrazy = new StreamWrapper("https://staging.speckle.dev/streams/4c3ce1459c/branches/next%20level");
+      Assert.AreEqual(wrapperCrazy.BranchName, "next level");
+      Assert.AreEqual(StreamWrapperType.Branch, wrapperCrazy.Type);
+    }
+
+    [Test]
+    public void ParseObject()
+    {
+      var wrapper = new StreamWrapper("https://staging.speckle.dev/streams/a75ab4f10f/objects/5530363e6d51c904903dafc3ea1d2ec6");
+      Assert.AreEqual(StreamWrapperType.Object, wrapper.Type);
+    }
+
+    [Test]
+    public void ParseCommit()
+    {
+      var wrapper = new StreamWrapper("https://staging.speckle.dev/streams/4c3ce1459c/commits/8b9b831792");
+      Assert.AreEqual(StreamWrapperType.Commit, wrapper.Type);
+    }
+
+  }
+}

--- a/Core/Tests/Wrapper.cs
+++ b/Core/Tests/Wrapper.cs
@@ -10,18 +10,18 @@ namespace Tests
     [Test]
     public void ParseStream()
     {
-      var wrapper = new StreamWrapper("https://staging.speckle.dev/streams/a75ab4f10f");
+      var wrapper = new StreamWrapper("https://testing.speckle.dev/streams/a75ab4f10f");
       Assert.AreEqual(StreamWrapperType.Stream, wrapper.Type);
     }
 
     [Test]
     public void ParseBranch()
     {
-      var wrapperCrazy = new StreamWrapper("https://staging.speckle.dev/streams/4c3ce1459c/branches/%F0%9F%8D%95%E2%AC%85%F0%9F%8C%9F%20you%20wat%3F");
+      var wrapperCrazy = new StreamWrapper("https://testing.speckle.dev/streams/4c3ce1459c/branches/%F0%9F%8D%95%E2%AC%85%F0%9F%8C%9F%20you%20wat%3F");
       Assert.AreEqual(wrapperCrazy.BranchName, "🍕⬅🌟 you wat?");
       Assert.AreEqual(StreamWrapperType.Branch, wrapperCrazy.Type);
 
-      wrapperCrazy = new StreamWrapper("https://staging.speckle.dev/streams/4c3ce1459c/branches/next%20level");
+      wrapperCrazy = new StreamWrapper("https://testing.speckle.dev/streams/4c3ce1459c/branches/next%20level");
       Assert.AreEqual(wrapperCrazy.BranchName, "next level");
       Assert.AreEqual(StreamWrapperType.Branch, wrapperCrazy.Type);
     }
@@ -29,14 +29,14 @@ namespace Tests
     [Test]
     public void ParseObject()
     {
-      var wrapper = new StreamWrapper("https://staging.speckle.dev/streams/a75ab4f10f/objects/5530363e6d51c904903dafc3ea1d2ec6");
+      var wrapper = new StreamWrapper("https://testing.speckle.dev/streams/a75ab4f10f/objects/5530363e6d51c904903dafc3ea1d2ec6");
       Assert.AreEqual(StreamWrapperType.Object, wrapper.Type);
     }
 
     [Test]
     public void ParseCommit()
     {
-      var wrapper = new StreamWrapper("https://staging.speckle.dev/streams/4c3ce1459c/commits/8b9b831792");
+      var wrapper = new StreamWrapper("https://testing.speckle.dev/streams/4c3ce1459c/commits/8b9b831792");
       Assert.AreEqual(StreamWrapperType.Commit, wrapper.Type);
     }
 

--- a/Core/Tests/Wrapper.cs
+++ b/Core/Tests/Wrapper.cs
@@ -1,11 +1,33 @@
 ﻿using NUnit.Framework;
 using Speckle.Core.Credentials;
+using TestsUnit;
 
 namespace Tests
 {
   [TestFixture]
   public class WrapperTests
   {
+    [SetUp]
+    public void Setup()
+    {
+
+      var acc = new Account
+      {
+        refreshToken = "foo",
+        token = "bar",
+        serverInfo = new ServerInfo
+        {
+          url = "https://testing.speckle.dev",
+          company = "qux"
+        },
+        userInfo = new UserInfo
+        {
+          email = "three@four.com"
+        }
+      };
+
+      Fixtures.UpdateOrSaveAccount(acc);
+    }
 
     [Test]
     public void ParseStream()

--- a/Core/Tests/Wrapper.cs
+++ b/Core/Tests/Wrapper.cs
@@ -7,28 +7,6 @@ namespace Tests
   [TestFixture]
   public class WrapperTests
   {
-    [SetUp]
-    public void Setup()
-    {
-
-      var acc = new Account
-      {
-        refreshToken = "foo",
-        token = "bar",
-        serverInfo = new ServerInfo
-        {
-          url = "https://testing.speckle.dev",
-          company = "qux"
-        },
-        userInfo = new UserInfo
-        {
-          email = "three@four.com"
-        }
-      };
-
-      Fixtures.UpdateOrSaveAccount(acc);
-    }
-
     [Test]
     public void ParseStream()
     {


### PR DESCRIPTION
Fixes: 
- stream wrappers around branch names (now are un-escaped)
- total children count now approximates chunk numbers too (should fix sender progress reports)
- minor bug in dynamo
- major bug in core serialisation
- bug in grasshopper receiver

Refactor:
- switches account handling to be based on user ids rather than account ids in gh & dynamo

Features: 
- adds wrapper case for an object url (eg, `https://staging.speckle.dev/streams/d631b3eecc/objects/4deba0f5e0e74b421cf8c130bc250fe2`)
- add possibility to receive a single object in gh from an object based wrapper
- add possibility to receive a single object in dynamo from an object based wrapper