### PR TITLE
fix(revit): scale lengths when converting to speckle

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
+++ b/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
@@ -50,6 +50,8 @@ namespace ConnectorRevit.Revit
           failedElements.AddRange(failure.GetFailingElementIds());
           _converter.ConversionErrors.Clear();
           _converter.ConversionErrors.Add(new Error { message = "Objects failed to bake due to fatal error: " + t, details = "Fatal Error"});
+          // logging the error
+          var exception = new Speckle.Core.Logging.SpeckleException("Revit commit failed: " + t, e, level: Sentry.Protocol.SentryLevel.Warning);
           return FailureProcessingResult.ProceedWithCommit;
         }
       }

--- a/Core/Core/Logging/SpeckleException.cs
+++ b/Core/Core/Logging/SpeckleException.cs
@@ -24,7 +24,7 @@ namespace Speckle.Core.Logging
     {
       GraphQLErrors = errors.Select(error => new KeyValuePair<string, object>("error", error.Message)).ToList();
       if (log)
-        Log.CaptureException(this, extra: GraphQLErrors);
+        Log.CaptureException(this, level, GraphQLErrors);
     }
 
     public SpeckleException(string message, Exception inner, bool log = true, SentryLevel level = SentryLevel.Info)
@@ -33,7 +33,7 @@ namespace Speckle.Core.Logging
       if (inner is SpeckleException)
         return;
       if (log)
-        Log.CaptureException(this);
+        Log.CaptureException(this, level);
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -109,7 +109,7 @@ namespace Objects.Converter.Revit
       l.start = PointToSpeckle(line.GetEndPoint(0), u);
       l.end = PointToSpeckle(line.GetEndPoint(1), u);
 
-      l.length = line.Length;
+      l.length = ScaleToSpeckle( line.Length );
       return l;
     }
 
@@ -120,7 +120,7 @@ namespace Objects.Converter.Revit
       var arcPlane = DB.Plane.CreateByNormalAndOrigin(arc.Normal, arc.Center);
 
       var c = new Circle(PlaneToSpeckle(arcPlane, u), u == Units.None ? arc.Radius : ScaleToSpeckle(arc.Radius), u);
-      c.length = arc.Length;
+      c.length = ScaleToSpeckle( arc.Length );
       return c;
     }
 
@@ -170,7 +170,7 @@ namespace Objects.Converter.Revit
       a.endPoint = PointToSpeckle(end, u);
       a.startPoint = PointToSpeckle(start, u);
       a.midPoint = PointToSpeckle(mid, u);
-      a.length = arc.Length;
+      a.length = ScaleToSpeckle( arc.Length );
 
       return a;
     }
@@ -209,7 +209,7 @@ namespace Objects.Converter.Revit
           new Interval(0, 2 * Math.PI),
           trim,
           u);
-        ellipseToSpeckle.length = ellipse.Length;
+        ellipseToSpeckle.length = ScaleToSpeckle( ellipse.Length );
         return ellipseToSpeckle;
       }
     }
@@ -233,7 +233,7 @@ namespace Objects.Converter.Revit
       speckleCurve.closed = RevitVersionHelper.IsCurveClosed(revitCurve);
       speckleCurve.units = units ?? ModelUnits;
       //speckleCurve.domain = new Interval(revitCurve.StartParameter(), revitCurve.EndParameter());
-      speckleCurve.length = revitCurve.Length;
+      speckleCurve.length = ScaleToSpeckle( revitCurve.Length );
 
       return speckleCurve;
     }
@@ -362,7 +362,7 @@ namespace Objects.Converter.Revit
       var polycurve = new Polycurve();
       polycurve.units = units ?? ModelUnits;
       polycurve.closed = loop.First().GetEndPoint(0).DistanceTo(loop.Last().GetEndPoint(1)) < 0.0164042; //5mm
-      polycurve.length = loop.Sum(x => x.Length);
+      polycurve.length = ScaleToSpeckle( loop.Sum(x => x.Length) );
       polycurve.segments.AddRange(loop.Select(x => CurveToSpeckle(x)));
       return polycurve;
     }


### PR DESCRIPTION
## Description

Length params in geometry conversions are now scaled appropriately when converting to speckle

- Fixes #303

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] Unit/Integration Tests (which?)
- [x] Manual Tests (what did you do?)

All relevant xUnitRevit tests pass  (breps fail due to unrelated isssue) and manual testing sending to server