### PR TITLE
Claire/autocad connector

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -244,6 +244,9 @@ namespace Objects.Converter.AutocadCivil
             case AcadDB.Polyline2d _:
               return true;
 
+            case AcadDB.Polyline3d _:
+              return true;
+
             default:
               return false;
           }

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -14,12 +14,18 @@ namespace Objects.Geometry
 
     public bool periodic { get; set; }
 
+    /// <summary>
+    /// "True" if weights differ, "False" if weights are the same.
+    /// </summary>
     public bool rational { get; set; }
 
     [DetachProperty]
     [Chunkable(20000)]
     public List<double> points { get; set; }
 
+    /// <summary>
+    /// Gets or sets the weights for this <see cref="Curve"/>. Use a default value of 1 for unweighted points.
+    /// </summary>
     [DetachProperty]
     [Chunkable(20000)]
     public List<double> weights { get; set; }


### PR DESCRIPTION
## Description

Changes: **Autocad** converter polyline and line `ToSpeckle` conversions. Added comments to **Objects** `Curve` definition.

Fix:
- `Polyline3d` sending is now properly supported and enabled in the converter
- `Spline` ToSpeckle conversion adds extra control points, knots, and weights for **closed periodic nurbs curves** to fit the speckle standard format.
  - Total Points:
    - standard (closed nurbs): # control pts + degree
    - autocad (closed periodic nurbs): # control pts
  - Knots:
    - standard: # total pts + degree + 1
    - autocad (closed periodic nurbs): # control pts + 1

Notes:
- Closed periodic **weighted** `Spline` curves from Rhino do not have their `IsClosed` property correctly set to `True` during the receiving conversion, most likely a bug in the .Net wrapper for ObjectARX in Autocad. This cannot be fixed manually either after baking, however the baked curve behaves as if it were closed. Natively created closed periodic weighted curves do not have this issue. Currently the converter is using a hack to set values appropriately when sending these curves. _This should be addressed if it causes problems later._

- Fixes #307 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [ ] Unit/Integration Tests

Received and sent all supported geometry from Rhino Test Case 1: https://staging.speckle.dev/streams/54850b5aff
Sent stream: https://staging.speckle.dev/streams/54850b5aff/commits/5f34e22d7c


