### PR TITLE
🌋 Refactor exception handling and pass GraphQL Errors from Client Operations

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -1,20 +1,20 @@
-﻿using Dynamo.Engine;
-using Dynamo.Graph.Nodes;
-using ProtoCore.AST.AssociativeAST;
-using Speckle.Core.Api;
-using Speckle.Core.Api.SubscriptionModels;
-using Speckle.Core.Credentials;
-using System;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using Speckle.Core.Logging;
-using System.Collections.Concurrent;
-using Dynamo.Utilities;
-using Speckle.ConnectorDynamo.Functions;
 using System.Threading;
 using System.Threading.Tasks;
+using Dynamo.Engine;
+using Dynamo.Graph.Nodes;
+using Dynamo.Utilities;
 using Newtonsoft.Json;
+using ProtoCore.AST.AssociativeAST;
+using Speckle.ConnectorDynamo.Functions;
+using Speckle.Core.Api;
+using Speckle.Core.Api.SubscriptionModels;
+using Speckle.Core.Credentials;
+using Speckle.Core.Logging;
 
 namespace Speckle.ConnectorDynamo.ReceiveNode
 {
@@ -67,7 +67,6 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
     /// Current Stream
     /// </summary>
     public StreamWrapper Stream { get; set; }
-
 
     /// <summary>
     /// Latest Commit received
@@ -222,7 +221,6 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       PropertyChanged += HandlePropertyChanged;
     }
 
-
     private void AddInputs()
     {
       InPorts.Add(new PortModel(PortType.Input, this, new PortData("stream", "The stream to receive from")));
@@ -271,7 +269,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       try
       {
         if (Stream == null)
-          throw new SpeckleException("The stream provided is invalid", log: true);
+          throw new SpeckleException("The stream provided is invalid");
 
         void ProgressAction(ConcurrentDictionary<string, int> dict)
         {
@@ -316,7 +314,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
         {
           _cancellationToken.Cancel();
           Message = e.Message;
-          if (e.InnerException != null) Warning(e.InnerException.Message);
+          if (e.InnerException != null)Warning(e.InnerException.Message);
           if (e is AggregateException agrException)
             agrException.InnerExceptions.ToList().ForEach(ex =>
             {
@@ -336,7 +334,6 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
         }
       }
     }
-
 
     /// <summary>
     /// Triggered when the node inputs change
@@ -398,7 +395,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       Stream = newStream;
 
       //StreamWrapper points to a Stream
-      if (newStream.Type == StreamWrapperType.Commit || newStream.Type == StreamWrapperType.Object) 
+      if (newStream.Type == StreamWrapperType.Commit || newStream.Type == StreamWrapperType.Object)
       {
         Name = "Receive Commit";
         AutoUpdate = false;
@@ -445,13 +442,12 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       var astId = valuesNode.GetAstIdentifierForOutputIndex(valuesIndex).Name;
       var inputMirror = engine.GetMirror(astId);
 
-      if (inputMirror?.GetData() == null) return default(T);
+      if (inputMirror?.GetData() == null)return default(T);
 
       var data = inputMirror.GetData();
 
       return (T)data.Data;
     }
-
 
     private void CheckIfBehind()
     {
@@ -467,7 +463,6 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
           Message = "Empty Stream";
           return;
         }
-
 
         var lastCommit = mainBranch.commits.items[0];
 
@@ -548,9 +543,9 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
 
     private void OnCommitChange(object sender, CommitInfo e)
     {
-      if (e.branchName != (Stream.BranchName ?? "main")) return;
-      
-      Task.Run(async () => GetExpiredObjectCount(e.objectId));
+      if (e.branchName != (Stream.BranchName ?? "main"))return;
+
+      Task.Run(async() => GetExpiredObjectCount(e.objectId));
       if (AutoUpdate)
         OnNewDataAvail?.Invoke();
     }

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -321,7 +321,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
               Warning(ex.Message);
               Message = ex.Message.Contains("401") || ex.Message.Contains("don't have access") ? "Not authorized" : e.Message;
             });
-          Core.Logging.Log.CaptureAndThrow(e);
+          throw new SpeckleException(e.Message, e);
         }
       }
       finally

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -271,7 +271,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       try
       {
         if (Stream == null)
-          Core.Logging.Log.CaptureAndThrow(new Exception("The stream provided is invalid"));
+          throw new SpeckleException("The stream provided is invalid");
 
         void ProgressAction(ConcurrentDictionary<string, int> dict)
         {

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -271,7 +271,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       try
       {
         if (Stream == null)
-          throw new SpeckleException("The stream provided is invalid");
+          throw new SpeckleException("The stream provided is invalid", log: true);
 
         void ProgressAction(ConcurrentDictionary<string, int> dict)
         {

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -307,7 +307,7 @@ namespace Speckle.ConnectorDynamo.SendNode
         {
           _cancellationToken.Cancel();
           Message = e.Message;
-          Core.Logging.Log.CaptureAndThrow(e);
+          throw new SpeckleException(e.Message, e);
         }
       }
       finally

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -236,9 +236,9 @@ namespace Speckle.ConnectorDynamo.SendNode
       try
       {
         if (_streams == null)
-          Core.Logging.Log.CaptureAndThrow(new Exception("The stream provided is invalid"));
+          throw new SpeckleException("The stream provided is invalid");
         if (_data == null)
-          Core.Logging.Log.CaptureAndThrow(new Exception("The data provided is invalid"));
+          throw new SpeckleException("The data provided is invalid");
 
         long totalCount = 0;
         Base @base = null;
@@ -252,7 +252,7 @@ namespace Speckle.ConnectorDynamo.SendNode
         {
           Message = "Conversion error";
           Warning(e.Message);
-          Core.Logging.Log.CaptureAndThrow(new Exception("Conversion error", e));
+          throw new SpeckleException("Conversion error", e);
         }
 
         if ( totalCount == 0 )

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -236,9 +236,9 @@ namespace Speckle.ConnectorDynamo.SendNode
       try
       {
         if (_streams == null)
-          throw new SpeckleException("The stream provided is invalid");
+          throw new SpeckleException("The stream provided is invalid", log: true);
         if (_data == null)
-          throw new SpeckleException("The data provided is invalid");
+          throw new SpeckleException("The data provided is invalid", log: true);
 
         long totalCount = 0;
         Base @base = null;
@@ -252,11 +252,11 @@ namespace Speckle.ConnectorDynamo.SendNode
         {
           Message = "Conversion error";
           Warning(e.Message);
-          throw new SpeckleException("Conversion error", e);
+          throw new SpeckleException("Conversion error", e, log: true);
         }
 
         if ( totalCount == 0 )
-          throw new SpeckleException("Zero objects converted successfully. Send stopped.");
+          throw new SpeckleException("Zero objects converted successfully. Send stopped.", log: true);
 
         Message = "Sending...";
 

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -236,9 +236,9 @@ namespace Speckle.ConnectorDynamo.SendNode
       try
       {
         if (_streams == null)
-          throw new SpeckleException("The stream provided is invalid", log: true);
+          throw new SpeckleException("The stream provided is invalid");
         if (_data == null)
-          throw new SpeckleException("The data provided is invalid", log: true);
+          throw new SpeckleException("The data provided is invalid");
 
         long totalCount = 0;
         Base @base = null;
@@ -252,11 +252,11 @@ namespace Speckle.ConnectorDynamo.SendNode
         {
           Message = "Conversion error";
           Warning(e.Message);
-          throw new SpeckleException("Conversion error", e, log: true);
+          throw new SpeckleException("Conversion error", e);
         }
 
         if ( totalCount == 0 )
-          throw new SpeckleException("Zero objects converted successfully. Send stopped.", log: true);
+          throw new SpeckleException("Zero objects converted successfully. Send stopped.");
 
         Message = "Sending...";
 

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -19,7 +19,7 @@ namespace Speckle.ConnectorDynamo.Functions
       var kit = KitManager.GetDefaultKit();
 
       if (kit == null)
-        throw new SpeckleException("Cannot find the Objects Kit. Has it been copied to the Kits folder?", log: true);
+        throw new SpeckleException("Cannot find the Objects Kit. Has it been copied to the Kits folder?");
 
       if (Globals.RevitDocument != null)
         _converter = kit.LoadConverter(Applications.DynamoRevit);
@@ -27,7 +27,7 @@ namespace Speckle.ConnectorDynamo.Functions
         _converter = kit.LoadConverter(Applications.DynamoSandbox);
 
       if (_converter == null)
-        throw new SpeckleException("Cannot find the Dynamo converter. Has it been copied to the Kits folder?", log: true);
+        throw new SpeckleException("Cannot find the Dynamo converter. Has it been copied to the Kits folder?");
 
       // if in Revit, we have a doc, injected by the Extension
       if (Globals.RevitDocument != null)
@@ -45,7 +45,7 @@ namespace Speckle.ConnectorDynamo.Functions
     public Base ConvertRecursivelyToSpeckle(object @object)
     {
       if (@object is ProtoCore.DSASM.StackValue)
-        throw new SpeckleException("Invalid input", log: true);
+        throw new SpeckleException("Invalid input");
 
       var converted = RecurseTreeToSpeckle(@object);
       var @base = new Base();
@@ -124,7 +124,7 @@ namespace Speckle.ConnectorDynamo.Functions
       }
       catch (Exception ex)
       {
-        throw new SpeckleException("Could not convert item to Speckle", ex, log: true);
+        throw new SpeckleException("Could not convert item to Speckle", ex);
       }
 
       return result;

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -124,7 +124,7 @@ namespace Speckle.ConnectorDynamo.Functions
       }
       catch (Exception ex)
       {
-        throw new SpeckleException("Could not convert item to Speckle", ex);
+        throw new SpeckleException("Could not convert item to Speckle", ex, log: true);
       }
 
       return result;

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -19,7 +19,7 @@ namespace Speckle.ConnectorDynamo.Functions
       var kit = KitManager.GetDefaultKit();
 
       if (kit == null)
-        throw new Exception("Cannot find the Objects Kit. Has it been copied to the Kits folder?");
+        throw new SpeckleException("Cannot find the Objects Kit. Has it been copied to the Kits folder?", log: true);
 
       if (Globals.RevitDocument != null)
         _converter = kit.LoadConverter(Applications.DynamoRevit);
@@ -27,7 +27,7 @@ namespace Speckle.ConnectorDynamo.Functions
         _converter = kit.LoadConverter(Applications.DynamoSandbox);
 
       if (_converter == null)
-        throw new Exception("Cannot find the Dynamo converter. Has it been copied to the Kits folder?");
+        throw new SpeckleException("Cannot find the Dynamo converter. Has it been copied to the Kits folder?", log: true);
 
       // if in Revit, we have a doc, injected by the Extension
       if (Globals.RevitDocument != null)
@@ -45,7 +45,7 @@ namespace Speckle.ConnectorDynamo.Functions
     public Base ConvertRecursivelyToSpeckle(object @object)
     {
       if (@object is ProtoCore.DSASM.StackValue)
-        throw new Exception("Invalid input");
+        throw new SpeckleException("Invalid input", log: true);
 
       var converted = RecurseTreeToSpeckle(@object);
       var @base = new Base();

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -123,7 +123,7 @@ namespace Speckle.ConnectorDynamo.Functions
       }
       catch (Exception ex)
       {
-        Core.Logging.Log.CaptureAndThrow(ex);
+        throw new SpeckleException("Could not convert item to Speckle", ex);
       }
 
       return result;

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Speckle.Core.Logging;
 
 namespace Speckle.ConnectorDynamo.Functions
 {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -205,7 +205,7 @@ namespace Speckle.ConnectorDynamo.Functions
       }
       catch (Exception ex)
       {
-        Core.Logging.Log.CaptureAndThrow(ex);
+        throw new SpeckleException(ex.Message, ex);
       }
 
       return null;

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -122,7 +122,7 @@ namespace Speckle.ConnectorDynamo.Functions
         var branch = branches.FirstOrDefault(b => b.name == stream.BranchName);
         if (branch == null)
         {
-          Log.CaptureAndThrow(new Exception("No branch found with name " + stream.BranchName));
+          throw new SpeckleException("No branch found with name " + stream.BranchName);
         }
 
         if (!branch.commits.items.Any())

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -55,11 +55,11 @@ namespace Speckle.ConnectorDynamo.Functions
             new CommitCreateInput
             {
               streamId = serverTransport.StreamId,
-              branchName = branchName,
-              objectId = objectId,
-              message = message,
-              sourceApplication = (Globals.RevitDocument != null) ? Applications.DynamoRevit : Applications.DynamoSandbox,
-              parents = new List<string> { serverTransport.StreamId }
+                branchName = branchName,
+                objectId = objectId,
+                message = message,
+                sourceApplication = (Globals.RevitDocument != null) ? Applications.DynamoRevit : Applications.DynamoSandbox,
+                parents = new List<string> { serverTransport.StreamId }
             }).Result;
 
           responses.Add(res);
@@ -95,7 +95,7 @@ namespace Speckle.ConnectorDynamo.Functions
     /// </summary>
     /// <param name="stream">Stream to receive from</param>
     /// <returns></returns>
-    [MultiReturn(new[] { "data", "commit" })]
+    [MultiReturn(new [ ] { "data", "commit" })]
     public static Dictionary<string, object> Receive(StreamWrapper stream, CancellationToken cancellationToken,
       Action<ConcurrentDictionary<string, int>> onProgressAction = null, Action<string, Exception> onErrorAction = null,
       Action<int> onTotalChildrenCountKnown = null)
@@ -105,8 +105,8 @@ namespace Speckle.ConnectorDynamo.Functions
 
       var client = new Client(account);
       Commit commit = null;
-      
-      if(stream.Type == StreamWrapperType.Stream || stream.Type == StreamWrapperType.Branch)
+
+      if (stream.Type == StreamWrapperType.Stream || stream.Type == StreamWrapperType.Branch)
       {
         List<Branch> branches;
         try
@@ -122,17 +122,17 @@ namespace Speckle.ConnectorDynamo.Functions
         var branch = branches.FirstOrDefault(b => b.name == stream.BranchName);
         if (branch == null)
         {
-          throw new SpeckleException("No branch found with name " + stream.BranchName, log: true);
+          throw new SpeckleException("No branch found with name " + stream.BranchName);
         }
 
         if (!branch.commits.items.Any())
         {
-          throw new SpeckleException("No commits found.", log: true);
+          throw new SpeckleException("No commits found.");
         }
 
         commit = branch.commits.items[0];
-      } 
-      else if(stream.Type == StreamWrapperType.Commit)
+      }
+      else if (stream.Type == StreamWrapperType.Commit)
       {
         try
         {
@@ -143,16 +143,15 @@ namespace Speckle.ConnectorDynamo.Functions
           Utils.HandleApiExeption(ex);
           return null;
         }
-      } 
-      else if(stream.Type == StreamWrapperType.Object)
+      }
+      else if (stream.Type == StreamWrapperType.Object)
       {
         commit = new Commit() { referencedObject = stream.ObjectId, id = Guid.NewGuid().ToString() };
       }
-     
 
       if (commit == null)
       {
-        throw new SpeckleException("Could not get commit.", log: true);
+        throw new SpeckleException("Could not get commit.");
       }
 
       if (cancellationToken.IsCancellationRequested)
@@ -162,10 +161,10 @@ namespace Speckle.ConnectorDynamo.Functions
       var @base = Operations.Receive(
         commit.referencedObject,
         cancellationToken,
-        remoteTransport: transport,
-        onProgressAction: onProgressAction,
-        onErrorAction: onErrorAction,
-        onTotalChildrenCountKnown: onTotalChildrenCountKnown
+        remoteTransport : transport,
+        onProgressAction : onProgressAction,
+        onErrorAction : onErrorAction,
+        onTotalChildrenCountKnown : onTotalChildrenCountKnown
       ).Result;
 
       if (cancellationToken.IsCancellationRequested)
@@ -176,7 +175,6 @@ namespace Speckle.ConnectorDynamo.Functions
 
       return new Dictionary<string, object> { { "data", data }, { "commit", commit } };
     }
-
 
     public static object ReceiveData(string inMemoryDataId)
     {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -127,7 +127,7 @@ namespace Speckle.ConnectorDynamo.Functions
 
         if (!branch.commits.items.Any())
         {
-          throw new Exception("No commits found.");
+          throw new SpeckleException("No commits found.", log: true);
         }
 
         commit = branch.commits.items[0];
@@ -152,7 +152,7 @@ namespace Speckle.ConnectorDynamo.Functions
 
       if (commit == null)
       {
-        throw new Exception("Could not get commit.");
+        throw new SpeckleException("Could not get commit.", log: true);
       }
 
       if (cancellationToken.IsCancellationRequested)

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -122,7 +122,7 @@ namespace Speckle.ConnectorDynamo.Functions
         var branch = branches.FirstOrDefault(b => b.name == stream.BranchName);
         if (branch == null)
         {
-          throw new SpeckleException("No branch found with name " + stream.BranchName);
+          throw new SpeckleException("No branch found with name " + stream.BranchName, log: true);
         }
 
         if (!branch.commits.items.Any())

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
@@ -30,11 +30,11 @@ namespace Speckle.ConnectorDynamo.Functions
       var streams = Utils.InputToStream(stream);
       if (!streams.Any())
       {
-        Log.CaptureAndThrow(new Exception("Please provide one or more Stream Ids."));
+        throw new SpeckleException("Please provide one or more Stream Ids.");
       }
       else if (streams.Count > 20)
       {
-        Log.CaptureAndThrow(new Exception("Please provide less than 20 Stream Ids."));
+        throw new SpeckleException("Please provide less than 20 Stream Ids.");
       }
 
 
@@ -114,7 +114,7 @@ namespace Speckle.ConnectorDynamo.Functions
 
       if (wrapper == null)
       {
-        Core.Logging.Log.CaptureAndThrow(new Exception("Invalid stream."));
+        throw new SpeckleException("Invalid stream.");
       }
 
       if (name == null && description == null && isPublic == null)
@@ -167,13 +167,11 @@ namespace Speckle.ConnectorDynamo.Functions
       var streams = Utils.InputToStream(stream);
 
       if (!streams.Any())
-      {
-        Log.CaptureAndThrow(new Exception("Please provide one or more Streams."));
-      }
-      else if (streams.Count > 20)
-      {
-        Log.CaptureAndThrow(new Exception("Please provide less than 20 Streams."));
-      }
+        throw new SpeckleException("Please provide one or more Streams.");
+
+      if (streams.Count > 20)
+        throw new SpeckleException("Please provide less than 20 Streams.");
+
 
       var details = new List<Dictionary<string, object>>();
 

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
@@ -30,11 +30,11 @@ namespace Speckle.ConnectorDynamo.Functions
       var streams = Utils.InputToStream(stream);
       if (!streams.Any())
       {
-        throw new SpeckleException("Please provide one or more Stream Ids.");
+        throw new SpeckleException("Please provide one or more Stream Ids.", log: true);
       }
       else if (streams.Count > 20)
       {
-        throw new SpeckleException("Please provide less than 20 Stream Ids.");
+        throw new SpeckleException("Please provide less than 20 Stream Ids.", log: true);
       }
 
 
@@ -114,7 +114,7 @@ namespace Speckle.ConnectorDynamo.Functions
 
       if (wrapper == null)
       {
-        throw new SpeckleException("Invalid stream.");
+        throw new SpeckleException("Invalid stream.", log: true);
       }
 
       if (name == null && description == null && isPublic == null)
@@ -167,10 +167,10 @@ namespace Speckle.ConnectorDynamo.Functions
       var streams = Utils.InputToStream(stream);
 
       if (!streams.Any())
-        throw new SpeckleException("Please provide one or more Streams.");
+        throw new SpeckleException("Please provide one or more Streams.", log: true);
 
       if (streams.Count > 20)
-        throw new SpeckleException("Please provide less than 20 Streams.");
+        throw new SpeckleException("Please provide less than 20 Streams.", log: true);
 
 
       var details = new List<Dictionary<string, object>>();

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Stream.cs
@@ -30,13 +30,12 @@ namespace Speckle.ConnectorDynamo.Functions
       var streams = Utils.InputToStream(stream);
       if (!streams.Any())
       {
-        throw new SpeckleException("Please provide one or more Stream Ids.", log: true);
+        throw new SpeckleException("Please provide one or more Stream Ids.");
       }
       else if (streams.Count > 20)
       {
-        throw new SpeckleException("Please provide less than 20 Stream Ids.", log: true);
+        throw new SpeckleException("Please provide less than 20 Stream Ids.");
       }
-
 
       try
       {
@@ -50,7 +49,6 @@ namespace Speckle.ConnectorDynamo.Functions
           else
             accountToUse = s.GetAccount().Result;
 
-
           var client = new Client(accountToUse);
 
           //Exists?
@@ -62,7 +60,6 @@ namespace Speckle.ConnectorDynamo.Functions
       {
         Utils.HandleApiExeption(ex);
       }
-
 
       if (streams.Count() == 1)
         return streams[0];
@@ -88,9 +85,6 @@ namespace Speckle.ConnectorDynamo.Functions
 
     //}
 
-
-
-
     /// <summary>
     /// Update a Stream details, use is limited to 1 stream at a time
     /// </summary>
@@ -99,13 +93,11 @@ namespace Speckle.ConnectorDynamo.Functions
     /// <param name="description">Description of the Stream</param>
     /// <param name="isPublic">True if the stream is to be publicly available</param>
     /// <returns name="stream">Updated Stream object</returns>
-    public static StreamWrapper Update([DefaultArgument("null")] object stream,
-      [DefaultArgument("null")] string name,
-      [DefaultArgument("null")] string description, [DefaultArgument("null")] bool? isPublic)
+    public static StreamWrapper Update([DefaultArgument("null")] object stream, [DefaultArgument("null")] string name, [DefaultArgument("null")] string description, [DefaultArgument("null")] bool? isPublic)
     {
       Tracker.TrackPageview(Tracker.STREAM_UPDATE);
 
-      if(stream == null)
+      if (stream == null)
       {
         return null;
       }
@@ -114,7 +106,7 @@ namespace Speckle.ConnectorDynamo.Functions
 
       if (wrapper == null)
       {
-        throw new SpeckleException("Invalid stream.", log: true);
+        throw new SpeckleException("Invalid stream.");
       }
 
       if (name == null && description == null && isPublic == null)
@@ -147,7 +139,6 @@ namespace Speckle.ConnectorDynamo.Functions
         Utils.HandleApiExeption(ex);
       }
 
-
       return null;
     }
 
@@ -156,9 +147,16 @@ namespace Speckle.ConnectorDynamo.Functions
     /// </summary>
     /// <param name="stream">Stream object</param>
     [NodeCategory("Query")]
-    [MultiReturn(new[]
+    [MultiReturn(new [ ]
     {
-      "id", "name", "description", "createdAt", "updatedAt", "isPublic", "collaborators", "branches"
+      "id",
+      "name",
+      "description",
+      "createdAt",
+      "updatedAt",
+      "isPublic",
+      "collaborators",
+      "branches"
     })]
     public static object Details([ArbitraryDimensionArrayImport] object stream)
     {
@@ -167,11 +165,10 @@ namespace Speckle.ConnectorDynamo.Functions
       var streams = Utils.InputToStream(stream);
 
       if (!streams.Any())
-        throw new SpeckleException("Please provide one or more Streams.", log: true);
+        throw new SpeckleException("Please provide one or more Streams.");
 
       if (streams.Count > 20)
-        throw new SpeckleException("Please provide less than 20 Streams.", log: true);
-
+        throw new SpeckleException("Please provide less than 20 Streams.");
 
       var details = new List<Dictionary<string, object>>();
 
@@ -186,23 +183,21 @@ namespace Speckle.ConnectorDynamo.Functions
           Core.Api.Stream res = client.StreamGet(streamWrapper.StreamId).Result;
 
           details.Add(new Dictionary<string, object>
-        {
-          {"id", res.id},
-          {"name", res.name},
-          {"description", res.description},
-          {"createdAt", res.createdAt},
-          {"updatedAt", res.updatedAt},
-          {"isPublic", res.isPublic},
-          {"collaborators", res.collaborators},
-          {"branches", res.branches?.items}
-        });
+          { { "id", res.id },
+            { "name", res.name },
+            { "description", res.description },
+            { "createdAt", res.createdAt },
+            { "updatedAt", res.updatedAt },
+            { "isPublic", res.isPublic },
+            { "collaborators", res.collaborators },
+            { "branches", res.branches?.items }
+          });
         }
         catch (Exception ex)
         {
           Utils.HandleApiExeption(ex);
           return details;
         }
-
 
       }
 
@@ -219,8 +214,7 @@ namespace Speckle.ConnectorDynamo.Functions
     /// <param name="limit">Max number of streams to get</param>
     /// <returns name="streams">Your Streams</returns>
     [NodeCategory("Query")]
-    public static List<StreamWrapper> List([DefaultArgument("null")] Core.Credentials.Account account = null,
-      [DefaultArgument("10")] int limit = 10)
+    public static List<StreamWrapper> List([DefaultArgument("null")] Core.Credentials.Account account = null, [DefaultArgument("10")] int limit = 10)
     {
       Tracker.TrackPageview(Tracker.STREAM_LIST);
 
@@ -231,7 +225,6 @@ namespace Speckle.ConnectorDynamo.Functions
       {
         Utils.HandleApiExeption(new Exception("No accounts found. Please use the Speckle Manager to manage your accounts on this computer."));
       }
-
 
       var client = new Client(account);
       var streamWrappers = new List<StreamWrapper>();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectAsync.cs
@@ -122,11 +122,11 @@ namespace ConnectorGrasshopper.Objects
             }
             catch (Exception e)
             {
-              Log.CaptureAndThrow(e);
               Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.Message}");
               Parent.Message = "Error";
               RhinoApp.InvokeOnUiThread(new Action(()=> Parent.OnDisplayExpired(true)));
               hasErrors = true;
+              throw new SpeckleException(e.Message, e);
             }
           }
           else

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
@@ -20,11 +20,11 @@ namespace ConnectorGrasshopper.Objects
     public ISpeckleConverter Converter;
 
     public ISpeckleKit Kit;
-    
+
     public SelectKitAsyncComponentBase(string name, string nickname, string description, string category, string subCategory) : base(name, nickname, description, category, subCategory)
     {
       var key = "Speckle2:kit.default.name";
-      var n = Grasshopper.Instances.Settings.GetValue(key,"Objects");
+      var n = Grasshopper.Instances.Settings.GetValue(key, "Objects");
       Kit = KitManager.GetKitsWithConvertersForApp(Applications.Rhino).FirstOrDefault(kit => kit.Name == n);
       try
       {
@@ -55,7 +55,7 @@ namespace ConnectorGrasshopper.Objects
 
     public void SetConverterFromKit(string kitName)
     {
-      if (kitName == Kit.Name) return;
+      if (kitName == Kit.Name)return;
 
       Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
       Converter = Kit.LoadConverter(Applications.Rhino);
@@ -69,12 +69,12 @@ namespace ConnectorGrasshopper.Objects
 
     protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
-      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Warning);
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", level : SentryLevel.Warning);
     }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
-      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Warning);
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", level : SentryLevel.Warning);
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
@@ -8,7 +8,9 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using GrasshopperAsyncComponent;
+using Sentry.Protocol;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 
 namespace ConnectorGrasshopper.Objects
@@ -67,12 +69,12 @@ namespace ConnectorGrasshopper.Objects
 
     protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
-      throw new Exception("Please inherit from this class, don't use SelectKitComponentBase directly");
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Error);
     }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
-      throw new Exception("Please inherit from this class, don't use SelectKitComponentBase directly");
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Error);
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
@@ -69,12 +69,12 @@ namespace ConnectorGrasshopper.Objects
 
     protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
-      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Error);
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Warning);
     }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
-      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Error);
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true, level: SentryLevel.Warning);
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
@@ -69,19 +69,19 @@ namespace ConnectorGrasshopper.Objects
     protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
       throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
-        SentryLevel.Error);
+        SentryLevel.Warning);
     }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
       throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
-        SentryLevel.Error);
+        SentryLevel.Warning);
     }
 
     protected override void SolveInstance(IGH_DataAccess DA)
     {
       throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
-        SentryLevel.Error);
+        SentryLevel.Warning);
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
@@ -54,7 +54,7 @@ namespace ConnectorGrasshopper.Objects
 
     public void SetConverterFromKit(string kitName)
     {
-      if (kitName == Kit.Name) return;
+      if (kitName == Kit.Name)return;
 
       Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
       Converter = Kit.LoadConverter(Applications.Rhino);
@@ -68,20 +68,20 @@ namespace ConnectorGrasshopper.Objects
 
     protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
-      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
-        SentryLevel.Warning);
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly",
+        level: SentryLevel.Warning);
     }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
-      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
-        SentryLevel.Warning);
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly",
+        level: SentryLevel.Warning);
     }
 
     protected override void SolveInstance(IGH_DataAccess DA)
     {
-      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
-        SentryLevel.Warning);
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly",
+        level: SentryLevel.Warning);
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
@@ -7,7 +7,9 @@ using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
+using Sentry.Protocol;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 
 namespace ConnectorGrasshopper.Objects
@@ -21,7 +23,7 @@ namespace ConnectorGrasshopper.Objects
     public SelectKitComponentBase(string name, string nickname, string description, string category, string subCategory) : base(name, nickname, description, category, subCategory)
     {
       var key = "Speckle2:kit.default.name";
-      var n = Grasshopper.Instances.Settings.GetValue(key,"Objects");
+      var n = Grasshopper.Instances.Settings.GetValue(key, "Objects");
       Kit = KitManager.GetKitsWithConvertersForApp(Applications.Rhino).FirstOrDefault(kit => kit.Name == n);
       try
       {
@@ -66,18 +68,20 @@ namespace ConnectorGrasshopper.Objects
 
     protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
-      throw new Exception("Please inherit from this class, don't use SelectKitComponentBase directly");
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
+        SentryLevel.Error);
     }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
-      throw new Exception("Please inherit from this class, don't use SelectKitComponentBase directly");
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
+        SentryLevel.Error);
     }
 
     protected override void SolveInstance(IGH_DataAccess DA)
     {
-      throw new Exception("Please inherit from this class, don't use SelectKitComponentBase directly");
-
+      throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly", log: true,
+        SentryLevel.Error);
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -34,10 +34,9 @@ namespace ConnectorGrasshopper
 
     public string Seed;
 
-    public CreateSchemaObject()
-      : base("Create Schema Object", "CsO",
-          "Allows you to create a Speckle object from a schema class.",
-          ComponentCategories.PRIMARY_RIBBON, ComponentCategories.OBJECTS)
+    public CreateSchemaObject() : base("Create Schema Object", "CsO",
+      "Allows you to create a Speckle object from a schema class.",
+      ComponentCategories.PRIMARY_RIBBON, ComponentCategories.OBJECTS)
     {
       Kit = KitManager.GetDefaultKit();
       try
@@ -86,10 +85,10 @@ namespace ConnectorGrasshopper
       var dialog = new CreateSchemaObjectDialog();
       dialog.Owner = Grasshopper.Instances.EtoDocumentEditor;
       var mouse = GH_Canvas.MousePosition;
-      dialog.Location = new Eto.Drawing.Point((int) ((mouse.X - 150) / dialog.Screen.LogicalPixelSize),(int) ((mouse.Y - 150) / dialog.Screen.LogicalPixelSize) ); //approx the dialog half-size
-      
+      dialog.Location = new Eto.Drawing.Point((int)((mouse.X - 150) / dialog.Screen.LogicalPixelSize), (int)((mouse.Y - 150) / dialog.Screen.LogicalPixelSize)); //approx the dialog half-size
+
       dialog.ShowModal();
-    
+
       if (dialog.HasResult)
       {
         base.AddedToDocument(document);
@@ -226,19 +225,19 @@ namespace ConnectorGrasshopper
       return base.Write(writer);
     }
 
-    private static byte[] ObjectToByteArray(object obj)
+    private static byte[ ] ObjectToByteArray(object obj)
     {
       BinaryFormatter bf = new BinaryFormatter();
-      using (var ms = new MemoryStream())
+      using(var ms = new MemoryStream())
       {
         bf.Serialize(ms, obj);
         return ms.ToArray();
       }
     }
 
-    private static T ByteArrayToObject<T>(byte[] arrBytes)
+    private static T ByteArrayToObject<T>(byte[ ] arrBytes)
     {
-      using (var memStream = new MemoryStream())
+      using(var memStream = new MemoryStream())
       {
         var binForm = new BinaryFormatter();
         memStream.Write(arrBytes, 0, arrBytes.Length);
@@ -249,8 +248,7 @@ namespace ConnectorGrasshopper
     }
 
     protected override void RegisterInputParams(GH_InputParamManager pManager)
-    {
-    }
+    { }
 
     protected override void RegisterOutputParams(GH_OutputParamManager pManager)
     {
@@ -265,7 +263,6 @@ namespace ConnectorGrasshopper
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No schema has been selected.");
         return;
       }
-
 
       List<object> cParamsValues = new List<object>();
       var cParams = SelectedConstructor.GetParameters();
@@ -313,7 +310,7 @@ namespace ConnectorGrasshopper
     //list input
     private object GetObjectListProp(IGH_Param param, List<object> values, Type t)
     {
-      if (!values.Any()) return null;
+      if (!values.Any())return null;
 
       var list = (IList)Activator.CreateInstance(t);
       var listElementType = list.GetType().GetGenericArguments().Single();
@@ -376,19 +373,17 @@ namespace ConnectorGrasshopper
         // Log conversion error?
       }
 
-
-
       //tries an explicit casting, given that the required type is a variable, we need to use reflection
       //not really sure this method is needed
       try
       {
         MethodInfo castIntoMethod = this.GetType().GetMethod("CastObject").MakeGenericMethod(type);
-        return castIntoMethod.Invoke(null, new[] { value });
+        return castIntoMethod.Invoke(null, new [ ] { value });
       }
       catch { }
 
       AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Unable to set " + name + ".");
-      throw new SpeckleException($"Could not covert object to {type}", log: true);
+      throw new SpeckleException($"Could not covert object to {type}");
     }
 
     //keep public so it can be picked by reflection
@@ -422,8 +417,7 @@ namespace ConnectorGrasshopper
     }
 
     public void VariableParameterMaintenance()
-    {
-    }
+    { }
 
     protected override void BeforeSolveInstance()
     {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -388,7 +388,7 @@ namespace ConnectorGrasshopper
       catch { }
 
       AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Unable to set " + name + ".");
-      throw new Exception($"Could not covert object to {type}");
+      throw new SpeckleException($"Could not covert object to {type}", log: true);
     }
 
     //keep public so it can be picked by reflection

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -55,8 +55,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -112,8 +111,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -188,8 +186,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -257,8 +254,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -321,8 +317,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -363,8 +358,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -405,8 +399,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -448,8 +441,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -498,8 +490,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -545,8 +536,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -620,8 +610,7 @@ namespace Speckle.Core.Api
       }
       catch ( Exception e )
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -662,8 +651,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -732,8 +720,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -774,8 +761,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -816,8 +802,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
     #endregion
@@ -879,8 +864,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -940,8 +924,7 @@ namespace Speckle.Core.Api
       }
       catch ( Exception e )
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -982,8 +965,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -1024,8 +1006,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -1066,8 +1047,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -1121,8 +1101,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -1169,8 +1148,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        throw new SpeckleException(e.Message, e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -49,14 +49,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.user;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -107,14 +106,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserSearchData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.userSearch.items;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -184,14 +182,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not get stream", res.Errors, log: true);
+          throw new SpeckleException("Could not get stream", res.Errors);
 
         return res.Data.stream;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -254,14 +251,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null )
-          throw new SpeckleException("Could not get streams", res.Errors, log: true);
+          throw new SpeckleException("Could not get streams", res.Errors);
 
         return res.Data.user.streams.items;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -319,14 +315,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not search streams", res.Errors, log: true);
+          throw new SpeckleException("Could not search streams", res.Errors);
 
         return res.Data.streams.items;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -362,14 +357,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not create stream", res.Errors, log: true);
+          throw new SpeckleException("Could not create stream", res.Errors);
 
         return (string)res.Data["streamCreate"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -405,14 +399,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not update stream", res.Errors, log: true);
+          throw new SpeckleException("Could not update stream", res.Errors);
 
         return (bool)res.Data["streamUpdate"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -448,15 +441,14 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not delete stream", res.Errors, log: true);
+          throw new SpeckleException("Could not delete stream", res.Errors);
 
 
         return (bool)res.Data["streamDelete"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -500,14 +492,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not grant permission", res.Errors, log: true);
+          throw new SpeckleException("Could not grant permission", res.Errors);
 
         return (bool)res.Data["streamGrantPermission"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -548,14 +539,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not revoke permission", res.Errors, log: true);
+          throw new SpeckleException("Could not revoke permission", res.Errors);
 
         return (bool)res.Data["streamRevokePermission"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -624,7 +614,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null && res.Errors.Any() )
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.branches.items;
       }
@@ -666,14 +656,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not create branch", res.Errors, log: true);
+          throw new SpeckleException("Could not create branch", res.Errors);
 
         return (string)res.Data["branchCreate"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -737,14 +726,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.branch;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -780,14 +768,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not update branch", res.Errors, log: true);
+          throw new SpeckleException("Could not update branch", res.Errors);
 
         return (bool)res.Data["branchUpdate"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -823,14 +810,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new SpeckleException("Could not delete branch", res.Errors, log: true);
+          throw new SpeckleException("Could not delete branch", res.Errors);
 
         return (bool)res.Data["branchDelete"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -887,14 +873,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.commit;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -949,7 +934,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null && res.Errors.Any() )
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.commits.items;
       }
@@ -991,14 +976,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return (string)res.Data["commitCreate"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -1034,14 +1018,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return (bool)res.Data["commitUpdate"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -1077,14 +1060,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return (bool)res.Data["commitDelete"];
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -1133,14 +1115,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendQueryAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.@object;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }
@@ -1182,14 +1163,13 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendQueryAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.@object;
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureException(e);
         throw e;
       }
     }

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -49,7 +49,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.user;
       }
@@ -106,7 +106,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserSearchData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.userSearch.items;
       }
@@ -182,7 +182,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not get stream"), res.Errors);
+          throw new GraphQLException("Could not get stream", res.Errors);
 
         return res.Data.stream;
       }
@@ -250,8 +250,8 @@ namespace Speckle.Core.Api
 
         var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
-        if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not get streams"), res.Errors);
+        if ( res.Errors != null )
+          throw new GraphQLException("Could not get streams", res.Errors);
 
         return res.Data.user.streams.items;
       }
@@ -315,7 +315,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not search streams"), res.Errors);
+          throw new GraphQLException("Could not search streams", res.Errors);
 
         return res.Data.streams.items;
       }
@@ -357,7 +357,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not create stream"), res.Errors);
+          throw new GraphQLException("Could not create stream", res.Errors);
 
         return (string)res.Data["streamCreate"];
       }
@@ -399,7 +399,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not update stream"), res.Errors);
+          throw new GraphQLException("Could not update stream", res.Errors);
 
         return (bool)res.Data["streamUpdate"];
       }
@@ -441,7 +441,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not delete stream"), res.Errors);
+          throw new GraphQLException("Could not delete stream", res.Errors);
 
 
         return (bool)res.Data["streamDelete"];
@@ -492,7 +492,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not grant permission"), res.Errors);
+          throw new GraphQLException("Could not grant permission", res.Errors);
 
         return (bool)res.Data["streamGrantPermission"];
       }
@@ -539,7 +539,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not revoke permission"), res.Errors);
+          throw new GraphQLException("Could not revoke permission", res.Errors);
 
         return (bool)res.Data["streamRevokePermission"];
       }
@@ -614,7 +614,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null && res.Errors.Any() )
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[ 0 ].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.branches.items;
       }
@@ -656,7 +656,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not create branch"), res.Errors);
+          throw new GraphQLException("Could not create branch", res.Errors);
 
         return (string)res.Data["branchCreate"];
       }
@@ -726,7 +726,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.branch;
       }
@@ -768,7 +768,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not update branch"), res.Errors);
+          throw new GraphQLException("Could not update branch", res.Errors);
 
         return (bool)res.Data["branchUpdate"];
       }
@@ -810,7 +810,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          Log.CaptureAndThrow(new GraphQLException("Could not delete branch"), res.Errors);
+          throw new GraphQLException("Could not delete branch", res.Errors);
 
         return (bool)res.Data["branchDelete"];
       }
@@ -873,7 +873,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.commit;
       }
@@ -934,7 +934,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null && res.Errors.Any() )
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[ 0 ].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.commits.items;
       }
@@ -976,7 +976,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return (string)res.Data["commitCreate"];
       }
@@ -1018,7 +1018,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return (bool)res.Data["commitUpdate"];
       }
@@ -1060,7 +1060,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return (bool)res.Data["commitDelete"];
       }
@@ -1115,7 +1115,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendQueryAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.@object;
       }
@@ -1163,7 +1163,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendQueryAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          Log.CaptureAndThrow(new GraphQLException(res.Errors[0].Message), res.Errors);
+          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
 
         return res.Data.stream.@object;
       }

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -49,7 +49,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.user;
       }
@@ -106,7 +106,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserSearchData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.userSearch.items;
       }
@@ -182,7 +182,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not get stream", res.Errors);
+          throw new SpeckleException("Could not get stream", res.Errors, log: true);
 
         return res.Data.stream;
       }
@@ -251,7 +251,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<UserData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null )
-          throw new GraphQLException("Could not get streams", res.Errors);
+          throw new SpeckleException("Could not get streams", res.Errors, log: true);
 
         return res.Data.user.streams.items;
       }
@@ -315,7 +315,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not search streams", res.Errors);
+          throw new SpeckleException("Could not search streams", res.Errors, log: true);
 
         return res.Data.streams.items;
       }
@@ -357,7 +357,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not create stream", res.Errors);
+          throw new SpeckleException("Could not create stream", res.Errors, log: true);
 
         return (string)res.Data["streamCreate"];
       }
@@ -399,7 +399,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not update stream", res.Errors);
+          throw new SpeckleException("Could not update stream", res.Errors, log: true);
 
         return (bool)res.Data["streamUpdate"];
       }
@@ -441,7 +441,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not delete stream", res.Errors);
+          throw new SpeckleException("Could not delete stream", res.Errors, log: true);
 
 
         return (bool)res.Data["streamDelete"];
@@ -492,7 +492,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not grant permission", res.Errors);
+          throw new SpeckleException("Could not grant permission", res.Errors, log: true);
 
         return (bool)res.Data["streamGrantPermission"];
       }
@@ -539,7 +539,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not revoke permission", res.Errors);
+          throw new SpeckleException("Could not revoke permission", res.Errors, log: true);
 
         return (bool)res.Data["streamRevokePermission"];
       }
@@ -614,7 +614,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null && res.Errors.Any() )
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.stream.branches.items;
       }
@@ -656,7 +656,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not create branch", res.Errors);
+          throw new SpeckleException("Could not create branch", res.Errors, log: true);
 
         return (string)res.Data["branchCreate"];
       }
@@ -726,7 +726,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.stream.branch;
       }
@@ -768,7 +768,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not update branch", res.Errors);
+          throw new SpeckleException("Could not update branch", res.Errors, log: true);
 
         return (bool)res.Data["branchUpdate"];
       }
@@ -810,7 +810,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null)
-          throw new GraphQLException("Could not delete branch", res.Errors);
+          throw new SpeckleException("Could not delete branch", res.Errors, log: true);
 
         return (bool)res.Data["branchDelete"];
       }
@@ -873,7 +873,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.stream.commit;
       }
@@ -934,7 +934,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if ( res.Errors != null && res.Errors.Any() )
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.stream.commits.items;
       }
@@ -976,7 +976,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return (string)res.Data["commitCreate"];
       }
@@ -1018,7 +1018,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return (bool)res.Data["commitUpdate"];
       }
@@ -1060,7 +1060,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendMutationAsync<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return (bool)res.Data["commitDelete"];
       }
@@ -1115,7 +1115,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendQueryAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.stream.@object;
       }
@@ -1163,7 +1163,7 @@ namespace Speckle.Core.Api
         var res = await GQLClient.SendQueryAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
 
         if (res.Errors != null && res.Errors.Any())
-          throw new GraphQLException(res.Errors[ 0 ].Message, res.Errors);
+          throw new SpeckleException(res.Errors[ 0 ].Message, res.Errors, log: true);
 
         return res.Data.stream.@object;
       }

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -55,7 +55,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -112,7 +113,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -188,7 +190,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -257,7 +260,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -321,7 +325,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -363,7 +368,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -405,7 +411,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -448,7 +455,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -498,7 +506,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -545,7 +554,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -662,7 +672,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -732,7 +743,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -774,7 +786,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -816,7 +829,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -879,7 +893,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -982,7 +997,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -1024,7 +1040,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -1066,7 +1083,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -1121,7 +1139,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }
@@ -1169,7 +1188,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
         throw e;
       }
     }

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         BranchCreatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to branchCreated"), response.Errors);
+            throw new GraphQLException("Could not subscribe to branchCreated", response.Errors);
 
           if (response.Data != null)
             OnBranchCreated(this, response.Data.branchCreated);
@@ -78,7 +78,7 @@ namespace Speckle.Core.Api
         BranchUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to branchUpdated"), response.Errors);
+            throw new GraphQLException("Could not subscribe to branchUpdated", response.Errors);
 
           if (response.Data != null)
             OnBranchUpdated(this, response.Data.branchUpdated);
@@ -123,7 +123,7 @@ namespace Speckle.Core.Api
         BranchDeletedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to branchDeleted"), response.Errors);
+            throw new GraphQLException("Could not subscribe to branchDeleted", response.Errors);
 
           if (response.Data != null)
             OnBranchDeleted(this, response.Data.branchDeleted);

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
@@ -42,7 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -86,7 +86,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -130,7 +130,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
@@ -42,7 +42,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
       }
     }
 
@@ -86,7 +87,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureAndThrow(e);
       }
     }
 
@@ -130,7 +132,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureException(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         BranchCreatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to branchCreated", response.Errors);
+            throw new SpeckleException("Could not subscribe to branchCreated", response.Errors, log: true);
 
           if (response.Data != null)
             OnBranchCreated(this, response.Data.branchCreated);
@@ -77,7 +77,7 @@ namespace Speckle.Core.Api
         BranchUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to branchUpdated", response.Errors);
+            throw new SpeckleException("Could not subscribe to branchUpdated", response.Errors, log: true);
 
           if (response.Data != null)
             OnBranchUpdated(this, response.Data.branchUpdated);
@@ -121,7 +121,7 @@ namespace Speckle.Core.Api
         BranchDeletedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to branchDeleted", response.Errors);
+            throw new SpeckleException("Could not subscribe to branchDeleted", response.Errors, log: true);
 
           if (response.Data != null)
             OnBranchDeleted(this, response.Data.branchDeleted);

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         BranchCreatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to branchCreated", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to branchCreated", response.Errors);
 
           if (response.Data != null)
             OnBranchCreated(this, response.Data.branchCreated);
@@ -42,8 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -78,7 +77,7 @@ namespace Speckle.Core.Api
         BranchUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to branchUpdated", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to branchUpdated", response.Errors);
 
           if (response.Data != null)
             OnBranchUpdated(this, response.Data.branchUpdated);
@@ -87,8 +86,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureAndThrow(e);
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -123,7 +121,7 @@ namespace Speckle.Core.Api
         BranchDeletedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to branchDeleted", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to branchDeleted", response.Errors);
 
           if (response.Data != null)
             OnBranchDeleted(this, response.Data.branchDeleted);
@@ -132,8 +130,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureException(e);
+        Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
@@ -42,8 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -87,8 +86,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -132,8 +130,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         CommitCreatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to commitCreated"), response.Errors);
+            throw new GraphQLException("Could not subscribe to commitCreated", response.Errors);
 
           if (response.Data != null)
             OnCommitCreated?.Invoke(this, response.Data.commitCreated);
@@ -78,7 +78,7 @@ namespace Speckle.Core.Api
         CommitUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to commitUpdated"), response.Errors);
+            throw new GraphQLException("Could not subscribe to commitUpdated", response.Errors);
 
           if (response.Data != null)
             OnCommitUpdated(this, response.Data.commitUpdated);
@@ -123,7 +123,7 @@ namespace Speckle.Core.Api
         CommitDeletedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to commitDeleted"), response.Errors);
+            throw new GraphQLException("Could not subscribe to commitDeleted", response.Errors);
 
           if (response.Data != null)
             OnCommitDeleted(this, response.Data.commitDeleted);

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -42,7 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -86,7 +86,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -130,7 +130,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -42,7 +42,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureAndThrow(e);
       }
     }
 
@@ -86,7 +87,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureAndThrow(e);
       }
     }
 
@@ -130,7 +132,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         CommitCreatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to commitCreated", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to commitCreated", response.Errors);
 
           if (response.Data != null)
             OnCommitCreated?.Invoke(this, response.Data.commitCreated);
@@ -42,8 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureAndThrow(e);
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -78,7 +77,7 @@ namespace Speckle.Core.Api
         CommitUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to commitUpdated", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to commitUpdated", response.Errors);
 
           if (response.Data != null)
             OnCommitUpdated(this, response.Data.commitUpdated);
@@ -87,8 +86,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureAndThrow(e);
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -123,7 +121,7 @@ namespace Speckle.Core.Api
         CommitDeletedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to commitDeleted", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to commitDeleted", response.Errors);
 
           if (response.Data != null)
             OnCommitDeleted(this, response.Data.commitDeleted);
@@ -132,8 +130,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureAndThrow(e);
+        Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -42,8 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -87,8 +86,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -132,8 +130,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         CommitCreatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to commitCreated", response.Errors);
+            throw new SpeckleException("Could not subscribe to commitCreated", response.Errors, log: true);
 
           if (response.Data != null)
             OnCommitCreated?.Invoke(this, response.Data.commitCreated);
@@ -77,7 +77,7 @@ namespace Speckle.Core.Api
         CommitUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to commitUpdated", response.Errors);
+            throw new SpeckleException("Could not subscribe to commitUpdated", response.Errors, log: true);
 
           if (response.Data != null)
             OnCommitUpdated(this, response.Data.commitUpdated);
@@ -121,7 +121,7 @@ namespace Speckle.Core.Api
         CommitDeletedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to commitDeleted", response.Errors);
+            throw new SpeckleException("Could not subscribe to commitDeleted", response.Errors, log: true);
 
           if (response.Data != null)
             OnCommitDeleted(this, response.Data.commitDeleted);

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
@@ -42,7 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -84,7 +84,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 
@@ -126,7 +126,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        throw new SpeckleException(e.Message, e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
@@ -42,8 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -85,8 +84,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -128,8 +126,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureException(e);
-        throw e;
+        Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
@@ -42,7 +42,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureAndThrow(e);
       }
     }
 
@@ -84,7 +85,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureAndThrow(e);
       }
     }
 
@@ -126,7 +128,8 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        Log.CaptureAndThrow(e);
+        if (!(e is SpeckleException))
+          Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         UserStreamAddedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to userStreamAdded"), response.Errors);
+            throw new GraphQLException("Could not subscribe to userStreamAdded", response.Errors);
 
           if (response.Data != null)
             OnUserStreamAdded(this, response.Data.userStreamAdded);
@@ -77,7 +77,7 @@ namespace Speckle.Core.Api
         StreamUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to streamUpdated"), response.Errors);
+            throw new GraphQLException("Could not subscribe to streamUpdated", response.Errors);
 
           if (response.Data != null)
             OnStreamUpdated(this, response.Data.streamUpdated);
@@ -120,7 +120,7 @@ namespace Speckle.Core.Api
         UserStreamRemovedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            Log.CaptureAndThrow(new GraphQLException("Could not subscribe to userStreamRemoved"), response.Errors);
+            throw new GraphQLException("Could not subscribe to userStreamRemoved", response.Errors);
 
           if (response.Data != null)
             OnUserStreamRemoved(this, response.Data.userStreamRemoved);

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         UserStreamAddedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to userStreamAdded", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to userStreamAdded", response.Errors);
 
           if (response.Data != null)
             OnUserStreamAdded(this, response.Data.userStreamAdded);
@@ -42,8 +42,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureAndThrow(e);
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -77,7 +76,7 @@ namespace Speckle.Core.Api
         StreamUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to streamUpdated", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to streamUpdated", response.Errors);
 
           if (response.Data != null)
             OnStreamUpdated(this, response.Data.streamUpdated);
@@ -85,8 +84,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureAndThrow(e);
+        Log.CaptureAndThrow(e);
       }
     }
 
@@ -120,7 +118,7 @@ namespace Speckle.Core.Api
         UserStreamRemovedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new SpeckleException("Could not subscribe to userStreamRemoved", response.Errors, log: true);
+            throw new SpeckleException("Could not subscribe to userStreamRemoved", response.Errors);
 
           if (response.Data != null)
             OnUserStreamRemoved(this, response.Data.userStreamRemoved);
@@ -128,8 +126,7 @@ namespace Speckle.Core.Api
       }
       catch (Exception e)
       {
-        if (!(e is SpeckleException))
-          Log.CaptureAndThrow(e);
+        Log.CaptureAndThrow(e);
       }
     }
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Api
         UserStreamAddedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to userStreamAdded", response.Errors);
+            throw new SpeckleException("Could not subscribe to userStreamAdded", response.Errors, log: true);
 
           if (response.Data != null)
             OnUserStreamAdded(this, response.Data.userStreamAdded);
@@ -76,7 +76,7 @@ namespace Speckle.Core.Api
         StreamUpdatedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to streamUpdated", response.Errors);
+            throw new SpeckleException("Could not subscribe to streamUpdated", response.Errors, log: true);
 
           if (response.Data != null)
             OnStreamUpdated(this, response.Data.streamUpdated);
@@ -118,7 +118,7 @@ namespace Speckle.Core.Api
         UserStreamRemovedSubscription = res.Subscribe(response =>
         {
           if (response.Errors != null)
-            throw new GraphQLException("Could not subscribe to userStreamRemoved", response.Errors);
+            throw new SpeckleException("Could not subscribe to userStreamRemoved", response.Errors, log: true);
 
           if (response.Data != null)
             OnUserStreamRemoved(this, response.Data.userStreamRemoved);

--- a/Core/Core/Api/GraphQL/Client.cs
+++ b/Core/Core/Api/GraphQL/Client.cs
@@ -36,7 +36,7 @@ namespace Speckle.Core.Api
     public Client(Account account)
     {
       if (account == null)
-        throw new SpeckleException($"Provided account is null.");
+        throw new SpeckleException($"Provided account is null.", log: true);
 
       Account = account;
       AccountId = account.id;

--- a/Core/Core/Api/GraphQL/Client.cs
+++ b/Core/Core/Api/GraphQL/Client.cs
@@ -36,7 +36,7 @@ namespace Speckle.Core.Api
     public Client(Account account)
     {
       if (account == null)
-        Log.CaptureAndThrow(new SpeckleException($"Provided account is null."));
+        throw new SpeckleException($"Provided account is null.");
 
       Account = account;
       AccountId = account.id;

--- a/Core/Core/Api/GraphQL/Client.cs
+++ b/Core/Core/Api/GraphQL/Client.cs
@@ -1,13 +1,13 @@
-﻿using Speckle.Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Specialized;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Threading.Tasks;
 using GraphQL.Client.Http;
+using Speckle.Core.Api.GraphQL.Serializer;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
-using Speckle.Core.Api.GraphQL.Serializer;
+using Speckle.Newtonsoft.Json;
 
 namespace Speckle.Core.Api
 {
@@ -36,7 +36,7 @@ namespace Speckle.Core.Api
     public Client(Account account)
     {
       if (account == null)
-        throw new SpeckleException($"Provided account is null.", log: true);
+        throw new SpeckleException($"Provided account is null.");
 
       Account = account;
       AccountId = account.id;
@@ -56,9 +56,9 @@ namespace Speckle.Core.Api
         new GraphQLHttpClientOptions
         {
           EndPoint = new Uri(new Uri(account.serverInfo.url), "/graphql"),
-          UseWebSocketForQueriesAndMutations = false,
-          ConfigureWebSocketConnectionInitPayload = (opts) => { return new { Authorization = $"Bearer {account.token}" }; },
-          OnWebsocketConnected = OnWebSocketConnect,
+            UseWebSocketForQueriesAndMutations = false,
+            ConfigureWebSocketConnectionInitPayload = (opts) => { return new { Authorization = $"Bearer {account.token}" }; },
+            OnWebsocketConnected = OnWebSocketConnect,
         },
         new NewtonsoftJsonSerializer(),
         HttpClient);

--- a/Core/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Core/Api/Operations/Operations.Receive.cs
@@ -82,7 +82,7 @@ namespace Speckle.Core.Api
       }
       else if (remoteTransport == null)
       {
-        throw new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it.");
+        throw new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it.", log: true, level: SentryLevel.Error);
       }
 
       // If we've reached this stage, it means that we didn't get a local transport hit on our object, so we will proceed to get it from the provided remote transport. 

--- a/Core/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Core/Api/Operations/Operations.Receive.cs
@@ -1,13 +1,13 @@
-﻿using Speckle.Newtonsoft.Json;
-using System;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Sentry.Protocol;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
-using System.Collections.Concurrent;
-using Speckle.Core.Logging;
-using Sentry.Protocol;
-using System.Threading;
-using System.Collections.Generic;
+using Speckle.Newtonsoft.Json;
 
 namespace Speckle.Core.Api
 {
@@ -34,7 +34,7 @@ namespace Speckle.Core.Api
         onProgressAction,
         onErrorAction,
         onTotalChildrenCountKnown
-        );
+      );
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ namespace Speckle.Core.Api
     {
       Log.AddBreadcrumb("Receive");
 
-      var (serializer, settings) = GetSerializerInstance();
+      var(serializer, settings) = GetSerializerInstance();
 
       var localProgressDict = new ConcurrentDictionary<string, int>();
       var internalProgressAction = GetInternalProgressAction(localProgressDict, onProgressAction);
@@ -82,7 +82,7 @@ namespace Speckle.Core.Api
       }
       else if (remoteTransport == null)
       {
-        throw new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it.", log: true, level: SentryLevel.Error);
+        throw new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it.", level : SentryLevel.Error);
       }
 
       // If we've reached this stage, it means that we didn't get a local transport hit on our object, so we will proceed to get it from the provided remote transport. 

--- a/Core/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Core/Api/Operations/Operations.Receive.cs
@@ -82,7 +82,7 @@ namespace Speckle.Core.Api
       }
       else if (remoteTransport == null)
       {
-        Log.CaptureAndThrow(new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it."), SentryLevel.Error);
+        throw new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it.");
       }
 
       // If we've reached this stage, it means that we didn't get a local transport hit on our object, so we will proceed to get it from the provided remote transport. 

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -60,7 +60,7 @@ namespace Speckle.Core.Api
 
       if (transports.Count == 0 && useDefaultCache == false)
       {
-        throw new SpeckleException($"You need to provide at least one transport: cannot send with an empty transport list and no default cache.");
+        throw new SpeckleException($"You need to provide at least one transport: cannot send with an empty transport list and no default cache.", log: true, level: SentryLevel.Error);
       }
 
       if (useDefaultCache)

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -1,6 +1,4 @@
-﻿using Speckle.Newtonsoft.Json;
-using Speckle.Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +9,8 @@ using Sentry.Protocol;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
+using Speckle.Newtonsoft.Json;
+using Speckle.Newtonsoft.Json.Linq;
 
 namespace Speckle.Core.Api
 {
@@ -36,7 +36,7 @@ namespace Speckle.Core.Api
         useDefaultCache,
         onProgressAction,
         onErrorAction
-        );
+      );
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ namespace Speckle.Core.Api
 
       if (transports.Count == 0 && useDefaultCache == false)
       {
-        throw new SpeckleException($"You need to provide at least one transport: cannot send with an empty transport list and no default cache.", log: true, level: SentryLevel.Error);
+        throw new SpeckleException($"You need to provide at least one transport: cannot send with an empty transport list and no default cache.", level : SentryLevel.Error);
       }
 
       if (useDefaultCache)
@@ -68,7 +68,7 @@ namespace Speckle.Core.Api
         transports.Insert(0, new SQLiteTransport() { TransportName = "LC" });
       }
 
-      var (serializer, settings) = GetSerializerInstance();
+      var(serializer, settings) = GetSerializerInstance();
 
       var localProgressDict = new ConcurrentDictionary<string, int>();
       var internalProgressAction = Operations.GetInternalProgressAction(localProgressDict, onProgressAction);
@@ -91,7 +91,7 @@ namespace Speckle.Core.Api
 
       var transportAwaits = serializer.WriteTransports.Select(t => t.WriteComplete()).ToList();
 
-      if (cancellationToken.IsCancellationRequested) return null;
+      if (cancellationToken.IsCancellationRequested)return null;
 
       await Task.WhenAll(transportAwaits).ConfigureAwait(false);
 
@@ -100,7 +100,7 @@ namespace Speckle.Core.Api
         t.EndWrite();
       }
 
-      if (cancellationToken.IsCancellationRequested) return null;
+      if (cancellationToken.IsCancellationRequested)return null;
 
       var hash = JObject.Parse(obj).GetValue("id").ToString();
       return hash;

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -60,7 +60,7 @@ namespace Speckle.Core.Api
 
       if (transports.Count == 0 && useDefaultCache == false)
       {
-        Log.CaptureAndThrow(new SpeckleException($"You need to provide at least one transport: cannot send with an empty transport list and no default cache."), SentryLevel.Error);
+        throw new SpeckleException($"You need to provide at least one transport: cannot send with an empty transport list and no default cache.");
       }
 
       if (useDefaultCache)

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -18,7 +18,7 @@ namespace Speckle.Core.Credentials
       get
       {
         if (serverInfo == null || userInfo == null)
-          throw new SpeckleException("Incomplete account info: cannot generate id.");
+          throw new SpeckleException("Incomplete account info: cannot generate id.", log: true);
         return Speckle.Core.Models.Utilities.hashString(serverInfo.url + userInfo.email);
       }
     }

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Threading.Tasks;
-using GraphQL.Client.Http;
-using GraphQL;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Speckle.Core.Logging;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Client.Http;
 using Speckle.Core.Api.GraphQL.Serializer;
+using Speckle.Core.Logging;
 
 namespace Speckle.Core.Credentials
 {
@@ -18,7 +18,7 @@ namespace Speckle.Core.Credentials
       get
       {
         if (serverInfo == null || userInfo == null)
-          throw new SpeckleException("Incomplete account info: cannot generate id.", log: true, Sentry.Protocol.SentryLevel.Error);
+          throw new SpeckleException("Incomplete account info: cannot generate id.", level: Sentry.Protocol.SentryLevel.Error);
         return Speckle.Core.Models.Utilities.hashString(serverInfo.url + userInfo.email);
       }
     }

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -18,7 +18,7 @@ namespace Speckle.Core.Credentials
       get
       {
         if (serverInfo == null || userInfo == null)
-          Log.CaptureAndThrow(new SpeckleException("Incomplete account info: cannot generate id."));
+          throw new SpeckleException("Incomplete account info: cannot generate id.");
         return Speckle.Core.Models.Utilities.hashString(serverInfo.url + userInfo.email);
       }
     }

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -18,7 +18,7 @@ namespace Speckle.Core.Credentials
       get
       {
         if (serverInfo == null || userInfo == null)
-          throw new SpeckleException("Incomplete account info: cannot generate id.", log: true);
+          throw new SpeckleException("Incomplete account info: cannot generate id.", log: true, Sentry.Protocol.SentryLevel.Error);
         return Speckle.Core.Models.Utilities.hashString(serverInfo.url + userInfo.email);
       }
     }

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Speckle.Core.Api;
+using Speckle.Core.Logging;
 
 namespace Speckle.Core.Credentials
 {
@@ -104,8 +105,8 @@ namespace Speckle.Core.Credentials
 
       if (account == null)
       {
-        throw new Exception(
-          $"You do not have any account. Please create one or add it to the Speckle Manager.");
+        throw new SpeckleException(
+          $"You do not have any account. Please create one or add it to the Speckle Manager.", log: true);
       }
 
       ServerUrl = account.serverInfo.url;
@@ -120,7 +121,7 @@ namespace Speckle.Core.Credentials
 
       if (uri.Segments.Length < 3)
       {
-        throw new Exception($"Cannot parse {uri} into a stream wrapper class.");
+        throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.", log: true);
       }
 
       switch (uri.Segments.Length)
@@ -132,7 +133,7 @@ namespace Speckle.Core.Credentials
           }
           else
           {
-            throw new Exception($"Cannot parse {uri} into a stream wrapper class.");
+            throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.", log: true);
           }
 
           break;
@@ -154,7 +155,7 @@ namespace Speckle.Core.Credentials
           }
           else
           {
-            throw new Exception($"Cannot parse {uri} into a stream wrapper class.");
+            throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.", log: true);
           }
 
           break;
@@ -216,7 +217,7 @@ namespace Speckle.Core.Credentials
       var accs = AccountManager.GetAccounts(ServerUrl);
       if (accs.Count() == 0)
       {
-        throw new Exception($"You don't have any accounts for ${ServerUrl}.");
+        throw new SpeckleException($"You don't have any accounts for ${ServerUrl}.", log: true);
       }
 
       foreach (var acc in accs)
@@ -259,14 +260,14 @@ namespace Speckle.Core.Credentials
       }
       catch
       {
-        throw new Exception(
-          $"You don't have access to stream {StreamId} on server {ServerUrl}, or the stream does not exist.");
+        throw new SpeckleException(
+          $"You don't have access to stream {StreamId} on server {ServerUrl}, or the stream does not exist.", log: true);
       }
       
       // Check if the branch exists
       if (Type == StreamWrapperType.Branch && await client.BranchGet(StreamId, BranchName, 1) == null)
-        throw new Exception(
-            $"The branch with name '{BranchName}' doesn't exist in stream {StreamId} on server {ServerUrl}");
+        throw new SpeckleException(
+            $"The branch with name '{BranchName}' doesn't exist in stream {StreamId} on server {ServerUrl}", log: true);
     }
 
     public override string ToString()

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -53,8 +53,7 @@ namespace Speckle.Core.Credentials
     }
 
     public StreamWrapper()
-    {
-    }
+    { }
 
     /// <summary>
     /// Creates a StreamWrapper from a stream url or a stream id
@@ -106,7 +105,7 @@ namespace Speckle.Core.Credentials
       if (account == null)
       {
         throw new SpeckleException(
-          $"You do not have any account. Please create one or add it to the Speckle Manager.", log: true);
+          $"You do not have any account. Please create one or add it to the Speckle Manager.");
       }
 
       ServerUrl = account.serverInfo.url;
@@ -121,7 +120,7 @@ namespace Speckle.Core.Credentials
 
       if (uri.Segments.Length < 3)
       {
-        throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.", log: true);
+        throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.");
       }
 
       switch (uri.Segments.Length)
@@ -133,7 +132,7 @@ namespace Speckle.Core.Credentials
           }
           else
           {
-            throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.", log: true);
+            throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.");
           }
 
           break;
@@ -155,7 +154,7 @@ namespace Speckle.Core.Credentials
           }
           else
           {
-            throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.", log: true);
+            throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.");
           }
 
           break;
@@ -173,7 +172,7 @@ namespace Speckle.Core.Credentials
     public async Task<Account> GetAccount()
     {
       Exception err = null;
-      
+
       if (_Account != null)
       {
         return _Account;
@@ -182,7 +181,7 @@ namespace Speckle.Core.Credentials
       // Step 1: check if direct account id (?u=)
       if (originalInput.Contains("?u="))
       {
-        var userId = originalInput.Split(new string[] {"?u="}, StringSplitOptions.None)[1];
+        var userId = originalInput.Split(new string[ ] { "?u=" }, StringSplitOptions.None)[1];
         var acc = AccountManager.GetAccounts().FirstOrDefault(acc => acc.userInfo.id == userId);
         if (acc != null)
         {
@@ -192,7 +191,7 @@ namespace Speckle.Core.Credentials
             _Account = acc;
             return acc;
           }
-          catch(Exception e)
+          catch (Exception e)
           {
             // If user specified account and fails, we should stop trying.
             throw e;
@@ -208,7 +207,7 @@ namespace Speckle.Core.Credentials
         _Account = defAcc;
         return defAcc;
       }
-      catch(Exception e)
+      catch (Exception e)
       {
         err = e;
       }
@@ -217,7 +216,7 @@ namespace Speckle.Core.Credentials
       var accs = AccountManager.GetAccounts(ServerUrl);
       if (accs.Count() == 0)
       {
-        throw new SpeckleException($"You don't have any accounts for ${ServerUrl}.", log: true);
+        throw new SpeckleException($"You don't have any accounts for ${ServerUrl}.");
       }
 
       foreach (var acc in accs)
@@ -228,7 +227,7 @@ namespace Speckle.Core.Credentials
           _Account = acc;
           return acc;
         }
-        catch(Exception e)
+        catch (Exception e)
         {
           err = e;
         }
@@ -236,20 +235,20 @@ namespace Speckle.Core.Credentials
 
       throw err;
     }
-    
+
     public bool Equals(StreamWrapper wrapper)
     {
-      if (wrapper == null) return false;
-      if (Type != wrapper.Type) return false;
-      return Type == wrapper.Type
-             && ServerUrl == wrapper.ServerUrl
-             && AccountId == wrapper.AccountId
-             && StreamId == wrapper.StreamId
-             && (Type == StreamWrapperType.Branch && BranchName == wrapper.BranchName)
-             || (Type == StreamWrapperType.Object && ObjectId == wrapper.ObjectId)
-             || (Type == StreamWrapperType.Commit && CommitId == wrapper.CommitId);
+      if (wrapper == null)return false;
+      if (Type != wrapper.Type)return false;
+      return Type == wrapper.Type &&
+        ServerUrl == wrapper.ServerUrl &&
+        AccountId == wrapper.AccountId &&
+        StreamId == wrapper.StreamId &&
+        (Type == StreamWrapperType.Branch && BranchName == wrapper.BranchName) ||
+        (Type == StreamWrapperType.Object && ObjectId == wrapper.ObjectId) ||
+        (Type == StreamWrapperType.Commit && CommitId == wrapper.CommitId);
     }
-    
+
     private async Task ValidateWithAccount(Account acc)
     {
       var client = new Client(acc);
@@ -261,13 +260,13 @@ namespace Speckle.Core.Credentials
       catch
       {
         throw new SpeckleException(
-          $"You don't have access to stream {StreamId} on server {ServerUrl}, or the stream does not exist.", log: true);
+          $"You don't have access to stream {StreamId} on server {ServerUrl}, or the stream does not exist.");
       }
-      
+
       // Check if the branch exists
       if (Type == StreamWrapperType.Branch && await client.BranchGet(StreamId, BranchName, 1) == null)
         throw new SpeckleException(
-            $"The branch with name '{BranchName}' doesn't exist in stream {StreamId} on server {ServerUrl}", log: true);
+          $"The branch with name '{BranchName}' doesn't exist in stream {StreamId} on server {ServerUrl}");
     }
 
     public override string ToString()
@@ -285,7 +284,7 @@ namespace Speckle.Core.Credentials
           url += $"/objects/{ObjectId}";
           break;
       }
-      var acc =  $"{(AccountId != null ? "?u=" + AccountId : "")}";
+      var acc = $"{(AccountId != null ? "?u=" + AccountId : "")}";
       return url + acc;
     }
   }

--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -189,9 +189,9 @@ namespace Speckle.Core.Kits
 
         return kitClass;
       }
-      catch (Exception e)
+      catch 
       {
-        Log.CaptureException(e);
+        // this will be a ReflectionTypeLoadException and is expected. we don't need to care!
         return null;
       }
     }

--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -100,7 +100,7 @@ namespace Speckle.Core.Kits
     /// <param name="kitFolderLocation"></param>
     public static void Initialize(string kitFolderLocation)
     {
-      if (_initialized) throw new SpeckleException("The kit manager has already been initialised. Make sure you call this method earlier in your code!");
+      if (_initialized) throw new SpeckleException("The kit manager has already been initialised. Make sure you call this method earlier in your code!", log: true, level: Sentry.Protocol.SentryLevel.Warning);
       
       KitsFolder = kitFolderLocation;
       Load();

--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -33,7 +33,7 @@ namespace Speckle.Core.Kits
       Initialize();
       return _SpeckleKits.ContainsKey(assemblyFullName);
     }
-     
+
     /// <summary>
     /// Gets a specific kit.
     /// </summary>
@@ -68,8 +68,7 @@ namespace Speckle.Core.Kits
         return _AvailableTypes;
       }
     }
-    
-    
+
     /// <summary>
     /// Gets the default Speckle provided kit, "Objects".
     /// </summary>
@@ -87,7 +86,7 @@ namespace Speckle.Core.Kits
     /// <returns></returns>
     public static IEnumerable<ISpeckleKit> GetKitsWithConvertersForApp(string app)
     {
-      foreach(var kit in Kits)
+      foreach (var kit in Kits)
       {
         if (kit.Converters.Contains(app))
           yield return kit;
@@ -100,8 +99,8 @@ namespace Speckle.Core.Kits
     /// <param name="kitFolderLocation"></param>
     public static void Initialize(string kitFolderLocation)
     {
-      if (_initialized) throw new SpeckleException("The kit manager has already been initialised. Make sure you call this method earlier in your code!", log: true, level: Sentry.Protocol.SentryLevel.Warning);
-      
+      if (_initialized)throw new SpeckleException("The kit manager has already been initialised. Make sure you call this method earlier in your code!", level : Sentry.Protocol.SentryLevel.Warning);
+
       KitsFolder = kitFolderLocation;
       Load();
       _initialized = true;
@@ -138,7 +137,7 @@ namespace Speckle.Core.Kits
           if (assembly.IsReferencing(SpeckleAssemblyName) && kitClass != null)
           {
             if (!_SpeckleKits.ContainsKey(assembly.FullName))
-              _SpeckleKits.Add(assembly.FullName, Activator.CreateInstance(kitClass) as ISpeckleKit);
+              _SpeckleKits.Add(assembly.FullName, Activator.CreateInstance(kitClass)as ISpeckleKit);
           }
         }
       }
@@ -167,7 +166,7 @@ namespace Speckle.Core.Kits
           if (assembly.IsReferencing(SpeckleAssemblyName) && kitClass != null)
           {
             if (!_SpeckleKits.ContainsKey(assembly.FullName))
-              _SpeckleKits.Add(assembly.FullName, Activator.CreateInstance(kitClass) as ISpeckleKit);
+              _SpeckleKits.Add(assembly.FullName, Activator.CreateInstance(kitClass)as ISpeckleKit);
           }
         }
       }
@@ -180,16 +179,16 @@ namespace Speckle.Core.Kits
         var kitClass = assembly.GetTypes().FirstOrDefault(type =>
         {
           return type
-          .GetInterfaces()
-          .FirstOrDefault(iface =>
-          {
-            return iface.Name == typeof(Speckle.Core.Kits.ISpeckleKit).Name;
-          }) != null;
+            .GetInterfaces()
+            .FirstOrDefault(iface =>
+            {
+              return iface.Name == typeof(Speckle.Core.Kits.ISpeckleKit).Name;
+            }) != null;
         });
 
         return kitClass;
       }
-      catch 
+      catch
       {
         // this will be a ReflectionTypeLoadException and is expected. we don't need to care!
         return null;
@@ -219,7 +218,7 @@ namespace Speckle.Core.Kits
         return null;
       }
     }
-    
+
     #endregion
   }
 

--- a/Core/Core/Kits/Units.cs
+++ b/Core/Core/Kits/Units.cs
@@ -156,9 +156,8 @@ namespace Speckle.Core.Kits
         case "none":
           return Units.None;
       }
-      var e = new SpeckleException($"Cannot understand what unit {unit} is.");
-      Log.CaptureException(e);
-      throw e;
+
+      throw new SpeckleException($"Cannot understand what unit {unit} is.");
     }
   }
 }

--- a/Core/Core/Kits/Units.cs
+++ b/Core/Core/Kits/Units.cs
@@ -157,7 +157,7 @@ namespace Speckle.Core.Kits
           return Units.None;
       }
 
-      throw new SpeckleException($"Cannot understand what unit {unit} is.");
+      throw new SpeckleException($"Cannot understand what unit {unit} is.", log: true);
     }
   }
 }

--- a/Core/Core/Kits/Units.cs
+++ b/Core/Core/Kits/Units.cs
@@ -26,87 +26,136 @@ namespace Speckle.Core.Kits
         case Units.Millimeters:
           switch (to)
           {
-            case Units.Centimeters: return 0.1;
-            case Units.Meters: return 0.001;
-            case Units.Kilometers: return 1e-6;
-            case Units.Inches: return 0.0393701;
-            case Units.Feet: return 0.00328084;
-            case Units.Yards: return 0.00109361;
-            case Units.Miles: return 6.21371e-7;
+            case Units.Centimeters:
+              return 0.1;
+            case Units.Meters:
+              return 0.001;
+            case Units.Kilometers:
+              return 1e-6;
+            case Units.Inches:
+              return 0.0393701;
+            case Units.Feet:
+              return 0.00328084;
+            case Units.Yards:
+              return 0.00109361;
+            case Units.Miles:
+              return 6.21371e-7;
           }
           break;
         case Units.Centimeters:
           switch (to)
           {
-            case Units.Millimeters: return 10;
-            case Units.Meters: return 0.01;
-            case Units.Kilometers: return 1e-5;
-            case Units.Inches: return 0.393701;
-            case Units.Feet: return 0.0328084;
-            case Units.Yards: return 0.0109361;
-            case Units.Miles: return 6.21371e-6;
+            case Units.Millimeters:
+              return 10;
+            case Units.Meters:
+              return 0.01;
+            case Units.Kilometers:
+              return 1e-5;
+            case Units.Inches:
+              return 0.393701;
+            case Units.Feet:
+              return 0.0328084;
+            case Units.Yards:
+              return 0.0109361;
+            case Units.Miles:
+              return 6.21371e-6;
           }
           break;
         case Units.Meters:
           switch (to)
           {
-            case Units.Millimeters: return 1000;
-            case Units.Centimeters: return 100;
-            case Units.Kilometers: return 1000;
-            case Units.Inches: return 39.3701;
-            case Units.Feet: return 3.28084;
-            case Units.Yards: return 1.09361;
-            case Units.Miles: return 0.000621371;
+            case Units.Millimeters:
+              return 1000;
+            case Units.Centimeters:
+              return 100;
+            case Units.Kilometers:
+              return 1000;
+            case Units.Inches:
+              return 39.3701;
+            case Units.Feet:
+              return 3.28084;
+            case Units.Yards:
+              return 1.09361;
+            case Units.Miles:
+              return 0.000621371;
           }
           break;
         case Units.Kilometers:
           switch (to)
           {
-            case Units.Millimeters: return 1000000;
-            case Units.Centimeters: return 100000;
-            case Units.Meters: return 1000;
-            case Units.Inches: return 39370.1;
-            case Units.Feet: return 3280.84;
-            case Units.Yards: return 1093.61;
-            case Units.Miles: return 0.621371;
+            case Units.Millimeters:
+              return 1000000;
+            case Units.Centimeters:
+              return 100000;
+            case Units.Meters:
+              return 1000;
+            case Units.Inches:
+              return 39370.1;
+            case Units.Feet:
+              return 3280.84;
+            case Units.Yards:
+              return 1093.61;
+            case Units.Miles:
+              return 0.621371;
           }
           break;
 
-        // IMPERIAL
+          // IMPERIAL
         case Units.Inches:
           switch (to)
           {
-            case Units.Millimeters: return 25.4;
-            case Units.Centimeters: return 2.54;
-            case Units.Meters: return 0.0254;
-            case Units.Kilometers: return 2.54e-5;
-            case Units.Feet: return 0.0833333;
-            case Units.Yards: return 0.027777694;
-            case Units.Miles: return 1.57828e-5;
+            case Units.Millimeters:
+              return 25.4;
+            case Units.Centimeters:
+              return 2.54;
+            case Units.Meters:
+              return 0.0254;
+            case Units.Kilometers:
+              return 2.54e-5;
+            case Units.Feet:
+              return 0.0833333;
+            case Units.Yards:
+              return 0.027777694;
+            case Units.Miles:
+              return 1.57828e-5;
           }
           break;
         case Units.Feet:
           switch (to)
           {
-            case Units.Millimeters: return 304.8;
-            case Units.Centimeters: return 30.48;
-            case Units.Meters: return 0.3048;
-            case Units.Kilometers: return 0.0003048;
-            case Units.Inches: return 12;
-            case Units.Yards: return 0.333332328;
-            case Units.Miles: return 0.000189394;
+            case Units.Millimeters:
+              return 304.8;
+            case Units.Centimeters:
+              return 30.48;
+            case Units.Meters:
+              return 0.3048;
+            case Units.Kilometers:
+              return 0.0003048;
+            case Units.Inches:
+              return 12;
+            case Units.Yards:
+              return 0.333332328;
+            case Units.Miles:
+              return 0.000189394;
           }
           break;
         case Units.Miles:
           switch (to)
           {
-            case Units.Millimeters: return 1.609e+6;
-            case Units.Centimeters: return 160934;
-            case Units.Meters: return 1609.34;
-            case Units.Kilometers: return 1.60934;
-            case Units.Inches: return 63360;
-            case Units.Feet: return 5280;
-            case Units.Yards: return 1759.99469184;
+            case Units.Millimeters:
+              return 1.609e+6;
+            case Units.Centimeters:
+              return 160934;
+            case Units.Meters:
+              return 1609.34;
+            case Units.Kilometers:
+              return 1.60934;
+            case Units.Inches:
+              return 63360;
+            case Units.Feet:
+              return 5280;
+            case Units.Yards:
+              return 1759.99469184;
           }
           break;
         case Units.None:
@@ -117,7 +166,7 @@ namespace Speckle.Core.Kits
 
     public static string GetUnitsFromString(string unit)
     {
-      if (unit == null) return null;
+      if (unit == null)return null;
       switch (unit.ToLower())
       {
         case "mm":
@@ -157,7 +206,7 @@ namespace Speckle.Core.Kits
           return Units.None;
       }
 
-      throw new SpeckleException($"Cannot understand what unit {unit} is.", log: true);
+      throw new SpeckleException($"Cannot understand what unit {unit} is.");
     }
   }
 }

--- a/Core/Core/Logging/Log.cs
+++ b/Core/Core/Logging/Log.cs
@@ -50,14 +50,14 @@ namespace Speckle.Core.Logging
     /// If the exception is not a SpeckleException, is it wrapped in one and set as the InnerException
     /// </summary>
     /// <param name="e">Exception to capture and throw</param>
-    public static void CaptureAndThrow(Exception e)
-    {
-      if ( !( e is TaskCanceledException ) )
-        CaptureException(e);
-      if (e is SpeckleException)
-        throw e;
-      throw new SpeckleException(e.Message, e, log: false);
-    }
+    // public static void CaptureAndThrow(Exception e)
+    // {
+    //   if ( !( e is TaskCanceledException ) )
+    //     CaptureException(e);
+    //   if (e is SpeckleException)
+    //     throw e;
+    //   throw new SpeckleException(e.Message, e, log: false);
+    // }
 
     //capture and make sure Sentry is initialized
     public static void CaptureException(

--- a/Core/Core/Logging/Log.cs
+++ b/Core/Core/Logging/Log.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using GraphQL;
 using Sentry;
 using Sentry.Protocol;
@@ -55,14 +56,15 @@ namespace Speckle.Core.Logging
     /// <param name="e">Exception to capture and throw</param>
     public static void CaptureAndThrow(Exception e)
     {
-      CaptureException(e);
+      if (!(e is TaskCanceledException))
+        CaptureException(e);
       throw e;
     }
 
     //capture and make sure Sentry is initialized
     public static void CaptureException(
       Exception e,
-      SentryLevel level = SentryLevel.Error,
+      SentryLevel level = SentryLevel.Info,
       List<KeyValuePair<string, object>> extra = null)
     {
       Instance();

--- a/Core/Core/Logging/Log.cs
+++ b/Core/Core/Logging/Log.cs
@@ -46,15 +46,17 @@ namespace Speckle.Core.Logging
 
     /// <summary>
     /// Captures and throws an exception
-    /// Unhandled exceptions are usually swallowed by host applications like Revit, Dynamo
-    /// So they need to be sent manually.
+    /// Unhandled exceptions are usually swallowed by host applications like Revit, Dynamo so they need to be sent manually.
+    /// If the exception is not a SpeckleException, is it wrapped in one and set as the InnerException
     /// </summary>
     /// <param name="e">Exception to capture and throw</param>
     public static void CaptureAndThrow(Exception e)
     {
       if ( !( e is TaskCanceledException ) )
         CaptureException(e);
-      throw e;
+      if (e is SpeckleException)
+        throw e;
+      throw new SpeckleException(e.Message, e);
     }
 
     //capture and make sure Sentry is initialized

--- a/Core/Core/Logging/Log.cs
+++ b/Core/Core/Logging/Log.cs
@@ -18,7 +18,6 @@ namespace Speckle.Core.Logging
     protected Log()
     {
 
-
       //TODO: set DSN & env in CI/CD pipeline
       SentrySdk.Init(o =>
         {
@@ -56,37 +55,9 @@ namespace Speckle.Core.Logging
     /// <param name="e">Exception to capture and throw</param>
     public static void CaptureAndThrow(Exception e)
     {
-      CaptureException(e, SentryLevel.Error);
+      CaptureException(e);
       throw e;
     }
-
-    /// <summary>
-    /// Captures and throws an exception
-    /// Unhandled exceptions are usually swallowed by host applications like Revit, Dynamo
-    /// So they need to be sent manually.
-    /// </summary>
-    /// <param name="e">Exception to capture and throw</param>
-    public static void CaptureAndThrow(Exception e, SentryLevel level)
-    {
-      CaptureException(e, level);
-      throw e;
-    }
-
-    /// <summary>
-    /// Captures and throws a GraphQL exception
-    /// </summary>
-    /// <param name="e">Exception to capture and throw</param>
-    public static void CaptureAndThrow(Exception e, GraphQLError[] errors)
-    {
-      var extra = new List<KeyValuePair<string, object>>();
-      foreach (var error in errors)
-      {
-        extra.Add(new KeyValuePair<string, object>("error", error.Message));
-      }
-      CaptureException(e, extra: extra);
-      throw e;
-    }
-
 
     //capture and make sure Sentry is initialized
     public static void CaptureException(

--- a/Core/Core/Logging/Log.cs
+++ b/Core/Core/Logging/Log.cs
@@ -56,7 +56,7 @@ namespace Speckle.Core.Logging
         CaptureException(e);
       if (e is SpeckleException)
         throw e;
-      throw new SpeckleException(e.Message, e);
+      throw new SpeckleException(e.Message, e, log: false);
     }
 
     //capture and make sure Sentry is initialized

--- a/Core/Core/Logging/SpeckleException.cs
+++ b/Core/Core/Logging/SpeckleException.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using GraphQL;
+using Sentry.Protocol;
+
 namespace Speckle.Core.Logging
 {
   public class SpeckleException : Exception
@@ -7,30 +12,41 @@ namespace Speckle.Core.Logging
     {
     }
 
-    public SpeckleException(string message) : base(message)
+    public SpeckleException(string message, SentryLevel level = SentryLevel.Error) : base(message)
     {
+      Log.CaptureException(this, level);
     }
 
     public SpeckleException(string message, Exception inner)
          : base(message, inner)
     {
+      Log.CaptureException(this);
     }
   }
 
 
   public class GraphQLException : Exception
   {
+    public List<KeyValuePair<string, object>> GraphQLErrors { get; set; }
     public GraphQLException()
     {
     }
 
     public GraphQLException(string message) : base(message)
     {
+      Log.CaptureException(this);
+    }
+
+    public GraphQLException(string message, GraphQLError[ ] errors) : base(message)
+    {
+      GraphQLErrors = errors.Select(error => new KeyValuePair<string, object>("error", error.Message)).ToList();
+      Log.CaptureException(this, extra:GraphQLErrors);
     }
 
     public GraphQLException(string message, Exception inner)
          : base(message, inner)
     {
+      Log.CaptureException(this);
     }
   }
 }

--- a/Core/Core/Logging/SpeckleException.cs
+++ b/Core/Core/Logging/SpeckleException.cs
@@ -13,18 +13,18 @@ namespace Speckle.Core.Logging
     {
     }
 
+    public SpeckleException(string message, bool log = false, SentryLevel level = SentryLevel.Info ) : base(message)
+    {
+      if (log)
+        Log.CaptureException(this, level);
+    }
+
     public SpeckleException(string message, GraphQLError[ ] errors, bool log = false,
       SentryLevel level = SentryLevel.Info) : base(message)
     {
       GraphQLErrors = errors.Select(error => new KeyValuePair<string, object>("error", error.Message)).ToList();
       if (log)
         Log.CaptureException(this, extra: GraphQLErrors);
-    }
-
-    public SpeckleException(string message, bool log = false, SentryLevel level = SentryLevel.Info ) : base(message)
-    {
-      if (log)
-        Log.CaptureException(this, level);
     }
 
     public SpeckleException(string message, Exception inner, bool log = false, SentryLevel level = SentryLevel.Info)

--- a/Core/Core/Logging/SpeckleException.cs
+++ b/Core/Core/Logging/SpeckleException.cs
@@ -8,45 +8,30 @@ namespace Speckle.Core.Logging
 {
   public class SpeckleException : Exception
   {
+    public List<KeyValuePair<string, object>> GraphQLErrors { get; set; }
     public SpeckleException()
     {
     }
 
-    public SpeckleException(string message, SentryLevel level = SentryLevel.Error) : base(message)
-    {
-      Log.CaptureException(this, level);
-    }
-
-    public SpeckleException(string message, Exception inner)
-         : base(message, inner)
-    {
-      Log.CaptureException(this);
-    }
-  }
-
-
-  public class GraphQLException : Exception
-  {
-    public List<KeyValuePair<string, object>> GraphQLErrors { get; set; }
-    public GraphQLException()
-    {
-    }
-
-    public GraphQLException(string message) : base(message)
-    {
-      Log.CaptureException(this);
-    }
-
-    public GraphQLException(string message, GraphQLError[ ] errors) : base(message)
+    public SpeckleException(string message, GraphQLError[ ] errors, bool log = false,
+      SentryLevel level = SentryLevel.Info) : base(message)
     {
       GraphQLErrors = errors.Select(error => new KeyValuePair<string, object>("error", error.Message)).ToList();
-      Log.CaptureException(this, extra:GraphQLErrors);
+      if (log)
+        Log.CaptureException(this, extra: GraphQLErrors);
     }
 
-    public GraphQLException(string message, Exception inner)
+    public SpeckleException(string message, bool log = false, SentryLevel level = SentryLevel.Info ) : base(message)
+    {
+      if (log)
+        Log.CaptureException(this, level);
+    }
+
+    public SpeckleException(string message, Exception inner, bool log = false, SentryLevel level = SentryLevel.Info)
          : base(message, inner)
     {
-      Log.CaptureException(this);
+      if (log)
+        Log.CaptureException(this);
     }
   }
 }

--- a/Core/Core/Logging/SpeckleException.cs
+++ b/Core/Core/Logging/SpeckleException.cs
@@ -13,13 +13,13 @@ namespace Speckle.Core.Logging
     {
     }
 
-    public SpeckleException(string message, bool log = false, SentryLevel level = SentryLevel.Info ) : base(message)
+    public SpeckleException(string message, bool log = true, SentryLevel level = SentryLevel.Info ) : base(message)
     {
       if (log)
         Log.CaptureException(this, level);
     }
 
-    public SpeckleException(string message, GraphQLError[ ] errors, bool log = false,
+    public SpeckleException(string message, GraphQLError[ ] errors, bool log = true,
       SentryLevel level = SentryLevel.Info) : base(message)
     {
       GraphQLErrors = errors.Select(error => new KeyValuePair<string, object>("error", error.Message)).ToList();
@@ -27,9 +27,11 @@ namespace Speckle.Core.Logging
         Log.CaptureException(this, extra: GraphQLErrors);
     }
 
-    public SpeckleException(string message, Exception inner, bool log = false, SentryLevel level = SentryLevel.Info)
+    public SpeckleException(string message, Exception inner, bool log = true, SentryLevel level = SentryLevel.Info)
          : base(message, inner)
     {
+      if (inner is SpeckleException)
+        return;
       if (log)
         Log.CaptureException(this);
     }

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -115,7 +115,7 @@ namespace Speckle.Core.Models
       }
       set
       {
-        if (!IsPropNameValid(key, out string reason)) Log.CaptureAndThrow(new Exception("Invalid prop name: " + reason));
+        if (!IsPropNameValid(key, out string reason)) throw new SpeckleException("Invalid prop name: " + reason);
         
         if (properties.ContainsKey(key))
         {

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -131,7 +131,7 @@ namespace Speckle.Core.Models
         }
         catch (Exception ex)
         {
-          Log.CaptureAndThrow(ex);
+          throw new SpeckleException(ex.Message, ex);
         }
       }
     }

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -1,11 +1,11 @@
-using Speckle.Core.Kits;
-using Speckle.Core.Logging;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 
 namespace Speckle.Core.Models
 {
@@ -26,8 +26,7 @@ namespace Speckle.Core.Models
     {
 
     }
-    
-    
+
     /// <summary>
     /// Gets properties via the dot syntax.
     /// <para><pre>((dynamic)myObject).superProperty;</pre></para>
@@ -54,7 +53,7 @@ namespace Speckle.Core.Models
         properties[binder.Name] = value;
       return valid;
     }
-    
+
     public bool IsPropNameValid(string name, out string reason)
     {
       // Regex rules
@@ -64,40 +63,39 @@ namespace Speckle.Core.Models
       var invalidChars = new Regex(@"[\.\/]");
       // Existing members
       var members = GetInstanceMembersNames();
-      
+
       // TODO: Check for detached/non-detached duplicate names? i.e: '@something' vs 'something'
       // TODO: Instance members will not be overwritten, this may cause issues.
-      var checks = new List<(bool,string)>
+      var checks = new List < (bool, string) >
       {
         (!(string.IsNullOrEmpty(name) || name == "@"), "Found empty prop name"),
         // Checks for multiple leading @
         (!manyLeadingAtChars.IsMatch(name), "Only one leading '@' char is allowed. This signals the property value should be detached."),
         // Checks for invalid chars
-        (!invalidChars.IsMatch(name), $"Prop with name '{name}' contains invalid characters. The following characters are not allowed: ./"), 
+        (!invalidChars.IsMatch(name), $"Prop with name '{name}' contains invalid characters. The following characters are not allowed: ./"),
         // Checks if you are trying to change a member property
         //(!members.Contains(name), "Modifying the value of instance member properties is not allowed.")
       };
 
       var r = "";
       // Prop name is valid if none of the checks are true
-      var isValid =  checks.TrueForAll(v =>
+      var isValid = checks.TrueForAll(v =>
       {
-        if (!v.Item1) r = v.Item2;
+        if (!v.Item1)r = v.Item2;
         return v.Item1;
       });
 
       reason = r;
       return isValid;
     }
-    
-    
+
     /// <summary>
     /// Sets and gets properties using the key accessor pattern. E.g.:
     /// <para><pre>((dynamic)myObject)["superProperty"] = 42;</pre></para>
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    public object this[string key]
+    public object this [string key]
     {
       get
       {
@@ -114,8 +112,8 @@ namespace Speckle.Core.Models
       }
       set
       {
-        if (!IsPropNameValid(key, out string reason)) throw new SpeckleException("Invalid prop name: " + reason, log: true);
-        
+        if (!IsPropNameValid(key, out string reason))throw new SpeckleException("Invalid prop name: " + reason);
+
         if (properties.ContainsKey(key))
         {
           properties[key] = value;
@@ -145,10 +143,10 @@ namespace Speckle.Core.Models
     public override IEnumerable<string> GetDynamicMemberNames()
     {
       var names = new List<string>();
-      foreach (var kvp in properties) names.Add(kvp.Key);
+      foreach (var kvp in properties)names.Add(kvp.Key);
 
       var pinfos = GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
-      foreach (var pinfo in pinfos) names.Add(pinfo.Name);
+      foreach (var pinfo in pinfos)names.Add(pinfo.Name);
 
       names.Remove("Item"); // TODO: investigate why we get Item out?
       return names;
@@ -162,7 +160,7 @@ namespace Speckle.Core.Models
     {
       var names = new List<string>();
       var pinfos = GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
-      foreach (var pinfo in pinfos) names.Add(pinfo.Name);
+      foreach (var pinfo in pinfos)names.Add(pinfo.Name);
 
       names.Remove("Item"); // TODO: investigate why we get Item out?
       return names;
@@ -178,7 +176,7 @@ namespace Speckle.Core.Models
       var pinfos = GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
 
       foreach (var pinfo in pinfos)
-        if (pinfo.Name != "Item") names.Add(pinfo);
+        if (pinfo.Name != "Item")names.Add(pinfo);
 
       return names;
     }
@@ -190,10 +188,10 @@ namespace Speckle.Core.Models
     public IEnumerable<string> GetMemberNames()
     {
       var names = new List<string>();
-      foreach (var kvp in properties) names.Add(kvp.Key);
+      foreach (var kvp in properties)names.Add(kvp.Key);
 
       var pinfos = GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.GetCustomAttribute(typeof(SchemaIgnore)) == null && x.Name != "Item");
-      foreach (var pinfo in pinfos) names.Add(pinfo.Name);
+      foreach (var pinfo in pinfos)names.Add(pinfo.Name);
 
       return names;
     }
@@ -214,7 +212,6 @@ namespace Speckle.Core.Models
         dic.Add(kvp.Key, kvp.Value);
       return dic;
     }
-
 
     /// <summary>
     /// Gets the dynamically added property names only.

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -1,4 +1,3 @@
-using Speckle.Newtonsoft.Json;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using System;
@@ -115,7 +114,7 @@ namespace Speckle.Core.Models
       }
       set
       {
-        if (!IsPropNameValid(key, out string reason)) throw new SpeckleException("Invalid prop name: " + reason);
+        if (!IsPropNameValid(key, out string reason)) throw new SpeckleException("Invalid prop name: " + reason, log: true);
         
         if (properties.ContainsKey(key))
         {

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -172,7 +172,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          Log.CaptureAndThrow(new SpeckleException("Cannot resolve reference, no transport is defined."), level: Sentry.Protocol.SentryLevel.Warning);
+          throw new SpeckleException("Cannot resolve reference, no transport is defined.", level: Sentry.Protocol.SentryLevel.Warning);
         }
 
         if (str != null && str != "")
@@ -182,7 +182,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          Log.CaptureAndThrow(new SpeckleException("Cannot resolve reference. The provided transport could not find it."), level: Sentry.Protocol.SentryLevel.Warning);
+          throw new SpeckleException("Cannot resolve reference. The provided transport could not find it.", level: Sentry.Protocol.SentryLevel.Warning);
         }
       }
 

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -1,7 +1,4 @@
-﻿using Speckle.Newtonsoft.Json;
-using Speckle.Newtonsoft.Json.Serialization;
-using Speckle.Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -10,6 +7,9 @@ using System.Threading;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
+using Speckle.Newtonsoft.Json;
+using Speckle.Newtonsoft.Json.Linq;
+using Speckle.Newtonsoft.Json.Serialization;
 
 namespace Speckle.Core.Serialisation
 {
@@ -64,7 +64,6 @@ namespace Speckle.Core.Serialisation
     public Action<string, int> OnProgressAction { get; set; }
 
     public Action<string, Exception> OnErrorAction { get; set; }
-
 
     public BaseObjectSerializer()
     {
@@ -172,7 +171,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          throw new SpeckleException("Cannot resolve reference, no transport is defined.", log: true, level: Sentry.Protocol.SentryLevel.Error);
+          throw new SpeckleException("Cannot resolve reference, no transport is defined.", level : Sentry.Protocol.SentryLevel.Error);
         }
 
         if (str != null && str != "")
@@ -182,7 +181,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          throw new SpeckleException("Cannot resolve reference. The provided transport could not find it.", log: true, level: Sentry.Protocol.SentryLevel.Error);
+          throw new SpeckleException("Cannot resolve reference. The provided transport could not find it.", level : Sentry.Protocol.SentryLevel.Error);
         }
       }
 
@@ -355,7 +354,7 @@ namespace Speckle.Core.Serialisation
             continue;
           }
 
-          if(prop == "id")
+          if (prop == "id")
           {
             continue;
           }

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -172,7 +172,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          throw new SpeckleException("Cannot resolve reference, no transport is defined.", level: Sentry.Protocol.SentryLevel.Warning);
+          throw new SpeckleException("Cannot resolve reference, no transport is defined.", log: true, level: Sentry.Protocol.SentryLevel.Error);
         }
 
         if (str != null && str != "")
@@ -182,7 +182,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          throw new SpeckleException("Cannot resolve reference. The provided transport could not find it.", level: Sentry.Protocol.SentryLevel.Warning);
+          throw new SpeckleException("Cannot resolve reference. The provided transport could not find it.", log: true, level: Sentry.Protocol.SentryLevel.Error);
         }
       }
 

--- a/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
+++ b/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
@@ -295,13 +295,13 @@ namespace Speckle.Core.Serialisation
       var myAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(ass => ass.GetName().Name == pieces[1]);
       if (myAssembly == null)
       {
-        Log.CaptureAndThrow(new SpeckleException("Could not load abstract object's assembly."), level: Sentry.Protocol.SentryLevel.Warning);
+        throw new SpeckleException("Could not load abstract object's assembly.", level: Sentry.Protocol.SentryLevel.Warning);
       }
 
       var myType = myAssembly.GetType(pieces[0]);
       if (myType == null)
       {
-        Log.CaptureAndThrow(new SpeckleException("Could not load abstract object's assembly."), level: Sentry.Protocol.SentryLevel.Warning);
+        throw new SpeckleException("Could not load abstract object's assembly.", level: Sentry.Protocol.SentryLevel.Warning);
       }
 
       cachedAbstractTypes[assemblyQualifiedName] = myType;

--- a/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
+++ b/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
@@ -1,7 +1,4 @@
-﻿using Speckle.Newtonsoft.Json;
-using Speckle.Newtonsoft.Json.Serialization;
-using Speckle.Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +8,9 @@ using Microsoft.CSharp.RuntimeBinder;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
+using Speckle.Newtonsoft.Json.Linq;
+using Speckle.Newtonsoft.Json.Serialization;
 
 namespace Speckle.Core.Serialisation
 {
@@ -127,16 +127,16 @@ namespace Speckle.Core.Serialisation
                 {
                   if (jsonProperty.PropertyType.GenericTypeArguments[0].IsAssignableFrom(dataItem.GetType()))
                   {
-                    addMethod.Invoke(arr, new object[] { dataItem });
+                    addMethod.Invoke(arr, new object[ ] { dataItem });
                   }
                   else
                   {
-                    addMethod.Invoke(arr, new object[] { Convert.ChangeType(dataItem, jsonProperty.PropertyType.GenericTypeArguments[0]) });
+                    addMethod.Invoke(arr, new object[ ] { Convert.ChangeType(dataItem, jsonProperty.PropertyType.GenericTypeArguments[0]) });
                   }
                 }
                 else
                 {
-                  addMethod.Invoke(arr, new object[] { dataItem });
+                  addMethod.Invoke(arr, new object[ ] { dataItem });
                 }
               }
             }
@@ -144,16 +144,16 @@ namespace Speckle.Core.Serialisation
             {
               if (jsonProperty.PropertyType.GenericTypeArguments[0].IsAssignableFrom(item.GetType()))
               {
-                addMethod.Invoke(arr, new object[] { item });
+                addMethod.Invoke(arr, new object[ ] { item });
               }
               else
               {
-                addMethod.Invoke(arr, new object[] { Convert.ChangeType(item, jsonProperty.PropertyType.GenericTypeArguments[0]) });
+                addMethod.Invoke(arr, new object[ ] { Convert.ChangeType(item, jsonProperty.PropertyType.GenericTypeArguments[0]) });
               }
             }
             else
             {
-              addMethod.Invoke(arr, new object[] { item });
+              addMethod.Invoke(arr, new object[ ] { item });
             }
           }
           return arr;
@@ -270,7 +270,7 @@ namespace Speckle.Core.Serialisation
           if (jsonProperty != null)
           {
             key = Convert.ChangeType(prop.Key, jsonProperty.PropertyType.GetGenericArguments()[0]);
-          } ((IDictionary)dict)[key] = HandleValue(prop.Value, serializer, CancellationToken);
+          }((IDictionary)dict)[key] = HandleValue(prop.Value, serializer, CancellationToken);
         }
         return dict;
       }
@@ -295,13 +295,13 @@ namespace Speckle.Core.Serialisation
       var myAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(ass => ass.GetName().Name == pieces[1]);
       if (myAssembly == null)
       {
-        throw new SpeckleException("Could not load abstract object's assembly.", log: true, level: Sentry.Protocol.SentryLevel.Error);
+        throw new SpeckleException("Could not load abstract object's assembly.", level : Sentry.Protocol.SentryLevel.Error);
       }
 
       var myType = myAssembly.GetType(pieces[0]);
       if (myType == null)
       {
-        throw new SpeckleException("Could not load abstract object's assembly.", log: true, level: Sentry.Protocol.SentryLevel.Error);
+        throw new SpeckleException("Could not load abstract object's assembly.", level : Sentry.Protocol.SentryLevel.Error);
       }
 
       cachedAbstractTypes[assemblyQualifiedName] = myType;
@@ -321,22 +321,23 @@ namespace Speckle.Core.Serialisation
     // https://github.com/mgravell/fast-member/blob/master/FastMember/CallSiteCache.cs
     // by Marc Gravell, https://github.com/mgravell
 
-    private static readonly Dictionary<string, CallSite<Func<CallSite, object, object, object>>> setters
-      = new Dictionary<string, CallSite<Func<CallSite, object, object, object>>>();
+    private static readonly Dictionary<string, CallSite<Func<CallSite, object, object, object>>> setters = new Dictionary<string, CallSite<Func<CallSite, object, object, object>>>();
 
     public static void SetValue(string propertyName, object target, object value)
     {
       CallSite<Func<CallSite, object, object, object>> site;
 
-      lock (setters)
+      lock(setters)
       {
         if (!setters.TryGetValue(propertyName, out site))
         {
           var binder = Microsoft.CSharp.RuntimeBinder.Binder.SetMember(CSharpBinderFlags.None,
-               propertyName, typeof(CallSiteCache),
-               new List<CSharpArgumentInfo>{
-                   CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
-                   CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)});
+            propertyName, typeof(CallSiteCache),
+            new List<CSharpArgumentInfo>
+            {
+              CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+              CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+            });
           setters[propertyName] = site = CallSite<Func<CallSite, object, object, object>>.Create(binder);
         }
       }

--- a/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
+++ b/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
@@ -295,13 +295,13 @@ namespace Speckle.Core.Serialisation
       var myAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(ass => ass.GetName().Name == pieces[1]);
       if (myAssembly == null)
       {
-        throw new SpeckleException("Could not load abstract object's assembly.", level: Sentry.Protocol.SentryLevel.Warning);
+        throw new SpeckleException("Could not load abstract object's assembly.", log: true, level: Sentry.Protocol.SentryLevel.Error);
       }
 
       var myType = myAssembly.GetType(pieces[0]);
       if (myType == null)
       {
-        throw new SpeckleException("Could not load abstract object's assembly.", level: Sentry.Protocol.SentryLevel.Warning);
+        throw new SpeckleException("Could not load abstract object's assembly.", log: true, level: Sentry.Protocol.SentryLevel.Error);
       }
 
       cachedAbstractTypes[assemblyQualifiedName] = myType;

--- a/Core/Core/Transports/Memory.cs
+++ b/Core/Core/Transports/Memory.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Speckle.Core.Logging;
-using Speckle.Core.Models;
 
 namespace Speckle.Core.Transports
 {
@@ -60,10 +58,7 @@ namespace Speckle.Core.Transports
 
       if (Objects.ContainsKey(hash)) return Objects[hash];
       else
-      {
-        Log.CaptureException(new SpeckleException("No object found in this memory transport."), level: Sentry.Protocol.SentryLevel.Warning);
-        throw new SpeckleException("No object found in this memory transport.");
-      }
+        throw new SpeckleException("No object found in this memory transport.", Sentry.Protocol.SentryLevel.Warning);
     }
 
     public Task<string> CopyObjectAndChildren(string id, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)

--- a/Core/Core/Transports/Memory.cs
+++ b/Core/Core/Transports/Memory.cs
@@ -39,10 +39,10 @@ namespace Speckle.Core.Transports
 
     public void SaveObject(string hash, string serializedObject)
     {
-      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+      if (CancellationToken.IsCancellationRequested)return; // Check for cancellation
 
       Objects[hash] = serializedObject;
-      
+
       SavedObjectCount++;
       OnProgressAction?.Invoke(TransportName, 1);
     }
@@ -54,11 +54,11 @@ namespace Speckle.Core.Transports
 
     public string GetObject(string hash)
     {
-      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+      if (CancellationToken.IsCancellationRequested)return null; // Check for cancellation
 
-      if (Objects.ContainsKey(hash)) return Objects[hash];
+      if (Objects.ContainsKey(hash))return Objects[hash];
       else
-        throw new SpeckleException("No object found in this memory transport.", log: true);
+        throw new SpeckleException("No object found in this memory transport.");
     }
 
     public Task<string> CopyObjectAndChildren(string id, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)

--- a/Core/Core/Transports/Memory.cs
+++ b/Core/Core/Transports/Memory.cs
@@ -58,7 +58,7 @@ namespace Speckle.Core.Transports
 
       if (Objects.ContainsKey(hash)) return Objects[hash];
       else
-        throw new SpeckleException("No object found in this memory transport.", Sentry.Protocol.SentryLevel.Warning);
+        throw new SpeckleException("No object found in this memory transport.", log: true);
     }
 
     public Task<string> CopyObjectAndChildren(string id, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)

--- a/Core/Core/Transports/Utilities.cs
+++ b/Core/Core/Transports/Utilities.cs
@@ -28,7 +28,7 @@ namespace Speckle.Core.Transports
       if (waitTask != await Task.WhenAny(waitTask,
               Task.Delay(timeout)))
       {
-        Log.CaptureAndThrow(new TimeoutException());
+        throw new SpeckleException("Process timed out", new TimeoutException());
       }
     }
 

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Tests;
 
@@ -19,11 +20,11 @@ namespace Tests
 
       // Only single leading @ allowed
       @base["@something"] = "A";
-      Assert.Throws<Exception>(() => { @base["@@@something"] = "Testing"; });
+      Assert.Throws<SpeckleException>(() => { @base["@@@something"] = "Testing"; });
 
       // Invalid chars:  ./
-      Assert.Throws<Exception>(() => { @base["some.thing"] = "Testing"; });
-      Assert.Throws<Exception>(() => { @base["some/thing"] = "Testing"; });
+      Assert.Throws<SpeckleException>(() => { @base["some.thing"] = "Testing"; });
+      Assert.Throws<SpeckleException>(() => { @base["some/thing"] = "Testing"; });
 
       // Trying to change a class member value will throw exceptions.
       //Assert.Throws<Exception>(() => { @base["speckle_type"] = "Testing"; });

--- a/Core/Transports/DiskTransport/DiskTransport.cs
+++ b/Core/Transports/DiskTransport/DiskTransport.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Speckle.Newtonsoft.Json;
 using Speckle.Core.Transports;
+using Speckle.Core.Logging;
 
 namespace DiskTransport
 {
@@ -53,7 +54,7 @@ namespace DiskTransport
         return File.ReadAllText(filePath, Encoding.UTF8);
       }
 
-      throw new Exception($"Could not find the specified object ({filePath}).");
+      throw new SpeckleException($"Could not find the specified object ({filePath}).", log: true);
     }
 
     public void SaveObject(string id, string serializedObject)

--- a/Core/Transports/DiskTransport/DiskTransport.cs
+++ b/Core/Transports/DiskTransport/DiskTransport.cs
@@ -4,9 +4,9 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Speckle.Newtonsoft.Json;
-using Speckle.Core.Transports;
 using Speckle.Core.Logging;
+using Speckle.Core.Transports;
+using Speckle.Newtonsoft.Json;
 
 namespace DiskTransport
 {
@@ -46,7 +46,7 @@ namespace DiskTransport
 
     public string GetObject(string id)
     {
-      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+      if (CancellationToken.IsCancellationRequested)return null; // Check for cancellation
 
       var filePath = Path.Combine(RootPath, id);
       if (File.Exists(filePath))
@@ -54,15 +54,15 @@ namespace DiskTransport
         return File.ReadAllText(filePath, Encoding.UTF8);
       }
 
-      throw new SpeckleException($"Could not find the specified object ({filePath}).", log: true);
+      throw new SpeckleException($"Could not find the specified object ({filePath}).");
     }
 
     public void SaveObject(string id, string serializedObject)
     {
-      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+      if (CancellationToken.IsCancellationRequested)return; // Check for cancellation
 
       var filePath = Path.Combine(RootPath, id);
-      if (File.Exists(filePath)) return;
+      if (File.Exists(filePath))return;
 
       File.WriteAllText(filePath, serializedObject, Encoding.UTF8);
       SavedObjectCount++;
@@ -71,7 +71,7 @@ namespace DiskTransport
 
     public void SaveObject(string id, ITransport sourceTransport)
     {
-      if (CancellationToken.IsCancellationRequested) return; // Check for cancellation
+      if (CancellationToken.IsCancellationRequested)return; // Check for cancellation
 
       var serializedObject = sourceTransport.GetObject(id);
       SaveObject(id, serializedObject);
@@ -84,7 +84,7 @@ namespace DiskTransport
 
     public async Task<string> CopyObjectAndChildren(string id, ITransport targetTransport, Action<int> onTotalChildrenCountKnown = null)
     {
-      if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+      if (CancellationToken.IsCancellationRequested)return null; // Check for cancellation
 
       var parent = GetObject(id);
 
@@ -92,12 +92,12 @@ namespace DiskTransport
 
       var partial = JsonConvert.DeserializeObject<Placeholder>(parent);
 
-      if (partial.__closure == null || partial.__closure.Count == 0) return parent;
+      if (partial.__closure == null || partial.__closure.Count == 0)return parent;
 
       int i = 0;
       foreach (var kvp in partial.__closure)
       {
-        if (CancellationToken.IsCancellationRequested) return null; // Check for cancellation
+        if (CancellationToken.IsCancellationRequested)return null; // Check for cancellation
 
         var child = GetObject(kvp.Key);
         targetTransport.SaveObject(kvp.Key, child);

--- a/Core/Transports/ServerTransport/Server.cs
+++ b/Core/Transports/ServerTransport/Server.cs
@@ -9,9 +9,9 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
-using Speckle.Newtonsoft.Json;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
+using Speckle.Newtonsoft.Json;
 
 namespace Speckle.Core.Transports
 {
@@ -34,7 +34,7 @@ namespace Speckle.Core.Transports
 
     private HttpClient Client { get; set; }
 
-    private ConcurrentQueue<(string, string, int)> Queue = new ConcurrentQueue<(string, string, int)>();
+    private ConcurrentQueue < (string, string, int) > Queue = new ConcurrentQueue < (string, string, int) > ();
 
     private System.Timers.Timer WriteTimer;
 
@@ -74,8 +74,8 @@ namespace Speckle.Core.Transports
       Client = new HttpClient(new HttpClientHandler()
       {
         AutomaticDecompression = System.Net.DecompressionMethods.GZip,
-      })
-      {
+        })
+        {
         BaseAddress = new Uri(baseUri),
         Timeout = new TimeSpan(0, 0, timeoutSeconds),
       };
@@ -96,7 +96,7 @@ namespace Speckle.Core.Transports
     {
       if (!GetWriteCompletionStatus())
       {
-        throw new SpeckleException("Transport is still writing.", log: true);
+        throw new SpeckleException("Transport is still writing.");
       }
       TotalSentBytes = 0;
       SavedObjectCount = 0;
@@ -122,7 +122,7 @@ namespace Speckle.Core.Transports
 
       if (CancellationToken.IsCancellationRequested)
       {
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         IS_WRITING = false;
         return;
       }
@@ -141,7 +141,7 @@ namespace Speckle.Core.Transports
     {
       if (CancellationToken.IsCancellationRequested)
       {
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         IS_WRITING = false;
         return;
       }
@@ -168,7 +168,7 @@ namespace Speckle.Core.Transports
       {
         if (CancellationToken.IsCancellationRequested)
         {
-          Queue = new ConcurrentQueue<(string, string, int)>();
+          Queue = new ConcurrentQueue < (string, string, int) > ();
           IS_WRITING = false;
           return;
         }
@@ -180,7 +180,7 @@ namespace Speckle.Core.Transports
         {
           if (CancellationToken.IsCancellationRequested)
           {
-            Queue = new ConcurrentQueue<(string, string, int)>();
+            Queue = new ConcurrentQueue < (string, string, int) > ();
             return;
           }
 
@@ -216,7 +216,7 @@ namespace Speckle.Core.Transports
 
       if (CancellationToken.IsCancellationRequested)
       {
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         IS_WRITING = false;
         return;
       }
@@ -231,7 +231,7 @@ namespace Speckle.Core.Transports
         IS_WRITING = false;
         OnErrorAction?.Invoke(TransportName, new Exception($"Remote error: {Account.serverInfo.url} is not reachable. \n {e.Message}", e));
 
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         return;
       }
 
@@ -252,7 +252,7 @@ namespace Speckle.Core.Transports
     {
       if (CancellationToken.IsCancellationRequested)
       {
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         IS_WRITING = false;
         return;
       }
@@ -270,7 +270,7 @@ namespace Speckle.Core.Transports
     {
       if (CancellationToken.IsCancellationRequested)
       {
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         IS_WRITING = false;
         return;
       }
@@ -294,7 +294,7 @@ namespace Speckle.Core.Transports
     {
       if (CancellationToken.IsCancellationRequested)
       {
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         return null;
       }
 
@@ -312,7 +312,7 @@ namespace Speckle.Core.Transports
     {
       if (CancellationToken.IsCancellationRequested)
       {
-        Queue = new ConcurrentQueue<(string, string, int)>();
+        Queue = new ConcurrentQueue < (string, string, int) > ();
         return null;
       }
 
@@ -336,22 +336,21 @@ namespace Speckle.Core.Transports
         OnErrorAction?.Invoke(TransportName, e);
       }
 
-
       var i = 0;
-      using (var stream = await response.Content.ReadAsStreamAsync())
+      using(var stream = await response.Content.ReadAsStreamAsync())
       {
-        using (var reader = new StreamReader(stream, Encoding.UTF8))
+        using(var reader = new StreamReader(stream, Encoding.UTF8))
         {
           while (reader.Peek() > 0)
           {
             if (CancellationToken.IsCancellationRequested)
             {
-              Queue = new ConcurrentQueue<(string, string, int)>();
+              Queue = new ConcurrentQueue < (string, string, int) > ();
               return null;
             }
 
             var line = reader.ReadLine();
-            var pcs = line.Split(new char[] { '\t' }, count: 2);
+            var pcs = line.Split(new char[ ] { '\t' }, count : 2);
             targetTransport.SaveObject(pcs[0], pcs[1]);
             if (i == 0)
             {
@@ -419,7 +418,7 @@ namespace Speckle.Core.Transports
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
     {
       // Open a GZipStream that writes to the specified output stream.
-      using (GZipStream gzip = new GZipStream(stream, CompressionMode.Compress, true))
+      using(GZipStream gzip = new GZipStream(stream, CompressionMode.Compress, true))
       {
         // Copy all the input content to the GZip stream.
         if (content != null)

--- a/Core/Transports/ServerTransport/Server.cs
+++ b/Core/Transports/ServerTransport/Server.cs
@@ -96,7 +96,7 @@ namespace Speckle.Core.Transports
     {
       if (!GetWriteCompletionStatus())
       {
-        throw new Exception("Transport is still writing.");
+        throw new SpeckleException("Transport is still writing.", log: true);
       }
       TotalSentBytes = 0;
       SavedObjectCount = 0;

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -249,7 +249,7 @@ namespace Objects.Converter.AutocadCivil
               polyline.AddVertexAt(i+1, PointToNative(o.endPoint).Convert2d(plane), 0, 0, 0);
             break;
           default:
-            throw new Exception("Polycurve segment is not a line or arc!");
+            throw new Speckle.Core.Logging.SpeckleException("Polycurve segment is not a line or arc!", log: true);
         }
       }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using Autodesk.AutoCAD.Geometry;
 using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.Geometry;
 using AcadDB = Autodesk.AutoCAD.DatabaseServices;
 
 using Arc = Objects.Geometry.Arc;
@@ -134,7 +133,7 @@ namespace Objects.Converter.AutocadCivil
     {
       var normal = VectorToNative(ellipse.plane.normal);
       var majorAxis = ScaleToNative((double)ellipse.firstRadius, ellipse.units) * VectorToNative(ellipse.plane.xdir);
-      var radiusRatio =(double)ellipse.secondRadius / (double)ellipse.firstRadius;
+      var radiusRatio = (double)ellipse.secondRadius / (double)ellipse.firstRadius;
       return new AcadDB.Ellipse(PointToNative(ellipse.plane.origin), normal, majorAxis, radiusRatio, 0, 2 * Math.PI);
     }
 
@@ -191,7 +190,7 @@ namespace Objects.Converter.AutocadCivil
       var segments = new List<ICurve>();
       var exploded = new DBObjectCollection();
       polyline.Explode(exploded);
-      for(int i = 0; i < exploded.Count; i++)
+      for (int i = 0; i < exploded.Count; i++)
         segments.Add((ICurve)ConvertToSpeckle(exploded[i]));
       polycurve.segments = segments;
 
@@ -240,16 +239,16 @@ namespace Objects.Converter.AutocadCivil
           case Line o:
             polyline.AddVertexAt(i, PointToNative(o.start).Convert2d(plane), 0, 0, 0);
             if (!polycurve.closed && i == polycurve.segments.Count - 1)
-              polyline.AddVertexAt(i+1, PointToNative(o.end).Convert2d(plane), 0, 0, 0);
+              polyline.AddVertexAt(i + 1, PointToNative(o.end).Convert2d(plane), 0, 0, 0);
             break;
           case Arc o:
             var bulge = Math.Tan((double)(o.endAngle - o.startAngle) / 4); // bulge 
             polyline.AddVertexAt(i, PointToNative(o.startPoint).Convert2d(plane), bulge, 0, 0);
             if (!polycurve.closed && i == polycurve.segments.Count - 1)
-              polyline.AddVertexAt(i+1, PointToNative(o.endPoint).Convert2d(plane), 0, 0, 0);
+              polyline.AddVertexAt(i + 1, PointToNative(o.endPoint).Convert2d(plane), 0, 0, 0);
             break;
           default:
-            throw new Speckle.Core.Logging.SpeckleException("Polycurve segment is not a line or arc!", log: true);
+            throw new Speckle.Core.Logging.SpeckleException("Polycurve segment is not a line or arc!");
         }
       }
 
@@ -263,13 +262,13 @@ namespace Objects.Converter.AutocadCivil
 
       // get nurbs and geo data 
       var data = spline.NurbsData;
-      var _spline = spline.GetGeCurve() as NurbCurve3d;
+      var _spline = spline.GetGeCurve()as NurbCurve3d;
 
       // handle the display polyline
       try
       {
         var poly = spline.ToPolyline(false, true);
-        Polyline displayValue = ConvertToSpeckle(poly) as Polyline;
+        Polyline displayValue = ConvertToSpeckle(poly)as Polyline;
         curve.displayValue = displayValue;
       }
       catch { }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -35,7 +35,7 @@ namespace Objects.Converter.AutocadCivil
     public Point3d[] PointListToNative(IEnumerable<double> arr, string units)
     {
       var enumerable = arr.ToList();
-      if (enumerable.Count % 3 != 0) throw new Exception("Array malformed: length%3 != 0.");
+      if (enumerable.Count % 3 != 0) throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
 
       Point3d[] points = new Point3d[enumerable.Count / 3];
       var asArray = enumerable.ToArray();

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Autodesk.AutoCAD.Geometry;
 using AC = Autodesk.AutoCAD.Geometry;
 
@@ -28,16 +27,16 @@ namespace Objects.Converter.AutocadCivil
 
     // Convenience methods:
     // TODO: Deprecate once these have been added to Objects.sln
-    public double[] PointToArray(Point3d pt)
+    public double[ ] PointToArray(Point3d pt)
     {
-      return new double[] { pt.X, pt.Y, pt.Z };
+      return new double[ ] { pt.X, pt.Y, pt.Z };
     }
-    public Point3d[] PointListToNative(IEnumerable<double> arr, string units)
+    public Point3d[ ] PointListToNative(IEnumerable<double> arr, string units)
     {
       var enumerable = arr.ToList();
-      if (enumerable.Count % 3 != 0) throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
+      if (enumerable.Count % 3 != 0)throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.");
 
-      Point3d[] points = new Point3d[enumerable.Count / 3];
+      Point3d[ ] points = new Point3d[enumerable.Count / 3];
       var asArray = enumerable.ToArray();
       for (int i = 2, k = 0; i < enumerable.Count; i += 3)
         points[k++] = new Point3d(
@@ -47,7 +46,7 @@ namespace Objects.Converter.AutocadCivil
 
       return points;
     }
-    public double[] PointsToFlatArray(IEnumerable<Point3d> points)
+    public double[ ] PointsToFlatArray(IEnumerable<Point3d> points)
     {
       return points.SelectMany(pt => PointToArray(pt)).ToArray();
     }
@@ -128,7 +127,7 @@ namespace Objects.Converter.AutocadCivil
       _line.length = line.GetLength(startParam, endParam, tolerance);
       _line.domain = IntervalToSpeckle(line.GetInterval());
       _line.bbox = BoxToSpeckle(line.OrthoBoundBlock);
-      
+
       return _line;
     }
     public Line LineToSpeckle(LineSegment3d line)
@@ -263,13 +262,12 @@ namespace Objects.Converter.AutocadCivil
       return _curve;
     }
 
-
     // Polycurve
     // TODO: NOT TESTED FROM HERE DOWN
     public PolylineCurve3d PolylineToNative(Polyline polyline)
     {
       var points = PointListToNative(polyline.value, polyline.units).ToList();
-      if (polyline.closed) points.Add(points[0]);
+      if (polyline.closed)points.Add(points[0]);
       var _polyline = new PolylineCurve3d(new Point3dCollection(points.ToArray()));
       if (polyline.domain != null)
         _polyline.SetInterval(IntervalToNative(polyline.domain));
@@ -312,8 +310,7 @@ namespace Objects.Converter.AutocadCivil
       if (curve.IsPlanar(out AC.Plane pln))
       {
         if (curve.IsPeriodic(out double period) && curve.IsClosed())
-        {
-        }
+        { }
 
         if (curve.IsLinear(out Line3d line)) // defaults to polyline
         {

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -1,10 +1,10 @@
-﻿using Autodesk.DesignScript.Geometry;
-using Objects.Geometry;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Speckle.Core.Models;
 using System.Runtime.CompilerServices;
+using Autodesk.DesignScript.Geometry;
+using Objects.Geometry;
+using Speckle.Core.Models;
 using DS = Autodesk.DesignScript.Geometry;
 using Objects.Primitive;
 using Point = Objects.Geometry.Point;
@@ -30,7 +30,6 @@ namespace Objects.Converter.Dynamo
   public partial class ConverterDynamo
   {
     #region Points
-
 
     /// <summary>
     /// DS Point to SpecklePoint
@@ -59,17 +58,16 @@ namespace Objects.Converter.Dynamo
       return point.SetDynamoProperties<DS.Point>(GetDynamicMembersFromBase(pt));
     }
 
-
     /// <summary>
     /// Array of point coordinates to array of DS Points
     /// </summary>
     /// <param name="arr"></param>
     /// <returns></returns>
-    public DS.Point[] ArrayToPointList(IEnumerable<double> arr, string units = null)
+    public DS.Point[ ] ArrayToPointList(IEnumerable<double> arr, string units = null)
     {
-      if (arr.Count() % 3 != 0) throw new SpeckleException("Array malformed: length%3 != 0.", log: true);
+      if (arr.Count() % 3 != 0)throw new SpeckleException("Array malformed: length%3 != 0.");
 
-      DS.Point[] points = new DS.Point[arr.Count() / 3];
+      DS.Point[ ] points = new DS.Point[arr.Count() / 3];
       var asArray = arr.ToArray();
       for (int i = 2, k = 0; i < arr.Count(); i += 3)
         points[k++] = DS.Point.ByCoordinates(ScaleToNative(asArray[i - 2], units), ScaleToNative(asArray[i - 1], units), ScaleToNative(asArray[i], units));
@@ -82,14 +80,14 @@ namespace Objects.Converter.Dynamo
     /// </summary>
     /// <param name="points"></param>
     /// <returns></returns>
-    public double[] PointListToFlatArray(IEnumerable<DS.Point> points)
+    public double[ ] PointListToFlatArray(IEnumerable<DS.Point> points)
     {
       return points.SelectMany(pt => PointToArray(pt)).ToArray();
     }
 
-    public double[] PointToArray(DS.Point pt)
+    public double[ ] PointToArray(DS.Point pt)
     {
-      return new double[] { pt.X, pt.Y, pt.Z };
+      return new double[ ] { pt.X, pt.Y, pt.Z };
     }
 
     #endregion
@@ -189,7 +187,7 @@ namespace Objects.Converter.Dynamo
     {
       var u = units ?? ModelUnits;
       var l = new Line(
-       PointListToFlatArray(new DS.Point[] { line.StartPoint, line.EndPoint }),
+        PointListToFlatArray(new DS.Point[ ] { line.StartPoint, line.EndPoint }),
         u);
 
       CopyProperties(l, line);
@@ -207,12 +205,12 @@ namespace Objects.Converter.Dynamo
     {
       var ptStart = PointToNative(line.start);
       var ptEnd = PointToNative(line.end);
-     
-      var ln = DS.Line.ByStartPointEndPoint(ptStart,ptEnd);
-      
+
+      var ln = DS.Line.ByStartPointEndPoint(ptStart, ptEnd);
+
       ptStart.Dispose();
       ptEnd.Dispose();
-      
+
       return ln.SetDynamoProperties<DS.Line>(GetDynamicMembersFromBase(line));
     }
 
@@ -233,7 +231,6 @@ namespace Objects.Converter.Dynamo
       poly.bbox = BoxToSpeckle(polygon.BoundingBox.ToCuboid(), u);
       return poly;
     }
-
 
     /// <summary>
     /// DS Rectangle to SpecklePolyline
@@ -276,8 +273,8 @@ namespace Objects.Converter.Dynamo
     public Circle CircleToSpeckle(DS.Circle circ, string units = null)
     {
       var u = units ?? ModelUnits;
-      using (DS.Vector xAxis = DS.Vector.ByTwoPoints(circ.CenterPoint, circ.StartPoint))
-      using (DS.Plane plane = DS.Plane.ByOriginNormalXAxis(circ.CenterPoint, circ.Normal, xAxis))
+      using(DS.Vector xAxis = DS.Vector.ByTwoPoints(circ.CenterPoint, circ.StartPoint))
+      using(DS.Plane plane = DS.Plane.ByOriginNormalXAxis(circ.CenterPoint, circ.Normal, xAxis))
       {
         var myCircle = new Circle(PlaneToSpeckle(plane, u), circ.Radius, u);
         CopyProperties(myCircle, circ);
@@ -295,9 +292,9 @@ namespace Objects.Converter.Dynamo
     /// <returns></returns>
     public DS.Circle CircleToNative(Circle circ)
     {
-      using (DS.Plane basePlane = PlaneToNative(circ.plane))
-      using (DS.Circle preCircle = DS.Circle.ByPlaneRadius(basePlane, ScaleToNative(circ.radius.Value, circ.units)))
-      using (DS.Vector preXvector = DS.Vector.ByTwoPoints(preCircle.CenterPoint, preCircle.StartPoint))
+      using(DS.Plane basePlane = PlaneToNative(circ.plane))
+      using(DS.Circle preCircle = DS.Circle.ByPlaneRadius(basePlane, ScaleToNative(circ.radius.Value, circ.units)))
+      using(DS.Vector preXvector = DS.Vector.ByTwoPoints(preCircle.CenterPoint, preCircle.StartPoint))
       {
         double angle = preXvector.AngleAboutAxis(basePlane.XAxis, basePlane.Normal);
         var circle = (DS.Circle)preCircle.Rotate(basePlane, angle);
@@ -314,8 +311,8 @@ namespace Objects.Converter.Dynamo
     public Arc ArcToSpeckle(DS.Arc a, string units = null)
     {
       var u = units ?? ModelUnits;
-      using (DS.Vector xAxis = DS.Vector.ByTwoPoints(a.CenterPoint, a.StartPoint))
-      using (DS.Plane basePlane = DS.Plane.ByOriginNormalXAxis(a.CenterPoint, a.Normal, xAxis))
+      using(DS.Vector xAxis = DS.Vector.ByTwoPoints(a.CenterPoint, a.StartPoint))
+      using(DS.Plane basePlane = DS.Plane.ByOriginNormalXAxis(a.CenterPoint, a.Normal, xAxis))
       {
         var arc = new Arc(
           PlaneToSpeckle(basePlane, u),
@@ -340,8 +337,8 @@ namespace Objects.Converter.Dynamo
     /// <returns></returns>
     public DS.Arc ArcToNative(Arc a)
     {
-      using (DS.Plane basePlane = PlaneToNative(a.plane))
-      using (DS.Point startPoint = (DS.Point)basePlane.Origin.Translate(basePlane.XAxis, ScaleToNative(a.radius.Value, a.units)))
+      using(DS.Plane basePlane = PlaneToNative(a.plane))
+      using(DS.Point startPoint = (DS.Point)basePlane.Origin.Translate(basePlane.XAxis, ScaleToNative(a.radius.Value, a.units)))
       {
         var arc = DS.Arc.ByCenterPointStartPointSweepAngle(
           basePlane.Origin,
@@ -361,7 +358,7 @@ namespace Objects.Converter.Dynamo
     public Ellipse EllipseToSpeckle(DS.Ellipse e, string units = null)
     {
       var u = units ?? ModelUnits;
-      using (DS.Plane basePlane = DS.Plane.ByOriginNormalXAxis(e.CenterPoint, e.Normal, e.MajorAxis))
+      using(DS.Plane basePlane = DS.Plane.ByOriginNormalXAxis(e.CenterPoint, e.Normal, e.MajorAxis))
       {
         var ellipse = new Ellipse(
           PlaneToSpeckle(basePlane, u),
@@ -375,7 +372,7 @@ namespace Objects.Converter.Dynamo
 
         ellipse.length = e.Length;
         ellipse.bbox = BoxToSpeckle(e.BoundingBox.ToCuboid(), u);
-        
+
         return ellipse;
       }
     }
@@ -402,9 +399,9 @@ namespace Objects.Converter.Dynamo
       {
         // Curve is an ellipse
         var ellipse = DS.Ellipse.ByPlaneRadii(
-            PlaneToNative(e.plane),
-            ScaleToNative(e.firstRadius.Value, e.units),
-            ScaleToNative(e.secondRadius.Value, e.units)
+          PlaneToNative(e.plane),
+          ScaleToNative(e.firstRadius.Value, e.units),
+          ScaleToNative(e.secondRadius.Value, e.units)
         );
         ellipse.SetDynamoProperties<DS.Ellipse>(GetDynamicMembersFromBase(e));
         return ellipse;
@@ -431,10 +428,9 @@ namespace Objects.Converter.Dynamo
 
       ellipArc.length = arc.Length;
       ellipArc.bbox = BoxToSpeckle(arc.BoundingBox.ToCuboid(), u);
-      
+
       return ellipArc;
     }
-
 
     /// <summary>
     /// DS Polycurve to SpecklePolyline if all curves are linear
@@ -454,7 +450,7 @@ namespace Objects.Converter.Dynamo
         CopyProperties(poly, polycurve);
         poly.length = polycurve.Length;
         poly.bbox = BoxToSpeckle(polycurve.BoundingBox.ToCuboid(), u);
-        
+
         return poly;
       }
       else
@@ -463,7 +459,7 @@ namespace Objects.Converter.Dynamo
         CopyProperties(spkPolycurve, polycurve);
 
         spkPolycurve.segments = polycurve.Curves().Select(c => (ICurve)CurveToSpeckle(c, u)).ToList();
-        
+
         spkPolycurve.length = polycurve.Length;
         spkPolycurve.bbox = BoxToSpeckle(polycurve.BoundingBox.ToCuboid(), u);
 
@@ -473,7 +469,7 @@ namespace Objects.Converter.Dynamo
 
     public PolyCurve PolycurveToNative(Polycurve polycurve)
     {
-      DS.Curve[] curves = new DS.Curve[polycurve.segments.Count];
+      DS.Curve[ ] curves = new DS.Curve[polycurve.segments.Count];
       for (var i = 0; i < polycurve.segments.Count; i++)
       {
         switch (polycurve.segments[i])
@@ -518,28 +514,28 @@ namespace Objects.Converter.Dynamo
       Base speckleCurve;
       if (curve.IsLinear())
       {
-        using (DS.Line line = curve.GetAsLine())
+        using(DS.Line line = curve.GetAsLine())
         {
           speckleCurve = LineToSpeckle(line, u);
         }
       }
       else if (curve.IsArc())
       {
-        using (DS.Arc arc = curve.GetAsArc())
+        using(DS.Arc arc = curve.GetAsArc())
         {
           speckleCurve = ArcToSpeckle(arc, u);
         }
       }
       else if (curve.IsCircle())
       {
-        using (DS.Circle circle = curve.GetAsCircle())
+        using(DS.Circle circle = curve.GetAsCircle())
         {
           speckleCurve = CircleToSpeckle(circle, u);
         }
       }
       else if (curve.IsEllipse())
       {
-        using (DS.Ellipse ellipse = curve.GetAsEllipse())
+        using(DS.Ellipse ellipse = curve.GetAsEllipse())
         {
           speckleCurve = EllipseToSpeckle(ellipse, u);
         }
@@ -576,28 +572,28 @@ namespace Objects.Converter.Dynamo
       Base speckleCurve;
       if (curve.IsLinear())
       {
-        using (DS.Line line = curve.GetAsLine())
+        using(DS.Line line = curve.GetAsLine())
         {
           speckleCurve = LineToSpeckle(line, u);
         }
       }
       else if (curve.IsArc())
       {
-        using (DS.Arc arc = curve.GetAsArc())
+        using(DS.Arc arc = curve.GetAsArc())
         {
           speckleCurve = ArcToSpeckle(arc, u);
         }
       }
       else if (curve.IsCircle())
       {
-        using (DS.Circle circle = curve.GetAsCircle())
+        using(DS.Circle circle = curve.GetAsCircle())
         {
           speckleCurve = CircleToSpeckle(circle, u);
         }
       }
       else if (curve.IsEllipse())
       {
-        using (DS.Ellipse ellipse = curve.GetAsEllipse())
+        using(DS.Ellipse ellipse = curve.GetAsEllipse())
         {
           speckleCurve = EllipseToSpeckle(ellipse, u);
         }
@@ -605,7 +601,7 @@ namespace Objects.Converter.Dynamo
       else
       {
         // SpeckleCurve DisplayValue
-        DS.Curve[] curves = curve.ApproximateWithArcAndLineSegments();
+        DS.Curve[ ] curves = curve.ApproximateWithArcAndLineSegments();
         List<double> polylineCoordinates =
           curves.SelectMany(c => PointListToFlatArray(new DS.Point[2] { c.StartPoint, c.EndPoint })).ToList();
         polylineCoordinates.AddRange(PointToArray(curves.Last().EndPoint));
@@ -630,7 +626,7 @@ namespace Objects.Converter.Dynamo
         //spkCurve.GenerateHash();
         spkCurve.length = curve.Length;
         spkCurve.bbox = BoxToSpeckle(curve.BoundingBox.ToCuboid(), u);
-        
+
         speckleCurve = spkCurve;
       }
 
@@ -640,7 +636,7 @@ namespace Objects.Converter.Dynamo
 
     public Base HelixToSpeckle(Helix helix, string units = null)
     {
-      using (NurbsCurve nurbsCurve = helix.ToNurbsCurve())
+      using(NurbsCurve nurbsCurve = helix.ToNurbsCurve())
       {
         var curve = CurveToSpeckle(nurbsCurve, units ?? ModelUnits);
         CopyProperties(curve, helix);
@@ -692,12 +688,12 @@ namespace Objects.Converter.Dynamo
       //  return new SpeckleMesh(vertices, faces, Colors, textureCoords, properties: mesh.UserDictionary.ToSpeckle());
       //}
 
-      var speckleMesh = new Mesh(vertices, faces, colors, units: u);
+      var speckleMesh = new Mesh(vertices, faces, colors, units : u);
 
       CopyProperties(speckleMesh, mesh);
 
-      using (var box = ComputeMeshBoundingBox(mesh))
-        speckleMesh.bbox = BoxToSpeckle(box, u);
+      using(var box = ComputeMeshBoundingBox(mesh))
+      speckleMesh.bbox = BoxToSpeckle(box, u);
 
       return speckleMesh;
     }
@@ -708,17 +704,17 @@ namespace Objects.Converter.Dynamo
       double highX = double.NegativeInfinity, highY = double.NegativeInfinity, highZ = double.NegativeInfinity;
       mesh.VertexPositions.ForEach(pos =>
       {
-        if (pos.X < lowX) lowX = pos.X;
-        if (pos.Y < lowY) lowY = pos.Y;
-        if (pos.Z < lowZ) lowZ = pos.Z;
-        if (pos.X > highX) highX = pos.X;
-        if (pos.Y > highY) highY = pos.Y;
-        if (pos.Z > highZ) highZ = pos.Z;
+        if (pos.X < lowX)lowX = pos.X;
+        if (pos.Y < lowY)lowY = pos.Y;
+        if (pos.Z < lowZ)lowZ = pos.Z;
+        if (pos.X > highX)highX = pos.X;
+        if (pos.Y > highY)highY = pos.Y;
+        if (pos.Z > highZ)highZ = pos.Z;
       });
 
-      using (var low = DS.Point.ByCoordinates(lowX, lowY, lowZ))
-      using (var high = DS.Point.ByCoordinates(highX, highY, highZ))
-        return DS.Cuboid.ByCorners(low, high);
+      using(var low = DS.Point.ByCoordinates(lowX, lowY, lowZ))
+      using(var high = DS.Point.ByCoordinates(highX, highY, highZ))
+      return DS.Cuboid.ByCorners(low, high);
     }
 
     public DS.Mesh MeshToNative(Mesh mesh)
@@ -755,37 +751,35 @@ namespace Objects.Converter.Dynamo
 
     #endregion
 
-
     public Cuboid BoxToNative(Box box)
     {
-      using (var coordinateSystem = PlaneToNative(box.basePlane).ToCoordinateSystem())
-        using (var cLow = DS.Point.ByCartesianCoordinates(coordinateSystem, box.xSize.start ?? 0, box.ySize.start ?? 0, box.zSize.start ?? 0))
-          using (var cHigh = DS.Point.ByCartesianCoordinates(coordinateSystem, box.xSize.end ?? 0, box.ySize.end ?? 0, box.zSize.end ?? 0))
-            return Cuboid.ByCorners(cLow, cHigh);
+      using(var coordinateSystem = PlaneToNative(box.basePlane).ToCoordinateSystem())
+      using(var cLow = DS.Point.ByCartesianCoordinates(coordinateSystem, box.xSize.start ?? 0, box.ySize.start ?? 0, box.zSize.start ?? 0))
+      using(var cHigh = DS.Point.ByCartesianCoordinates(coordinateSystem, box.xSize.end ?? 0, box.ySize.end ?? 0, box.zSize.end ?? 0))
+      return Cuboid.ByCorners(cLow, cHigh);
     }
 
     public Box BoxToSpeckle(Cuboid box, string units = null)
     {
       var u = units ?? ModelUnits;
       var plane = PlaneToSpeckle(box.ContextCoordinateSystem.XYPlane, u);
-      
+
       // Todo: Check for cubes that are offset from the plane origin to ensure correct positioning.
-      var boxToSpeckle = new Box(plane, new Interval(-box.Width/2, box.Width/2), new Interval(-box.Length/2, box.Length/2), new Interval(-box.Height/2, box.Height/2),u);
+      var boxToSpeckle = new Box(plane, new Interval(-box.Width / 2, box.Width / 2), new Interval(-box.Length / 2, box.Length / 2), new Interval(-box.Height / 2, box.Height / 2), u);
       boxToSpeckle.volume = box.Volume;
       boxToSpeckle.area = box.Area;
       return boxToSpeckle;
     }
-    
+
     public NurbsSurface SurfaceToNative(Surface surface)
     {
-      var points = new DS.Point[][] { };
-      var weights = new double[][] { };
+      var points = new DS.Point[ ][ ] { };
+      var weights = new double[ ][ ] { };
 
       var controlPoints = surface.GetControlPoints();
 
-      points = controlPoints.Select(row => row.Select(p
-        => DS.Point.ByCoordinates(
-        ScaleToNative(p.x, p.units),
+      points = controlPoints.Select(row => row.Select(p => DS.Point.ByCoordinates(
+          ScaleToNative(p.x, p.units),
           ScaleToNative(p.y, p.units),
           ScaleToNative(p.z, p.units))).ToArray())
         .ToArray();
@@ -844,7 +838,7 @@ namespace Objects.Converter.Dynamo
 
       result.area = surface.Area;
       result.bbox = BoxToSpeckle(surface.BoundingBox.ToCuboid(), u);
-      
+
       return result;
     }
 
@@ -856,7 +850,7 @@ namespace Objects.Converter.Dynamo
     public void CopyProperties(Base to, DesignScriptEntity from)
     {
       var dict = from.GetSpeckleProperties();
-      foreach(var kvp in dict)
+      foreach (var kvp in dict)
       {
         to[kvp.Key] = kvp.Value;
       }
@@ -865,7 +859,7 @@ namespace Objects.Converter.Dynamo
     public Dictionary<string, object> GetDynamicMembersFromBase(Base obj)
     {
       var dict = new Dictionary<string, object>();
-      foreach( var prop in obj.GetDynamicMembers())
+      foreach (var prop in obj.GetDynamicMembers())
       {
         dict.Add(prop, obj[prop]);
       }

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -19,6 +19,7 @@ using Mesh = Objects.Geometry.Mesh;
 using Objects;
 using Surface = Objects.Geometry.Surface;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 
 namespace Objects.Converter.Dynamo
 {
@@ -66,7 +67,7 @@ namespace Objects.Converter.Dynamo
     /// <returns></returns>
     public DS.Point[] ArrayToPointList(IEnumerable<double> arr, string units = null)
     {
-      if (arr.Count() % 3 != 0) throw new Exception("Array malformed: length%3 != 0.");
+      if (arr.Count() % 3 != 0) throw new SpeckleException("Array malformed: length%3 != 0.", log: true);
 
       DS.Point[] points = new DS.Point[arr.Count() / 3];
       var asArray = arr.ToArray();

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.Revit.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.Revit.cs
@@ -33,7 +33,7 @@ namespace Objects.Converter.Dynamo
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
         default:
-          throw new Exception("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
       }
 
     }
@@ -78,7 +78,7 @@ namespace Objects.Converter.Dynamo
     //  else if (typeId == UnitTypeId.Feet.TypeId)
     //    return Speckle.Core.Kits.Units.Feet;
 
-    //  throw new Exception("The current Unit System is unsupported.");
+    //  throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
     //}
   }
 }

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.Revit.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.Revit.cs
@@ -33,7 +33,7 @@ namespace Objects.Converter.Dynamo
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
+          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
       }
 
     }
@@ -78,7 +78,7 @@ namespace Objects.Converter.Dynamo
     //  else if (typeId == UnitTypeId.Feet.TypeId)
     //    return Speckle.Core.Kits.Units.Feet;
 
-    //  throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
+    //  throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
     //}
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -445,7 +445,7 @@ namespace Objects.Converter.Revit
         }
       }
 
-      throw new Exception($"Could not find any family symbol to use.");
+      throw new Speckle.Core.Logging.SpeckleException($"Could not find any family symbol to use.", log: true);
     }
 
     private T GetElementType<T>(Base element)
@@ -465,7 +465,7 @@ namespace Objects.Converter.Revit
 
       if (types.Count == 0)
       {
-        throw new Exception($"Could not find any type symbol to use for family {nameof(T)}.");
+        throw new Speckle.Core.Logging.SpeckleException($"Could not find any type symbol to use for family {nameof(T)}.", log: true);
       }
 
       var family = element["family"] as string;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -1,11 +1,11 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
 using Objects.BuiltElements;
 using Objects.BuiltElements.Revit;
 using Objects.Other;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using DB = Autodesk.Revit.DB;
 using ElementType = Autodesk.Revit.DB.ElementType;
 using Floor = Objects.BuiltElements.Floor;
@@ -18,8 +18,6 @@ namespace Objects.Converter.Revit
   {
 
     #region hosted elements
-
-
 
     private bool ShouldConvertHostedElement(DB.Element element, DB.Element host)
     {
@@ -135,7 +133,6 @@ namespace Objects.Converter.Revit
 
     #endregion
 
-
     #region parameters
 
     #region ToSpeckle
@@ -212,18 +209,17 @@ namespace Objects.Converter.Revit
 
     }
 
-
     //rp must HaveValue
     private Parameter ParameterToSpeckle(DB.Parameter rp, bool isTypeParameter = false)
     {
       var sp = new Parameter
       {
-        name = rp.Definition.Name,
-        applicationId = GetParamInternalName(rp),
-        isShared = rp.IsShared,
-        isReadOnly = rp.IsReadOnly,
-        isTypeParameter = isTypeParameter,
-        revitUnitType = rp.Definition.UnitType.ToString() //eg UT_Length
+      name = rp.Definition.Name,
+      applicationId = GetParamInternalName(rp),
+      isShared = rp.IsShared,
+      isReadOnly = rp.IsReadOnly,
+      isTypeParameter = isTypeParameter,
+      revitUnitType = rp.Definition.UnitType.ToString() //eg UT_Length
       };
 
       switch (rp.StorageType)
@@ -257,13 +253,13 @@ namespace Objects.Converter.Revit
           if (sp.value == null)
             sp.value = rp.AsValueString();
           break;
-        //case StorageType.ElementId:
-        //  // NOTE: if this collects too much garbage, maybe we can ignore it
-        //  var id = rp.AsElementId();
-        //  var e = Doc.GetElement(id);
-        //  if (e != null && CanConvertToSpeckle(e))
-        //    sp.value = ConvertToSpeckle(e);
-        //  break;
+          //case StorageType.ElementId:
+          //  // NOTE: if this collects too much garbage, maybe we can ignore it
+          //  var id = rp.AsElementId();
+          //  var e = Doc.GetElement(id);
+          //  if (e != null && CanConvertToSpeckle(e))
+          //    sp.value = ConvertToSpeckle(e);
+          //  break;
         default:
           return null;
           break;
@@ -282,11 +278,9 @@ namespace Objects.Converter.Revit
       if (revitElement == null)
         return;
 
-
       var speckleParameters = speckleElement["parameters"] as List<Parameter>;
       if (speckleParameters == null || !speckleParameters.Any())
         return;
-
 
       // NOTE: we are using the ParametersMap here and not Parameters, as it's a much smaller list of stuff and 
       // Parameters most likely contains extra (garbage) stuff that we don't need to set anyways
@@ -302,7 +296,7 @@ namespace Objects.Converter.Revit
 
       //only loop params we can set and that actually exist on the revit element
       var filteredSpeckleParameters = speckleParameters.Where(x => !x.isReadOnly &&
-      (revitParameterById.ContainsKey(x.applicationId) || revitParameterByName.ContainsKey(x.name)));
+        (revitParameterById.ContainsKey(x.applicationId) || revitParameterByName.ContainsKey(x.name)));
 
       foreach (var sp in filteredSpeckleParameters)
       {
@@ -391,8 +385,6 @@ namespace Objects.Converter.Revit
       }
     }
 
-
-
     #endregion
 
     #region  element types
@@ -445,14 +437,13 @@ namespace Objects.Converter.Revit
         }
       }
 
-      throw new Speckle.Core.Logging.SpeckleException($"Could not find any family symbol to use.", log: true);
+      throw new Speckle.Core.Logging.SpeckleException($"Could not find any family symbol to use.");
     }
 
     private T GetElementType<T>(Base element)
     {
       List<ElementType> types = new List<ElementType>();
       ElementFilter filter = GetCategoryFilter(element);
-
 
       if (filter != null)
       {
@@ -465,7 +456,7 @@ namespace Objects.Converter.Revit
 
       if (types.Count == 0)
       {
-        throw new Speckle.Core.Logging.SpeckleException($"Could not find any type symbol to use for family {nameof(T)}.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException($"Could not find any type symbol to use for family {nameof(T)}.");
       }
 
       var family = element["family"] as string;
@@ -512,7 +503,6 @@ namespace Objects.Converter.Revit
 
       return (T)(object)match;
     }
-
 
     private ElementFilter GetCategoryFilter(Base element)
     {
@@ -612,7 +602,6 @@ namespace Objects.Converter.Revit
     /// Rant end
     ////////////////////////////////////////////////
 
-
     private BetterBasePoint _basePoint;
     private BetterBasePoint BasePoint
     {
@@ -620,7 +609,7 @@ namespace Objects.Converter.Revit
       {
         if (_basePoint == null)
         {
-          var bp = new FilteredElementCollector(Doc).WherePasses(new ElementCategoryFilter(BuiltInCategory.OST_ProjectBasePoint)).FirstOrDefault() as BasePoint;
+          var bp = new FilteredElementCollector(Doc).WherePasses(new ElementCategoryFilter(BuiltInCategory.OST_ProjectBasePoint)).FirstOrDefault()as BasePoint;
           if (bp == null)
           {
             _basePoint = new BetterBasePoint();
@@ -674,9 +663,7 @@ namespace Objects.Converter.Revit
     }
     #endregion
 
-
     #region Floor/ceiling/roof openings
-
 
     //a floor/roof/ceiling outline can have "voids/holes" for 3 reasons:
     // - there is a shaft cutting through it > we don't need to create an opening (the shaft will be created on its own)
@@ -747,9 +734,7 @@ namespace Objects.Converter.Revit
       return false;
     }
 
-
     #endregion
-
 
     public WallLocationLine GetWallLocationLine(LocationLine location)
     {
@@ -777,7 +762,7 @@ namespace Objects.Converter.Revit
         return material;
       }
 
-      var revitMaterial = Doc.GetElement(matId) as Material;
+      var revitMaterial = Doc.GetElement(matId)as Material;
       material = new RenderMaterial();
       material.opacity = 1 - revitMaterial.Transparency / 100f;
       material.diffuse = System.Drawing.Color.FromArgb(revitMaterial.Color.Red, revitMaterial.Color.Green, revitMaterial.Color.Blue).ToArgb();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
@@ -15,7 +15,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleBeam.baseLine == null)
       {
-        throw new Exception("Only line based Beams are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.", log: true);
       }
 
       DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleBeam);
@@ -96,7 +96,7 @@ namespace Objects.Converter.Revit
       var baseLine = baseGeometry as ICurve;
       if (baseLine == null)
       {
-        throw new Exception("Only line based Beams are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.", log: true);
       }
 
       var speckleBeam = new RevitBeam();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
@@ -1,10 +1,10 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
 using Objects.BuiltElements;
 using Objects.BuiltElements.Revit;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
 using DB = Autodesk.Revit.DB;
 
 namespace Objects.Converter.Revit
@@ -15,7 +15,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleBeam.baseLine == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.");
       }
 
       DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleBeam);
@@ -43,7 +43,7 @@ namespace Objects.Converter.Revit
       {
         try
         {
-          var revitType = Doc.GetElement(docObj.GetTypeId()) as ElementType;
+          var revitType = Doc.GetElement(docObj.GetTypeId())as ElementType;
 
           // if family changed, tough luck. delete and let us create a new one.
           if (familySymbol.FamilyName != revitType.FamilyName)
@@ -96,7 +96,7 @@ namespace Objects.Converter.Revit
       var baseLine = baseGeometry as ICurve;
       if (baseLine == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.");
       }
 
       var speckleBeam = new RevitBeam();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -17,7 +17,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleColumn.baseLine == null)
       {
-        throw new Exception("Only line based Beams are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.", log: true);
       }
 
       DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn); ;
@@ -204,7 +204,7 @@ namespace Objects.Converter.Revit
 
       if (baseLine == null)
       {
-        throw new Exception("Only line based Columns are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Columns are currently supported.", log: true);
       }
 
       speckleColumn.baseLine = baseLine; //all speckle columns should be line based

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -1,9 +1,9 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
 using Objects.BuiltElements.Revit;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
 using Column = Objects.BuiltElements.Column;
 using DB = Autodesk.Revit.DB;
 using Line = Objects.Geometry.Line;
@@ -17,10 +17,10 @@ namespace Objects.Converter.Revit
     {
       if (speckleColumn.baseLine == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.");
       }
 
-      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn); ;
+      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn);;
       var baseLine = CurveToNative(speckleColumn.baseLine).get_Item(0);
 
       // If the start point elevation is higher than the end point elevation, reverse the line.
@@ -58,7 +58,7 @@ namespace Objects.Converter.Revit
       {
         try
         {
-          var revitType = Doc.GetElement(docObj.GetTypeId()) as ElementType;
+          var revitType = Doc.GetElement(docObj.GetTypeId())as ElementType;
 
           // if family changed, tough luck. delete and let us create a new one.
           if (familySymbol.FamilyName != revitType.FamilyName)
@@ -160,8 +160,8 @@ namespace Objects.Converter.Revit
       var topOffset = ScaleToNative(speckleRevitColumn.topOffset, speckleRevitColumn.units);
 
       //these have been set previously
-      DB.Level level = Doc.GetElement(baseLevelParam.AsElementId()) as DB.Level;
-      DB.Level topLevel = Doc.GetElement(topLevelParam.AsElementId()) as DB.Level;
+      DB.Level level = Doc.GetElement(baseLevelParam.AsElementId())as DB.Level;
+      DB.Level topLevel = Doc.GetElement(topLevelParam.AsElementId())as DB.Level;
 
       //checking if BASE offset needs to be set before or after TOP offset
       if (topLevel != null && topLevel.Elevation + baseOffset <= level.Elevation)
@@ -204,7 +204,7 @@ namespace Objects.Converter.Revit
 
       if (baseLine == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only line based Columns are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Columns are currently supported.");
       }
 
       speckleColumn.baseLine = baseLine; //all speckle columns should be line based
@@ -221,7 +221,6 @@ namespace Objects.Converter.Revit
 
       return speckleColumn;
     }
-
 
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -94,7 +94,7 @@ namespace Objects.Converter.Revit
       try
       {
         var solid = BrepToNative(brep);
-        if (solid == null) throw new SpeckleException("Could not convert brep to native");
+        if (solid == null) throw new SpeckleException("Could not convert brep to native", log: true);
         revitDs.SetShape(new List<GeometryObject>{solid});
       }
       catch (Exception e)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -1,15 +1,14 @@
-﻿using Autodesk.Revit.DB;
-using Speckle.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autodesk.Revit.DB;
 using Objects.Geometry;
 using Speckle.Core.Logging;
+using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
 using DirectShape = Objects.BuiltElements.Revit.DirectShape;
 using Mesh = Objects.Geometry.Mesh;
 using Parameter = Objects.BuiltElements.Revit.Parameter;
-
 
 namespace Objects.Converter.Revit
 {
@@ -94,8 +93,8 @@ namespace Objects.Converter.Revit
       try
       {
         var solid = BrepToNative(brep);
-        if (solid == null) throw new SpeckleException("Could not convert brep to native", log: true);
-        revitDs.SetShape(new List<GeometryObject>{solid});
+        if (solid == null)throw new SpeckleException("Could not convert brep to native");
+        revitDs.SetShape(new List<GeometryObject> { solid });
       }
       catch (Exception e)
       {
@@ -142,20 +141,21 @@ namespace Objects.Converter.Revit
       var category = Categories.GetCategory(cat);
       var element = revitAc.get_Geometry(new Options());
       var geometries = element.ToList().Select<GeometryObject, Base>(obj =>
-       {
-         return obj switch
-         {
-           DB.Mesh mesh => MeshToSpeckle(mesh),
-           Solid solid => BrepToSpeckle(solid),
-           _ => null
-         };
-       });
+        {
+          return obj
+          switch
+          {
+          DB.Mesh mesh => MeshToSpeckle(mesh),
+          Solid solid => BrepToSpeckle(solid),
+          _ => null
+          };
+        });
       var speckleAc = new DirectShape(
         revitAc.Name,
         category,
         geometries.ToList(),
         new List<Parameter>()
-        );
+      );
       GetAllRevitParamsAndIds(speckleAc, revitAc);
       speckleAc["type"] = revitAc.Name;
       return speckleAc;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -74,7 +74,7 @@ namespace Objects.Converter.Revit
       var baseLine = baseGeometry as Line;
       if (baseLine == null)
       {
-        throw new Exception("Only line base Ducts are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only line base Ducts are currently supported.", log: true);
       }
 
       // SPECKLE DUCT

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -1,11 +1,11 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Mechanical;
 using Objects.BuiltElements;
 using Objects.BuiltElements.Revit;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using DB = Autodesk.Revit.DB.Mechanical;
 using Line = Objects.Geometry.Line;
 
@@ -74,7 +74,7 @@ namespace Objects.Converter.Revit
       var baseLine = baseGeometry as Line;
       if (baseLine == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only line base Ducts are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only line base Ducts are currently supported.");
       }
 
       // SPECKLE DUCT

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
@@ -1,11 +1,11 @@
-﻿using Autodesk.Revit.DB;
-using ConverterRevitShared.Revit;
-using Objects.BuiltElements.Revit;
-using Speckle.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Autodesk.Revit.DB;
+using ConverterRevitShared.Revit;
+using Objects.BuiltElements.Revit;
+using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
 using Mesh = Objects.Geometry.Mesh;
 
@@ -21,12 +21,11 @@ namespace Objects.Converter.Revit
     {
       if (speckleWall.surface == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only surface based FaceWalls are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only surface based FaceWalls are currently supported.");
       }
 
-
       // Cannot update revit wall to new mass face
-      FaceWall revitWall = GetExistingElementByApplicationId(speckleWall.applicationId) as DB.FaceWall;
+      FaceWall revitWall = GetExistingElementByApplicationId(speckleWall.applicationId)as DB.FaceWall;
       if (revitWall != null)
       {
         Doc.Delete(revitWall.Id);
@@ -42,26 +41,25 @@ namespace Objects.Converter.Revit
       var tempMassFamilyPath = CreateMassFamily(famPath, speckleWall.surface, speckleWall.applicationId);
       Family fam;
       Doc.LoadFamily(tempMassFamilyPath, new FamilyLoadOption(), out fam);
-      var symbol = Doc.GetElement(fam.GetFamilySymbolIds().First()) as FamilySymbol;
+      var symbol = Doc.GetElement(fam.GetFamilySymbolIds().First())as FamilySymbol;
       symbol.Activate();
 
       try
       {
         File.Delete(tempMassFamilyPath);
       }
-      catch 
+      catch
       {
 
       }
-
 
       var mass = Doc.Create.NewFamilyInstance(XYZ.Zero, symbol, DB.Structure.StructuralType.NonStructural);
       // NOTE: must set a schedule level!
       // otherwise the wall creation will fail with "Could not create a face wall."
       var level = new FilteredElementCollector(Doc)
-         .WhereElementIsNotElementType()
-         .OfCategory(BuiltInCategory.OST_Levels) // this throws a null error if user tries to recieve stream in a file with no levels
-         .ToElements().FirstOrDefault();
+        .WhereElementIsNotElementType()
+        .OfCategory(BuiltInCategory.OST_Levels) // this throws a null error if user tries to recieve stream in a file with no levels
+        .ToElements().FirstOrDefault();
 
       if (level == null) // create a new level at 0 if no levels could be retrieved from doc
         level = Level.Create(Doc, 0);
@@ -72,21 +70,20 @@ namespace Objects.Converter.Revit
       Doc.Regenerate();
       Reference faceRef = GetFaceRef(mass);
 
-      var wallType = GetElementType<WallType>(speckleWall); 
+      var wallType = GetElementType<WallType>(speckleWall);
       if (!FaceWall.IsWallTypeValidForFaceWall(Doc, wallType.Id))
       {
         ConversionErrors.Add(new Error { message = $"Wall type not valid for face wall ${speckleWall.applicationId}." });
         return null;
       }
 
-      revitWall = null;  
+      revitWall = null;
       try
       {
         revitWall = DB.FaceWall.Create(Doc, wallType.Id, GetWallLocationLine(speckleWall.locationLine), faceRef);
       }
       catch (Exception e)
-      {
-      }
+      { }
 
       if (revitWall == null)
       {
@@ -98,12 +95,15 @@ namespace Objects.Converter.Revit
 
       SetInstanceParameters(revitWall, speckleWall);
 
-      var placeholders = new List<ApplicationPlaceholderObject>() {new ApplicationPlaceholderObject
+      var placeholders = new List<ApplicationPlaceholderObject>()
       {
+        new ApplicationPlaceholderObject
+        {
         applicationId = speckleWall.applicationId,
         ApplicationGeneratedId = revitWall.UniqueId,
         NativeObject = revitWall
-      } };
+        }
+      };
 
       var hostedElements = SetHostedElements(speckleWall, revitWall);
       placeholders.AddRange(hostedElements);
@@ -118,9 +118,7 @@ namespace Objects.Converter.Revit
       geomOption.IncludeNonVisibleObjects = true;
       geomOption.DetailLevel = ViewDetailLevel.Fine;
 
-
       GeometryElement ge = e.get_Geometry(geomOption);
-
 
       foreach (GeometryObject geomObj in ge)
       {
@@ -145,8 +143,7 @@ namespace Objects.Converter.Revit
     {
       var famDoc = Doc.Application.NewFamilyDocument(famPath);
 
-
-      using (Transaction t = new Transaction(famDoc, "Create Mass"))
+      using(Transaction t = new Transaction(famDoc, "Create Mass"))
       {
         t.Start();
 
@@ -189,8 +186,6 @@ namespace Objects.Converter.Revit
 
       return tempFamilyPath;
     }
-
-
 
   }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
@@ -21,7 +21,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleWall.surface == null)
       {
-        throw new Exception("Only surface based FaceWalls are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only surface based FaceWalls are currently supported.", log: true);
       }
 
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -161,7 +161,7 @@ namespace Objects.Converter.Revit
       var basePoint = baseGeometry as Point;
       if (basePoint == null)
       {
-        throw new Exception("Only point based Family Instances are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only point based Family Instances are currently supported.", log: true);
       }
 
       var lev1 = ConvertAndCacheLevel(revitFi, BuiltInParameter.FAMILY_LEVEL_PARAM);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -1,10 +1,10 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
 using Objects.BuiltElements.Revit;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using DB = Autodesk.Revit.DB;
 using Point = Objects.Geometry.Point;
 
@@ -26,7 +26,7 @@ namespace Objects.Converter.Revit
       {
         try
         {
-          var revitType = Doc.GetElement(docObj.GetTypeId()) as ElementType;
+          var revitType = Doc.GetElement(docObj.GetTypeId())as ElementType;
 
           // if family changed, tough luck. delete and let us create a new one.
           if (familySymbol.FamilyName != revitType.FamilyName)
@@ -102,14 +102,15 @@ namespace Objects.Converter.Revit
       }
       catch { }
 
-
       SetInstanceParameters(familyInstance, speckleFi);
 
-      var placeholders = new List<ApplicationPlaceholderObject>() {
-        new ApplicationPlaceholderObject {
-          applicationId = speckleFi.applicationId,
-          ApplicationGeneratedId = familyInstance.UniqueId,
-          NativeObject = familyInstance
+      var placeholders = new List<ApplicationPlaceholderObject>()
+      {
+        new ApplicationPlaceholderObject
+        {
+        applicationId = speckleFi.applicationId,
+        ApplicationGeneratedId = familyInstance.UniqueId,
+        NativeObject = familyInstance
         }
       };
 
@@ -161,13 +162,13 @@ namespace Objects.Converter.Revit
       var basePoint = baseGeometry as Point;
       if (basePoint == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only point based Family Instances are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only point based Family Instances are currently supported.");
       }
 
       var lev1 = ConvertAndCacheLevel(revitFi, BuiltInParameter.FAMILY_LEVEL_PARAM);
       var lev2 = ConvertAndCacheLevel(revitFi, BuiltInParameter.FAMILY_BASE_LEVEL_PARAM);
 
-      var symbol = Doc.GetElement(revitFi.GetTypeId()) as FamilySymbol;
+      var symbol = Doc.GetElement(revitFi.GetTypeId())as FamilySymbol;
 
       var speckleFi = new BuiltElements.Revit.FamilyInstance();
       speckleFi.basePoint = basePoint;
@@ -211,7 +212,6 @@ namespace Objects.Converter.Revit
       {
         speckleFi.elements = convertedSubElements;
       }
-
 
       #endregion
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -19,7 +19,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleFloor.outline == null)
       {
-        throw new Exception("Only outline based Floor are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only outline based Floor are currently supported.", log: true);
       }
 
       bool structural = false;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -1,13 +1,12 @@
-﻿
-using Autodesk.Revit.DB;
-using Objects.BuiltElements.Revit;
-using Objects.Geometry;
-using Objects.BuiltElements;
-using Objects.BuiltElements.Revit;
-using Speckle.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autodesk.Revit.DB;
+using Objects.BuiltElements;
+using Objects.BuiltElements.Revit;
+using Objects.BuiltElements.Revit;
+using Objects.Geometry;
+using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
 using Opening = Objects.BuiltElements.Opening;
 
@@ -19,7 +18,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleFloor.outline == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only outline based Floor are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only outline based Floor are currently supported.");
       }
 
       bool structural = false;
@@ -79,10 +78,6 @@ namespace Objects.Converter.Revit
       return placeholders;
     }
 
-
-
-
-
     private RevitFloor FloorToSpeckle(DB.Floor revitFloor)
     {
       var profiles = GetProfiles(revitFloor);
@@ -115,7 +110,7 @@ namespace Objects.Converter.Revit
     {
       var profiles = new List<ICurve>();
       var faces = HostObjectUtils.GetTopFaces(floor);
-      Face face = floor.GetGeometryObjectFromReference(faces[0]) as Face;
+      Face face = floor.GetGeometryObjectFromReference(faces[0])as Face;
       var crvLoops = face.GetEdgesAsCurveLoops();
       foreach (var crvloop in crvLoops)
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -1,10 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Autodesk.Revit.DB;
 using Objects.Geometry;
 using Objects.Primitive;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Arc = Objects.Geometry.Arc;
 using Curve = Objects.Geometry.Curve;
 using DB = Autodesk.Revit.DB;
@@ -37,7 +37,7 @@ namespace Objects.Converter.Revit
           return VectorToNative(g);
 
         default:
-          throw new Speckle.Core.Logging.SpeckleException("Cannot convert Curve of type " + geom.GetType(), log: true);
+          throw new Speckle.Core.Logging.SpeckleException("Cannot convert Curve of type " + geom.GetType());
       }
     }
 
@@ -156,7 +156,6 @@ namespace Objects.Converter.Revit
 
       XYZ center = arc.Center;
 
-
       XYZ dir0 = (arc.GetEndPoint(0) - center).Normalize();
       XYZ dir1 = (arc.GetEndPoint(1) - center).Normalize();
 
@@ -179,7 +178,7 @@ namespace Objects.Converter.Revit
     public DB.Ellipse EllipseToNative(Ellipse ellipse)
     {
       //TODO: support ellipse arcs
-      using (DB.Plane basePlane = PlaneToNative(ellipse.plane))
+      using(DB.Plane basePlane = PlaneToNative(ellipse.plane))
       {
         var e = DB.Ellipse.CreateCurve(
           PointToNative(ellipse.plane.origin),
@@ -187,9 +186,9 @@ namespace Objects.Converter.Revit
           ScaleToNative((double)ellipse.secondRadius, ellipse.units),
           basePlane.XVec.Normalize(),
           basePlane.YVec.Normalize(),
-           ellipse.domain.start ?? 0,
-           ellipse.domain.end ?? 2 * Math.PI
-          ) as DB.Ellipse;
+          ellipse.domain.start ?? 0,
+          ellipse.domain.end ?? 2 * Math.PI
+        )as DB.Ellipse;
 
         e.MakeBound(ellipse.trimDomain?.start ?? 0, ellipse.trimDomain?.end ?? 2 * Math.PI);
         return e;
@@ -199,7 +198,7 @@ namespace Objects.Converter.Revit
     public Ellipse EllipseToSpeckle(DB.Ellipse ellipse, string units = null)
     {
       var u = units ?? ModelUnits;
-      using (DB.Plane basePlane = DB.Plane.CreateByOriginAndBasis(ellipse.Center, ellipse.XDirection, ellipse.YDirection))
+      using(DB.Plane basePlane = DB.Plane.CreateByOriginAndBasis(ellipse.Center, ellipse.XDirection, ellipse.YDirection))
       {
         var trim = ellipse.IsBound ? new Interval(ellipse.GetEndParameter(0), ellipse.GetEndParameter(1)) : null;
 
@@ -227,7 +226,7 @@ namespace Objects.Converter.Revit
       Curve speckleCurve = new Curve();
       speckleCurve.weights = revitCurve.Weights.Cast<double>().ToList();
       speckleCurve.points = points;
-      speckleCurve.knots = revitCurve.Knots.Cast<double>().ToList(); ;
+      speckleCurve.knots = revitCurve.Knots.Cast<double>().ToList();;
       speckleCurve.degree = revitCurve.Degree;
       //speckleCurve.periodic = revitCurve.Period;
       speckleCurve.rational = revitCurve.isRational;
@@ -238,7 +237,6 @@ namespace Objects.Converter.Revit
 
       return speckleCurve;
     }
-
 
     public DB.Curve CurveToNative(Curve speckleCurve)
     {
@@ -321,7 +319,7 @@ namespace Objects.Converter.Revit
 
           return curveArray;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The provided geometry is not a valid curve", log: true);
+          throw new Speckle.Core.Logging.SpeckleException("The provided geometry is not a valid curve");
       }
     }
 
@@ -355,7 +353,7 @@ namespace Objects.Converter.Revit
         case DB.HermiteSpline spline:
           return HermiteSplineToSpeckle(spline, u);
         default:
-          throw new Speckle.Core.Logging.SpeckleException("Cannot convert Curve of type " + curve.GetType(), log: true);
+          throw new Speckle.Core.Logging.SpeckleException("Cannot convert Curve of type " + curve.GetType());
       }
     }
 
@@ -399,13 +397,13 @@ namespace Objects.Converter.Revit
 
         for (var i = 1; i < pts.Count; i++)
         {
-          var speckleLine = new Line(new double[] { pts[i - 1].x, pts[i - 1].y, pts[i - 1].z, pts[i].x, pts[i].y, pts[i].z }, polyline.units);
+          var speckleLine = new Line(new double[ ] { pts[i - 1].x, pts[i - 1].y, pts[i - 1].z, pts[i].x, pts[i].y, pts[i].z }, polyline.units);
           curveArray.Append(LineToNative(speckleLine));
         }
 
         if (polyline.closed)
         {
-          var speckleLine = new Line(new double[] { pts[pts.Count - 1].x, pts[pts.Count - 1].y, pts[pts.Count - 1].z, pts[0].x, pts[0].y, pts[0].z }, polyline.units);
+          var speckleLine = new Line(new double[ ] { pts[pts.Count - 1].x, pts[pts.Count - 1].y, pts[pts.Count - 1].z, pts[0].x, pts[0].y, pts[0].z }, polyline.units);
           curveArray.Append(LineToNative(speckleLine));
         }
       }
@@ -418,7 +416,7 @@ namespace Objects.Converter.Revit
       foreach (var vert in mesh.Vertices)
       {
         var vertex = PointToSpeckle(vert);
-        speckleMesh.vertices.AddRange(new double[] { vertex.x, vertex.y, vertex.z });
+        speckleMesh.vertices.AddRange(new double[ ] { vertex.x, vertex.y, vertex.z });
       }
 
       for (int i = 0; i < mesh.NumTriangles; i++)
@@ -428,7 +426,8 @@ namespace Objects.Converter.Revit
         var B = triangle.get_Index(1);
         var C = triangle.get_Index(2);
         speckleMesh.faces.Add(0);
-        speckleMesh.faces.AddRange(new int[] { (int)A, (int)B, (int)C });
+        speckleMesh.faces.AddRange(new int[ ] {
+          (int)A, (int)B, (int)C });
       }
 
       speckleMesh.units = units ?? ModelUnits;
@@ -478,17 +477,16 @@ namespace Objects.Converter.Revit
       var result = tsb.GetBuildResult();
       return result.GetGeometricalObjects();
 
-
     }
 
-    public XYZ[] ArrayToPoints(IEnumerable<double> arr, string units = null)
+    public XYZ[ ] ArrayToPoints(IEnumerable<double> arr, string units = null)
     {
       if (arr.Count() % 3 != 0)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.");
       }
 
-      XYZ[] points = new XYZ[arr.Count() / 3];
+      XYZ[ ] points = new XYZ[arr.Count() / 3];
       var asArray = arr.ToArray();
       for (int i = 2, k = 0; i < arr.Count(); i += 3)
       {
@@ -582,8 +580,8 @@ namespace Objects.Converter.Revit
 
       var nativeCurveArray = CurveToNative(edge.Curve);
       bool isTrimmed = edge.Curve.domain != null && edge.Domain != null &&
-                       (edge.Curve.domain.start != edge.Domain.start
-                        || edge.Curve.domain.end != edge.Domain.end);
+        (edge.Curve.domain.start != edge.Domain.start ||
+          edge.Curve.domain.end != edge.Domain.end);
       if (nativeCurveArray.Size == 1)
       {
         var nativeCurve = nativeCurveArray.get_Item(0);
@@ -627,9 +625,9 @@ namespace Objects.Converter.Revit
         return new List<BRepBuilderEdgeGeometry> { fullEdge };
       }
 
-      var iterator = edge.ProxyCurveIsReversed
-        ? nativeCurveArray.ReverseIterator()
-        : nativeCurveArray.ForwardIterator();
+      var iterator = edge.ProxyCurveIsReversed ?
+        nativeCurveArray.ReverseIterator() :
+        nativeCurveArray.ForwardIterator();
 
       var result = new List<BRepBuilderEdgeGeometry>();
       while (iterator.MoveNext())
@@ -643,7 +641,7 @@ namespace Objects.Converter.Revit
       return result;
     }
 
-    public double[] ControlPointWeightsToNative(List<List<ControlPoint>> controlPoints)
+    public double[ ] ControlPointWeightsToNative(List<List<ControlPoint>> controlPoints)
     {
       var uCount = controlPoints.Count;
       var vCount = controlPoints[0].Count;
@@ -658,7 +656,7 @@ namespace Objects.Converter.Revit
       return weights;
     }
 
-    public XYZ[] ControlPointsToNative(List<List<ControlPoint>> controlPoints)
+    public XYZ[ ] ControlPointsToNative(List<List<ControlPoint>> controlPoints)
     {
       var uCount = controlPoints.Count;
       var vCount = controlPoints[0].Count;
@@ -671,13 +669,12 @@ namespace Objects.Converter.Revit
         {
           var point = new Point(pt.x, pt.y, pt.z, pt.units);
           points[p++] = PointToNative(point);
-        }
-         ));
+        }));
 
       return points;
     }
 
-    public double[] SurfaceKnotsToNative(List<double> list)
+    public double[ ] SurfaceKnotsToNative(List<double> list)
     {
       var count = list.Count;
       var knots = new double[count + 2];
@@ -718,11 +715,9 @@ namespace Objects.Converter.Revit
       return result;
     }
 
-
     public Solid BrepToNative(Brep brep)
     {
       //Make sure face references are calculated by revit
-
 
       var bRepType = BRepType.OpenShell;
       switch (brep.Orientation)
@@ -791,10 +786,10 @@ namespace Objects.Converter.Revit
 
       var removedFace = builder.RemovedSomeFaces();
       var bRepBuilderOutcome = builder.Finish();
-      if (bRepBuilderOutcome == BRepBuilderOutcome.Failure) return null;
+      if (bRepBuilderOutcome == BRepBuilderOutcome.Failure)return null;
 
       var isResultAvailable = builder.IsResultAvailable();
-      if (!isResultAvailable) return null;
+      if (!isResultAvailable)return null;
       var result = builder.GetResult();
       return result;
     }
@@ -807,7 +802,7 @@ namespace Objects.Converter.Revit
       var brep = new Brep();
       brep.units = u;
 
-      if (solid is null || solid.Faces.IsEmpty) return null;
+      if (solid is null || solid.Faces.IsEmpty)return null;
 
       var faceIndex = 0;
       var edgeIndex = 0;
@@ -868,7 +863,7 @@ namespace Objects.Converter.Revit
               curve3dIndex++;
 
               // Create a trim with just one of the trimIndices set, the second one will be set on the opposite condition.
-              var sEdge = new BrepEdge(brep, sCurveIndex, new[] { sTrimIndex }, -1, -1, edge.IsFlippedOnFace(face), null);
+              var sEdge = new BrepEdge(brep, sCurveIndex, new [ ] { sTrimIndex }, -1, -1, edge.IsFlippedOnFace(face), null);
               speckleEdges.Add(edge, sEdge);
               speckleEdgeIndexes.Add(edge, edgeIndex);
               edgeIndex++;
@@ -916,26 +911,34 @@ namespace Objects.Converter.Revit
       brep.displayValue = mesh;
       return brep;
 #else
-      throw new Speckle.Core.Logging.SpeckleException("Converting BREPs to Speckle is currently only supported in Revit 2021.", log: true);
+      throw new Speckle.Core.Logging.SpeckleException("Converting BREPs to Speckle is currently only supported in Revit 2021.");
 #endif
     }
 
     public Surface FaceToSpeckle(DB.Face face, out bool parametricOrientation, double relativeTolerance = 0.0, string units = null)
     {
       var u = units ?? ModelUnits;
-      using (var surface = face.GetSurface())
-        parametricOrientation = surface.OrientationMatchesParametricOrientation;
+      using(var surface = face.GetSurface())
+      parametricOrientation = surface.OrientationMatchesParametricOrientation;
 
       switch (face)
       {
-        case null: return null;
-        case PlanarFace planar: return FaceToSpeckle(planar, relativeTolerance, u);
-        case ConicalFace conical: return FaceToSpeckle(conical, relativeTolerance, u);
-        case CylindricalFace cylindrical: return FaceToSpeckle(cylindrical, relativeTolerance, u);
-        case RevolvedFace revolved: return FaceToSpeckle(revolved, relativeTolerance, u);
-        case RuledFace ruled: return FaceToSpeckle(ruled, relativeTolerance, u);
-        case HermiteFace hermite: return FaceToSpeckle(hermite, face.GetBoundingBox(), u);
-        default: throw new NotImplementedException();
+        case null:
+          return null;
+        case PlanarFace planar:
+          return FaceToSpeckle(planar, relativeTolerance, u);
+        case ConicalFace conical:
+          return FaceToSpeckle(conical, relativeTolerance, u);
+        case CylindricalFace cylindrical:
+          return FaceToSpeckle(cylindrical, relativeTolerance, u);
+        case RevolvedFace revolved:
+          return FaceToSpeckle(revolved, relativeTolerance, u);
+        case RuledFace ruled:
+          return FaceToSpeckle(ruled, relativeTolerance, u);
+        case HermiteFace hermite:
+          return FaceToSpeckle(hermite, face.GetBoundingBox(), u);
+        default:
+          throw new NotImplementedException();
       }
     }
     public Surface FaceToSpeckle(PlanarFace planarFace, double tolerance, string units = null)
@@ -959,13 +962,13 @@ namespace Objects.Converter.Revit
       throw new NotImplementedException();
     }
 
-    public int AddSurface(Brep brep, DB.Face face, out List<BrepBoundary>[] shells,
+    public int AddSurface(Brep brep, DB.Face face, out List<BrepBoundary>[ ] shells,
       Dictionary<DB.Edge, BrepEdge> brepEdges = null)
     {
       throw new NotImplementedException();
     }
 
-    public void TrimSurface(Brep brep, int surface, bool orientationReversed, List<BrepBoundary>[] shells)
+    public void TrimSurface(Brep brep, int surface, bool orientationReversed, List<BrepBoundary>[ ] shells)
     {
       // TODO: Incomplete method.
       foreach (var shell in shells)
@@ -981,7 +984,7 @@ namespace Objects.Converter.Revit
           {
             var brepEdge = loop.edges[e];
             var orientation = loop.orientation[e];
-            if (orientation == 0) continue;
+            if (orientation == 0)continue;
 
             if (loop.trims.segments[e] is Curve trim)
             {
@@ -1010,7 +1013,7 @@ namespace Objects.Converter.Revit
       try
       {
         var solid = BrepToNative(brep);
-        if (solid == null) throw new Speckle.Core.Logging.SpeckleException("Could not convert Brep to Solid", log: true);
+        if (solid == null)throw new Speckle.Core.Logging.SpeckleException("Could not convert Brep to Solid");
         revitDs.SetShape(new List<GeometryObject> { solid });
       }
       catch (Exception e)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -37,7 +37,7 @@ namespace Objects.Converter.Revit
           return VectorToNative(g);
 
         default:
-          throw new Exception("Cannot convert Curve of type " + geom.GetType());
+          throw new Speckle.Core.Logging.SpeckleException("Cannot convert Curve of type " + geom.GetType(), log: true);
       }
     }
 
@@ -321,7 +321,7 @@ namespace Objects.Converter.Revit
 
           return curveArray;
         default:
-          throw new Exception("The provided geometry is not a valid curve");
+          throw new Speckle.Core.Logging.SpeckleException("The provided geometry is not a valid curve", log: true);
       }
     }
 
@@ -355,7 +355,7 @@ namespace Objects.Converter.Revit
         case DB.HermiteSpline spline:
           return HermiteSplineToSpeckle(spline, u);
         default:
-          throw new Exception("Cannot convert Curve of type " + curve.GetType());
+          throw new Speckle.Core.Logging.SpeckleException("Cannot convert Curve of type " + curve.GetType(), log: true);
       }
     }
 
@@ -485,7 +485,7 @@ namespace Objects.Converter.Revit
     {
       if (arr.Count() % 3 != 0)
       {
-        throw new Exception("Array malformed: length%3 != 0.");
+        throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
       }
 
       XYZ[] points = new XYZ[arr.Count() / 3];
@@ -916,7 +916,7 @@ namespace Objects.Converter.Revit
       brep.displayValue = mesh;
       return brep;
 #else
-      throw new Exception("Converting BREPs to Speckle is currently only supported in Revit 2021.");
+      throw new Speckle.Core.Logging.SpeckleException("Converting BREPs to Speckle is currently only supported in Revit 2021.", log: true);
 #endif
     }
 
@@ -1010,7 +1010,7 @@ namespace Objects.Converter.Revit
       try
       {
         var solid = BrepToNative(brep);
-        if (solid == null) throw new Exception("Could not convert Brep to Solid");
+        if (solid == null) throw new Speckle.Core.Logging.SpeckleException("Could not convert Brep to Solid", log: true);
         revitDs.SetShape(new List<GeometryObject> { solid });
       }
       catch (Exception e)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
@@ -1,8 +1,8 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
 using Objects.BuiltElements;
 using Speckle.Core.Models;
-using System;
 using DB = Autodesk.Revit.DB;
 using Line = Objects.Geometry.Line;
 using Point = Objects.Geometry.Point;
@@ -17,8 +17,8 @@ namespace Objects.Converter.Revit
       if (revitElement is FamilyInstance familyInstance)
       {
         //vertical columns are point based, and the point does not reflect the actual vertical location
-        if (Categories.columnCategories.Contains(familyInstance.Category)
-             || familyInstance.StructuralType == StructuralType.Column)
+        if (Categories.columnCategories.Contains(familyInstance.Category) ||
+          familyInstance.StructuralType == StructuralType.Column)
         {
           return TryGetLocationAsCurve(familyInstance);
         }
@@ -40,13 +40,13 @@ namespace Objects.Converter.Revit
               curve = curve.CreateTransformed(tf);
             }
 
-            return CurveToSpeckle(curve) as Base;
+            return CurveToSpeckle(curve)as Base;
           }
         case LocationPoint locationPoint:
           {
             return PointToSpeckle(locationPoint.Point);
           }
-        // TODO what is the correct way to handle this?
+          // TODO what is the correct way to handle this?
         case null:
           return null;
 
@@ -68,7 +68,7 @@ namespace Objects.Converter.Revit
         var analiticalModel = familyInstance.GetAnalyticalModel();
         if (analiticalModel != null)
         {
-          return CurveToSpeckle(analiticalModel.GetCurve()) as Base;
+          return CurveToSpeckle(analiticalModel.GetCurve())as Base;
         }
       }
       var point = (familyInstance.Location as LocationPoint).Point;
@@ -101,7 +101,7 @@ namespace Objects.Converter.Revit
 
       if (elem["baseLine"] == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Location is null.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Location is null.");
       }
 
       //must be a curve!?
@@ -116,7 +116,7 @@ namespace Objects.Converter.Revit
         if (!(bool)elem["isSlanted"] || IsVertical(curve))
         {
           var baseLine = elem["baseLine"] as Line;
-          var point = new Point(baseLine.start.x, baseLine.start.y, baseLine.start.z - (double) offset, ModelUnits);
+          var point = new Point(baseLine.start.x, baseLine.start.y, baseLine.start.z - (double)offset, ModelUnits);
 
           return PointToNative(point);
         }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
@@ -101,7 +101,7 @@ namespace Objects.Converter.Revit
 
       if (elem["baseLine"] == null)
       {
-        throw new Exception("Location is null.");
+        throw new Speckle.Core.Logging.SpeckleException("Location is null.", log: true);
       }
 
       //must be a curve!?

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
@@ -1,10 +1,10 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
 using Objects.BuiltElements.Revit;
 using Objects.Geometry;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using DB = Autodesk.Revit.DB;
 using Point = Objects.Geometry.Point;
@@ -30,7 +30,7 @@ namespace Objects.Converter.Revit
         case RevitWallOpening rwo:
           {
             if (CurrentHostElement as Wall == null)
-              throw new Speckle.Core.Logging.SpeckleException($"Hosted wall openings require a host wall", log: true);
+              throw new Speckle.Core.Logging.SpeckleException($"Hosted wall openings require a host wall");
             var points = (rwo.outline as Polyline).points.Select(x => PointToNative(x)).ToList();
             revitOpening = Doc.Create.NewOpening(CurrentHostElement as Wall, points[0], points[2]);
             break;
@@ -39,7 +39,7 @@ namespace Objects.Converter.Revit
         case RevitVerticalOpening rvo:
           {
             if (CurrentHostElement == null)
-              throw new Speckle.Core.Logging.SpeckleException($"Hosted vertical openings require a host family", log: true);
+              throw new Speckle.Core.Logging.SpeckleException($"Hosted vertical openings require a host family");
             revitOpening = Doc.Create.NewOpening(CurrentHostElement, baseCurves, true);
             break;
           }
@@ -63,11 +63,10 @@ namespace Objects.Converter.Revit
           else
           {
             ConversionErrors.Add(new Error("Cannot create Opening", "Opening type not supported"));
-            throw new Speckle.Core.Logging.SpeckleException("Opening type not supported", log: true);
+            throw new Speckle.Core.Logging.SpeckleException("Opening type not supported");
           }
           break;
       }
-
 
       if (speckleOpening is RevitOpening ro)
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
@@ -30,7 +30,7 @@ namespace Objects.Converter.Revit
         case RevitWallOpening rwo:
           {
             if (CurrentHostElement as Wall == null)
-              throw new Exception($"Hosted wall openings require a host wall");
+              throw new Speckle.Core.Logging.SpeckleException($"Hosted wall openings require a host wall", log: true);
             var points = (rwo.outline as Polyline).points.Select(x => PointToNative(x)).ToList();
             revitOpening = Doc.Create.NewOpening(CurrentHostElement as Wall, points[0], points[2]);
             break;
@@ -39,7 +39,7 @@ namespace Objects.Converter.Revit
         case RevitVerticalOpening rvo:
           {
             if (CurrentHostElement == null)
-              throw new Exception($"Hosted vertical openings require a host family");
+              throw new Speckle.Core.Logging.SpeckleException($"Hosted vertical openings require a host family", log: true);
             revitOpening = Doc.Create.NewOpening(CurrentHostElement, baseCurves, true);
             break;
           }
@@ -63,7 +63,7 @@ namespace Objects.Converter.Revit
           else
           {
             ConversionErrors.Add(new Error("Cannot create Opening", "Opening type not supported"));
-            throw new Exception("Opening type not supported");
+            throw new Speckle.Core.Logging.SpeckleException("Opening type not supported", log: true);
           }
           break;
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -1,12 +1,11 @@
-﻿
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
 using Objects.BuiltElements.Revit;
 using Objects.Geometry;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Autodesk.Revit.DB.Architecture;
 
 namespace Objects.Converter.Revit
 {
@@ -16,13 +15,13 @@ namespace Objects.Converter.Revit
     {
       if (speckleRailing.path == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only line based Railings are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Railings are currently supported.");
       }
 
-      var revitRailing = GetExistingElementByApplicationId(speckleRailing.applicationId) as Railing;
+      var revitRailing = GetExistingElementByApplicationId(speckleRailing.applicationId)as Railing;
 
       var railingType = GetElementType<RailingType>(speckleRailing);
-      Level level = LevelToNative(speckleRailing.level); ;
+      Level level = LevelToNative(speckleRailing.level);;
       var baseCurve = CurveArrayToCurveLoop(CurveToNative(speckleRailing.path));
 
       //if it's a new element, we don't need to update certain properties
@@ -49,7 +48,6 @@ namespace Objects.Converter.Revit
         TrySetParam(revitRailing, BuiltInParameter.WALL_BASE_CONSTRAINT, level);
       }
 
-
       if (speckleRailing.flipped != revitRailing.Flipped)
       {
         revitRailing.Flip();
@@ -57,12 +55,15 @@ namespace Objects.Converter.Revit
 
       SetInstanceParameters(revitRailing, speckleRailing);
 
-      var placeholders = new List<ApplicationPlaceholderObject>() {new ApplicationPlaceholderObject
+      var placeholders = new List<ApplicationPlaceholderObject>()
       {
+        new ApplicationPlaceholderObject
+        {
         applicationId = speckleRailing.applicationId,
         ApplicationGeneratedId = revitRailing.UniqueId,
         NativeObject = revitRailing
-      } };
+        }
+      };
 
       Doc.Regenerate();
 
@@ -73,7 +74,7 @@ namespace Objects.Converter.Revit
     private RevitRailing RailingToSpeckle(Railing revitRailing)
     {
 
-      var railingType = Doc.GetElement(revitRailing.GetTypeId()) as RailingType;
+      var railingType = Doc.GetElement(revitRailing.GetTypeId())as RailingType;
       var speckleRailing = new RevitRailing();
       //speckleRailing.family = railingType.FamilyName;
       speckleRailing.type = railingType.Name;
@@ -89,7 +90,6 @@ namespace Objects.Converter.Revit
 
       return speckleRailing;
     }
-
 
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -16,7 +16,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleRailing.path == null)
       {
-        throw new Exception("Only line based Railings are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Railings are currently supported.", log: true);
       }
 
       var revitRailing = GetExistingElementByApplicationId(speckleRailing.applicationId) as Railing;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -19,7 +19,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleRoof.outline == null)
       {
-        throw new Exception("Only outline based Floor are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only outline based Floor are currently supported.", log: true);
       }
 
       DB.RoofBase revitRoof = null;
@@ -115,7 +115,7 @@ namespace Objects.Converter.Revit
           }
         default:
           ConversionErrors.Add(new Error("Cannot create Roof", "Roof type not supported"));
-          throw new Exception("Roof type not supported");
+          throw new Speckle.Core.Logging.SpeckleException("Roof type not supported", log: true);
 
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -1,12 +1,12 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
 using Objects.BuiltElements;
 using Objects.BuiltElements.Revit;
 using Objects.BuiltElements.Revit.RevitRoof;
 using Objects.Geometry;
 using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using DB = Autodesk.Revit.DB;
 using Line = Objects.Geometry.Line;
@@ -19,7 +19,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleRoof.outline == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only outline based Floor are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only outline based Floor are currently supported.");
       }
 
       DB.RoofBase revitRoof = null;
@@ -103,7 +103,6 @@ namespace Objects.Converter.Revit
               TrySetParam(revitFootprintRoof, BuiltInParameter.ROOF_SLOPE, (double)speckleFootprintRoof.slope);
             }
 
-
             if (speckleFootprintRoof.cutOffLevel != null)
             {
               var cutOffLevel = LevelToNative(speckleFootprintRoof.cutOffLevel);
@@ -115,7 +114,7 @@ namespace Objects.Converter.Revit
           }
         default:
           ConversionErrors.Add(new Error("Cannot create Roof", "Roof type not supported"));
-          throw new Speckle.Core.Logging.SpeckleException("Roof type not supported", log: true);
+          throw new Speckle.Core.Logging.SpeckleException("Roof type not supported");
 
       }
 
@@ -137,14 +136,11 @@ namespace Objects.Converter.Revit
 
       var placeholders = new List<ApplicationPlaceholderObject>() { new ApplicationPlaceholderObject { applicationId = speckleRevitRoof.applicationId, ApplicationGeneratedId = revitRoof.UniqueId, NativeObject = revitRoof } };
 
-
       var hostedElements = SetHostedElements(speckleRoof, revitRoof);
       placeholders.AddRange(hostedElements);
 
       return placeholders;
     }
-
-
 
     private Roof RoofToSpeckle(DB.RoofBase revitRoof)
     {
@@ -177,7 +173,7 @@ namespace Objects.Converter.Revit
             };
             var plane = revitExtrusionRoof.GetProfile().get_Item(0).SketchPlane.GetPlane();
             speckleExtrusionRoof.referenceLine =
-              new Line(PointToSpeckle(plane.Origin.Add(plane.XVec.Normalize().Negate())), PointToSpeckle(plane.Origin), ModelUnits); //TODO: test!
+            new Line(PointToSpeckle(plane.Origin.Add(plane.XVec.Normalize().Negate())), PointToSpeckle(plane.Origin), ModelUnits); //TODO: test!
             speckleExtrusionRoof.level = ConvertAndCacheLevel(revitExtrusionRoof, BuiltInParameter.ROOF_CONSTRAINT_LEVEL_PARAM);
             speckleRoof = speckleExtrusionRoof;
             break;
@@ -231,7 +227,7 @@ namespace Objects.Converter.Revit
                   continue;
                 }
 
-                var segment = CurveToSpeckle(curve.GeometryCurve) as Base; //it's a safe casting
+                var segment = CurveToSpeckle(curve.GeometryCurve)as Base; //it's a safe casting
                 segment["slopeAngle"] = GetParamValue<double>(curve, BuiltInParameter.ROOF_SLOPE);
                 segment["isSloped"] = GetParamValue<bool>(curve, BuiltInParameter.ROOF_CURVE_IS_SLOPE_DEFINING);
                 segment["offset"] = GetParamValue<double>(curve, BuiltInParameter.ROOF_CURVE_HEIGHT_OFFSET);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -1,9 +1,9 @@
-﻿using Autodesk.Revit.DB;
-using Objects.BuiltElements.Revit;
-using Speckle.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autodesk.Revit.DB;
+using Objects.BuiltElements.Revit;
+using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
 using Mesh = Objects.Geometry.Mesh;
 
@@ -16,10 +16,10 @@ namespace Objects.Converter.Revit
     {
       if (speckleWall.baseLine == null)
       {
-        throw new Speckle.Core.Logging.SpeckleException("Only line based Walls are currently supported.", log: true);
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Walls are currently supported.");
       }
 
-      var revitWall = GetExistingElementByApplicationId(speckleWall.applicationId) as DB.Wall;
+      var revitWall = GetExistingElementByApplicationId(speckleWall.applicationId)as DB.Wall;
 
       var wallType = GetElementType<WallType>(speckleWall);
       Level level = null;
@@ -101,12 +101,15 @@ namespace Objects.Converter.Revit
 
       SetInstanceParameters(revitWall, speckleWall);
 
-      var placeholders = new List<ApplicationPlaceholderObject>() {new ApplicationPlaceholderObject
+      var placeholders = new List<ApplicationPlaceholderObject>()
       {
+        new ApplicationPlaceholderObject
+        {
         applicationId = speckleWall.applicationId,
         ApplicationGeneratedId = revitWall.UniqueId,
         NativeObject = revitWall
-      } };
+        }
+      };
 
       var hostedElements = SetHostedElements(speckleWall, revitWall);
       placeholders.AddRange(hostedElements);
@@ -138,8 +141,15 @@ namespace Objects.Converter.Revit
 
       speckleWall["@displayMesh"] = GetWallDisplayMesh(revitWall);
 
-      GetAllRevitParamsAndIds(speckleWall, revitWall, new List<string> { "WALL_USER_HEIGHT_PARAM", "WALL_BASE_OFFSET", "WALL_TOP_OFFSET", "WALL_BASE_CONSTRAINT",
-      "WALL_HEIGHT_TYPE", "WALL_STRUCTURAL_SIGNIFICANT"});
+      GetAllRevitParamsAndIds(speckleWall, revitWall, new List<string>
+      {
+        "WALL_USER_HEIGHT_PARAM",
+        "WALL_BASE_OFFSET",
+        "WALL_TOP_OFFSET",
+        "WALL_BASE_CONSTRAINT",
+        "WALL_HEIGHT_TYPE",
+        "WALL_STRUCTURAL_SIGNIFICANT"
+      });
 
       GetHostedElements(speckleWall, revitWall);
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -16,7 +16,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleWall.baseLine == null)
       {
-        throw new Exception("Only line based Walls are currently supported.");
+        throw new Speckle.Core.Logging.SpeckleException("Only line based Walls are currently supported.", log: true);
       }
 
       var revitWall = GetExistingElementByApplicationId(speckleWall.applicationId) as DB.Wall;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -167,7 +167,7 @@ namespace Objects.Converter.Revit
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
         default:
-          throw new Exception("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
       }
 
     }
@@ -187,7 +187,7 @@ namespace Objects.Converter.Revit
         case Speckle.Core.Kits.Units.Feet:
           return DisplayUnitType.DUT_DECIMAL_FEET;
         default:
-          throw new Exception("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
       }
     }
     //#endif

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -95,7 +95,6 @@ namespace Objects.Converter.Revit
       }
     }
 
-
     private DisplayUnitType _revitUnitsTypeId = DisplayUnitType.DUT_UNDEFINED;
     public DisplayUnitType RevitLengthTypeId
     {
@@ -110,7 +109,6 @@ namespace Objects.Converter.Revit
       }
     }
 
-
     /// <summary>
     /// Converts Speckle length values to internal ones
     /// NOTE: use only to convert double values, not point or vector coordinates. For those use Point/VectorToNative
@@ -123,7 +121,6 @@ namespace Objects.Converter.Revit
     {
       return UnitUtils.ConvertToInternalUnits(value, UnitsToNative(units));
     }
-
 
     /// <summary>
     /// Converts Speckle length values to internal ones
@@ -167,7 +164,7 @@ namespace Objects.Converter.Revit
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
+          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
       }
 
     }
@@ -187,10 +184,9 @@ namespace Objects.Converter.Revit
         case Speckle.Core.Kits.Units.Feet:
           return DisplayUnitType.DUT_DECIMAL_FEET;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.", log: true);
+          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
       }
     }
     //#endif
   }
 }
-

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/BrepTests.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/BrepTests.cs
@@ -56,7 +56,7 @@ namespace ConverterRevitTests
       var @base = Operations.Deserialize(contents);
       
       // You read the wrong file, OOOPS!!
-      if (!(@base is Brep brep)) throw new Speckle.Core.Logging.SpeckleException("Object was not a brep, did you choose the right file?");
+      if (!(@base is Brep brep)) throw new Exception("Object was not a brep, did you choose the right file?");
       DirectShape native = null;
       
       xru.RunInTransaction(() =>
@@ -83,10 +83,10 @@ namespace ConverterRevitTests
       converter.SetContextDocument(fixture.NewDoc);
 
       if(!(fixture.Selection[0] is DirectShape ds))
-        throw new Speckle.Core.Logging.SpeckleException("Selected object was not a direct shape.");
+        throw new Exception("Selected object was not a direct shape.");
       var geo = ds.get_Geometry(new Options());
       if(!(geo.First() is Solid solid))
-        throw new Speckle.Core.Logging.SpeckleException("DS was not composed of a solid.");
+        throw new Exception("DS was not composed of a solid.");
       var converted = converter.BrepToSpeckle(solid);
       var nativeconverted = converter.BrepToNative(converted);
       Assert.NotNull(nativeconverted);

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/BrepTests.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/BrepTests.cs
@@ -56,7 +56,7 @@ namespace ConverterRevitTests
       var @base = Operations.Deserialize(contents);
       
       // You read the wrong file, OOOPS!!
-      if (!(@base is Brep brep)) throw new Exception("Object was not a brep, did you choose the right file?");
+      if (!(@base is Brep brep)) throw new Speckle.Core.Logging.SpeckleException("Object was not a brep, did you choose the right file?");
       DirectShape native = null;
       
       xru.RunInTransaction(() =>
@@ -83,10 +83,10 @@ namespace ConverterRevitTests
       converter.SetContextDocument(fixture.NewDoc);
 
       if(!(fixture.Selection[0] is DirectShape ds))
-        throw new Exception("Selected object was not a direct shape.");
+        throw new Speckle.Core.Logging.SpeckleException("Selected object was not a direct shape.");
       var geo = ds.get_Geometry(new Options());
       if(!(geo.First() is Solid solid))
-        throw new Exception("DS was not composed of a solid.");
+        throw new Speckle.Core.Logging.SpeckleException("DS was not composed of a solid.");
       var converted = converter.BrepToSpeckle(solid);
       var nativeconverted = converter.BrepToNative(converted);
       Assert.NotNull(nativeconverted);

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -62,7 +62,7 @@ namespace Objects.Converter.RhinoGh
     public Point3d[] PointListToNative(IEnumerable<double> arr, string units)
     {
       var enumerable = arr.ToList();
-      if (enumerable.Count % 3 != 0) throw new Exception("Array malformed: length%3 != 0.");
+      if (enumerable.Count % 3 != 0) throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
 
       Point3d[] points = new Point3d[enumerable.Count / 3];
       var asArray = enumerable.ToArray();

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -1,16 +1,16 @@
-using Grasshopper.Kernel.Types;
-using Objects.Geometry;
-using Objects.Primitive;
-using Rhino.Geometry;
-using Rhino.Geometry.Collections;
-using Rhino.DocObjects;
-using Speckle.Core.Models;
-using Speckle.Core.Kits;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Grasshopper.Kernel.Types;
+using Objects.Geometry;
+using Objects.Primitive;
 using Rhino;
+using Rhino.DocObjects;
+using Rhino.Geometry;
+using Rhino.Geometry.Collections;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
 using Arc = Objects.Geometry.Arc;
 using Box = Objects.Geometry.Box;
 using Brep = Objects.Geometry.Brep;
@@ -41,30 +41,29 @@ namespace Objects.Converter.RhinoGh
   public partial class ConverterRhinoGh
   {
 
-
     // Convenience methods point:
-    public double[] PointToArray(Point3d pt)
+    public double[ ] PointToArray(Point3d pt)
     {
-      return new double[] { pt.X, pt.Y, pt.Z };
+      return new double[ ] { pt.X, pt.Y, pt.Z };
     }
 
-    public double[] PointToArray(Point2d pt)
+    public double[ ] PointToArray(Point2d pt)
     {
-      return new double[] { pt.X, pt.Y };
+      return new double[ ] { pt.X, pt.Y };
     }
 
-    public double[] PointToArray(Point2f pt)
+    public double[ ] PointToArray(Point2f pt)
     {
-      return new double[] { pt.X, pt.Y };
+      return new double[ ] { pt.X, pt.Y };
     }
 
     // Mass point converter
-    public Point3d[] PointListToNative(IEnumerable<double> arr, string units)
+    public Point3d[ ] PointListToNative(IEnumerable<double> arr, string units)
     {
       var enumerable = arr.ToList();
-      if (enumerable.Count % 3 != 0) throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
+      if (enumerable.Count % 3 != 0)throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.");
 
-      Point3d[] points = new Point3d[enumerable.Count / 3];
+      Point3d[ ] points = new Point3d[enumerable.Count / 3];
       var asArray = enumerable.ToArray();
       for (int i = 2, k = 0; i < enumerable.Count; i += 3)
         points[k++] = new Point3d(
@@ -75,23 +74,23 @@ namespace Objects.Converter.RhinoGh
       return points;
     }
 
-    public double[] PointsToFlatArray(IEnumerable<Point3d> points)
+    public double[ ] PointsToFlatArray(IEnumerable<Point3d> points)
     {
       return points.SelectMany(pt => PointToArray(pt)).ToArray();
     }
 
-    public double[] PointsToFlatArray(IEnumerable<Point2f> points)
+    public double[ ] PointsToFlatArray(IEnumerable<Point2f> points)
     {
       return points.SelectMany(pt => PointToArray(pt)).ToArray();
     }
 
     // Convenience methods vector:
-    public double[] VectorToArray(Vector3d vc)
+    public double[ ] VectorToArray(Vector3d vc)
     {
-      return new double[] { vc.X, vc.Y, vc.Z };
+      return new double[ ] { vc.X, vc.Y, vc.Z };
     }
 
-    public Vector3d ArrayToVector(double[] arr)
+    public Vector3d ArrayToVector(double[ ] arr)
     {
       return new Vector3d(arr[0], arr[1], arr[2]);
     }
@@ -179,7 +178,7 @@ namespace Objects.Converter.RhinoGh
     public Line LineToSpeckle(RH.Line line, string units = null)
     {
       var u = units ?? ModelUnits;
-      var sLine =  new Line(PointsToFlatArray(new Point3d[] { line.From, line.To }), u);
+      var sLine = new Line(PointsToFlatArray(new Point3d[ ] { line.From, line.To }), u);
       sLine.length = line.Length;
       sLine.domain = new Interval(0, line.Length);
       var box = new RH.Box(line.BoundingBox);
@@ -191,9 +190,9 @@ namespace Objects.Converter.RhinoGh
     public Line LineToSpeckle(LineCurve line, string units = null)
     {
       var u = units ?? ModelUnits;
-      var sLine =  new Line(PointsToFlatArray(new Point3d[] { line.PointAtStart, line.PointAtEnd }), u)
+      var sLine = new Line(PointsToFlatArray(new Point3d[ ] { line.PointAtStart, line.PointAtEnd }), u)
       {
-        domain = IntervalToSpeckle(line.Domain)
+      domain = IntervalToSpeckle(line.Domain)
       };
       sLine.length = line.GetLength();
       var box = new RH.Box(line.GetBoundingBox(true));
@@ -206,7 +205,7 @@ namespace Objects.Converter.RhinoGh
     public LineCurve LineToNative(Line line)
     {
       var myLine = new LineCurve(PointToNative(line.start).Location, PointToNative(line.end).Location);
-      myLine.Domain = line.domain == null ?  new RH.Interval(0, line.length) : IntervalToNative(line.domain);
+      myLine.Domain = line.domain == null ? new RH.Interval(0, line.length) : IntervalToNative(line.domain);
       return myLine;
     }
 
@@ -216,15 +215,15 @@ namespace Objects.Converter.RhinoGh
       var u = units ?? ModelUnits;
       var length = rect.Height * 2 + rect.Width * 2;
       var sPoly = new Polyline(
-        PointsToFlatArray(new Point3d[] { rect.Corner(0), rect.Corner(1), rect.Corner(2), rect.Corner(3) }), u)
+        PointsToFlatArray(new Point3d[ ] { rect.Corner(0), rect.Corner(1), rect.Corner(2), rect.Corner(3) }), u)
       {
-        closed = true,
-        area = rect.Area,
-        bbox = BoxToSpeckle(new RH.Box(rect.BoundingBox), u),
-        length = length,
-        domain = new Interval(0, length)
+      closed = true,
+      area = rect.Area,
+      bbox = BoxToSpeckle(new RH.Box(rect.BoundingBox), u),
+      length = length,
+      domain = new Interval(0, length)
       };
-      
+
       return sPoly;
     }
 
@@ -282,11 +281,11 @@ namespace Objects.Converter.RhinoGh
     public Arc ArcToSpeckle(RH.Arc a, string units = null)
     {
       var u = units ?? ModelUnits;
-      Arc arc = new Arc(PlaneToSpeckle(a.Plane,u), a.Radius, a.StartAngle, a.EndAngle, a.Angle, u);
-      arc.endPoint = PointToSpeckle(a.EndPoint,u);
-      arc.startPoint = PointToSpeckle(a.StartPoint,u);
-      arc.midPoint = PointToSpeckle(a.MidPoint,u);
-      arc.domain = new Interval(0,1);
+      Arc arc = new Arc(PlaneToSpeckle(a.Plane, u), a.Radius, a.StartAngle, a.EndAngle, a.Angle, u);
+      arc.endPoint = PointToSpeckle(a.EndPoint, u);
+      arc.startPoint = PointToSpeckle(a.StartPoint, u);
+      arc.midPoint = PointToSpeckle(a.MidPoint, u);
+      arc.domain = new Interval(0, 1);
       arc.length = a.Length;
       arc.bbox = BoxToSpeckle(new RH.Box(a.BoundingBox()), u);
       return arc;
@@ -312,8 +311,8 @@ namespace Objects.Converter.RhinoGh
     public Ellipse EllipseToSpeckle(RH.Ellipse e, string units = null)
     {
       var u = units ?? ModelUnits;
-      var el =  new Ellipse(PlaneToSpeckle(e.Plane,u), e.Radius1, e.Radius2, u);
-      el.domain = new Interval(0,1);
+      var el = new Ellipse(PlaneToSpeckle(e.Plane, u), e.Radius1, e.Radius2, u);
+      el.domain = new Interval(0, 1);
       el.length = e.ToNurbsCurve().GetLength();
       el.bbox = BoxToSpeckle(new RH.Box(e.ToNurbsCurve().GetBoundingBox(true)), u);
       el.area = Math.PI * e.Radius1 * e.Radius2; // Manual area computing, could not find the Rhino way...
@@ -343,11 +342,11 @@ namespace Objects.Converter.RhinoGh
       var u = units ?? ModelUnits;
       if (poly.Count == 2)
       {
-        var l =  new Line(PointsToFlatArray(poly), u);
+        var l = new Line(PointsToFlatArray(poly), u);
         l.domain = domain;
         return l;
       }
-      
+
       var myPoly = new Polyline(PointsToFlatArray(poly), u);
       myPoly.closed = poly.IsClosed;
 
@@ -357,7 +356,7 @@ namespace Objects.Converter.RhinoGh
       myPoly.domain = domain;
       myPoly.bbox = BoxToSpeckle(new RH.Box(poly.BoundingBox), u);
       myPoly.length = poly.Length;
-      
+
       // TODO: Area of 3d polyline cannot be resolved... 
       return myPoly;
     }
@@ -375,8 +374,8 @@ namespace Objects.Converter.RhinoGh
         {
           var polylineToSpeckle = new Line(PointsToFlatArray(polyline), u)
           {
-            domain = intervalToSpeckle
-          };  
+          domain = intervalToSpeckle
+          };
           return polylineToSpeckle;
         }
 
@@ -399,7 +398,7 @@ namespace Objects.Converter.RhinoGh
     public PolylineCurve PolylineToNative(Polyline poly)
     {
       var points = PointListToNative(poly.value, poly.units).ToList();
-      if (poly.closed) points.Add(points[0]);
+      if (poly.closed)points.Add(points[0]);
 
       var myPoly = new PolylineCurve(points);
       if (poly.domain != null)
@@ -418,7 +417,7 @@ namespace Objects.Converter.RhinoGh
       myPoly.domain = IntervalToSpeckle(p.Domain);
       myPoly.length = p.GetLength();
       myPoly.bbox = BoxToSpeckle(new RH.Box(p.GetBoundingBox(true)), u);
-      
+
       var segments = new List<RH.Curve>();
       CurveSegments(segments, p, true);
 
@@ -439,8 +438,7 @@ namespace Objects.Converter.RhinoGh
           myPolyc.AppendSegment((RH.Curve)ConvertToNative((Base)segment));
         }
         catch
-        {
-        }
+        { }
       }
 
       if (p.domain != null)
@@ -489,7 +487,7 @@ namespace Objects.Converter.RhinoGh
 
       if (curve.IsCircle(tolerance) && curve.IsClosed)
       {
-        curve.TryGetCircle(out var getObj,tolerance);
+        curve.TryGetCircle(out var getObj, tolerance);
         var cir = CircleToSpeckle(getObj, u);
         cir.domain = IntervalToSpeckle(curve.Domain);
         return cir;
@@ -497,16 +495,16 @@ namespace Objects.Converter.RhinoGh
 
       if (curve.IsArc(tolerance))
       {
-        curve.TryGetArc(out var getObj,tolerance);
-        var arc =  ArcToSpeckle(getObj, u);
+        curve.TryGetArc(out var getObj, tolerance);
+        var arc = ArcToSpeckle(getObj, u);
         arc.domain = IntervalToSpeckle(curve.Domain);
         return arc;
       }
 
       if (curve.IsEllipse(tolerance) && curve.IsClosed)
       {
-        curve.TryGetEllipse(pln, out var getObj,tolerance);
-        var ellipse =  EllipseToSpeckle(getObj, u);
+        curve.TryGetEllipse(pln, out var getObj, tolerance);
+        var ellipse = EllipseToSpeckle(getObj, u);
         ellipse.domain = IntervalToSpeckle(curve.Domain);
       }
 
@@ -538,7 +536,7 @@ namespace Objects.Converter.RhinoGh
       }
       else
       {
-        displayValue = PolylineToSpeckle(poly, u) as Polyline;
+        displayValue = PolylineToSpeckle(poly, u)as Polyline;
       }
 
       var myCurve = new Curve(displayValue, u);
@@ -564,7 +562,7 @@ namespace Objects.Converter.RhinoGh
       myCurve.closed = nurbsCurve.IsClosed;
       myCurve.length = nurbsCurve.GetLength();
       myCurve.bbox = BoxToSpeckle(new RH.Box(nurbsCurve.GetBoundingBox(true)), u);
-      
+
       return myCurve;
     }
 
@@ -618,8 +616,8 @@ namespace Objects.Converter.RhinoGh
 
       var Faces = mesh.Faces.SelectMany(face =>
       {
-        if (face.IsQuad) return new int[] { 1, face.A, face.B, face.C, face.D };
-        return new int[] { 0, face.A, face.B, face.C };
+        if (face.IsQuad)return new int[ ] { 1, face.A, face.B, face.C, face.D };
+        return new int[ ] { 0, face.A, face.B, face.C };
       }).ToArray();
 
       var Colors = mesh.VertexColors.Select(cl => cl.ToArgb()).ToArray();
@@ -627,7 +625,7 @@ namespace Objects.Converter.RhinoGh
       var speckleMesh = new Mesh(verts, Faces, Colors, null, u);
       speckleMesh.volume = mesh.Volume();
       speckleMesh.bbox = BoxToSpeckle(new RH.Box(mesh.GetBoundingBox(true)), u);
-      
+
       return speckleMesh;
     }
 
@@ -659,8 +657,7 @@ namespace Objects.Converter.RhinoGh
         m.VertexColors.AppendColors(mesh.colors.Select(c => System.Drawing.Color.FromArgb((int)c)).ToArray());
       }
       catch
-      {
-      }
+      { }
 
       if (mesh.textureCoordinates != null)
         for (int j = 0; j < mesh.textureCoordinates.Count; j += 2)
@@ -685,7 +682,7 @@ namespace Objects.Converter.RhinoGh
       }
       return false;
     }
-    
+
     /// <summary>
     /// Converts a Rhino <see cref="Rhino.Geometry.Brep"/> instance to a Speckle <see cref="Brep"/>
     /// </summary>
@@ -696,7 +693,8 @@ namespace Objects.Converter.RhinoGh
       var tol = 0.0;
       var u = units ?? ModelUnits;
       brep.Repair(tol); //should maybe use ModelAbsoluteTolerance ?
-      foreach(var f in brep.Faces){
+      foreach (var f in brep.Faces)
+      {
         f.RebuildEdges(tol, false, false);
       }
       // Create complex
@@ -704,10 +702,10 @@ namespace Objects.Converter.RhinoGh
       var mySettings = MeshingParameters.FastRenderMesh;
       joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
       joinedMesh.Weld(Math.PI);
-      joinedMesh.Vertices.CombineIdentical(true,true);
+      joinedMesh.Vertices.CombineIdentical(true, true);
       joinedMesh.Compact();
-      
-      var spcklBrep = new Brep(displayValue: MeshToSpeckle(joinedMesh, u), provenance: Applications.Rhino, units: u);
+
+      var spcklBrep = new Brep(displayValue: MeshToSpeckle(joinedMesh, u), provenance : Applications.Rhino, units : u);
 
       // Vertices, uv curves, 3d curves and surfaces
       spcklBrep.Vertices = brep.Vertices
@@ -731,7 +729,7 @@ namespace Objects.Converter.RhinoGh
             nurbsCurve.Domain = curve3d.Domain;
             crv = nurbsCurve;
           }
-          var icrv = ConvertToSpeckle(crv) as ICurve;
+          var icrv = ConvertToSpeckle(crv)as ICurve;
           return icrv;
 
           // And finally convert to speckle
@@ -740,8 +738,8 @@ namespace Objects.Converter.RhinoGh
       {
         var nurbsCurve = c.ToNurbsCurve();
         //nurbsCurve.Knots.RemoveMultipleKnots(1, nurbsCurve.Degree, Doc.ModelAbsoluteTolerance );
-        var rebuild = nurbsCurve.Rebuild(nurbsCurve.Points.Count,nurbsCurve.Degree,true);
-        
+        var rebuild = nurbsCurve.Rebuild(nurbsCurve.Points.Count, nurbsCurve.Degree, true);
+
         var crv = CurveToSpeckle(rebuild, Units.None);
         return crv;
       }).ToList();
@@ -902,17 +900,16 @@ namespace Objects.Converter.RhinoGh
     {
       RH.Curve outerProfile = CurveToNative((Curve)extrusion.profile);
       RH.Curve innerProfile = null;
-      if (extrusion.profiles.Count == 2) innerProfile = CurveToNative((Curve)extrusion.profiles[1]);
+      if (extrusion.profiles.Count == 2)innerProfile = CurveToNative((Curve)extrusion.profiles[1]);
 
       try
       {
-        var IsClosed = extrusion.profile.GetType().GetProperty("IsClosed").GetValue(extrusion.profile, null) as bool?;
+        var IsClosed = extrusion.profile.GetType().GetProperty("IsClosed").GetValue(extrusion.profile, null)as bool?;
         if (IsClosed != true)
           outerProfile.Reverse();
       }
       catch
-      {
-      }
+      { }
 
       var myExtrusion =
         RH.Extrusion.Create(outerProfile.ToNurbsCurve(), (double)extrusion.length, (bool)extrusion.capped);
@@ -999,7 +996,7 @@ namespace Objects.Converter.RhinoGh
           polycurve.RemoveNesting();
         }
 
-        RH.Curve[] segments = polycurve.Explode();
+        RH.Curve[ ] segments = polycurve.Explode();
 
         if (segments == null)
         {
@@ -1022,7 +1019,7 @@ namespace Objects.Converter.RhinoGh
         {
           foreach (RH.Curve S in segments)
           {
-            L.Add(S.DuplicateShallow() as RH.Curve);
+            L.Add(S.DuplicateShallow()as RH.Curve);
           }
         }
 

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -55,7 +55,7 @@ namespace Objects.Geometry
 
     public IEnumerable<Point> GetPoints()
     {
-      if (points.Count % 3 != 0) throw new Exception("Array malformed: length%3 != 0.");
+      if (points.Count % 3 != 0) throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
 
       Point[] pts = new Point[points.Count / 3];
       var asArray = points.ToArray();

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -1,10 +1,10 @@
-﻿using Objects.Primitive;
-using Speckle.Core.Kits;
-using Speckle.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Objects.Primitive;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
 
 namespace Objects.Geometry
 {
@@ -19,7 +19,7 @@ namespace Objects.Geometry
     [DetachProperty]
     [Chunkable(20000)]
     public List<double> points { get; set; }
-    
+
     [DetachProperty]
     [Chunkable(20000)]
     public List<double> weights { get; set; }
@@ -33,7 +33,6 @@ namespace Objects.Geometry
 
     public Interval domain { get; set; }
 
-    
     public Polyline displayValue { get; set; }
 
     public bool closed { get; set; }
@@ -55,9 +54,9 @@ namespace Objects.Geometry
 
     public IEnumerable<Point> GetPoints()
     {
-      if (points.Count % 3 != 0) throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.", log: true);
+      if (points.Count % 3 != 0)throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.");
 
-      Point[] pts = new Point[points.Count / 3];
+      Point[ ] pts = new Point[points.Count / 3];
       var asArray = points.ToArray();
       for (int i = 2, k = 0; i < points.Count; i += 3)
         pts[k++] = new Point(asArray[i - 2], asArray[i - 1], asArray[i], units);

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -62,7 +62,7 @@ namespace Objects.Geometry
     {
       var enumerable = coordinatesArray.ToList();
       if (enumerable.Count < 6)
-        throw new SpeckleException("Line from coordinate array requires 6 coordinates.");
+        throw new SpeckleException("Line from coordinate array requires 6 coordinates.", log: true);
       this.start = new Point(enumerable[0], enumerable[1], enumerable[2], units, applicationId);
       this.end = new Point(enumerable[3], enumerable[4], enumerable[5], units, applicationId);
       this.applicationId = applicationId;

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -1,12 +1,12 @@
-﻿using Objects.Primitive;
-using Speckle.Core.Kits;
-using Speckle.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Speckle.Newtonsoft.Json;
+using Objects.Primitive;
+using Speckle.Core.Kits;
 using Speckle.Core.Logging;
+using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
@@ -28,16 +28,16 @@ namespace Objects.Geometry
       {
         start = new Point(value[0], value[1], value[2]);
         end = new Point(value[3], value[4], value[5]);
-      } 
+      }
     }
-    
+
     public Interval domain { get; set; }
 
     public Box bbox { get; set; }
 
     public double area { get; set; }
     public double length { get; set; }
-    
+
     public Point start { get; set; }
     public Point end { get; set; }
     public Line() { }
@@ -62,7 +62,7 @@ namespace Objects.Geometry
     {
       var enumerable = coordinatesArray.ToList();
       if (enumerable.Count < 6)
-        throw new SpeckleException("Line from coordinate array requires 6 coordinates.", log: true);
+        throw new SpeckleException("Line from coordinate array requires 6 coordinates.");
       this.start = new Point(enumerable[0], enumerable[1], enumerable[2], units, applicationId);
       this.end = new Point(enumerable[3], enumerable[4], enumerable[5], units, applicationId);
       this.applicationId = applicationId;

--- a/Objects/Objects/ObjectsKit.cs
+++ b/Objects/Objects/ObjectsKit.cs
@@ -84,7 +84,7 @@ namespace Objects
         }
         else
         {
-          throw new SpeckleException($"Converter for {app} was not found in kit {basePath}");
+          throw new SpeckleException($"Converter for {app} was not found in kit {basePath}", log: true);
         }
 
       }

--- a/Objects/Objects/ObjectsKit.cs
+++ b/Objects/Objects/ObjectsKit.cs
@@ -84,7 +84,7 @@ namespace Objects
         }
         else
         {
-          throw new SpeckleException($"Converter for {app} was not found in kit {basePath}", log: true);
+          throw new SpeckleException($"Converter for {app} was not found in kit {basePath}", level: Sentry.Protocol.SentryLevel.Warning);
         }
 
       }


### PR DESCRIPTION
## Description

Previously, exceptions were thrown by calling `CaptureAndThrow( new SpeckleException( ... ) )` or `CaptureAndThrow( new GraphQLException( ... ) )`. Additionally, GraphQL Errors were not passed on to the dev when a `GraphQLException` was thrown.

This refactor changes the behaviour so exceptions are captured on construction and should be thrown like any other exception.
```cs
throw new SpeckleException("Something went wrong 😢", log: true, level: SentryLevel.VerySad)
```

- closes #32 

--- 

## Key Changes

1. Exceptions are captured in the constructors. Default is `log = true` and default log level is `Info`:
```cs
    public SpeckleException(string message, bool log = true, SentryLevel level = SentryLevel.Info ) : base(message)
    {
      if (log)
        Log.CaptureException(this, level);
    }
```

2. the GraphQL errors are now passed along to the dev (via a `SpeckleException` - the `GraphQLException` has been removed):
```cs
    public SpeckleException(string message, GraphQLError[ ] errors, bool log = true,
      SentryLevel level = SentryLevel.Info) : base(message)
    {
      GraphQLErrors = errors.Select(error => new KeyValuePair<string, object>("error", error.Message)).ToList();
      if (log)
        Log.CaptureException(this, extra: GraphQLErrors);
    }
```

3. `TaskCancelledException`s are never captured
```cs
    public static void CaptureAndThrow(Exception e)
    {
      if ( !( e is TaskCanceledException ) )
        CaptureException(e);
      throw e;
    }
```

4. `AggregateException`s are unpacked and the inner exceptions are captured individually
![unpacked aggregate exceptions in the sentry dashboard](https://user-images.githubusercontent.com/7717434/109687145-deda3100-7b7a-11eb-9224-da8f38c2d357.png)

5. `CaptureAndThrow` has been removed 
5. `SpeckleException` with `InnerException` will be ignored and not captured

```cs
    public SpeckleException(string message, Exception inner, bool log = true, SentryLevel level = SentryLevel.Info)
         : base(message, inner)
    {
      if (inner is SpeckleException)
        return;
      if (log)
        Log.CaptureException(this);
    }
```

### Additional Details

- GraphQL exceptions are no longer being double reported

- All generic `System.Exception`s that we were throwing have been converted to `SpeckleException`s and are being logged. We can revisit this and weed out / adjust log levels if we find this is too much and we don't care about some of these. 

- `ReflectionTypeLoadException`s when loading kits are ignored.


## Notes

### Log Levels

Regarding log levels, I'm not too clear on the strategy here. At the moment, basically everything is info. The things I have elevated are:

1. `🔴 Error`: critical core stuff (exceptions in `Operations.Send`/`Receive` and the `BaseObjectSerialiser`) 
2. `🔴 Error`: unable to generate account id (`Account.id`)
3. `🟡 Warning`: inheriting from `SelectKitComponentBase` in grasshopper
4. `🟡 Warning`: failure to load kits

I'm not sure about a lot of other stuff tho. eg exceptions from GraphQL queries are handled properly everywhere they are used, so I have this as `Info`. However, if a dev is using it from Core and not handling possible exceptions then for them this is an `Error`. Should all GraphQL errors then be `Error` level? 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This changes the behaviour of the `SpeckleException` but the rest of `speckle-sharp` has also been refactored to reflect this.

## How has this been tested?

- [x] Manual Tests (what did you do?)

triggered errors manually and checked sentry dashboard to ensure errors are being reported as expected