### PR TITLE
Claire/small rhino fixes

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoCommand.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoCommand.cs
@@ -15,16 +15,29 @@ namespace SpeckleRhino
     {
       Instance = this;
       RhinoDoc.EndOpenDocument += RhinoDoc_EndOpenDocument;
+      RhinoDoc.BeginSaveDocument += RhinoDoc_WriteDocument;
       // RhinoApp.Idle += RhinoApp_Idle;
     }
 
     private void RhinoDoc_EndOpenDocument(object sender, DocumentOpenEventArgs e)
     {
+      if (e.Merge) // this is a paste or import operation, skip binding
+      {
+        return;
+      }
       var bindings = new ConnectorBindingsRhino();
       if (bindings.GetStreamsInFile().Count > 0)
         SpeckleCommand.Instance.StartOrShowPanel();
     }
 
+    private void RhinoDoc_WriteDocument(object sender, DocumentSaveEventArgs e)
+    {
+      if (e.ExportSelected) // this is a copy or export operation, delete doc streams (otherwise will copy stream data into destination file)
+      {
+        e.Document.Strings.Delete("speckle");
+      }
+      return;
+    }
 
     public override PlugInLoadTime LoadTime => PlugInLoadTime.AtStartup;
   }

--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -26,6 +26,8 @@ namespace SpeckleRhino
 
     public Timer SelectionTimer;
 
+    private static string SpeckleKey = "speckle";
+
     /// <summary>
     /// TODO: Any errors thrown should be stored here and passed to the ui state (somehow).
     /// </summary>
@@ -85,28 +87,28 @@ namespace SpeckleRhino
 
     public override void AddNewStream(StreamState state)
     {
-      Doc.Strings.SetString("speckle", state.Stream.id, JsonConvert.SerializeObject(state));
+      Doc.Strings.SetString(SpeckleKey, state.Stream.id, JsonConvert.SerializeObject(state));
     }
 
     public override void RemoveStreamFromFile(string streamId)
     {
-      Doc.Strings.Delete("speckle", streamId);
+      Doc.Strings.Delete(SpeckleKey, streamId);
     }
 
     public override void PersistAndUpdateStreamInFile(StreamState state)
     {
-      Doc.Strings.SetString("speckle", state.Stream.id, JsonConvert.SerializeObject(state));
+      Doc.Strings.SetString(SpeckleKey, state.Stream.id, JsonConvert.SerializeObject(state));
     }
 
     public override List<StreamState> GetStreamsInFile()
     {
-      var strings = Doc?.Strings.GetEntryNames("speckle");
+      var strings = Doc?.Strings.GetEntryNames(SpeckleKey);
       if (strings == null)
       {
         return new List<StreamState>();
       }
 
-      var states = strings.Select(s => JsonConvert.DeserializeObject<StreamState>(Doc.Strings.GetValue("speckle", s))).ToList();
+      var states = strings.Select(s => JsonConvert.DeserializeObject<StreamState>(Doc.Strings.GetValue(SpeckleKey, s))).ToList();
 
       if (states != null)
       {


### PR DESCRIPTION
## Description

Rhino: fixed bug where copy pasting objects from a file with streams into a new file also adds streams to the new file and opens UI. Fix removes any added streams for paste and import operations, and no longer calls UI during merge events.

- Fixes #265

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manually tested:
- pasting objects from a file with streams into a new unsaved file with no streams
- pasting objects from a file with streams into the same file, with UI closed
- pasting objects from a file with streams into a new unsaved file with some of the same streams
- sending the rhino geometry standard test file

