### PR TITLE
Claire/builtelements units

### DIFF
--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -11,18 +11,13 @@ namespace Objects.BuiltElements
   {
     public ICurve baseLine { get; set; }
 
-    public Beam()
-    {
-
-    }
+    public Beam() { }
 
     [SchemaInfo("Beam", "Creates a Speckle beam")]
     public Beam(ICurve baseLine)
     {
       this.baseLine = baseLine;
     }
-
-
   }
 }
 
@@ -37,10 +32,7 @@ namespace Objects.BuiltElements.Revit
     public string elementId { get; set; }
     public Level level { get; set; }
 
-    public RevitBeam()
-    {
-
-    }
+    public RevitBeam() { }
 
     [SchemaInfo("RevitBeam", "Creates a Revit beam by curve and base level.")]
     public RevitBeam(string family, string type, ICurve baseLine, Level level, List<Parameter> parameters = null)
@@ -50,7 +42,6 @@ namespace Objects.BuiltElements.Revit
       this.baseLine = baseLine;
       this.parameters = parameters;
       this.level = level;
-
     }
   }
 

--- a/Objects/Objects/BuiltElements/Brace.cs
+++ b/Objects/Objects/BuiltElements/Brace.cs
@@ -46,7 +46,6 @@ namespace Objects.BuiltElements.Revit
       this.baseLine = baseLine;
       this.parameters = parameters;
       this.level = level;
-
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Ceiling.cs
+++ b/Objects/Objects/BuiltElements/Ceiling.cs
@@ -38,17 +38,10 @@ namespace Objects.BuiltElements.Revit
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-
     public RevitCeiling() { }
 
-    [SchemaInfo("RevitCeiling", "Creates a Revit ceiling by level and offset.")]
-    public RevitCeiling(string family, string type, Level level, double offset, List<Parameter> parameters = null, string units = Units.Meters)
+    public RevitCeiling(string units = Units.Meters)
     {
-      this.family = family;
-      this.type = type;
-      this.level = level;
-      this.offset = offset;
-      this.parameters = parameters;
       this.units = units;
     }
   }

--- a/Objects/Objects/BuiltElements/Ceiling.cs
+++ b/Objects/Objects/BuiltElements/Ceiling.cs
@@ -14,7 +14,7 @@ namespace Objects.BuiltElements
 
     public Ceiling() { }
 
-    [SchemaInfo("Floor", "Creates a Speckle ceiling")]
+    [SchemaInfo("Ceiling", "Creates a Speckle ceiling")]
     public Ceiling(ICurve outline, List<ICurve> voids = null,
       [SchemaParamInfo("Any nested elements that this ceiling might have")] List<Base> elements = null)
     {
@@ -37,9 +37,19 @@ namespace Objects.BuiltElements.Revit
     public double offset { get; set; }
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
-    public RevitCeiling()
-    {
 
+
+    public RevitCeiling() { }
+
+    [SchemaInfo("RevitCeiling", "Creates a Revit ceiling by level and offset.")]
+    public RevitCeiling(string family, string type, Level level, double offset, List<Parameter> parameters = null, string units = Units.Meters)
+    {
+      this.family = family;
+      this.type = type;
+      this.level = level;
+      this.offset = offset;
+      this.parameters = parameters;
+      this.units = units;
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -27,40 +27,27 @@ namespace Objects.BuiltElements.Revit
   public class RevitColumn : Column
   {
     public Level level { get; set; }
-
     public Level topLevel { get; set; }
-
     public double baseOffset { get; set; }
-
     public double topOffset { get; set; }
-
     public bool facingFlipped { get; set; }
-
     public bool handFlipped { get; set; }
-
     public bool structural { get; set; }
-
     public double rotation { get; set; }
-
     public bool isSlanted { get; set; }
-
     public string family { get; set; }
     public string type { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
-    public RevitColumn()
-    {
 
-    }
+    public RevitColumn() { }
 
     [SchemaInfo("Vertical Column", "Creates a vertical Revit Column by point and levels.")]
     public RevitColumn(string family, string type,
       [SchemaParamInfo("Only the lower point of this line will be used as base point.")] ICurve baseLine,
       Level level, Level topLevel,
       double baseOffset = 0, double topOffset = 0, bool structural = false,
-      double rotation = 0, List<Parameter> parameters = null)
+      double rotation = 0, List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.family = family;
       this.type = type;
@@ -72,10 +59,11 @@ namespace Objects.BuiltElements.Revit
       this.rotation = rotation;
       this.parameters = parameters;
       this.level = level;
+      this.units = units;
     }
 
     [SchemaInfo("Slanted Column", "Creates a slanted Revit Column by curve.")]
-    public RevitColumn(string family, string type, ICurve baseLine, Level level, bool structural = false, List<Parameter> parameters = null)
+    public RevitColumn(string family, string type, ICurve baseLine, Level level, bool structural = false, List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.family = family;
       this.type = type;
@@ -83,7 +71,7 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
       this.structural = structural;
       this.parameters = parameters;
-
+      this.units = units;
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Duct.cs
+++ b/Objects/Objects/BuiltElements/Duct.cs
@@ -11,20 +11,20 @@ namespace Objects.BuiltElements
     public double width { get; set; }
     public double height { get; set; }
     public double diameter { get; set; }
-
     public double length { get; set; }
     public double velocity { get; set; }
 
     public Duct() { }
 
     [SchemaInfo("Duct", "Creates a Speckle duct")]
-    public Duct(Line baseLine, double width, double height, double diameter, double velocity = 0)
+    public Duct(Line baseLine, double width, double height, double diameter, double velocity = 0, string units = Units.Meters)
     {
       this.baseLine = baseLine;
       this.width = width;
       this.height = height;
       this.diameter = diameter;
       this.velocity = velocity;
+      this.units = units;
     }
   }
 }
@@ -42,12 +42,13 @@ namespace Objects.BuiltElements.Revit
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-    public RevitDuct()
-    {
-    }
+    public RevitDuct() { }
 
     [SchemaInfo("RevitDuct", "Creates a Revit duct")]
-    public RevitDuct(string family, string type, Line baseLine, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, List<Parameter> parameters = null)
+    public RevitDuct(string family, string type, Line baseLine, 
+      string systemName, string systemType, Level level, 
+      double width, double height, double diameter, 
+      double velocity = 0, List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.baseLine = baseLine;
       this.family = family;
@@ -60,6 +61,7 @@ namespace Objects.BuiltElements.Revit
       this.systemType = systemType;
       this.parameters = parameters;
       this.level = level;
+      this.units = units;
     }
   }
 

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -37,9 +37,8 @@ namespace Objects.BuiltElements.Revit
     public bool structural { get; set; }
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
-    public RevitFloor()
-    {
-    }
+
+    public RevitFloor() { }
 
     [SchemaInfo("RevitFloor", "Creates a Revit floor by outline and level")]
     public RevitFloor(string family, string type, ICurve outline,

--- a/Objects/Objects/BuiltElements/Level.cs
+++ b/Objects/Objects/BuiltElements/Level.cs
@@ -15,10 +15,11 @@ namespace Objects.BuiltElements
     public Level() { }
 
     [SchemaInfo("Level", "Creates a Speckle level")]
-    public Level(string name, double elevation)
+    public Level(string name, double elevation, string units = Units.Meters)
     {
       this.name = name;
       this.elevation = elevation;
+      this.units = units;
     }
   }
 }
@@ -43,13 +44,14 @@ namespace Objects.BuiltElements.Revit
       [SchemaParamInfo("Level name. NOTE: updating level name is not supported")] string name,
       [SchemaParamInfo("Level elevation. NOTE: updating level elevation is not supported, a new one will be created unless another level at the new elevation already exists.")] double elevation,
       [SchemaParamInfo("If true, it creates an associated view in Revit. NOTE: only used when creating a level for the first time")] bool createView,
-      List<Parameter> parameters = null)
+      List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.name = name;
       this.elevation = elevation;
       this.createView = createView;
       this.parameters = parameters;
       this.referenceOnly = false;
+      this.units = units;
     }
 
     [SchemaInfo("Level by name", "Gets an existing Revit level by name")]

--- a/Objects/Objects/BuiltElements/Opening.cs
+++ b/Objects/Objects/BuiltElements/Opening.cs
@@ -27,11 +27,8 @@ namespace Objects.BuiltElements.Revit
   public class RevitOpening : Opening
   {
     //public string family { get; set; }
-
     //public string type { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
     public RevitOpening() { }
@@ -51,20 +48,19 @@ namespace Objects.BuiltElements.Revit
   public class RevitShaft : RevitOpening
   {
     public Level bottomLevel { get; set; }
-
     public Level topLevel { get; set; }
-
     public double height { get; set; }
 
     public RevitShaft() { }
 
     [SchemaInfo("RevitShaft", "Creates a Revit shaft")]
-    public RevitShaft(ICurve outline, Level bottomLevel, Level topLevel, List<Parameter> parameters = null)
+    public RevitShaft(ICurve outline, Level bottomLevel, Level topLevel, List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.outline = outline;
       this.bottomLevel = bottomLevel;
       this.topLevel = topLevel;
       this.parameters = parameters;
+      this.units = units;
     }
   }
 

--- a/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
+++ b/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
@@ -9,18 +9,12 @@ namespace Objects.BuiltElements.Revit
   {
     public string type { get; set; }
     public string family { get; set; }
-
     public List<Point> basePoints { get; set; }
-
     public bool flipped { get; set; }
-
     public string elementId { get; set; }
-
     public List<Parameter> parameters { get; set; }
 
-    public AdaptiveComponent()
-    {
-    }
+    public AdaptiveComponent() { }
 
     [SchemaInfo("AdaptiveComponent", "Creates a Revit adaptive component by points")]
     public AdaptiveComponent(string type, string family, List<Point> basePoints, bool flipped = false, List<Parameter> parameters = null)

--- a/Objects/Objects/BuiltElements/Revit/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Revit/DirectShape.cs
@@ -8,20 +8,12 @@ namespace Objects.BuiltElements.Revit
   public class DirectShape : Base
   {
     public string name { get; set; }
-
     public RevitCategory category { get; set; }
-
     public List<Base> baseGeometries { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
-
-    public DirectShape()
-    {
-
-    }
+    public DirectShape() { }
 
     /// <summary>
     ///  Constructs a new <see cref="DirectShape"/> instance given a list of <see cref="Base"/> objects.

--- a/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
+++ b/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
@@ -8,30 +8,20 @@ namespace Objects.BuiltElements.Revit
   public class FamilyInstance : Base
   {
     public Point basePoint { get; set; }
-
     public string family { get; set; }
-
     public string type { get; set; }
     public string category { get; set; }
     public Level level { get; set; }
-
     public double rotation { get; set; }
-
     public bool facingFlipped { get; set; }
-
     public bool handFlipped { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
     [DetachProperty]
     public List<Base> elements { get; set; }
 
-    public FamilyInstance()
-    {
-
-    }
+    public FamilyInstance() { }
 
     [SchemaInfo("FamilyInstance", "Creates a Revit family instance")]
     public FamilyInstance(Point basePoint, string family, string type, Level level,

--- a/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
+++ b/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
@@ -12,6 +12,7 @@ namespace Objects.BuiltElements.Revit.Curve
     public string elementId { get; set; }
 
     public ModelCurve() { }
+
     [SchemaInfo("ModelCurve", "Creates a Revit model curve")]
     public ModelCurve(ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
     {
@@ -26,10 +27,10 @@ namespace Objects.BuiltElements.Revit.Curve
     public ICurve baseCurve { get; set; }
     public string lineStyle { get; set; }
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
     public DetailCurve() { }
+
     [SchemaInfo("DetailCurve", "Creates a Revit detail curve")]
     public DetailCurve(ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
     {
@@ -42,13 +43,11 @@ namespace Objects.BuiltElements.Revit.Curve
   public class RoomBoundaryLine : Base
   {
     public ICurve baseCurve { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
-    public RoomBoundaryLine()
-    { }
+    public RoomBoundaryLine() { }
+
     [SchemaInfo("RoomBoundaryLine", "Creates a Revit room boundary line")]
     public RoomBoundaryLine(ICurve baseCurve, List<Parameter> parameters = null)
     {

--- a/Objects/Objects/BuiltElements/Revit/RevitRailing.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitRailing.cs
@@ -12,11 +12,8 @@ namespace Objects.BuiltElements.Revit
     public Level level { get; set; }
     public Polycurve path { get; set; }
     public bool flipped { get; set; }
-
     public string elementId { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
 
     public RevitRailing() { }
 
@@ -28,7 +25,5 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
       this.flipped = flipped;
     }
-
-
   }
 }

--- a/Objects/Objects/BuiltElements/Revit/RevitStair.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitStair.cs
@@ -57,6 +57,7 @@ namespace Objects.BuiltElements.Revit
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
+    public RevitStairRun() { }
 
     public RevitStairRun(string units = Units.Meters) 
     {

--- a/Objects/Objects/BuiltElements/Revit/RevitStair.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitStair.cs
@@ -26,10 +26,13 @@ namespace Objects.BuiltElements.Revit
     public List<RevitStairSupport> supports { get; set; }
     public string elementId { get; set; }
 
-
     public RevitStair() { }
 
-
+    [SchemaInfo("RevitStair", "Creates a Revit stair")]
+    public RevitStair(string units = Units.Meters)
+    {
+      this.units = units;
+    }
   }
 
   public class RevitStairRun : Base
@@ -55,7 +58,10 @@ namespace Objects.BuiltElements.Revit
     public string elementId { get; set; }
 
 
-    public RevitStairRun() { }
+    public RevitStairRun(string units = Units.Meters) 
+    {
+      this.units = units;
+    }
   }
 
   public class RevitStairLanding : Base
@@ -69,8 +75,13 @@ namespace Objects.BuiltElements.Revit
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-
     public RevitStairLanding() { }
+
+    [SchemaInfo("RevitStairLanding", "Creates a Revit stair landing")]
+    public RevitStairLanding(string units = Units.Meters)
+    {
+      this.units = units;
+    }
   }
 
   public class RevitStairSupport : Base
@@ -79,7 +90,6 @@ namespace Objects.BuiltElements.Revit
     public string type { get; set; }
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
-
 
     public RevitStairSupport() { }
   }

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -37,9 +37,7 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     public string elementId { get; set; }
     public Level level { get; set; }
 
-    public RevitRoof()
-    {
-    }
+    public RevitRoof() { }
   }
 
   public class RevitExtrusionRoof : RevitRoof
@@ -48,15 +46,11 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     public double end { get; set; }
     public Line referenceLine { get; set; }
 
-    public RevitExtrusionRoof()
-    {
-
-    }
+    public RevitExtrusionRoof() { }
 
     [SchemaInfo("RevitExtrusionRoof", "Creates a Revit roof by extruding a curve")]
     public RevitExtrusionRoof(string family, string type, double start, double end, Line referenceLine, Level level,
-      List<Base> elements = null,
-      List<Parameter> parameters = null)
+      List<Base> elements = null, List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.family = family;
       this.type = type;
@@ -66,6 +60,7 @@ namespace Objects.BuiltElements.Revit.RevitRoof
       this.end = end;
       this.referenceLine = referenceLine;
       this.elements = elements;
+      this.units = units;
     }
 
   }
@@ -75,14 +70,11 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     public RevitLevel cutOffLevel { get; set; }
     public double? slope { get; set; }
 
-    public RevitFootprintRoof()
-    {
+    public RevitFootprintRoof() { }
 
-    }
     [SchemaInfo("RevitFootprintRoof", "Creates a Revit roof by outline")]
     public RevitFootprintRoof(ICurve outline, string family, string type, Level level, RevitLevel cutOffLevel = null, double slope = 0, List<ICurve> voids = null,
-      List<Base> elements = null,
-      List<Parameter> parameters = null)
+      List<Base> elements = null, List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.outline = outline;
       this.voids = voids;
@@ -93,6 +85,7 @@ namespace Objects.BuiltElements.Revit.RevitRoof
       this.level = level;
       this.cutOffLevel = cutOffLevel;
       this.elements = elements;
+      this.units = units;
     }
   }
 

--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -18,7 +18,15 @@ namespace Objects.BuiltElements
     public Point center { get; set; }
     public List<ICurve> voids { get; set; } = new List<ICurve>();
     public ICurve outline { get; set; }
+
     public Room() { }
 
+    [SchemaInfo("Room", "Creates a Speckle room")]
+    public Room(ICurve outline, List<ICurve> voids = null, string units = Units.Meters)
+    {
+      this.outline = outline;
+      this.voids = voids;
+      this.units = units;
+    }
   }
 }

--- a/Objects/Objects/BuiltElements/Topography.cs
+++ b/Objects/Objects/BuiltElements/Topography.cs
@@ -10,6 +10,7 @@ namespace Objects.BuiltElements
   public class Topography : Base
   {
     public Mesh baseGeometry { get; set; } = new Mesh();
+
     public Topography() { }
 
     [SchemaInfo("Topography", "Creates a Speckle topography")]
@@ -25,12 +26,9 @@ namespace Objects.BuiltElements.Revit
   public class RevitTopography : Topography
   {
     public string elementId { get; set; }
-
     public List<Parameter> parameters { get; set; }
-    public RevitTopography()
-    {
 
-    }
+    public RevitTopography() { }
 
     [SchemaInfo("RevitTopography", "Creates a Revit topography")]
     public RevitTopography(Mesh baseGeometry, List<Parameter> parameters = null)

--- a/Objects/Objects/BuiltElements/View.cs
+++ b/Objects/Objects/BuiltElements/View.cs
@@ -21,6 +21,7 @@ namespace Objects.BuiltElements
     public Vector forwardDirection { get; set; }
     //public double zoom { get; set; }
     public bool isOrthogonal { get; set; } = false;
+
     public View3D() { }
   }
 
@@ -28,6 +29,7 @@ namespace Objects.BuiltElements
   {
     //public Point topLeft { get; set; }
     //public Point bottomRight { get; set; }
+
     public View2D() { }
   }
 }

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -17,11 +17,12 @@ namespace Objects.BuiltElements
 
     [SchemaInfo("Wall", "Creates a Speckle wall")]
     public Wall(double height, ICurve baseLine,
-      [SchemaParamInfo("Any nested elements that this wall might have")] List<Base> elements = null)
+      [SchemaParamInfo("Any nested elements that this wall might have")] List<Base> elements = null, string units = Units.Meters)
     {
       this.height = height;
       this.baseLine = baseLine;
       this.elements = elements;
+      this.units = units;
     }
   }
 }
@@ -38,20 +39,16 @@ namespace Objects.BuiltElements.Revit
     public bool structural { get; set; }
     public Level level { get; set; }
     public Level topLevel { get; set; }
-
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-    public RevitWall()
-    {
-
-    }
+    public RevitWall() { }
 
     [SchemaInfo("Wall by curve and levels", "Creates a Revit wall with a top and base level.")]
     public RevitWall(string family, string type,
       ICurve baseLine, Level level, Level topLevel, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      List<Parameter> parameters = null)
+      List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.family = family;
       this.type = type;
@@ -64,13 +61,14 @@ namespace Objects.BuiltElements.Revit
       this.topLevel = topLevel;
       this.elements = elements;
       this.parameters = parameters;
+      this.units = units;
     }
 
     [SchemaInfo("Wall by curve and height", "Creates an unconnected Revit wall.")]
     public RevitWall(string family, string type,
       ICurve baseLine, Level level, double height, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      List<Parameter> parameters = null)
+      List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.family = family;
       this.type = type;
@@ -83,6 +81,7 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
       this.elements = elements;
       this.parameters = parameters;
+      this.units = units;
     }
   }
 
@@ -90,26 +89,20 @@ namespace Objects.BuiltElements.Revit
   {
     public string family { get; set; }
     public string type { get; set; }
-
     public Surface surface { get; set; }
     public Level level { get; set; }
-
     public LocationLine locationLine { get; set; }
-
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-    public RevitFaceWall()
-    {
-
-    }
+    public RevitFaceWall() { }
 
     [SchemaInfo("Wall by face", "Creates a Revit wall from a surface.")]
     public RevitFaceWall(string family, string type,
       [SchemaParamInfo("Surface or single face Brep to use")] Brep surface,
       Level level, LocationLine locationLine = LocationLine.Interior,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      List<Parameter> parameters = null)
+      List<Parameter> parameters = null, string units = Units.Meters)
     {
       this.family = family;
       this.type = type;
@@ -118,6 +111,7 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
       this.elements = elements;
       this.parameters = parameters;
+      this.units = units;
     }
   }
 


### PR DESCRIPTION
## Description

Added units to BuiltElements constructors:
- Default unit is `Meters`
- Added **if** built element class or its inherited base class has a double measurement property (eg offset, height, run)
- Added placeholder constructor with optional units argument for classes that only had an empty constructor and also had a double measurement property

**NOTE** This will introduce a units param in the Grasshopper CSO component - need to address with new issue

- Fixes #319

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

Sent some BuiltElements via grasshopper and rhino just in case
- [ ] Tests not required
- [ ] Manual Tests (what did you do?)

