### PR TITLE
feat(grasshopper): disallow 0 obj commits

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -256,7 +256,7 @@ namespace Speckle.ConnectorDynamo.SendNode
         }
 
         if ( totalCount == 0 )
-          throw new SpeckleException("Zero objects were successfully converted, so there are no objects to send. Send was stopped.");
+          throw new SpeckleException("Zero objects were successfully converted. Send stopped.");
 
         Message = "Sending...";
 

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -255,6 +255,9 @@ namespace Speckle.ConnectorDynamo.SendNode
           Core.Logging.Log.CaptureAndThrow(new Exception("Conversion error", e));
         }
 
+        if ( totalCount == 0 )
+          throw new SpeckleException("Zero objects were successfully converted, so there are no objects to send. Send was stopped.");
+
         Message = "Sending...";
 
         void ProgressAction(ConcurrentDictionary<string, int> dict)

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -256,7 +256,7 @@ namespace Speckle.ConnectorDynamo.SendNode
         }
 
         if ( totalCount == 0 )
-          throw new SpeckleException("Zero objects were successfully converted. Send stopped.");
+          throw new SpeckleException("Zero objects converted successfully. Send stopped.");
 
         Message = "Sending...";
 

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -1,15 +1,10 @@
 ﻿using Autodesk.DesignScript.Runtime;
-using Newtonsoft.Json;
-using ProtoCore.Lang;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Speckle.ConnectorDynamo.Functions
 {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -23,7 +23,7 @@ namespace Speckle.ConnectorDynamo.Functions
       var kit = KitManager.GetDefaultKit();
 
       if (kit == null)
-        throw new Exception("Cannot find the Dynamo converter, has it been copied to the Kits folder?");
+        throw new Exception("Cannot find the Objects Kit. Has it been copied to the Kits folder?");
 
       if (Globals.RevitDocument != null)
         _converter = kit.LoadConverter(Applications.DynamoRevit);
@@ -31,7 +31,7 @@ namespace Speckle.ConnectorDynamo.Functions
         _converter = kit.LoadConverter(Applications.DynamoSandbox);
 
       if (_converter == null)
-        throw new Exception("Cannot find the Dynamo converter, has it been copied to the Kits folder?");
+        throw new Exception("Cannot find the Dynamo converter. Has it been copied to the Kits folder?");
 
       // if in Revit, we have a doc, injected by the Extension
       if (Globals.RevitDocument != null)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -335,7 +335,12 @@ namespace ConnectorGrasshopper.Ops
         {
           ReportProgress("Conversion", convertedCount++ / (double)DataInput.DataCount);
         });
-
+        if ( convertedCount == 0 )
+        {
+          RuntimeMessages.Add(( GH_RuntimeMessageLevel.Warning, "There are zero objects to send; send stopped." ));
+          Done();
+          return;
+        }
         ObjectToSend = new Base();
         ObjectToSend["@data"] = converted;
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -337,7 +337,7 @@ namespace ConnectorGrasshopper.Ops
         });
         if ( convertedCount == 0 )
         {
-          RuntimeMessages.Add(( GH_RuntimeMessageLevel.Error, "Zero objects were successfully converted. Send stopped." ));
+          RuntimeMessages.Add(( GH_RuntimeMessageLevel.Error, "Zero objects converted successfully. Send stopped." ));
           Done();
           return;
         }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -337,7 +337,7 @@ namespace ConnectorGrasshopper.Ops
         });
         if ( convertedCount == 0 )
         {
-          RuntimeMessages.Add(( GH_RuntimeMessageLevel.Warning, "There are zero objects to send; send stopped." ));
+          RuntimeMessages.Add(( GH_RuntimeMessageLevel.Error, "Zero objects were successfully converted. Send stopped." ));
           Done();
           return;
         }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -119,7 +119,7 @@ namespace Speckle.ConnectorRevit.UI
 
       if (convertedCount == 0)
       {
-        Globals.Notify("Failed to convert any objects. Push aborted.");
+        Globals.Notify("Zero objects converted successfully. Send stopped.");
         return state;
       }
 

--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -490,6 +490,12 @@ namespace SpeckleRhino
         objCount++;
       }
 
+      if (objCount == 0)
+      {
+        RaiseNotification("Zero objects converted successfully. Send stopped.");
+        return state;
+      }
+
       if (renamedlayers)
         RaiseNotification("Replaced illegal chars ./ with - in one or more layer names.");
 


### PR DESCRIPTION
## Description

Rhino and Revit already disallow commits with 0 objects. This should also be enforced in:

- [x] grasshopper
![image](https://user-images.githubusercontent.com/7717434/109630005-56d53680-7b3c-11eb-84db-0a9b869b8724.png)
- [x] dynamo 
- [x] rhino when converted objects == 0

- Fixes #255 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Commits will now not be created if you try and send with no data, so this will no longer be allowed:
![image](https://user-images.githubusercontent.com/7717434/109539519-4def5100-7ab9-11eb-9289-a7c875089574.png)


## How has this been tested?

- [x] Manual Tests in each of the connectors

