### PR TITLE
GH: Fix error reporting on nodes

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
@@ -222,9 +222,9 @@ namespace ConnectorGrasshopper.Conversion
         var path = _objects.Paths[branchIndex];
         foreach (var item in list)
         {
-          // Only try to convert valid items and report any other invalid ones as warnings.
-          if(item.IsValid) Objects.Append(item, path);
-          else RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"Item at path {path}[{list.IndexOf(item)}] is not a Base object."));
+          if(!item.IsValid) 
+             RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"Item at path {path}[{list.IndexOf(item)}] is not a Base object."));
+          Objects.Append(item, path);
         }
 
         branchIndex++;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
@@ -224,7 +224,7 @@ namespace ConnectorGrasshopper.Conversion
         {
           // Only try to convert valid items and report any other invalid ones as warnings.
           if(item.IsValid) Objects.Append(item, path);
-          else RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"Item at path {path}[{list.IndexOf(item)}] was not Base."));
+          else RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"Item at path {path}[{list.IndexOf(item)}] is not a Base object."));
         }
 
         branchIndex++;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.SerialiseObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.SerialiseObject.cs
@@ -67,7 +67,7 @@ namespace ConnectorGrasshopper.Conversion
           {
             if (CancellationToken.IsCancellationRequested)return;
 
-            if (item != null)
+            if (item != null && item.Value != null)
             {
               try
               {
@@ -81,9 +81,8 @@ namespace ConnectorGrasshopper.Conversion
             }
             else
             {
-              ConvertedObjects.Append(new GH_String { Value = null }, path);
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"Object at {Objects.Paths[branchIndex]} is not a Speckle object."));
-            }
+              ConvertedObjects.Append(null, path);
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"Item at path {path}[{list.IndexOf(item)}] is not a Base object."));            }
 
             ReportProgress(Id, ((completed++ + 1) / (double)Objects.Count()));
           }
@@ -120,8 +119,7 @@ namespace ConnectorGrasshopper.Conversion
         var path = _objects.Paths[branchIndex];
         foreach (var item in list)
         {
-          if(item.IsValid) Objects.Append(item, path);
-          else RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, $"Item at path {path}[{list.IndexOf(item)}] is not a Base object."));
+          Objects.Append(item, path);
         }
         branchIndex++;
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -125,7 +125,7 @@ namespace ConnectorGrasshopper.Extras
     {
       object result = null;
 
-      if (value is null) throw new Speckle.Core.Logging.SpeckleException("Null values are not supported, please clean your data tree.");
+      if (value is null) return null;
       
       if (value is IGH_Goo)
       {
@@ -141,9 +141,7 @@ namespace ConnectorGrasshopper.Extras
       {
         return converter.ConvertToSpeckle(value);
       }
-
-
-
+      
       return result;
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectAsync.cs
@@ -215,7 +215,7 @@ namespace ConnectorGrasshopper.Objects
         if (speckleObjects.get_Branch(path).Count == 0) continue;
         // Loop through all dynamic properties
         var baseGoo = speckleObjects.get_DataItem(path, 0) as GH_SpeckleBase;
-        if (baseGoo == null)
+        if (baseGoo == null || baseGoo.Value == null)
         {
           continue;
         }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectAsync.cs
@@ -178,10 +178,14 @@ namespace ConnectorGrasshopper.Objects
 
     public override void SetData(IGH_DataAccess DA)
     {
+      // 👉 Checking for cancellation!
+      if (CancellationToken.IsCancellationRequested) return;
+
       foreach (var (level, message) in RuntimeMessages)
       {
         Parent.AddRuntimeMessage(level, message);
       }
+      
       DA.SetData(0, new GH_SpeckleBase { Value = @base });
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectAsync.cs
@@ -63,14 +63,15 @@ namespace ConnectorGrasshopper.Objects
       return new ExtendSpeckleObjectWorker(Parent, Converter);
     }
 
-    private void AssignToObject(Base b, List<string> keys, List<IGH_Goo> values)
+    private bool AssignToObject(Base b, List<string> keys, List<IGH_Goo> values)
     {
       var index = 0;
+      var hasErrors = false;
       keys.ForEach(key =>
       {
         if (b[key] != null)
         {
-          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, $"Object {b.id} - Property {key} has been overwritten");
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Remark, $"Object {b.id} - Property {key} has been overwritten"));
         }
 
         try
@@ -79,9 +80,12 @@ namespace ConnectorGrasshopper.Objects
         }
         catch (Exception e)
         {
-          Console.WriteLine(e);
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.Message));
+          hasErrors = true;
         }
       });
+
+      return hasErrors;
     }
 
     public override void DoWork(Action<string, double> ReportProgress, Action Done)
@@ -96,25 +100,28 @@ namespace ConnectorGrasshopper.Objects
           // Input is a list of values. Assign them directly
           if (keys.Count != values?.Count)
           {
-            Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Key and Value lists are not the same length.");
-            Parent.Message = "Error";
+            RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, "Key and Value lists are not the same length."));
+            @base = null;
+            Done();
             return;
           }
 
-          AssignToObject(@base, keys, values);
+          var hasErrors = AssignToObject(@base, keys, values);
+          if (hasErrors) @base = null;
         }
         else if (valueTree.Branches.Count == 1)
         {
           var values = valueTree.Branches[0];
           if (keys.Count != values.Count)
           {
-            Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Key and Value lists are not the same length.");
-            Parent.Message = "Error";
+            RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, "Key and Value lists are not the same length."));
+            Done();
             return;
           }
 
           // Input is just one list, so use it.
-          AssignToObject(@base, keys, values);
+          var hasErrors = AssignToObject(@base, keys, values);
+          if (hasErrors) @base = null;
         }
         else
         {
@@ -137,7 +144,7 @@ namespace ConnectorGrasshopper.Objects
                 }
                 catch (Exception e)
                 {
-                  Console.WriteLine(e);
+                  RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.Message));
                 }
               };
             }
@@ -152,7 +159,7 @@ namespace ConnectorGrasshopper.Objects
           if (foundTree)
           {
             // TODO: Handle tree conversions
-            Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Cannot handle trees yet");
+            RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, "Cannot handle trees yet"));
             Parent.Message = "Error";
           }
         }
@@ -163,13 +170,18 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Log.CaptureException(e);
-        Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
-        Parent.Message = "Error";
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message));
       }
     }
 
+    List<(GH_RuntimeMessageLevel, string)> RuntimeMessages { get; set; } = new List<(GH_RuntimeMessageLevel, string)>();
+
     public override void SetData(IGH_DataAccess DA)
     {
+      foreach (var (level, message) in RuntimeMessages)
+      {
+        Parent.AddRuntimeMessage(level, message);
+      }
       DA.SetData(0, new GH_SpeckleBase { Value = @base });
     }
 


### PR DESCRIPTION
## Description

- Fixes #289: several error reporting issues with some of the `dev` nodes. All that was fixed is specified in the linked issue.
   Introduced the same behaviour as in the `Send/Receive` nodes. A new  `RuntimeMessages` property in the worker keeps track of the worker's errors and reports them on `SetData()`.
   This requires that `Done()` must always be called (as was already recommended).

- Fixes #290: Local send/receive now properly reporting all errors, and local receiver no longer gets _stuck_ after first error was thrown.

- Fixes smaller error reporting issues in:
    - Create Speckle Object by Key/Value
    - ExpandSpeckleObject
    - ExtendSpeckleObject


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. 

- [x] Manual Tests (what did you do?)

Added edge cases to the Grasshopper exception file and checked for consistent behaviour with multiple items/data tree
