### PR TITLE
Revit: PolyCurve support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ ConnectorDynamo/ConnectorDynamo/GPUCache/
 ConnectorDynamo/ConnectorDynamo/dist/
 *.3dmbak
 *.rhl
+
+speckle-sharp-ci-tools

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -421,7 +421,7 @@ namespace ConnectorGrasshopper
 
     protected override void BeforeSolveInstance()
     {
-      Converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+      Converter?.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
       Tracker.TrackPageview("objects", "create", "variableinput");
       base.BeforeSolveInstance();
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
@@ -135,13 +135,10 @@ namespace Objects.Converter.Revit
       return speckleCurve;
     }
 
-    public List<ApplicationPlaceholderObject> RoomBoundaryLineToNative(RoomBoundaryLine speckleCurve)
+    public ApplicationPlaceholderObject RoomBoundaryLineToNative(RoomBoundaryLine speckleCurve)
     {
-      var placeholders = new List<ApplicationPlaceholderObject>();
       var docObj = GetExistingElementByApplicationId(speckleCurve.applicationId);
-
-      //TODO: support poliline/polycurve lines
-      var baseCurve = CurveToNative(speckleCurve.baseCurve as ICurve);
+      var baseCurve = CurveToNative(speckleCurve.baseCurve);
 
       //delete and re-create line
       //TODO: check if can be modified
@@ -153,15 +150,15 @@ namespace Objects.Converter.Revit
       try
       {
         var res = Doc.Create.NewRoomBoundaryLines(NewSketchPlaneFromCurve(baseCurve.get_Item(0)), baseCurve, Doc.ActiveView).get_Item(0);
-        placeholders.Add( new ApplicationPlaceholderObject() { applicationId = speckleCurve.applicationId, ApplicationGeneratedId = res.UniqueId, NativeObject = res });
-      }
+        return new ApplicationPlaceholderObject()
+          {applicationId = speckleCurve.applicationId, ApplicationGeneratedId = res.UniqueId, NativeObject = res};      }
       catch (Exception)
       {
         ConversionErrors.Add(new Error("Room boundary line creation failed", $"View is not valid for room boundary line creation."));
         throw;
       }
 
-      return placeholders;
+
     }
 
     /// <summary>

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -314,9 +314,12 @@ namespace Objects.Converter.Revit
         case Polycurve plc:
           foreach (var seg in plc.segments)
           {
-            curveArray.Append(CurveToNative(seg).get_Item(0));
+            var enumerator = CurveToNative(seg).GetEnumerator();
+            while (enumerator.MoveNext() && enumerator.Current != null)
+            {
+              curveArray.Append(enumerator.Current as DB.Curve);
+            }
           }
-
           return curveArray;
         default:
           throw new Speckle.Core.Logging.SpeckleException("The provided geometry is not a valid curve");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -314,11 +314,10 @@ namespace Objects.Converter.Revit
         case Polycurve plc:
           foreach (var seg in plc.segments)
           {
-            var enumerator = CurveToNative(seg).GetEnumerator();
-            while (enumerator.MoveNext() && enumerator.Current != null)
-            {
-              curveArray.Append(enumerator.Current as DB.Curve);
-            }
+            // Enumerate all curves in the array to ensure polylines get fully converted.
+            var crvEnumerator = CurveToNative(seg).GetEnumerator();
+            while (crvEnumerator.MoveNext() && crvEnumerator.Current != null)
+              curveArray.Append(crvEnumerator.Current as DB.Curve);
           }
           return curveArray;
         default:


### PR DESCRIPTION
## Description

Added recursive conversion in `PolyCurves`. Since they do not exist in Revit, each segment will be created as an individual `Curve`. 

Also added support for `PolyCurves` when converting:

- ModelCurves
- DetailCurves

- Fixes #296
- Minor fix in CreateSchemaObject (GH)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. 

- [x] Unit/Integration Tests
    - Ran curve conversion tests with all passing.
- [x] Manual Tests (what did you do?)
    - Sent several polycurves from GH to Revit as **model curves**, **detail curves**, native Speckle curves and floors with polycurves as outlines.
