### PR TITLE
feat(revit): swallow document corruption errors 

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Entry/App.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/App.cs
@@ -1,8 +1,4 @@
-﻿using Autodesk.Revit.UI;
-using Speckle.ConnectorRevit.Storage;
-using Speckle.ConnectorRevit.UI;
-using Speckle.DesktopUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,6 +8,11 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Speckle.ConnectorRevit.Storage;
+using Speckle.ConnectorRevit.UI;
+using Speckle.DesktopUI;
 
 namespace Speckle.ConnectorRevit.Entry
 {
@@ -22,6 +23,9 @@ namespace Speckle.ConnectorRevit.Entry
 
     public static UIControlledApplication UICtrlApp { get; set; }
 
+    // public static readonly FailureDefinitionId GenericFailureGuid =
+    //   new FailureDefinitionId(new Guid("bcada956-0645-4a09-b264-f2154444c677"));
+
     public Result OnStartup(UIControlledApplication application)
     {
       UICtrlApp = application;
@@ -29,7 +33,7 @@ namespace Speckle.ConnectorRevit.Entry
       UICtrlApp.Idling += Initialise;
 
       var SpecklePanel = application.CreateRibbonPanel("Speckle 2");
-      var SpeckleButton = SpecklePanel.AddItem(new PushButtonData("Speckle 2", "Revit Connector", typeof(App).Assembly.Location, typeof(SpeckleRevitCommand).FullName)) as PushButton;
+      var SpeckleButton = SpecklePanel.AddItem(new PushButtonData("Speckle 2", "Revit Connector", typeof(App).Assembly.Location, typeof(SpeckleRevitCommand).FullName))as PushButton;
 
       if (SpeckleButton != null)
       {
@@ -40,6 +44,14 @@ namespace Speckle.ConnectorRevit.Entry
         SpeckleButton.AvailabilityClassName = typeof(CmdAvailabilityViews).FullName;
         SpeckleButton.SetContextualHelp(new ContextualHelp(ContextualHelpType.Url, "https://speckle.systems"));
       }
+
+      // var failDef = FailureDefinition.CreateFailureDefinition(
+      //   GenericFailureGuid, FailureSeverity.DocumentCorruption,
+      //   "Generic Speckle failure to resolve unresolvable Revit errors");
+      // failDef.AddResolutionType(FailureResolutionType.DeleteElements, "delete elements to resolve error",
+      //   typeof(DeleteElements));
+      // failDef.SetDefaultResolutionType(FailureResolutionType.DeleteElements);
+      // var defRes = failDef.GetDefaultResolutionType();
 
       return Result.Succeeded;
     }
@@ -54,7 +66,6 @@ namespace Speckle.ConnectorRevit.Entry
       var eventHandler = ExternalEvent.Create(new SpeckleExternalEventHandler(SpeckleRevitCommand.Bindings));
       SpeckleRevitCommand.Bindings.SetExecutorAndInit(eventHandler);
     }
-
 
     public Result OnShutdown(UIControlledApplication application)
     {

--- a/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
+++ b/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Autodesk.Revit.DB;
+using Speckle.ConnectorRevit.Entry;
+using Speckle.ConnectorRevit.UI;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 
@@ -10,16 +14,20 @@ namespace ConnectorRevit.Revit
   public class ErrorEater : IFailuresPreprocessor
   {
     private ISpeckleConverter _converter;
+
     public ErrorEater(ISpeckleConverter converter)
     {
       _converter = converter;
     }
+
     public FailureProcessingResult PreprocessFailures(FailuresAccessor failuresAccessor)
     {
       IList<FailureMessageAccessor> failList = new List<FailureMessageAccessor>();
+      var criticalFails = 0;
+      var failedElements = new List<ElementId>();
       // Inside event handler, get all warnings
       failList = failuresAccessor.GetFailureMessages();
-      foreach (FailureMessageAccessor failure in failList)
+      foreach ( FailureMessageAccessor failure in failList )
       {
         // check FailureDefinitionIds against ones that you want to dismiss, 
         //FailureDefinitionId failID = failure.GetFailureDefinitionId();
@@ -27,9 +35,23 @@ namespace ConnectorRevit.Revit
         //if (failID == BuiltInFailures.RoomFailures.RoomNotEnclosed)
         //{
         var t = failure.GetDescriptionText();
-        var r = failure.GetDefaultResolutionCaption();
+        _converter.ConversionErrors.Add(new Error {message = t, details = ""});
 
-        _converter.ConversionErrors.Add(new Error { message = t, details = "" });
+        var s = failure.GetSeverity();
+        if ( s == FailureSeverity.Warning ) continue;
+        try
+        {
+          failuresAccessor.ResolveFailure(failure);
+        }
+        catch ( Exception e )
+        {
+          // currently, the whole commit is rolled back. this should be investigated further at a later date
+          // to properly proceed with commit
+          failedElements.AddRange(failure.GetFailingElementIds());
+          _converter.ConversionErrors.Clear();
+          _converter.ConversionErrors.Add(new Error { message = "Objects failed to bake due to fatal error: " + t, details = "Fatal Error"});
+          return FailureProcessingResult.ProceedWithCommit;
+        }
       }
 
       failuresAccessor.DeleteAllWarnings();

--- a/DesktopUI/DesktopUI/Streams/StreamsRepository.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamsRepository.cs
@@ -61,6 +61,8 @@ namespace Speckle.DesktopUI.Streams
         return null;
       }
 
+      _bindings.RaiseNotification($"Data received from {state.Stream.name}");
+
       return state;
     }
 

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -624,7 +624,6 @@ namespace Speckle.DesktopUI.Utils
       ShowProgressBar = false;
       Progress.ResetProgress();
       IsReceiving = false;
-      Globals.Notify($"Data received from {Stream.name}!");
 
       if (Errors.Count != 0)
       {


### PR DESCRIPTION
## Description

This swallows failures with level `DocumentCorruption` which before were not swallowed by our `ErrorEater`. I was not able to fully fix this to allow the commit to continue, so will open a separate issue for this. For now, the failure will try to be resolved and if it can't (eg in the popup for the user, the only option is "Cancel" not "Ok") the commit is rolled back. The conversion errors are cleared and the error shown to the user is the fatal one that failed during commit. 

closes #189 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] Manual Tests in revit with successful stream objects and invalid stream objects (objects too small eg 2 mm)