### PR TITLE
fix(rhino): Model unit converter now checks for unit change.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
@@ -74,5 +74,12 @@ namespace ConnectorGrasshopper.Objects
     {
       throw new Exception("Please inherit from this class, don't use SelectKitComponentBase directly");
     }
+
+    protected override void BeforeSolveInstance()
+    {      
+      //Ensure converter document is up to date
+      Converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+      base.BeforeSolveInstance();
+    }
   }
 }

--- a/Core/Core/Kits/Units.cs
+++ b/Core/Core/Kits/Units.cs
@@ -153,6 +153,9 @@ namespace Speckle.Core.Kits
         case "mile":
         case "mi":
           return Units.Miles;
+        case "kilometers":
+        case "km":
+          return Units.Kilometers;
         case "none":
           return Units.None;
       }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Units.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Units.cs
@@ -13,13 +13,15 @@ namespace Objects.Converter.RhinoGh
   public partial class ConverterRhinoGh
   {
     private string _modelUnits;
+    
     public string ModelUnits
     {
       get
       {
-        if (string.IsNullOrEmpty(_modelUnits))
+        var unitToSpeckle = UnitToSpeckle(Doc.ModelUnitSystem);
+        if (string.IsNullOrEmpty(_modelUnits) || unitToSpeckle != _modelUnits)
         {
-          _modelUnits = UnitToSpeckle(Doc.ModelUnitSystem);
+          _modelUnits = unitToSpeckle;
         }
         return _modelUnits;
       }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Units.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Units.cs
@@ -12,20 +12,11 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
-    private string _modelUnits;
-    
-    public string ModelUnits
-    {
-      get
-      {
-        var unitToSpeckle = UnitToSpeckle(Doc.ModelUnitSystem);
-        if (string.IsNullOrEmpty(_modelUnits) || unitToSpeckle != _modelUnits)
-        {
-          _modelUnits = unitToSpeckle;
-        }
-        return _modelUnits;
-      }
-    }
+    /// <summary>
+    /// Computes the Speckle Units of the current Document. The Rhino document is passed as a reference, so it will always be up to date.
+    /// </summary>    
+    public string ModelUnits => UnitToSpeckle(Doc.ModelUnitSystem);
+
     private void SetUnits(Base geom)
     {
       geom.units = ModelUnits;


### PR DESCRIPTION
## Description

Grasshopper nodes were not properly updating the `ModelUnits` when the Document units in Rhino changed.

Added missing switch case for `km` and `kilometer` to be converted to Speckle Units.

Initially, @teocomi suggested to create a new `IConverter` every time we wanted to run a conversion, which would guarantee the proper units were set. This turned out to be a bigger change than intended, so I settled for a fast and simple check on the `ModelUnits` getter.

Previous behaviour was checking `_modelUnits` for `null` or `empty` values, we now also check if the saved value corresponds to the document's model units.

Added `Converter.Set` call on the `BeforeSolveInstance` method of `SelectKitComponentBase`, so that it would propagate to any components inheriting from it. This ensures correct units are set even when the Active RhinoDoc changes (new document is created or a different document is opened while grasshopper was open).

- Fixes #239 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. 

- [x] Manual Tests (what did you do?)

Tested with some basic geometric objects (points, curves, simple surfaces) and serialized the result to check the set units corresponded to the newly changed units in Rhino.

Also tested changing to "unsupported" units.
