### PR TITLE
GH/DYN: Handling incorrect account/stream in sender/receiver

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -397,9 +397,13 @@ namespace Speckle.ConnectorDynamo.SendNode
         _streams = transportsDict.Keys.ToList();
         _branchNames = transportsDict;
       }
-      catch
+      catch(Exception e)
       {
         //ignored
+        ResetNode(true);
+        Warning(e.InnerException?.Message ?? e.Message);
+        Message = "Not authorized";
+        return;
       }
 
       if (_streams == null || !_streams.Any())

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -458,7 +458,7 @@ namespace ConnectorGrasshopper.Ops
         }
         catch (Exception e)
         {
-          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error,e.InnerException?.Message ?? e.Message));
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,e.InnerException?.Message ?? e.Message));
           Done();
           return;
         }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -451,7 +451,17 @@ namespace ConnectorGrasshopper.Ops
           asyncParent.CancellationSources.ForEach(source => source.Cancel());
         };
 
-        var client = new Client(InputWrapper?.GetAccount().Result);
+        Client client = null;
+        try
+        {
+          client = new Client(InputWrapper?.GetAccount().Result);
+        }
+        catch (Exception e)
+        {
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error,e.InnerException?.Message ?? e.Message));
+          Done();
+          return;
+        }
         var remoteTransport = new ServerTransport(InputWrapper?.GetAccount().Result, InputWrapper?.StreamId);
         remoteTransport.TransportName = "R";
 
@@ -540,11 +550,8 @@ namespace ConnectorGrasshopper.Ops
       {
         // If we reach this, something happened that we weren't expecting...
         Log.CaptureException(e);
-        Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
-        Parent.Message = "Error";
-        receiveComponent.CurrentComponentState = "up_to_date";
-        receiveComponent.JustPastedIn = false;
-        RhinoApp.InvokeOnUiThread(new Action(()=> receiveComponent.OnDisplayExpired(true)));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message));
+        Done();
       }
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -433,7 +433,6 @@ namespace ConnectorGrasshopper.Ops
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"{transportName}: {exception.Message}"));
           var asyncParent = (GH_AsyncComponent)Parent;
           asyncParent.CancellationSources.ForEach(source => source.Cancel());
-          Done();
         };
 
         if (CancellationToken.IsCancellationRequested)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -396,8 +396,7 @@ namespace ConnectorGrasshopper.Ops
             }
             catch (Exception e)
             {
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.Message));
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.InnerException.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message));
               continue;
             }
 
@@ -416,7 +415,7 @@ namespace ConnectorGrasshopper.Ops
 
         if (Transports.Count == 0)
         {
-          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Could not identify any valid transports to send to."));
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, "Could not identify any valid transports to send to."));
           Done();
           return;
         }
@@ -434,6 +433,7 @@ namespace ConnectorGrasshopper.Ops
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"{transportName}: {exception.Message}"));
           var asyncParent = (GH_AsyncComponent)Parent;
           asyncParent.CancellationSources.ForEach(source => source.Cancel());
+          Done();
         };
 
         if (CancellationToken.IsCancellationRequested)
@@ -525,7 +525,6 @@ namespace ConnectorGrasshopper.Ops
 
           Done();
         }, CancellationToken);
-        task.Wait();
       }
       catch (Exception e)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -16,6 +16,7 @@ using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using GrasshopperAsyncComponent;
 using Rhino;
+using Sentry.PlatformAbstractions;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
@@ -370,7 +371,7 @@ namespace ConnectorGrasshopper.Ops
             catch (Exception e)
             {
               // TODO: Check this with team.
-              Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.Message);
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.Message));
             }
           }
 
@@ -378,13 +379,13 @@ namespace ConnectorGrasshopper.Ops
           {
             if (sw.Type == StreamWrapperType.Undefined)
             {
-              Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Input stream is invalid.");
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, "Input stream is invalid."));
               continue;
             }
 
             if (sw.Type == StreamWrapperType.Commit)
             {
-              Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Cannot push to a specific commit stream url.");
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, "Cannot push to a specific commit stream url."));
               continue;
             }
 
@@ -395,7 +396,8 @@ namespace ConnectorGrasshopper.Ops
             }
             catch (Exception e)
             {
-              Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.InnerException.Message));
               continue;
             }
 
@@ -518,7 +520,7 @@ namespace ConnectorGrasshopper.Ops
           if (CancellationToken.IsCancellationRequested)
           {
             ((SendComponent)Parent).CurrentComponentState = "expired";
-            return;
+            Done();
           }
 
           Done();
@@ -529,9 +531,10 @@ namespace ConnectorGrasshopper.Ops
       {
         // If we reach this, something happened that we weren't expecting...
         Log.CaptureException(e);
-        Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message));
         Parent.Message = "Error";
         ((SendComponent)Parent).CurrentComponentState = "expired";
+        Done();
       }
     }
 

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -167,7 +167,8 @@ namespace Speckle.Core.Credentials
     /// Gets a valid account for this stream wrapper. 
     /// <para>Note: this method ensures that the stream exists and/or that the user has an account which has access to that stream. If used in a sync manner, make sure it's not blocking.</para>
     /// </summary>
-    /// <returns></returns>
+    /// <exception cref="Exception">Throws exception if account fetching failed. This could be due to non-existent account or stream.</exception>
+    /// <returns>The valid account object for this stream.</returns>
     public async Task<Account> GetAccount()
     {
       Exception err = null;


### PR DESCRIPTION
From issue #226.

Grasshopper was not correctly displaying account/stream errors in sender and receiver. This should work now.

Also, after a conversation with @didimitrie, we decided to also add `branch` name validation to the `GetAccount` method in the StreamWrapper class. It was currently only checking for stream existence.

This change also required to update the way Dynamo's send/receive nodes handled the `GetAccount` exceptions, and some other minor tweaks.