### PR TITLE
fix(dynamo): sets copy local == false on Dynamo nugets

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
+++ b/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DynamoVisualProgramming.Core">
+      <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>runtime</ExcludeAssets>
       <Version>2.8.0.2471</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -73,7 +74,6 @@
     <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary" Version="2.8.0.2471">
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>runtime</ExcludeAssets>
-      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MaterialDesignColors">
       <Version>1.2.7</Version>

--- a/ConnectorDynamo/ConnectorDynamoExtension/ConnectorDynamoExtension.csproj
+++ b/ConnectorDynamo/ConnectorDynamoExtension/ConnectorDynamoExtension.csproj
@@ -77,6 +77,7 @@
     <PackageReference Include="DynamoVisualProgramming.WpfUILibrary">
       <Version>2.8.0.2471</Version>
       <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <PackageReference Include="DynamoVisualProgramming.Core">
       <Version>2.8.0.2471</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Dynamo bug fix: a `System.Windows.Interactivity` dll slipped into the bin folder, because one of the Dynamo nugets didn't have `copy local = false`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] Manual Tests in Dynamo Sandbox and Revit by sending receiving a simple stream

