### PR TITLE
Claire/invalid char fixes

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -403,7 +403,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
           var _layer = new AcadDb.LayerTableRecord();
 
           // Assign the layer properties
-          _layer.Color = Autodesk.AutoCAD.Colors.Color.FromColor(Color.Blue);
+          _layer.Color = Autodesk.AutoCAD.Colors.Color.FromColor(Color.White);
           _layer.Name = cleanName;
 
           // Append the new layer to the layer table and the transaction

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -170,7 +170,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
       var converter = kit.LoadConverter(Utils.AutocadAppName);
       var transport = new ServerTransport(state.Client.Account, state.Stream.id);
 
-      var myStream = await state.Client.StreamGet(state.Stream.id);
+      var stream = await state.Client.StreamGet(state.Stream.id);
 
       if (state.CancellationTokenSource.Token.IsCancellationRequested)
       {
@@ -221,9 +221,11 @@ namespace Speckle.ConnectorAutocadCivil.UI
             UpdateProgress(conversionProgressDict, state.Progress);
           };
 
-          // create a layer prefix hash: this is to prevent geometry from being imported into original layers
-          var layerPrefix = $"{myStream.name}[{state.Branch.name}@{id}]";
-          layerPrefix = Regex.Replace(layerPrefix, @"[^\u0000-\u007F]+", string.Empty); // emits emojis
+          // keep track of any layer name changes for notification here
+          bool changedLayerNames = false;
+
+          // create a commit layer prefix: all nested layers will be concatenated with this
+          var layerPrefix = DesktopUI.Utils.Formatting.CommitLayer(stream.name, state.Branch.name, id);
 
           // delete existing commit layers
           try
@@ -247,10 +249,9 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
             if (GetOrMakeLayer(layerName, tr, out string cleanName))
             {
-              // if the layer name has been modified, add an error
-              // this may need to be sent as 1 message at commit level if streaming large files with many layer name changes.
-              if (cleanName.Length<layerName.Length)
-                state.Errors.Add(new Exception($"layer {layerName} contained invalid characters: created {cleanName} instead."));
+              // record if layer name has been modified
+              if (!cleanName.Equals(layerName))
+                changedLayerNames = true;
 
               // convert obj and add to doc
               // try catch to prevent memory access violation crash in case a conversion goes wrong
@@ -273,6 +274,10 @@ namespace Speckle.ConnectorAutocadCivil.UI
               state.Errors.Add(new Exception($"could not create layer {layerName} to bake objects into."));
             }
           }
+
+          // raise any warnings from layer name modification
+          if (changedLayerNames)
+            state.Errors.Add(new Exception($"Layer names were modified: one or more layers contained invalid characters {Utils.invalidChars}"));
 
           tr.Commit();
         }

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -20,7 +20,7 @@ namespace Speckle.ConnectorAutocadCivil
     public static string AutocadAppName = Applications.Civil2021;
     public static string AppName = "Civil 3D";
 #endif
-    public static string invalidChars = @"[<>/\:;""?*|=‘]";
+    public static string invalidChars = @"<>/\:;""?*|=‘";
 
     #region extension methods
 
@@ -127,7 +127,7 @@ namespace Speckle.ConnectorAutocadCivil
       string cleanDelimiter = str.Replace("::", "$");
 
       // remove all other invalid chars
-      return Regex.Replace(cleanDelimiter, invalidChars, string.Empty);
+      return Regex.Replace(cleanDelimiter, $"[{invalidChars}]", string.Empty);
     }
 
     public static string RemoveInvalidDynamicPropChars(string str)

--- a/DesktopUI/DesktopUI/Utils/Helpers.cs
+++ b/DesktopUI/DesktopUI/Utils/Helpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -142,6 +143,13 @@ namespace Speckle.DesktopUI.Utils
     public static string PluralS(int num)
     {
       return num != 1 ? "s" : "";
+    }
+
+    public static string CommitLayer(string stream, string branch, string commitId)
+    {
+      string formatted = $"{stream}[ {branch} @ {commitId} ]";
+      string clean = Regex.Replace(formatted, @"[^\u0000-\u007F]+", string.Empty).Trim(); // remove emojis and trim :( 
+      return clean;
     }
   }
 


### PR DESCRIPTION
## Description

Fixed layer naming issues with invalid characters:
- Rhino now replaces invalid dynamic prop characters ./ with - in layer names on stream send and successfully sends objs
- standard commit layer name formatting added to DesktopUI and updated in AutoCAD and Rhino

**Fixes #253 #254**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

Tested manual send and receive between standard geometry test models for Rhino and AutoCAD