### PR TITLE
fix(autocad): failed conversion handling

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.IO;
 using System.Windows.Media.Imaging;
 using System.Linq;
+using Forms = System.Windows.Forms;
 
 using Speckle.ConnectorAutocadCivil.UI;
 
@@ -20,21 +21,28 @@ namespace Speckle.ConnectorAutocadCivil.Entry
     #region Initializing and termination
     public void Initialize()
     {
-      ribbon = ComponentManager.Ribbon;
-      if (ribbon != null) //the assembly was loaded using netload
+      try
       {
-        Create();
-      }
-      else
-      {
-        // load the custom ribbon on startup, but wait for ribbon control to be created
-        ComponentManager.ItemInitialized += new System.EventHandler<RibbonItemEventArgs>(ComponentManager_ItemInitialized);
-        Application.SystemVariableChanged += TrapWSCurrentChange;
-      }
+        ribbon = ComponentManager.Ribbon;
+        if (ribbon != null) //the assembly was loaded using netload
+        {
+          Create();
+        }
+        else
+        {
+          // load the custom ribbon on startup, but wait for ribbon control to be created
+          ComponentManager.ItemInitialized += new System.EventHandler<RibbonItemEventArgs>(ComponentManager_ItemInitialized);
+          Application.SystemVariableChanged += TrapWSCurrentChange;
+        }
 
-      // set up bindings and subscribe to doument events
-      SpeckleAutocadCommand.Bindings = new ConnectorBindingsAutocad();
-      SpeckleAutocadCommand.Bindings.SetExecutorAndInit();
+        // set up bindings and subscribe to doument events
+        SpeckleAutocadCommand.Bindings = new ConnectorBindingsAutocad();
+        SpeckleAutocadCommand.Bindings.SetExecutorAndInit();
+      }
+      catch(System.Exception e)
+      {
+        Forms.MessageBox.Show($"Add-in initialize context (true = application, false = doc): {Application.DocumentManager.IsApplicationContext.ToString()}. Error encountered: {e.ToString()}");
+      }
     }
 
     public void ComponentManager_ItemInitialized(object sender, RibbonItemEventArgs e)

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -61,7 +61,6 @@ namespace Objects.Converter.AutocadCivil
     public Circle CircleToSpeckle(AcadDB.Circle circle)
     {
       var _circle = new Circle(PlaneToSpeckle(circle.GetPlane()), circle.Radius, ModelUnits);
-      _circle.center = PointToSpeckle(circle.Center); // This is essential on send, otherwise recieve will throw null point exception! Fix this by adding req constructor arg?
       return _circle;
 
     }
@@ -69,14 +68,13 @@ namespace Objects.Converter.AutocadCivil
     {
       var normal = VectorToNative(circle.plane.normal);
       var radius = ScaleToNative((double)circle.radius, circle.units);
-      return new AcadDB.Circle(PointToNative(circle.center), normal, radius);
+      return new AcadDB.Circle(PointToNative(circle.plane.origin), normal, radius);
     }
 
     // Ellipses
     public Ellipse EllipseToSpeckle(AcadDB.Ellipse ellipse)
     {
       var _ellipse = new Ellipse(PlaneToSpeckle(ellipse.GetPlane()), ellipse.MajorRadius, ellipse.MinorRadius, ModelUnits);
-      _ellipse.center = PointToSpeckle(ellipse.Center); // This is essential on send, otherwise recieve will throw null point exception! Fix this by adding req constructor arg?
       _ellipse.domain = new Interval(0, 1);
       return _ellipse;
     }
@@ -85,7 +83,8 @@ namespace Objects.Converter.AutocadCivil
       var normal = VectorToNative(ellipse.plane.normal);
       var majorAxis = ScaleToNative((double)ellipse.firstRadius, ellipse.units) * VectorToNative(ellipse.plane.xdir);
       var radiusRatio =(double)ellipse.secondRadius / (double)ellipse.firstRadius;
-      return new AcadDB.Ellipse(PointToNative(ellipse.center), normal, majorAxis, radiusRatio, 0, 2 * Math.PI);
+      var _ellipse = new AcadDB.Ellipse(PointToNative(ellipse.plane.origin), normal, majorAxis, radiusRatio, 0, 2 * Math.PI);
+      return _ellipse;
     }
 
     // Rectangles

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -83,8 +83,7 @@ namespace Objects.Converter.AutocadCivil
       var normal = VectorToNative(ellipse.plane.normal);
       var majorAxis = ScaleToNative((double)ellipse.firstRadius, ellipse.units) * VectorToNative(ellipse.plane.xdir);
       var radiusRatio =(double)ellipse.secondRadius / (double)ellipse.firstRadius;
-      var _ellipse = new AcadDB.Ellipse(PointToNative(ellipse.plane.origin), normal, majorAxis, radiusRatio, 0, 2 * Math.PI);
-      return _ellipse;
+      return new AcadDB.Ellipse(PointToNative(ellipse.plane.origin), normal, majorAxis, radiusRatio, 0, 2 * Math.PI);
     }
 
     // Rectangles
@@ -100,6 +99,9 @@ namespace Objects.Converter.AutocadCivil
       List<Point3d> vertices = new List<Point3d>();
       for (int i = 0; i < polyline.NumberOfVertices; i++)
         vertices.Add(polyline.GetPoint3dAt(i));
+      if (polyline.Closed)
+        vertices.Add(polyline.GetPoint3dAt(0));
+
       return new Polyline(PointsToFlatArray(vertices), ModelUnits) { closed = polyline.Closed };
     }
     public Polyline3d PolylineToNativeDB(Polyline polyline) // Polyline3d does NOT support curves

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -169,10 +169,6 @@ namespace Objects.Converter.AutocadCivil
     /// </summary>
     /// <param name="obj">DB Object to be converted.</param>
     /// <returns></returns>
-    /// <remarks>
-    /// faster way but less readable method is to check object class name string: obj.ObjectId.ObjectClass.DxfName
-    /// https://spiderinnet1.typepad.com/blog/2012/04/various-ways-to-check-object-types-in-autocad-net.html
-    /// </remarks>
     public Base ObjectToSpeckle(DBObject obj)
     {
       switch (obj)

--- a/Objects/Objects/Geometry/Circle.cs
+++ b/Objects/Objects/Geometry/Circle.cs
@@ -14,7 +14,7 @@ namespace Objects.Geometry
 
     public Box bbox { get; set; }
 
-    public Point center { get; set; }
+    //public Point center { get; set; }
 
     public double area { get; set; }
 

--- a/Objects/Objects/Geometry/Ellipse.cs
+++ b/Objects/Objects/Geometry/Ellipse.cs
@@ -38,7 +38,7 @@ namespace Objects.Geometry
     public Box bbox { get; set; }
 
     /// <inheritdoc />
-    public Point center { get; set; }
+    //public Point center { get; set; }
 
     /// <inheritdoc />
     public double area { get; set; }


### PR DESCRIPTION
-converter using circle.plane.origin instead of circle.center
-deprecated objects circle.center and ellipse.center properties
-added try catch for failed conversions
-added try catch for add-in initialize()

closes #245 #246