### PR TITLE
fix(revit): resolve issues with column conversions

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -253,16 +253,15 @@ namespace Objects.Converter.Revit
           if (sp.value == null)
             sp.value = rp.AsValueString();
           break;
-        case StorageType.ElementId:
-          // NOTE: if this collects too much garbage, maybe we can ignore it
-          var id = rp.AsElementId();
-          var e = Doc.GetElement(id);
-          if (e != null && CanConvertToSpeckle(e))
-            sp.value = ConvertToSpeckle(e);
-          break;
+          // case StorageType.ElementId:
+          //   // NOTE: if this collects too much garbage, maybe we can ignore it
+          //   var id = rp.AsElementId();
+          //   var e = Doc.GetElement(id);
+          //   if (e != null && CanConvertToSpeckle(e))
+          //     sp.value = ConvertToSpeckle(e);
+          //   break;
         default:
           return null;
-          break;
       }
       return sp;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -253,13 +253,13 @@ namespace Objects.Converter.Revit
           if (sp.value == null)
             sp.value = rp.AsValueString();
           break;
-          //case StorageType.ElementId:
-          //  // NOTE: if this collects too much garbage, maybe we can ignore it
-          //  var id = rp.AsElementId();
-          //  var e = Doc.GetElement(id);
-          //  if (e != null && CanConvertToSpeckle(e))
-          //    sp.value = ConvertToSpeckle(e);
-          //  break;
+        case StorageType.ElementId:
+          // NOTE: if this collects too much garbage, maybe we can ignore it
+          var id = rp.AsElementId();
+          var e = Doc.GetElement(id);
+          if (e != null && CanConvertToSpeckle(e))
+            sp.value = ConvertToSpeckle(e);
+          break;
         default:
           return null;
           break;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -197,8 +197,7 @@ namespace Objects.Converter.Revit
       //make line from point and height
       if (baseLine == null && baseGeometry is Point basePoint)
       {
-        var topLevelParam = revitColumn.get_Parameter(BuiltInParameter.FAMILY_TOP_LEVEL_PARAM);
-        var elevation = (double)((RevitLevel)ParameterToSpeckle(topLevelParam).value).elevation;
+        var elevation = ConvertAndCacheLevel(revitColumn, BuiltInParameter.FAMILY_TOP_LEVEL_PARAM).elevation;
         baseLine = new Line(basePoint, new Point(basePoint.x, basePoint.y, elevation + speckleColumn.topOffset, ModelUnits), ModelUnits);
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
@@ -76,10 +76,11 @@ namespace Objects.Converter.Revit
       {
         //apply offset tranform and create line
         var baseOffset = familyInstance.get_Parameter(BuiltInParameter.FAMILY_BASE_LEVEL_OFFSET_PARAM).AsDouble(); //keep internal units
+        var baseLevel = ( DB.Level )Doc.GetElement(familyInstance.get_Parameter(BuiltInParameter.FAMILY_BASE_LEVEL_PARAM).AsElementId()); //keep internal units
         var topOffset = familyInstance.get_Parameter(BuiltInParameter.FAMILY_TOP_LEVEL_OFFSET_PARAM).AsDouble(); //keep internal units
-        var topLevel = (DB.Level)Doc.GetElement(familyInstance.get_Parameter(BuiltInParameter.FAMILY_TOP_LEVEL_PARAM).AsElementId()); //keep internal units
+        var topLevel = ( DB.Level )Doc.GetElement(familyInstance.get_Parameter(BuiltInParameter.FAMILY_TOP_LEVEL_PARAM).AsElementId()); //keep internal units
 
-        var baseLine = DB.Line.CreateBound(new XYZ(point.X, point.Y, point.Z + baseOffset), new XYZ(point.X, point.Y, topLevel.Elevation));
+        var baseLine = DB.Line.CreateBound(new XYZ(point.X, point.Y, baseLevel.Elevation + baseOffset), new XYZ(point.X, point.Y, topLevel.Elevation + topOffset));
 
         return LineToSpeckle(baseLine);
       }


### PR DESCRIPTION
## Description

This was a super ez fix! Just some small changes to fix column conversion issues
- uncomments handling of case `ElementId` in `ParameterToSpeckle()`
- adjusts line creation logic for vertical columns with the "top level" at the bottom of the column

before:
![borked columns](https://user-images.githubusercontent.com/7717434/110676368-c6e25d00-81cb-11eb-825d-273edf60389d.png)

after:
![fixed columns](https://user-images.githubusercontent.com/7717434/110676380-cba71100-81cb-11eb-815a-908edb76db2a.png)

[the commit](https://speckle.xyz/streams/4a8efa56a8/commits/176028dfb7) if you're curious

- Fixes #309 and #310 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] Unit/Integration Tests
- [x] Manual Tests 

Ran all xUnitRevit tests and tested manually using the revit connector 
