### PR TITLE
Claire/rhino schema improvements

### DIFF
--- a/ConnectorRhino/ConnectorRhino/SchemaBuilder/SchemaObjectFilter.cs
+++ b/ConnectorRhino/ConnectorRhino/SchemaBuilder/SchemaObjectFilter.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Reflection;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Rhino;
 using Rhino.DocObjects;
 using Rhino.Geometry;
 using System.Collections;
@@ -21,6 +22,7 @@ namespace SpeckleRhino
     public enum SupportedSchema { Floor, Wall, Roof, Ceiling, Column, Beam, FaceWall, none };
     private Rhino.RhinoDoc Doc;
     public Dictionary<string, List<RhinoObject>> SchemaDictionary = new Dictionary<string, List<RhinoObject>>();
+    public double minDimension = 25 * Units.GetConversionFactor(Units.Millimeters, RhinoDoc.ActiveDoc.ModelUnitSystem.ToString());
     #endregion
 
     #region Constructors
@@ -152,6 +154,8 @@ namespace SpeckleRhino
           try // assumes z vertical planar single surface
           {
             Brep brp = obj.Geometry as Brep; // assumes this has already been filtered for single surface
+            if (brp.Edges.Where(o => o.GetLength() < minDimension).Count() > 0)
+              return false;
             if (IsPlanar(brp.Surfaces.First(), out bool singleH, out bool singleV))
               if (singleV)
                 return true;

--- a/ConnectorRhino/ConnectorRhino/SchemaBuilder/SchemaObjectFilter.cs
+++ b/ConnectorRhino/ConnectorRhino/SchemaBuilder/SchemaObjectFilter.cs
@@ -238,7 +238,7 @@ namespace SpeckleRhino
       {
         case ObjectType.Brep:
           Brep brp = obj.Geometry as Brep;
-          if (brp.IsSurface)
+          if (brp.Faces.Count == 1)
             return ObjectType.Surface;
           else if (!brp.IsSolid && brp.IsManifold)
             return ObjectType.PolysrfFilter;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
@@ -24,22 +24,22 @@ namespace Objects.Converter.RhinoGh
   {
     public Column CurveToSpeckleColumn(RH.Curve curve)
     {
-      return new Column((ICurve)ConvertToSpeckle(curve));
+      return new Column((ICurve)ConvertToSpeckle(curve)) { units = ModelUnits };
     }
 
     public Beam CurveToSpeckleBeam(RH.Curve curve)
     {
-      return new Beam((ICurve)ConvertToSpeckle(curve));
+      return new Beam((ICurve)ConvertToSpeckle(curve)) { units = ModelUnits };
     }
 
     public Opening CurveToSpeckleOpening(RH.Curve curve)
     {
-      return new Opening((ICurve)ConvertToSpeckle(curve));
+      return new Opening((ICurve)ConvertToSpeckle(curve)) { units = ModelUnits };
     }
 
     public Floor CurveToSpeckleFloor(RH.Curve curve)
     {
-      return new Floor((ICurve)ConvertToSpeckle(curve));
+      return new Floor((ICurve)ConvertToSpeckle(curve)) { units = ModelUnits };
     }
 
     public Wall BrepToSpeckleWall(RH.Brep brep)
@@ -53,7 +53,7 @@ namespace Objects.Converter.RhinoGh
       foreach (ICurve crv in intCurves)
         openings.Add(new Opening(crv));
       if (bottomCurves != null && height > 0)
-        wall = new Wall(height, bottomCurves[0], openings);
+        wall = new Wall(height, bottomCurves[0], openings) { units = ModelUnits };
       return wall;
     }
 
@@ -63,7 +63,7 @@ namespace Objects.Converter.RhinoGh
       var extCurves = GetSurfaceBrepEdges(brep, getExterior: true); // extract outline
       var intCurves = GetSurfaceBrepEdges(brep, getInterior: true); // extract voids
       if (extCurves != null)
-        floor = new Floor(extCurves[0], intCurves);
+        floor = new Floor(extCurves[0], intCurves) { units = ModelUnits };
       return floor;
     }
 
@@ -73,7 +73,7 @@ namespace Objects.Converter.RhinoGh
       var extCurves = GetSurfaceBrepEdges(brep, getExterior: true); // extract outline
       var intCurves = GetSurfaceBrepEdges(brep, getInterior: true); // extract voids
       if (extCurves != null)
-        ceiling = new Ceiling(extCurves[0], intCurves);
+        ceiling = new Ceiling(extCurves[0], intCurves) { units = ModelUnits };
       return ceiling;
     }
 
@@ -83,7 +83,7 @@ namespace Objects.Converter.RhinoGh
       var extCurves = GetSurfaceBrepEdges(brep, getExterior: true); // extract outline
       var intCurves = GetSurfaceBrepEdges(brep, getInterior: true); // extract voids
       if (extCurves != null)
-        roof = new Roof(extCurves[0], intCurves);
+        roof = new Roof(extCurves[0], intCurves) { units = ModelUnits };
       return roof;
     }
 
@@ -95,7 +95,7 @@ namespace Objects.Converter.RhinoGh
       string family = "Default";
       string type = "Default";
       try { family = args[0]; type = args[1]; } catch { }
-      return new RV.RevitFaceWall(family, type, BrepToSpeckle(brep), null);
+      return new RV.RevitFaceWall(family, type, BrepToSpeckle(brep), null) { units = ModelUnits };
     }
 
     public RV.DirectShape BrepToDirectShape(RH.Brep brep, string[] args)
@@ -106,7 +106,7 @@ namespace Objects.Converter.RhinoGh
         return null;
       string name = "DirectShape";
       try { name = args[1]; } catch { }
-      return new RV.DirectShape(name, category, new List<Base>() { ConvertToSpeckle(brep) });
+      return new RV.DirectShape(name, category, new List<Base>() { ConvertToSpeckle(brep) }) { units = ModelUnits };
     }
 
     public RV.DirectShape ExtrusionToDirectShape(RH.Extrusion extrusion, string[] args)
@@ -117,7 +117,7 @@ namespace Objects.Converter.RhinoGh
         return null;
       string name = "DirectShape";
       try { name = args[1]; } catch { }
-      return new RV.DirectShape(name, category, new List<Base>() { ConvertToSpeckle(extrusion) });
+      return new RV.DirectShape(name, category, new List<Base>() { ConvertToSpeckle(extrusion) }) { units = ModelUnits };
     }
 
     public RV.DirectShape MeshToDirectShape(RH.Mesh mesh, string[] args)
@@ -128,7 +128,7 @@ namespace Objects.Converter.RhinoGh
         return null;
       string name = "DirectShape";
       try { name = args[1]; } catch { }
-      return new RV.DirectShape(name, category, new List<Base>() { ConvertToSpeckle(mesh) });
+      return new RV.DirectShape(name, category, new List<Base>() { ConvertToSpeckle(mesh) }) { units = ModelUnits };
     }
 
     // edge curve convenience method

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -376,6 +376,9 @@ namespace Objects.Converter.RhinoGh
           {
           domain = intervalToSpeckle
           };
+          polylineToSpeckle.length = polyline.Length;
+          var box = new RH.Box(poly.GetBoundingBox(true));
+          polylineToSpeckle.bbox = BoxToSpeckle(box, u);
           return polylineToSpeckle;
         }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -165,7 +165,6 @@ namespace Objects.Converter.RhinoGh
       return objects.Select(x => ConvertToSpeckle(x)).ToList();
     }
 
-    // NOTE: is there a way of retrieving class name from BuiltElements class directly? using hardcoded strings atm
     public Base ConvertToSpeckleBE(object @object)
     {
       // get schema if it exists


### PR DESCRIPTION
## Description

Improvements to Rhino SchemaBuilder:
- Adds a 25mm check for minimum surface edge length before assigning wall schemas. Could not find documentation on the minimum dimension for Revit walls, can adjust this parameter if necessary. "Bad" walls can still be sent via Rhino schema builder if a previously valid surface was assigned the wall schema, and then scaled or modified post assignment.
- Adds unit property to all RhinoGH BuiltElement conversions
- Fixes bug that prevented single surface breps with trim to be assigned as floors: previously they were being passed as polysurfaces instead of surfaces

- Fixes #301

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

Manually tested schema command on custom geometry in Rhino, and sent both Rhino Standard Geometry and BuiltElements Geometry test files.

Streams: 
https://staging.speckle.dev/streams/76ad4bd698/commits/014db2cd4d
https://staging.speckle.dev/streams/76ad4bd698/commits/a901e1567f

- [ ] Unit/Integration Tests (which?)
- [ ] Manual Tests (what did you do?)

