### PR TITLE
Claire/small rhino fixes

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System;
 using System.Text.RegularExpressions;
 
 using Speckle.Core.Kits;
@@ -90,30 +91,41 @@ namespace Speckle.ConnectorAutocadCivil
     public static DBObject GetObject(this Handle handle, out string type, out string layer)
     {
       Document Doc = Application.DocumentManager.MdiActiveDocument;
-
-      // get objectId
-      ObjectId id = Doc.Database.GetObjectId(false, handle, 0);
-
-      // get the db object from id
       DBObject obj = null;
       type = null;
       layer = null;
-      using (Transaction tr = Doc.TransactionManager.StartTransaction())
-      {
-        obj = tr.GetObject(id, OpenMode.ForRead);
-        if (obj != null)
-        {
-          Entity objEntity = obj as Entity;
-          type = id.ObjectClass.DxfName;
-          layer = objEntity.Layer;
-        }
-        tr.Commit();
-      }
 
+      // get objectId
+      ObjectId id = Doc.Database.GetObjectId(false, handle, 0);
+      if (!id.IsErased && !id.IsNull)
+      {
+        // get the db object from id
+        using (Transaction tr = Doc.TransactionManager.StartTransaction())
+        {
+          obj = tr.GetObject(id, OpenMode.ForRead);
+          if (obj != null)
+          {
+            Entity objEntity = obj as Entity;
+            type = id.ObjectClass.DxfName;
+            layer = objEntity.Layer;
+          }
+          tr.Commit();
+        }
+      }
       return obj;
     }
 
     #endregion
+
+    /// <summary>
+    /// Retrieves the handle from an input string
+    /// </summary>
+    /// <param name="str"></param>
+    /// <returns></returns>
+    public static Handle GetHandle(string str)
+    {
+      return new Handle(Convert.ToInt64(str, 16));
+    }
 
     /// <summary>
     /// Removes invalid characters for Autocad names

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -46,6 +46,7 @@ namespace Speckle.ConnectorRevit.UI
       }
       else //selection was by cursor
       {
+        // TODO: update state by removing any deleted or null object ids
         selectedObjects = state.SelectedObjectIds.Select(x => CurrentDoc.Document.GetElement(x)).Where(x => x != null).ToList();
       }
 

--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -152,7 +152,7 @@ namespace SpeckleRhino
 
     public override List<ISelectionFilter> GetSelectionFilters()
     {
-      var layers = Doc.Layers.ToList().Select(layer => layer.FullPath).ToList();
+      var layers = Doc.Layers.ToList().Where(layer => !layer.IsDeleted).Select(layer => layer.FullPath).ToList();
 
       return new List<ISelectionFilter>()
       {
@@ -566,8 +566,9 @@ namespace SpeckleRhino
           List<string> objs = new List<string>();
           foreach (var layerName in f.Selection)
           {
-            var docObjs = Doc.Objects.FindByLayer(layerName).Select(o => o.Id.ToString());
-            objs.AddRange(docObjs);
+            var docObjs = Doc.Objects.FindByLayer(layerName)?.Select(o => o.Id.ToString());
+            if (docObjs != null)
+              objs.AddRange(docObjs);
           }
           return objs;
         default:

--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -152,7 +152,7 @@ namespace SpeckleRhino
 
     public override List<ISelectionFilter> GetSelectionFilters()
     {
-      var layers = Doc.Layers.ToList().Select(layer => layer.Name).ToList();
+      var layers = Doc.Layers.ToList().Select(layer => layer.FullPath).ToList();
 
       return new List<ISelectionFilter>()
       {
@@ -419,11 +419,13 @@ namespace SpeckleRhino
       int objCount = 0;
       bool renamedlayers = false;
 
-      // TODO: check for filters and trawl the doc.
       if (state.Filter != null)
       {
         state.SelectedObjectIds = GetObjectsFromFilter(state.Filter);
       }
+
+      // remove object ids of any objects that may have been deleted
+      state.SelectedObjectIds = state.SelectedObjectIds.Where(o => Doc.Objects.FindId(new Guid(o)) != null).ToList();
 
       if (state.SelectedObjectIds.Count == 0)
       {

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -17,7 +17,7 @@ namespace Objects.BuiltElements
 
     [SchemaInfo("Wall", "Creates a Speckle wall")]
     public Wall(double height, ICurve baseLine,
-      [SchemaParamInfo("Any nested elements that this floor might have")] List<Base> elements = null)
+      [SchemaParamInfo("Any nested elements that this wall might have")] List<Base> elements = null)
     {
       this.height = height;
       this.baseLine = baseLine;


### PR DESCRIPTION
## Description

Rhino: 
  - Removed deleted object ids from stream state before sending
  - Changed UI layer filter to display full layer path
  - Removed deleted layers from UI filter list

Autocad:
  - Removed deleted object ids from stream state before sending

Fixes #313, Fixes #311 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual tests in changing filter state with deleted layers and trying to send deleted objects in Autocad and Rhino. Manually tested trying to send with filter set to a deleted layer in Rhino.

Successfully sent Standard Geometry files for AutoCad and Rhino.

- [ ] Unit/Integration Tests 
- [ ] Manual Tests

