### PR TITLE
fix(gh): Brep conversion fallback to mesh.

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -10,6 +10,7 @@ using Rhino.DocObjects;
 using Rhino.Geometry;
 using Rhino.Geometry.Collections;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Arc = Objects.Geometry.Arc;
 using Box = Objects.Geometry.Box;
@@ -871,7 +872,7 @@ namespace Objects.Converter.RhinoGh
       }
       catch (Exception e)
       {
-        System.Diagnostics.Debug.WriteLine("Failed to deserialize brep");
+        ConversionErrors.Add(new Error("Failed to convert brep.", e.Message));
         return null;
       }
     }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -288,7 +288,12 @@ namespace Objects.Converter.RhinoGh
           return MeshToNative(o);
 
         case Brep o:
-          return BrepToNative(o);
+          // Brep conversion should always fallback to mesh if it fails.
+          var b = BrepToNative(o);
+          if (b == null)
+            return MeshToNative(o.displayValue);
+          else
+            return b;
 
         case Surface o:
           return SurfaceToNative(o);


### PR DESCRIPTION
## Description

Failing to convert BREPs will now try to extract the displayValue instead of returning a `null` object.

- Fixes #334 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. 

- [x] Manual Tests (what did you do?)

Forced conversion to fail and ensured that meshes where being assigned to the output and warnings were being shown to the user.
