### PR TITLE
🐛 DesktopUI Bug Fixes

### DIFF
--- a/DesktopUI/DesktopUI/RootView.xaml
+++ b/DesktopUI/DesktopUI/RootView.xaml
@@ -47,15 +47,16 @@
         <DockPanel>
           <ToggleButton
             x:Name="MenuToggleButton"
-            Width="40"
-            Height="40"
+            Width="30"
+            Height="30"
             Margin="12,0,0,0"
-            HorizontalAlignment="Right"
+            HorizontalAlignment="Left"
             md:ShadowAssist.ShadowDepth="Depth0"
+            Foreground="Gray"
             Background="Transparent"
             BorderBrush="Transparent"
             Command="{s:Action GoToSettingsOrBack}"
-            Content="{Binding MainButtonIcon}"
+            Content="{Binding  MainButtonIcon}"
             IsChecked="{Binding MainButton_Checked}"
             Style="{StaticResource MaterialDesignFloatingActionDarkButton}" />
           <TextBlock
@@ -64,6 +65,19 @@
             FontSize="20"
             Style="{StaticResource MaterialDesignHeadline3TextBlock}"
             Text="{Binding ViewName, Converter={StaticResource StringToUpperConverter}}" />
+          <Button
+            Width="30"
+            Height="30"
+            Margin="0 0 12 0 "
+            md:ShadowAssist.ShadowDepth="Depth0"
+            Background="Transparent"
+            BorderBrush="Transparent"
+            VerticalAlignment="Center"
+            HorizontalAlignment="Right"
+            Foreground="Gray"
+            Content="{md:PackIcon Kind=Refresh}"
+            Command="{s:Action RefreshActiveView}"
+            Style="{StaticResource MaterialDesignFloatingActionDarkButton}" />
 
         </DockPanel>
       </md:Card>

--- a/DesktopUI/DesktopUI/RootViewModel.cs
+++ b/DesktopUI/DesktopUI/RootViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
 using MaterialDesignThemes.Wpf;
+using Speckle.DesktopUI.Settings;
 using Speckle.DesktopUI.Streams;
 using Speckle.DesktopUI.Utils;
 using Stylet;
@@ -26,9 +27,9 @@ namespace Speckle.DesktopUI
       set => SetAndNotify(ref _viewName, value);
     }
 
-    private PackIcon BackIcon = new PackIcon { Kind = PackIconKind.ArrowLeft, Foreground = System.Windows.Media.Brushes.Gray };
+    private PackIcon BackIcon = new PackIcon { Kind = PackIconKind.ArrowLeft };
 
-    private PackIcon SettingsIcon = new PackIcon { Kind = PackIconKind.Settings, Foreground = System.Windows.Media.Brushes.Gray };
+    private PackIcon SettingsIcon = new PackIcon { Kind = PackIconKind.Settings };
 
     private PackIcon _mainButtonIcon;
     public PackIcon MainButtonIcon
@@ -111,6 +112,22 @@ namespace Speckle.DesktopUI
     public void GoToStreamViewPage( StreamViewModel streamItem)
     {
       ActivateItem(streamItem);
+    }
+
+    public void RefreshActiveView()
+    {
+      switch ( ActiveItem )
+      {
+        case SettingsViewModel settingsPage:
+          settingsPage.Refresh();
+          break;
+        case AllStreamsViewModel streamsPage:
+          streamsPage.Refresh();
+          break;
+        case StreamViewModel streamPage:
+          streamPage.Refresh();
+          break;
+      }
     }
 
     public void Handle(StreamRemovedEvent message)

--- a/DesktopUI/DesktopUI/Settings/SettingsView.xaml
+++ b/DesktopUI/DesktopUI/Settings/SettingsView.xaml
@@ -57,34 +57,18 @@
       <Grid Margin="0">
         <Grid Margin="20">
           <StackPanel>
-            <Grid>
-              <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-              </Grid.ColumnDefinitions>
-              <md:Badged Badge="{Binding LocalAccountsCount}"
-                         BadgeForeground="{DynamicResource MaterialDesignPaper}"
-                         BadgePlacementMode="Right"
-                         ToolTip="total accounts"
-                         ToolTipService.Placement="Mouse">
+            <md:Badged Badge="{Binding LocalAccountsCount}"
+                       BadgeForeground="{DynamicResource MaterialDesignPaper}"
+                       BadgePlacementMode="Right"
+                       ToolTip="total accounts"
+                       ToolTipService.Placement="Mouse">
                 <TextBlock Margin="0,8,16,8"
                            FontSize="16"
                            Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                            Text="Default Account" />
               </md:Badged>
-              <Button Grid.Column="1"
-                      Width="28"
-                      Height="28"
-                      HorizontalAlignment="Right"
-                      md:RippleAssist.ClipToBounds="True"
-                      Command="{s:Action RefreshAccounts}"
-                      Content="{md:PackIcon Kind=Refresh,
-                                          Size=16}"
-                      Style="{StaticResource MaterialDesignIconButton}"
-                      ToolTip="Refresh accounts" />
-            </Grid>
 
-            <Grid>
+              <Grid>
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />

--- a/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
@@ -411,13 +411,18 @@
 
                 <Grid Name="StreamCardTitle"
                       Grid.Row="0">
+                  <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                  </Grid.RowDefinitions>
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="auto" />
                     <ColumnDefinition Width="auto" />
                   </Grid.ColumnDefinitions>
 
-                  <WrapPanel Grid.Column="0">
+                  <WrapPanel Grid.Row="0"
+                             Grid.Column="0">
                     <TextBlock Grid.Column="0"
                                VerticalAlignment="Center"
                                Style="{StaticResource MaterialDesignHeadline4TextBlock}"
@@ -431,7 +436,8 @@
                     </TextBlock>
                   </WrapPanel>
 
-                  <ToggleButton Grid.Column="2"
+                  <ToggleButton Grid.Row="0"
+                                Grid.Column="2"
                                 Width="28"
                                 Height="28"
                                 Command="{s:Action SwapState}"
@@ -468,7 +474,8 @@
                     </md:ToggleButtonAssist.OnContent>
                   </ToggleButton>
 
-                  <Button Grid.Column="1"
+                  <Button Grid.Row="0"
+                          Grid.Column="1"
                           Width="28"
                           Height="28"
                           HorizontalAlignment="Right"
@@ -479,7 +486,16 @@
                                           Size=16}"
                           Style="{StaticResource MaterialDesignIconButton}"
                           ToolTip="Open this stream in the browser" />
-
+                  <StackPanel Orientation="Horizontal"
+                              Grid.Row="1"
+                              Grid.Column="0"
+                              Grid.ColumnSpan="3"
+                              Margin="0,6 0 0">
+                    <TextBlock Margin="0 0 12 0" FontFamily="Consolas"
+                               FontSize="12"
+                               Foreground="{DynamicResource MaterialDesignBodyLight}"
+                               Text="{Binding Stream.id}" />
+                  </StackPanel>
 
                 </Grid>
                 <!--#endregion-->

--- a/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
@@ -1,16 +1,15 @@
-﻿<UserControl
-  x:Class="Speckle.DesktopUI.Streams.AllStreamsView"
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-  xmlns:local="clr-namespace:Speckle.DesktopUI.Streams"
-  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
-  xmlns:s="https://github.com/canton7/Stylet"
-  xmlns:utils="clr-namespace:Speckle.DesktopUI.Utils"
-  d:DesignHeight="450"
-  d:DesignWidth="600"
-  mc:Ignorable="d">
+﻿<UserControl x:Class="Speckle.DesktopUI.Streams.AllStreamsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Speckle.DesktopUI.Streams"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:s="https://github.com/canton7/Stylet"
+             xmlns:utils="clr-namespace:Speckle.DesktopUI.Utils"
+             d:DesignHeight="450"
+             d:DesignWidth="600"
+             mc:Ignorable="d">
   <UserControl.Resources>
     <ResourceDictionary>
 
@@ -20,16 +19,15 @@
 
       <!--#region Branch Swapping Button (Sender/Receiver shared)-->
       <ControlTemplate x:Key="BranchButton">
-        <Button
-          x:Name="BranchButton"
-          Width="auto"
-          Padding="10,0"
-          HorizontalAlignment="Left"
-          local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
-          md:ButtonAssist.CornerRadius="3"
-          ContextMenuService.Placement="Bottom"
-          FontSize="12"
-          Style="{StaticResource MaterialDesignFlatButton}">
+        <Button x:Name="BranchButton"
+                Width="auto"
+                Padding="10,0"
+                HorizontalAlignment="Left"
+                local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
+                md:ButtonAssist.CornerRadius="3"
+                ContextMenuService.Placement="Bottom"
+                FontSize="12"
+                Style="{StaticResource MaterialDesignFlatButton}">
           <Button.ToolTip>
             <TextBlock>
               <Run Text="Current branch is" />
@@ -43,40 +41,40 @@
               <ColumnDefinition Width="20" />
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <md:PackIcon
-              Grid.Column="0"
-              Margin="0,0,0,0"
-              HorizontalAlignment="Left"
-              Kind="SourceBranch" />
-            <TextBlock
-              Grid.Column="1"
-              Margin="4,0"
-              FontWeight="Normal"
-              Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext.Branch.name}" />
+            <md:PackIcon Grid.Column="0"
+                         Margin="0,0,0,0"
+                         HorizontalAlignment="Left"
+                         Kind="SourceBranch" />
+            <TextBlock Grid.Column="1"
+                       Margin="4,0"
+                       FontWeight="Normal"
+                       Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext.Branch.name}" />
           </Grid>
           <Button.Resources>
-            <local:BindingProxy x:Key="Proxy" Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
+            <local:BindingProxy x:Key="Proxy"
+                                Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
           </Button.Resources>
           <Button.ContextMenu>
-            <ContextMenu FontSize="12" ItemsSource="{Binding BranchContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+            <ContextMenu FontSize="12"
+                         ItemsSource="{Binding BranchContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
               <ContextMenu.ItemTemplate>
                 <DataTemplate>
-                  <Grid Background="Transparent" ToolTip="{Binding Tooltip}">
+                  <Grid Background="Transparent"
+                        ToolTip="{Binding Tooltip}">
                     <Grid.InputBindings>
-                      <MouseBinding
-                        Command="{s:Action SwitchBranch}"
-                        CommandParameter="{Binding CommandArgument}"
-                        Gesture="LeftClick" />
+                      <MouseBinding Command="{s:Action SwitchBranch}"
+                                    CommandParameter="{Binding CommandArgument}"
+                                    Gesture="LeftClick" />
                     </Grid.InputBindings>
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="20" />
                       <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-                    <md:PackIcon Grid.Column="0" Kind="{Binding Icon.Kind}" />
-                    <TextBlock
-                      Grid.Column="1"
-                      Text="{Binding Branch.name}"
-                      TextAlignment="Left" />
+                    <md:PackIcon Grid.Column="0"
+                                 Kind="{Binding Icon.Kind}" />
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding Branch.name}"
+                               TextAlignment="Left" />
                   </Grid>
                 </DataTemplate>
               </ContextMenu.ItemTemplate>
@@ -88,32 +86,39 @@
 
       <!--#region Sender Selection/Filters Button (Sender)-->
       <ControlTemplate x:Key="SelectionButton">
-        <Button
-          x:Name="SelectionButton"
-          MinWidth="120"
-          Padding="5"
-          HorizontalAlignment="Left"
-          local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="true"
-          md:ButtonAssist.CornerRadius="3"
-          FontSize="12"
-          FontWeight="Normal">
+        <Button x:Name="SelectionButton"
+                MinWidth="120"
+                Padding="5"
+                HorizontalAlignment="Left"
+                local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="true"
+                md:ButtonAssist.CornerRadius="3"
+                FontSize="12"
+                FontWeight="Normal">
           <Button.Style>
-            <Style BasedOn="{StaticResource MaterialDesignRaisedButton}" TargetType="Button">
+            <Style BasedOn="{StaticResource MaterialDesignRaisedButton}"
+                   TargetType="Button">
               <Style.Triggers>
-                <DataTrigger Binding="{Binding SendDisabled}" Value="True">
-                  <Setter Property="md:ShadowAssist.ShadowDepth" Value="Depth3" />
+                <DataTrigger Binding="{Binding SendDisabled}"
+                             Value="True">
+                  <Setter Property="md:ShadowAssist.ShadowDepth"
+                          Value="Depth3" />
                 </DataTrigger>
-                <DataTrigger Binding="{Binding SendEnabled}" Value="True">
-                  <Setter Property="Background" Value="Transparent" />
-                  <Setter Property="BorderBrush" Value="Transparent" />
-                  <Setter Property="Foreground" Value="{StaticResource PrimaryHueMidBrush}" />
+                <DataTrigger Binding="{Binding SendEnabled}"
+                             Value="True">
+                  <Setter Property="Background"
+                          Value="Transparent" />
+                  <Setter Property="BorderBrush"
+                          Value="Transparent" />
+                  <Setter Property="Foreground"
+                          Value="{StaticResource PrimaryHueMidBrush}" />
                 </DataTrigger>
               </Style.Triggers>
             </Style>
           </Button.Style>
           <Button.ToolTip>
             <TextBlock>
-              <Run FontWeight="Bold" Text="{Binding ObjectSelectionTooltipText, Mode=OneWay}" />
+              <Run FontWeight="Bold"
+                   Text="{Binding ObjectSelectionTooltipText, Mode=OneWay}" />
               <LineBreak />
               <Run Text="Click to change." />
             </TextBlock>
@@ -123,24 +128,24 @@
               <ColumnDefinition Width="Auto" />
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <md:PackIcon Grid.Column="0" Kind="{Binding ObjectSelectionButtonIcon.Kind}" />
-            <TextBlock
-              Grid.Column="2"
-              Margin="5,2"
-              FontWeight="Normal">
+            <md:PackIcon Grid.Column="0"
+                         Kind="{Binding ObjectSelectionButtonIcon.Kind}" />
+            <TextBlock Grid.Column="2"
+                       Margin="5,2"
+                       FontWeight="Normal">
               <Run Text="{Binding ObjectSelectionButtonText, Mode=OneWay}" />
             </TextBlock>
           </Grid>
           <Button.Resources>
-            <local:BindingProxy x:Key="Proxy" Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+            <local:BindingProxy x:Key="Proxy"
+                                Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}}" />
           </Button.Resources>
           <Button.ContextMenu>
             <ContextMenu FontSize="12">
-              <MenuItem
-                Command="{s:Action ShowStreamUpdateObjectsDialog}"
-                CommandParameter="{Binding}"
-                ToolTip="A filter will run automatically and dynamically select elements that match when sending."
-                Visibility="{Binding AppHasFilters, Converter={StaticResource BooleanToVisibilityConverter}}">
+              <MenuItem Command="{s:Action ShowStreamUpdateObjectsDialog}"
+                        CommandParameter="{Binding}"
+                        ToolTip="A filter will run automatically and dynamically select elements that match when sending."
+                        Visibility="{Binding AppHasFilters, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <MenuItem.Icon>
                   <md:PackIcon Kind="FilterList" />
                 </MenuItem.Icon>
@@ -153,7 +158,8 @@
 
               <Separator Visibility="{Binding AppHasFilters, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-              <MenuItem Command="{s:Action SetObjectSelection}" CommandParameter="{Binding}">
+              <MenuItem Command="{s:Action SetObjectSelection}"
+                        CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Clears any existing objects, and sets the current selected ones.</Run>
@@ -162,7 +168,8 @@
                   </TextBlock>
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
-                  <md:PackIcon Foreground="Green" Kind="AddCircle" />
+                  <md:PackIcon Foreground="Green"
+                               Kind="AddCircle" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -171,7 +178,8 @@
                 </MenuItem.Header>
               </MenuItem>
 
-              <MenuItem Command="{s:Action AddObjectSelection}" CommandParameter="{Binding}">
+              <MenuItem Command="{s:Action AddObjectSelection}"
+                        CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Adds the currently selected objects to the existing list. Does not clear old ones.</Run>
@@ -180,7 +188,8 @@
                   </TextBlock>
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
-                  <md:PackIcon Foreground="{StaticResource PrimaryHueLightBrush}" Kind="AddCircle" />
+                  <md:PackIcon Foreground="{StaticResource PrimaryHueLightBrush}"
+                               Kind="AddCircle" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -189,7 +198,8 @@
                 </MenuItem.Header>
               </MenuItem>
 
-              <MenuItem Command="{s:Action RemoveObjectSelection}" CommandParameter="{Binding}">
+              <MenuItem Command="{s:Action RemoveObjectSelection}"
+                        CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Removes the selected objects.</Run>
@@ -198,7 +208,8 @@
                   </TextBlock>
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
-                  <md:PackIcon Foreground="IndianRed" Kind="MinusCircle" />
+                  <md:PackIcon Foreground="IndianRed"
+                               Kind="MinusCircle" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -207,7 +218,8 @@
                 </MenuItem.Header>
               </MenuItem>
 
-              <MenuItem Command="{s:Action ClearObjectSelection}" CommandParameter="{Binding}">
+              <MenuItem Command="{s:Action ClearObjectSelection}"
+                        CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Removes all selected objects.</Run>
@@ -216,7 +228,8 @@
                   </TextBlock>
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
-                  <md:PackIcon Foreground="OrangeRed" Kind="RemoveCircleMultiple" />
+                  <md:PackIcon Foreground="OrangeRed"
+                               Kind="RemoveCircleMultiple" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -233,16 +246,15 @@
 
       <!--#region Commit Swapping Button (Receiver)-->
       <ControlTemplate x:Key="CommitSwappingButton">
-        <Button
-          x:Name="CommitSwappingButton"
-          Width="auto"
-          Padding="0"
-          HorizontalAlignment="Left"
-          local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
-          md:ButtonAssist.CornerRadius="3"
-          ContextMenuService.Placement="Bottom"
-          FontSize="12"
-          Style="{StaticResource MaterialDesignFlatButton}">
+        <Button x:Name="CommitSwappingButton"
+                Width="auto"
+                Padding="0"
+                HorizontalAlignment="Left"
+                local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
+                md:ButtonAssist.CornerRadius="3"
+                ContextMenuService.Placement="Bottom"
+                FontSize="12"
+                Style="{StaticResource MaterialDesignFlatButton}">
           <Button.ToolTip>
             <TextBlock>
               <Run Text="Current commit is" />
@@ -256,31 +268,30 @@
               <ColumnDefinition Width="20" />
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <md:PackIcon
-              Grid.Column="0"
-              Margin="0,0,0,0"
-              HorizontalAlignment="Left"
-              Kind="SourceCommit" />
-            <TextBlock
-              Grid.Column="1"
-              Margin="3,1,14,1"
-              FontWeight="Normal"
-              Text="{Binding Commit.id}" />
+            <md:PackIcon Grid.Column="0"
+                         Margin="0,0,0,0"
+                         HorizontalAlignment="Left"
+                         Kind="SourceCommit" />
+            <TextBlock Grid.Column="1"
+                       Margin="3,1,14,1"
+                       FontWeight="Normal"
+                       Text="{Binding Commit.id}" />
           </Grid>
           <Button.Resources>
-            <local:BindingProxy x:Key="Proxy" Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
+            <local:BindingProxy x:Key="Proxy"
+                                Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
           </Button.Resources>
           <Button.ContextMenu>
-            <ContextMenu FontSize="12" ItemsSource="{Binding CommitContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+            <ContextMenu FontSize="12"
+                         ItemsSource="{Binding CommitContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
               <ContextMenu.ItemTemplate>
                 <DataTemplate>
                   <StackPanel>
                     <Grid Margin="0,0">
                       <Grid.InputBindings>
-                        <MouseBinding
-                          Command="{s:Action SwitchCommit}"
-                          CommandParameter="{Binding CommandArgument}"
-                          Gesture="LeftClick" />
+                        <MouseBinding Command="{s:Action SwitchCommit}"
+                                      CommandParameter="{Binding CommandArgument}"
+                                      Gesture="LeftClick" />
                       </Grid.InputBindings>
                       <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="10" />
@@ -290,19 +301,18 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                       </Grid.RowDefinitions>
-                      <md:PackIcon
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Margin="-20,0,0,0"
-                        HorizontalAlignment="Left"
-                        Kind="{Binding Icon.Kind}" />
-                      <TextBlock
-                        Grid.Row="0"
-                        Grid.Column="1"
-                        TextAlignment="Left">
+                      <md:PackIcon Grid.Row="0"
+                                   Grid.Column="0"
+                                   Margin="-20,0,0,0"
+                                   HorizontalAlignment="Left"
+                                   Kind="{Binding Icon.Kind}" />
+                      <TextBlock Grid.Row="0"
+                                 Grid.Column="1"
+                                 TextAlignment="Left">
                         <Run Text="{Binding MainText}" />
                         <!--<Run Text="-" />-->
-                        <Run FontWeight="Bold" Text="{Binding SecondaryText}" />
+                        <Run FontWeight="Bold"
+                             Text="{Binding SecondaryText}" />
                       </TextBlock>
                     </Grid>
                   </StackPanel>
@@ -324,65 +334,73 @@
 
           <!--#region Disabled Card (no account)-->
 
-          <Grid
-            Grid.Row="0"
-            Margin="24"
-            Panel.ZIndex="2"
-            Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
-            <Border
-              Width="260"
-              Height="Auto"
-              Background="{DynamicResource MaterialDesignTextFieldBoxDisabledBackground}"
-              CornerRadius="6">
-              <StackPanel
-                Margin="8"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center">
-                <TextBlock
-                  FontSize="14"
-                  Text="No local account for server:"
-                  TextWrapping="Wrap" />
-                <TextBlock
-                  Margin="0,4"
-                  FontFamily="Consolas"
-                  Text="{Binding ServerUrl}"
-                  TextWrapping="Wrap" />
-                <TextBlock Text="Please ensure you have an account for this server and have added it to the Speckle Manager" TextWrapping="Wrap" />
-              </StackPanel>
-            </Border>
-          </Grid>
+          <md:Card Grid.Row="0"
+                   Width="Auto"
+                   Margin="12,10,12,10"
+                   Panel.ZIndex="100"
+                   md:ShadowAssist.ShadowDepth="Depth0"
+                   Opacity=".9"
+                   UniformCornerRadius="8"
+                   Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
 
-          <md:Card
-            Grid.Row="0"
-            Width="Auto"
-            Margin="8"
-            Panel.ZIndex="100"
-            md:ShadowAssist.ShadowDepth="Depth0"
-            Foreground="{DynamicResource MaterialDesignTextFieldBoxDisabledBackground}"
-            Opacity=".9"
-            UniformCornerRadius="8"
-            Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}" />
+            <Grid Margin="16"
+                  Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
+              <StackPanel Margin="8"
+                          Grid.ColumnSpan="2"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center">
+                <TextBlock FontSize="14"
+                           Text="No local account for server:"
+                           TextWrapping="Wrap" />
+                <TextBlock Margin="0,4"
+                           FontFamily="Consolas"
+                           Text="{Binding ServerUrl}"
+                           TextWrapping="Wrap" />
+                <TextBlock
+                  Text="Please ensure you have an account for this server and have added it to the Speckle Manager"
+                  TextWrapping="Wrap" />
+              </StackPanel>
+              <Button Width="28"
+                      Height="28"
+                      HorizontalAlignment="Right"
+                      VerticalAlignment="Top"
+                      md:RippleAssist.ClipToBounds="True"
+                      Command="{s:Action RemoveDisabledStream}"
+                      CommandParameter="{Binding}"
+                      Content="{md:PackIcon Kind=TrashCanOutline,
+                                          Size=16}"
+                      Style="{StaticResource MaterialDesignIconButton}"
+                      ToolTip="Remove this stream" />
+
+            </Grid>
+          </md:Card>
+
+
           <!--#endregion-->
 
-          <md:Card
-            Grid.Row="0"
-            Width="Auto"
-            Margin="12,10,12,10"
-            UniformCornerRadius="8">
+          <md:Card Grid.Row="0"
+                   Width="Auto"
+                   Margin="12,10,12,10"
+                   UniformCornerRadius="8">
             <md:Card.Style>
               <Style>
                 <Style.Triggers>
-                  <DataTrigger Binding="{Binding ServerUpdates}" Value="True">
-                    <Setter Property="md:ShadowAssist.ShadowDepth" Value="Depth5" />
+                  <DataTrigger Binding="{Binding ServerUpdates}"
+                               Value="True">
+                    <Setter Property="md:ShadowAssist.ShadowDepth"
+                            Value="Depth5" />
                   </DataTrigger>
-                  <DataTrigger Binding="{Binding ServerUpdates}" Value="False">
-                    <Setter Property="md:ShadowAssist.ShadowDepth" Value="Depth1" />
+                  <DataTrigger Binding="{Binding ServerUpdates}"
+                               Value="False">
+                    <Setter Property="md:ShadowAssist.ShadowDepth"
+                            Value="Depth1" />
                   </DataTrigger>
                 </Style.Triggers>
               </Style>
             </md:Card.Style>
             <StackPanel>
-              <Grid x:Name="CardGrid" Margin="16">
+              <Grid x:Name="CardGrid"
+                    Margin="16">
                 <Grid.RowDefinitions>
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="Auto" />
@@ -391,7 +409,8 @@
 
                 <!--#region Card Header-->
 
-                <Grid Name="StreamCardTitle" Grid.Row="0">
+                <Grid Name="StreamCardTitle"
+                      Grid.Row="0">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="auto" />
@@ -399,42 +418,43 @@
                   </Grid.ColumnDefinitions>
 
                   <WrapPanel Grid.Column="0">
-                    <TextBlock
-                      Grid.Column="0"
-                      VerticalAlignment="Center"
-                      Style="{StaticResource MaterialDesignHeadline4TextBlock}"
-                      TextWrapping="Wrap">
-                      <Hyperlink
-                        Command="{s:Action ShowStreamInfo}"
-                        CommandParameter="{Binding}"
-                        ToolTip="Open stream details page.">
-                        <TextBlock FontSize="20" Text="{Binding Stream.name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <TextBlock Grid.Column="0"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource MaterialDesignHeadline4TextBlock}"
+                               TextWrapping="Wrap">
+                      <Hyperlink Command="{s:Action ShowStreamInfo}"
+                                 CommandParameter="{Binding}"
+                                 ToolTip="Open stream details page.">
+                        <TextBlock FontSize="20"
+                                   Text="{Binding Stream.name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                       </Hyperlink>
                     </TextBlock>
                   </WrapPanel>
 
-                  <ToggleButton
-                    Grid.Column="2"
-                    Width="28"
-                    Height="28"
-                    Command="{s:Action SwapState}"
-                    IsEnabled="{Binding RoleIsReviewer, Converter={StaticResource InverseBooleanConverter}}"
-                    CommandParameter="{Binding}"
-                    ToolTipService.ShowOnDisabled="True"
-                    Style="{StaticResource MaterialDesignWhiteToggleButton}">
+                  <ToggleButton Grid.Column="2"
+                                Width="28"
+                                Height="28"
+                                Command="{s:Action SwapState}"
+                                CommandParameter="{Binding}"
+                                IsEnabled="{Binding RoleIsReviewer, Converter={StaticResource InverseBooleanConverter}}"
+                                Style="{StaticResource MaterialDesignWhiteToggleButton}"
+                                ToolTipService.ShowOnDisabled="True">
                     <ToggleButton.ToolTip>
                       <StackPanel Orientation="Vertical">
-                        <TextBlock Visibility="{Binding IsSenderCard, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <TextBlock
+                          Visibility="{Binding IsSenderCard, Converter={StaticResource BooleanToVisibilityConverter}}">
                           <Run>Swaps the type of this stream card.</Run>
                           <LineBreak />
                           <Run FontWeight="Bold">Click to make it a receiver!</Run>
                         </TextBlock>
-                        <TextBlock Visibility="{Binding IsReceiverCard, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <TextBlock
+                          Visibility="{Binding IsReceiverCard, Converter={StaticResource BooleanToVisibilityConverter}}">
                           <Run>Swaps the type of this stream card.</Run>
                           <LineBreak />
                           <Run FontWeight="Bold">Click to make it a sender!</Run>
                         </TextBlock>
-                        <TextBlock Visibility="{Binding RoleIsReviewer, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <TextBlock
+                          Visibility="{Binding RoleIsReviewer, Converter={StaticResource BooleanToVisibilityConverter}}">
                           <LineBreak />
                           <Run FontWeight="Bold">Disabled because you do not have the required permissions.</Run>
                         </TextBlock>
@@ -448,30 +468,28 @@
                     </md:ToggleButtonAssist.OnContent>
                   </ToggleButton>
 
-                  <Button
-                    Grid.Column="1"
-                    Width="28"
-                    Height="28"
-                    HorizontalAlignment="Right"
-                    md:RippleAssist.ClipToBounds="True"
-                    Command="{s:Action OpenStreamInWeb}"
-                    CommandParameter="{Binding}"
-                    Content="{md:PackIcon Kind=OpenInNew,
+                  <Button Grid.Column="1"
+                          Width="28"
+                          Height="28"
+                          HorizontalAlignment="Right"
+                          md:RippleAssist.ClipToBounds="True"
+                          Command="{s:Action OpenStreamInWeb}"
+                          CommandParameter="{Binding}"
+                          Content="{md:PackIcon Kind=OpenInNew,
                                           Size=16}"
-                    Style="{StaticResource MaterialDesignIconButton}"
-                    ToolTip="Open this stream in the browser" />
+                          Style="{StaticResource MaterialDesignIconButton}"
+                          ToolTip="Open this stream in the browser" />
 
 
                 </Grid>
                 <!--#endregion-->
 
                 <!--  Stream Card Sender Actions  -->
-                <Grid
-                  Name="StreamCardSenderActions"
-                  Grid.Row="1"
-                  Margin="0,30,0,0"
-                  IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
-                  Visibility="{Binding IsSenderCard, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Grid Name="StreamCardSenderActions"
+                      Grid.Row="1"
+                      Margin="0,30,0,0"
+                      IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
+                      Visibility="{Binding IsSenderCard, Converter={StaticResource BooleanToVisibilityConverter}}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
@@ -483,20 +501,20 @@
                   <Control Template="{StaticResource BranchButton}" />
 
                   <!--  The Objects button  -->
-                  <Control Grid.Column="1" Template="{StaticResource SelectionButton}" />
+                  <Control Grid.Column="1"
+                           Template="{StaticResource SelectionButton}" />
 
                   <!--  The Send Button  -->
-                  <Button
-                    x:Name="SendButton"
-                    Grid.Column="2"
-                    Width="120"
-                    HorizontalAlignment="Right"
-                    md:ButtonAssist.CornerRadius="3"
-                    md:ShadowAssist.ShadowDepth="Depth3"
-                    Command="{s:Action Send}"
-                    CommandParameter="{Binding}"
-                    ContextMenuService.Placement="Center"
-                    IsEnabled="{Binding SendEnabled}">
+                  <Button x:Name="SendButton"
+                          Grid.Column="2"
+                          Width="120"
+                          HorizontalAlignment="Right"
+                          md:ButtonAssist.CornerRadius="3"
+                          md:ShadowAssist.ShadowDepth="Depth3"
+                          Command="{s:Action Send}"
+                          CommandParameter="{Binding}"
+                          ContextMenuService.Placement="Center"
+                          IsEnabled="{Binding SendEnabled}">
                     <Button.ToolTip>
                       <TextBlock>
                         <Run>Send to Specke: either the selected objects, or the ones picked up by the filter.</Run>
@@ -505,7 +523,8 @@
                       </TextBlock>
                     </Button.ToolTip>
                     <Button.Resources>
-                      <local:BindingProxy x:Key="Proxy" Data="{Binding}" />
+                      <local:BindingProxy x:Key="Proxy"
+                                          Data="{Binding}" />
                     </Button.Resources>
                     <!--<Button.ContextMenu>
                       <ContextMenu>
@@ -543,26 +562,23 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                       </Grid.ColumnDefinitions>
-                      <Image
-                        Grid.Column="0"
-                        Width="32"
-                        Height="32"
-                        Margin="-10,0,5,0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Center"
-                        Source="/SpeckleDesktopUI;Component/Resources/SenderWhite@32.png" />
-                      <TextBlock
-                        Grid.Column="1"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Text="Send" />
+                      <Image Grid.Column="0"
+                             Width="32"
+                             Height="32"
+                             Margin="-10,0,5,0"
+                             HorizontalAlignment="Left"
+                             VerticalAlignment="Center"
+                             Source="/SpeckleDesktopUI;Component/Resources/SenderWhite@32.png" />
+                      <TextBlock Grid.Column="1"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center"
+                                 Text="Send" />
                     </Grid>
                   </Button>
 
-                  <md:PopupBox
-                    Grid.Column="3"
-                    IsEnabled="{Binding SendEnabled}"
-                    StaysOpen="True">
+                  <md:PopupBox Grid.Column="3"
+                               IsEnabled="{Binding SendEnabled}"
+                               StaysOpen="True">
                     <md:PopupBox.ToolTip>
                       <TextBlock>
                         <Run>Send data with a commit message.</Run>
@@ -570,7 +586,8 @@
                     </md:PopupBox.ToolTip>
                     <MenuItem Margin="10">
                       <MenuItem.Resources>
-                        <local:BindingProxy x:Key="Proxy" Data="{Binding}" />
+                        <local:BindingProxy x:Key="Proxy"
+                                            Data="{Binding}" />
                       </MenuItem.Resources>
                       <MenuItem.Template>
                         <ControlTemplate>
@@ -579,21 +596,19 @@
                               <ColumnDefinition Width="*" />
                               <ColumnDefinition Width="30" />
                             </Grid.ColumnDefinitions>
-                            <md:PackIcon
-                              Grid.Column="1"
-                              Margin="0,10,0,10"
-                              Kind="MessageAdd"
-                              Opacity="0.5" />
-                            <TextBox
-                              Grid.Column="0"
-                              Width="200"
-                              Margin="4"
-                              md:HintAssist.HelperText="Commit message (press enter to send)"
-                              md:TextBlockAssist.AutoToolTip="False"
-                              s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
-                              PreviewKeyDown="{s:Action SendWithCommitMessage}"
-                              Text="{Binding Path=Data.CommitMessage, Source={StaticResource Proxy}}"
-                              ToolTip="A commit message helps keep track of the changes made, and the reasons behind them." />
+                            <md:PackIcon Grid.Column="1"
+                                         Margin="0,10,0,10"
+                                         Kind="MessageAdd"
+                                         Opacity="0.5" />
+                            <TextBox Grid.Column="0"
+                                     Width="200"
+                                     Margin="4"
+                                     md:HintAssist.HelperText="Commit message (press enter to send)"
+                                     md:TextBlockAssist.AutoToolTip="False"
+                                     s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
+                                     PreviewKeyDown="{s:Action SendWithCommitMessage}"
+                                     Text="{Binding Path=Data.CommitMessage, Source={StaticResource Proxy}}"
+                                     ToolTip="A commit message helps keep track of the changes made, and the reasons behind them." />
                           </Grid>
                         </ControlTemplate>
                       </MenuItem.Template>
@@ -603,12 +618,11 @@
                 <!--#endregion-->
 
                 <!--#region Stream Card Receiver Actions-->
-                <Grid
-                  x:Name="StreamCardReceiverActions"
-                  Grid.Row="1"
-                  Margin="0,30,0,0"
-                  IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
-                  Visibility="{Binding IsReceiverCard, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Grid x:Name="StreamCardReceiverActions"
+                      Grid.Row="1"
+                      Margin="0,30,0,0"
+                      IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
+                      Visibility="{Binding IsReceiverCard, Converter={StaticResource BooleanToVisibilityConverter}}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
@@ -619,37 +633,35 @@
                   <Control Template="{StaticResource BranchButton}" />
 
                   <!--  The commit button  -->
-                  <Control Grid.Column="1" Template="{StaticResource CommitSwappingButton}" />
+                  <Control Grid.Column="1"
+                           Template="{StaticResource CommitSwappingButton}" />
 
-                  <Button
-                    x:Name="ReceiveButton"
-                    Grid.Column="2"
-                    Width="120"
-                    HorizontalAlignment="Right"
-                    md:ButtonAssist.CornerRadius="3"
-                    Command="{s:Action Receive}"
-                    CommandParameter="{Binding}"
-                    IsEnabled="{Binding ReceiveEnabled}"
-                    Style="{StaticResource MaterialDesignRaisedButton}"
-                    ToolTip="Edit/Change Objects">
+                  <Button x:Name="ReceiveButton"
+                          Grid.Column="2"
+                          Width="120"
+                          HorizontalAlignment="Right"
+                          md:ButtonAssist.CornerRadius="3"
+                          Command="{s:Action Receive}"
+                          CommandParameter="{Binding}"
+                          IsEnabled="{Binding ReceiveEnabled}"
+                          Style="{StaticResource MaterialDesignRaisedButton}"
+                          ToolTip="Edit/Change Objects">
                     <Grid>
                       <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                       </Grid.ColumnDefinitions>
-                      <Image
-                        Grid.Column="0"
-                        Width="32"
-                        Height="32"
-                        Margin="0,0,5,0"
-                        VerticalAlignment="Center"
-                        Source="/SpeckleDesktopUI;Component/Resources/ReceiverWhite@32.png" />
+                      <Image Grid.Column="0"
+                             Width="32"
+                             Height="32"
+                             Margin="0,0,5,0"
+                             VerticalAlignment="Center"
+                             Source="/SpeckleDesktopUI;Component/Resources/ReceiverWhite@32.png" />
 
-                      <TextBlock
-                        Grid.Column="1"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Text="Receive  " />
+                      <TextBlock Grid.Column="1"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center"
+                                 Text="Receive  " />
                     </Grid>
                   </Button>
                 </Grid>
@@ -659,108 +671,105 @@
 
               <!--#region Progress Bar-->
 
-              <Grid Visibility="{Binding Path=DataContext.ShowProgressBar, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BooleanToVisibilityConverter}}">
+              <Grid
+                Visibility="{Binding Path=DataContext.ShowProgressBar, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.Resources>
-                  <local:BindingProxy x:Key="Proxy" Data="{Binding}" />
+                  <local:BindingProxy x:Key="Proxy"
+                                      Data="{Binding}" />
                 </Grid.Resources>
-                <ProgressBar
-                  x:Name="ProgressBar"
-                  Grid.Column="0"
-                  Height="15"
-                  Margin="0,0"
-                  VerticalAlignment="Center"
-                  md:TransitionAssist.DisableTransitions="True"
-                  BorderBrush="Transparent"
-                  BorderThickness="0"
-                  IsIndeterminate="{Binding Path=DataContext.ProgressBarIsIndeterminate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                  Maximum="{Binding Path=DataContext.Progress.Maximum, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                  Minimum="0"
-                  Value="{Binding Path=DataContext.Progress.Value, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
-                <TextBlock
-                  Grid.Column="0"
-                  Height="10"
-                  Margin="20,0"
-                  HorizontalAlignment="Left"
-                  FontSize="9"
-                  Foreground="White"
-                  Opacity="0.7"
-                  Text="{Binding Path=DataContext.Progress.ProgressSummary, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                  TextAlignment="Center" />
+                <ProgressBar x:Name="ProgressBar"
+                             Grid.Column="0"
+                             Height="15"
+                             Margin="0,0"
+                             VerticalAlignment="Center"
+                             md:TransitionAssist.DisableTransitions="True"
+                             BorderBrush="Transparent"
+                             BorderThickness="0"
+                             IsIndeterminate="{Binding Path=DataContext.ProgressBarIsIndeterminate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                             Maximum="{Binding Path=DataContext.Progress.Maximum, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                             Minimum="0"
+                             Value="{Binding Path=DataContext.Progress.Value, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                <TextBlock Grid.Column="0"
+                           Height="10"
+                           Margin="20,0"
+                           HorizontalAlignment="Left"
+                           FontSize="9"
+                           Foreground="White"
+                           Opacity="0.7"
+                           Text="{Binding Path=DataContext.Progress.ProgressSummary, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                           TextAlignment="Center" />
                 <!--  TODO: Figure out how to make this nice  -->
-                <Button
-                  x:Name="Cancel"
-                  Grid.Column="0"
-                  Width="14"
-                  Height="15"
-                  Margin="0,0,20,0"
-                  HorizontalAlignment="Right"
-                  md:ButtonAssist.CornerRadius="3"
-                  s:View.ActionTarget="{Binding Source={StaticResource Proxy}, Path=Data}"
-                  Background="Transparent"
-                  BorderBrush="Transparent"
-                  BorderThickness="0"
-                  Command="{s:Action CancelSendOrReceive}"
-                  Content="{md:PackIcon Kind=Close,
+                <Button x:Name="Cancel"
+                        Grid.Column="0"
+                        Width="14"
+                        Height="15"
+                        Margin="0,0,20,0"
+                        HorizontalAlignment="Right"
+                        md:ButtonAssist.CornerRadius="3"
+                        s:View.ActionTarget="{Binding Source={StaticResource Proxy}, Path=Data}"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
+                        BorderThickness="0"
+                        Command="{s:Action CancelSendOrReceive}"
+                        Content="{md:PackIcon Kind=Close,
                                         Size=12}"
-                  Style="{StaticResource MaterialDesignFloatingActionButton}"
-                  ToolTip="Cancel" />
+                        Style="{StaticResource MaterialDesignFloatingActionButton}"
+                        ToolTip="Cancel" />
               </Grid>
               <!--#endregion-->
 
               <!--#region Updates display-->
-              <md:Card
-                Grid.Row="1"
-                Margin="0,0,0,0"
-                Padding="5"
-                Panel.ZIndex="1000"
-                md:ShadowAssist.ShadowDepth="Depth0"
-                Background="{StaticResource PrimaryHueDarkBrush}"
-                UniformCornerRadius="0"
-                Visibility="{Binding ServerUpdates, Converter={StaticResource BooleanToVisibilityConverter}}">
+              <md:Card Grid.Row="1"
+                       Margin="0,0,0,0"
+                       Padding="5"
+                       Panel.ZIndex="1000"
+                       md:ShadowAssist.ShadowDepth="Depth0"
+                       Background="{StaticResource PrimaryHueDarkBrush}"
+                       UniformCornerRadius="0"
+                       Visibility="{Binding ServerUpdates, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <md:Card.Resources>
-                  <local:BindingProxy x:Key="Proxy" Data="{Binding}" />
+                  <local:BindingProxy x:Key="Proxy"
+                                      Data="{Binding}" />
                 </md:Card.Resources>
                 <Grid Margin="10,5,10,0">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="20" />
                   </Grid.ColumnDefinitions>
-                  <TextBlock
-                    Grid.Column="0"
-                    Padding="4"
-                    FontSize="12"
-                    Foreground="White"
-                    Text="{Binding ServerUpdateSummary}"
-                    TextWrapping="Wrap" />
+                  <TextBlock Grid.Column="0"
+                             Padding="4"
+                             FontSize="12"
+                             Foreground="White"
+                             Text="{Binding ServerUpdateSummary}"
+                             TextWrapping="Wrap" />
 
-                  <Button
-                    Grid.Column="1"
-                    Width="20"
-                    Height="20"
-                    s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
-                    Background="White"
-                    BorderBrush="White"
-                    Command="{s:Action CloseUpdateNotification}"
-                    CommandParameter="{Binding}"
-                    Content="{md:PackIcon Kind=Close,
+                  <Button Grid.Column="1"
+                          Width="20"
+                          Height="20"
+                          s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
+                          Background="White"
+                          BorderBrush="White"
+                          Command="{s:Action CloseUpdateNotification}"
+                          CommandParameter="{Binding}"
+                          Content="{md:PackIcon Kind=Close,
                                           Size=10}"
-                    Foreground="Black"
-                    Style="{StaticResource MaterialDesignFloatingActionLightButton}"
-                    ToolTip="Close notification." />
+                          Foreground="Black"
+                          Style="{StaticResource MaterialDesignFloatingActionLightButton}"
+                          ToolTip="Close notification." />
                 </Grid>
               </md:Card>
               <!--#endregion-->
 
               <!--#region Error display-->
-              <md:Card
-                Grid.Row="1"
-                Margin="0,0,0,0"
-                Padding="5"
-                Panel.ZIndex="1000"
-                md:ShadowAssist.ShadowDepth="Depth0"
-                Visibility="{Binding ShowErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
+              <md:Card Grid.Row="1"
+                       Margin="0,0,0,0"
+                       Padding="5"
+                       Panel.ZIndex="1000"
+                       md:ShadowAssist.ShadowDepth="Depth0"
+                       Visibility="{Binding ShowErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <md:Card.Resources>
-                  <local:BindingProxy x:Key="Proxy" Data="{Binding}" />
+                  <local:BindingProxy x:Key="Proxy"
+                                      Data="{Binding}" />
                 </md:Card.Resources>
                 <Grid Margin="0,0,10,0">
                   <Grid.RowDefinitions>
@@ -772,47 +781,45 @@
                       <ColumnDefinition Width="*" />
                       <ColumnDefinition Width="20" />
                     </Grid.ColumnDefinitions>
-                    <Expander
-                      Grid.Row="1"
-                      HorizontalAlignment="Stretch"
-                      md:ExpanderAssist.DownHeaderPadding="0"
-                      Background="Transparent"
-                      FontSize="12">
+                    <Expander Grid.Row="1"
+                              HorizontalAlignment="Stretch"
+                              md:ExpanderAssist.DownHeaderPadding="0"
+                              Background="Transparent"
+                              FontSize="12">
                       <Expander.Header>
                         <TextBlock FontSize="12">Warnings</TextBlock>
                       </Expander.Header>
-                      <TextBox
-                        MaxHeight="200"
-                        Margin="25,0,25,0"
-                        HorizontalAlignment="Stretch"
-                        Background="Transparent"
-                        BorderBrush="Transparent"
-                        Foreground="Gray"
-                        IsReadOnly="True"
-                        Style="{x:Null}"
-                        TextWrapping="Wrap"
-                        VerticalScrollBarVisibility="Visible">
+                      <TextBox MaxHeight="200"
+                               Margin="25,0,25,0"
+                               HorizontalAlignment="Stretch"
+                               Background="Transparent"
+                               BorderBrush="Transparent"
+                               Foreground="Gray"
+                               IsReadOnly="True"
+                               Style="{x:Null}"
+                               TextWrapping="Wrap"
+                               VerticalScrollBarVisibility="Visible">
                         <TextBox.Text>
-                          <Binding Mode="OneWay" Path="FormattedErrors" />
+                          <Binding Mode="OneWay"
+                                   Path="FormattedErrors" />
                         </TextBox.Text>
                       </TextBox>
                     </Expander>
-                    <Button
-                      Grid.Column="1"
-                      Width="20"
-                      Height="20"
-                      Margin="0,13"
-                      VerticalAlignment="Top"
-                      s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
-                      Background="White"
-                      BorderBrush="White"
-                      Command="{s:Action CloseErrorNotification}"
-                      CommandParameter="{Binding}"
-                      Content="{md:PackIcon Kind=Close,
+                    <Button Grid.Column="1"
+                            Width="20"
+                            Height="20"
+                            Margin="0,13"
+                            VerticalAlignment="Top"
+                            s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
+                            Background="White"
+                            BorderBrush="White"
+                            Command="{s:Action CloseErrorNotification}"
+                            CommandParameter="{Binding}"
+                            Content="{md:PackIcon Kind=Close,
                                             Size=10}"
-                      Foreground="Black"
-                      Style="{StaticResource MaterialDesignFloatingActionLightButton}"
-                      ToolTip="Close notification." />
+                            Foreground="Black"
+                            Style="{StaticResource MaterialDesignFloatingActionLightButton}"
+                            ToolTip="Close notification." />
                   </Grid>
 
 
@@ -839,35 +846,31 @@
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ScrollViewer
-          Grid.Row="0"
-          Grid.Column="0"
-          HorizontalAlignment="Stretch"
-          VerticalAlignment="Stretch"
-          HorizontalScrollBarVisibility="Disabled"
-          VerticalScrollBarVisibility="Auto">
-          <ItemsControl
-            Margin="0,10"
-            ItemTemplate="{StaticResource StreamCardTemplate}"
-            ItemsSource="{Binding StreamList, Mode=OneWay, UpdateSourceTrigger=Default}" />
+        <ScrollViewer Grid.Row="0"
+                      Grid.Column="0"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Stretch"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto">
+          <ItemsControl Margin="0,10"
+                        ItemTemplate="{StaticResource StreamCardTemplate}"
+                        ItemsSource="{Binding StreamList, Mode=OneWay, UpdateSourceTrigger=Default}" />
         </ScrollViewer>
-        <StackPanel
-          Grid.Row="0"
-          Margin="58,30,58,0"
-          Visibility="{Binding EmptyState, Converter={StaticResource BooleanToVisibilityConverter}}">
-          <TextBlock
-            FontSize="30"
-            FontWeight="Light"
-            Foreground="Gray"
-            TextWrapping="Wrap">
+        <StackPanel Grid.Row="0"
+                    Margin="58,30,58,0"
+                    Visibility="{Binding EmptyState, Converter={StaticResource BooleanToVisibilityConverter}}">
+          <TextBlock FontSize="30"
+                     FontWeight="Light"
+                     Foreground="Gray"
+                     TextWrapping="Wrap">
             Hello! Seems like you have no streams in this file.
           </TextBlock>
-          <Separator Margin="0,20,300,20" Background="Gray" />
-          <TextBlock
-            FontSize="20"
-            FontWeight="Light"
-            Foreground="Gray"
-            TextWrapping="Wrap">
+          <Separator Margin="0,20,300,20"
+                     Background="Gray" />
+          <TextBlock FontSize="20"
+                     FontWeight="Light"
+                     Foreground="Gray"
+                     TextWrapping="Wrap">
             You can add or create a stream from the big friendly blue button in the lower right.
           </TextBlock>
         </StackPanel>
@@ -875,25 +878,23 @@
 
       <!--#region The BAB (Big Add Button)-->
       <Canvas>
-        <Button
-          x:Name="CreateStreamButton"
-          Canvas.Right="0"
-          Canvas.Bottom="0"
-          Width="60"
-          Height="60"
-          Margin="32"
-          HorizontalAlignment="Right"
-          VerticalAlignment="Bottom"
-          md:ShadowAssist.ShadowDepth="Depth3"
-          Command="{s:Action ShowStreamCreateDialog}"
-          DockPanel.Dock="Bottom"
-          Style="{StaticResource FlatFloatingActionButton}"
-          ToolTip="Add a stream"
-          ToolTipService.Placement="Left">
-          <Image
-            Width="32"
-            Height="32"
-            Source="/SpeckleDesktopUI;Component/Resources/CreateStreamWhite@32.png" />
+        <Button x:Name="CreateStreamButton"
+                Canvas.Right="0"
+                Canvas.Bottom="0"
+                Width="60"
+                Height="60"
+                Margin="32"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                md:ShadowAssist.ShadowDepth="Depth3"
+                Command="{s:Action ShowStreamCreateDialog}"
+                DockPanel.Dock="Bottom"
+                Style="{StaticResource FlatFloatingActionButton}"
+                ToolTip="Add a stream"
+                ToolTipService.Placement="Left">
+          <Image Width="32"
+                 Height="32"
+                 Source="/SpeckleDesktopUI;Component/Resources/CreateStreamWhite@32.png" />
         </Button>
       </Canvas>
       <!--#endregion-->

--- a/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
@@ -486,7 +486,7 @@
                                           Size=16}"
                           Style="{StaticResource MaterialDesignIconButton}"
                           ToolTip="Open this stream in the browser" />
-                  <StackPanel Orientation="Horizontal"
+                  <!--<StackPanel Orientation="Horizontal"
                               Grid.Row="1"
                               Grid.Column="0"
                               Grid.ColumnSpan="3"
@@ -495,7 +495,7 @@
                                FontSize="12"
                                Foreground="{DynamicResource MaterialDesignBodyLight}"
                                Text="{Binding Stream.id}" />
-                  </StackPanel>
+                  </StackPanel>-->
 
                 </Grid>
                 <!--#endregion-->

--- a/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
@@ -154,6 +154,19 @@ namespace Speckle.DesktopUI.Streams
       var result = await DialogHost.Show(view, "RootDialogHost");
     }
 
+    public void RemoveDisabledStream(StreamState state)
+    {
+      Tracker.TrackPageview("stream", "remove", "no-account-found");
+      RemoveStream(state.Stream.id);
+    }
+
+    private void RemoveStream(string streamId)
+    {
+      var state = StreamList.First(s => s.Stream.id == streamId);
+      StreamList.Remove(state);
+      NotifyOfPropertyChange(nameof(EmptyState));
+    }
+
     public void OpenStreamInWeb(StreamState state)
     {
       Tracker.TrackPageview(Tracker.STREAM_VIEW);
@@ -175,9 +188,7 @@ namespace Speckle.DesktopUI.Streams
 
     public void Handle(StreamRemovedEvent message)
     {
-      var state = StreamList.First(s => s.Stream.id == message.StreamId);
-      StreamList.Remove(state);
-      NotifyOfPropertyChange(nameof(EmptyState));
+      RemoveStream(message.StreamId);
     }
 
     public void Handle(ApplicationEvent message)

--- a/DesktopUI/DesktopUI/Streams/StreamView.xaml
+++ b/DesktopUI/DesktopUI/Streams/StreamView.xaml
@@ -131,6 +131,11 @@
                      Text="Name" />
           <TextBox FontSize="25"
                    Text="{Binding StreamName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=1500}" />
+          <TextBlock FontFamily="Consolas"
+                     FontSize="12"
+                     Margin="0,6,0, 0"
+                     Foreground="{DynamicResource MaterialDesignBodyLight}"
+                     Text="{Binding StreamState.Stream.id}" />
 
           <WrapPanel MaxWidth="{Binding ActualWidth, ElementName=StreamViewStackPanel}"
                      Margin="0,20,0,0">
@@ -142,12 +147,11 @@
                      FontSize="13"
                      ToolTip="open this stream in the browser">
               <StackPanel Orientation="Horizontal">
-                <md:PackIcon
-                  Width="12"
-                  Height="12"
-                  Margin="0,0,4,0"
-                  VerticalAlignment="Center"
-                  Kind="OpenInNew" />
+                <md:PackIcon Width="12"
+                             Height="12"
+                             Margin="0,0,4,0"
+                             VerticalAlignment="Center"
+                             Kind="OpenInNew" />
                 <TextBlock Margin="0,0,4,0">Server:</TextBlock>
                 <TextBlock Text="{Binding StreamState.Client.Account.serverInfo.name}" />
                 <TextBlock Margin="4,0,0,0">(</TextBlock>
@@ -203,14 +207,6 @@
 
           <ItemsControl ItemTemplate="{StaticResource CollaboratorChipTemplate}"
                         ItemsSource="{Binding StreamState.Stream.collaborators}" />
-
-          <!--<TextBox  Margin="0,10,0,10"
-                    Grid.Column="0"
-                    Padding="2"
-                    md:HintAssist.Hint="Search for other collaborators to add"
-                    FontSize="18"
-                    Text="{Binding StreamQuery, UpdateSourceTrigger=PropertyChanged,Mode=OneWayToSource, Delay=300}">
-          </TextBox>-->
 
           <!--<Separator Margin="0,20,0,0"></Separator>-->
           <TextBlock Grid.Column="0"

--- a/DesktopUI/DesktopUI/Utils/Converters.cs
+++ b/DesktopUI/DesktopUI/Utils/Converters.cs
@@ -116,8 +116,16 @@ namespace Speckle.DesktopUI.Utils
           break;
         case Account account:
           var client = new Client(account);
-          var userRes = Task.Run(async () => ( await client.UserSearch(account.userInfo.email) ).FirstOrDefault()).Result;
-          imgString = userRes.avatar ?? $"https://robohash.org/{userRes.id}";
+          User userRes = new User();
+          try
+          {
+            userRes = Task.Run(async () => ( await client.UserSearch(account.userInfo.email) ).FirstOrDefault()).Result;
+          }
+          catch ( Exception )
+          {
+            // server is offline
+          }
+          imgString = userRes.avatar ?? $"https://robohash.org/{account.userInfo.id}";
           break;
         default:
           throw new InvalidOperationException("Unrecognised type given to robot converter");

--- a/DesktopUI/DesktopUI/Utils/Events.cs
+++ b/DesktopUI/DesktopUI/Utils/Events.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Speckle.Core.Api;
 using Speckle.Core.Models;
 


### PR DESCRIPTION
## Description

This is a collection of smol bug fixes for the DesktopUI

- refactor nav bar logic to make it simpler and fix the bug with the nav bar text not updating after removing a stream
- catch and handle exception on settings page if the server is down 
- fix the overlay issue on stream cards that have been disabled because no local account was found 
![image](https://user-images.githubusercontent.com/7717434/109992043-c8f77800-7d02-11eb-8832-c1b502954a41.png)
- add option to remove a stream that has been disabled
- add refresh button to menu bar
![desktopui-refresh](https://user-images.githubusercontent.com/7717434/109992097-d7459400-7d02-11eb-99c5-f9f5875f5299.gif)
- add stream id to details page
![image](https://user-images.githubusercontent.com/7717434/109996775-75d3f400-7d07-11eb-9835-e9cb15269f80.png)


closes #276 
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] Manual Tests (what did you do?)

in desktopui and in revit
