### PR TITLE
fix(gh): Account details missing from csproj!

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Accounts\AccountDetails.cs" />
     <Compile Include="Accounts\Accounts.ListAccounts.cs" />
     <Compile Include="ComponentCategories.cs" />
     <Compile Include="Conversion\Convert.ToSpeckleAsync.cs" />


### PR DESCRIPTION
Account Details node was there all along, next merge in apparently replaced the line.

https://github.com/specklesystems/speckle-sharp/commit/2ba7f827f8940f72ba4c435f530e4dab3844497a#diff-dff20b243514d6c12f91b7010ce4c6891b6fb7135461b2aa9697847bfc6e2d9e


Fixes #122 