### PR TITLE
Objects builtelements cleanup

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertStair.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertStair.cs
@@ -24,7 +24,7 @@ namespace Objects.Converter.Revit
       speckleStair.topLevel = ConvertAndCacheLevel(revitStair, BuiltInParameter.STAIRS_TOP_LEVEL_PARAM);
       speckleStair.riserHeight = ScaleToSpeckle(revitStair.ActualRiserHeight);
       speckleStair.risersNumber = revitStair.ActualRisersNumber;
-      speckleStair.treradDepth = ScaleToSpeckle(revitStair.ActualTreadDepth);
+      speckleStair.treadDepth = ScaleToSpeckle(revitStair.ActualTreadDepth);
       speckleStair.treadsNumber = revitStair.ActualTreadsNumber;
       speckleStair.baseElevation = ScaleToSpeckle(revitStair.BaseElevation);
       speckleStair.topElevation = ScaleToSpeckle(revitStair.TopElevation);

--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -11,24 +11,18 @@ namespace Objects.BuiltElements
   {
     public ICurve baseLine { get; set; }
 
-    public Beam()
-    {
-
-    }
+    public Beam() { }
 
     [SchemaInfo("Beam", "Creates a Speckle beam")]
     public Beam(ICurve baseLine)
     {
       this.baseLine = baseLine;
     }
-
-
   }
 }
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitBeam : Beam
   {
     public string family { get; set; }
@@ -37,10 +31,7 @@ namespace Objects.BuiltElements.Revit
     public string elementId { get; set; }
     public Level level { get; set; }
 
-    public RevitBeam()
-    {
-
-    }
+    public RevitBeam() { }
 
     [SchemaInfo("RevitBeam", "Creates a Revit beam by curve and base level.")]
     public RevitBeam(string family, string type, ICurve baseLine, Level level, List<Parameter> parameters = null)
@@ -50,8 +41,6 @@ namespace Objects.BuiltElements.Revit
       this.baseLine = baseLine;
       this.parameters = parameters;
       this.level = level;
-
     }
   }
-
 }

--- a/Objects/Objects/BuiltElements/Brace.cs
+++ b/Objects/Objects/BuiltElements/Brace.cs
@@ -13,7 +13,6 @@ namespace Objects.BuiltElements
 
     public Brace() { }
 
-
     [SchemaInfo("Brace", "Creates a Speckle brace")]
     public Brace(ICurve baseLine)
     {
@@ -24,7 +23,6 @@ namespace Objects.BuiltElements
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitBrace : Brace
   {
     public string family { get; set; }
@@ -33,10 +31,7 @@ namespace Objects.BuiltElements.Revit
     public string elementId { get; set; }
     public Level level { get; set; }
 
-    public RevitBrace()
-    {
-
-    }
+    public RevitBrace() { }
 
     [SchemaInfo("RevitBrace", "Creates a Revit brace by curve and base level.")]
     public RevitBrace(string family, string type, ICurve baseLine, Level level, List<Parameter> parameters = null)
@@ -46,7 +41,6 @@ namespace Objects.BuiltElements.Revit
       this.baseLine = baseLine;
       this.parameters = parameters;
       this.level = level;
-
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Ceiling.cs
+++ b/Objects/Objects/BuiltElements/Ceiling.cs
@@ -14,7 +14,7 @@ namespace Objects.BuiltElements
 
     public Ceiling() { }
 
-    [SchemaInfo("Floor", "Creates a Speckle ceiling")]
+    [SchemaInfo("Ceiling", "Creates a Speckle ceiling")]
     public Ceiling(ICurve outline, List<ICurve> voids = null,
       [SchemaParamInfo("Any nested elements that this ceiling might have")] List<Base> elements = null)
     {
@@ -23,12 +23,10 @@ namespace Objects.BuiltElements
       this.elements = elements;
     }
   }
-
 }
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitCeiling : Ceiling
   {
     public string family { get; set; }
@@ -37,9 +35,7 @@ namespace Objects.BuiltElements.Revit
     public double offset { get; set; }
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
-    public RevitCeiling()
-    {
 
-    }
+    public RevitCeiling() { }
   }
 }

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -23,38 +23,38 @@ namespace Objects.BuiltElements
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitColumn : Column
   {
     public Level level { get; set; }
-
     public Level topLevel { get; set; }
-
     public double baseOffset { get; set; }
-
     public double topOffset { get; set; }
-
     public bool facingFlipped { get; set; }
-
     public bool handFlipped { get; set; }
-
     public bool structural { get; set; }
-
     public double rotation { get; set; }
-
     public bool isSlanted { get; set; }
-
     public string family { get; set; }
     public string type { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
-    public RevitColumn()
-    {
 
-    }
+    public RevitColumn() { }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit column
+    /// </summary>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="baseLine"></param>
+    /// <param name="level"></param>
+    /// <param name="topLevel"></param>
+    /// <param name="baseOffset"></param>
+    /// <param name="topOffset"></param>
+    /// <param name="structural"></param>
+    /// <param name="rotation"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="baseOffset"/> and <paramref name="topOffset"/> params</remarks>
     [SchemaInfo("Vertical Column", "Creates a vertical Revit Column by point and levels.")]
     public RevitColumn(string family, string type,
       [SchemaParamInfo("Only the lower point of this line will be used as base point.")] ICurve baseLine,
@@ -83,7 +83,6 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
       this.structural = structural;
       this.parameters = parameters;
-
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Duct.cs
+++ b/Objects/Objects/BuiltElements/Duct.cs
@@ -11,12 +11,20 @@ namespace Objects.BuiltElements
     public double width { get; set; }
     public double height { get; set; }
     public double diameter { get; set; }
-
     public double length { get; set; }
     public double velocity { get; set; }
 
     public Duct() { }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Speckle duct
+    /// </summary>
+    /// <param name="baseLine"></param>
+    /// <param name="width"></param>
+    /// <param name="height"></param>
+    /// <param name="diameter"></param>
+    /// <param name="velocity"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
     [SchemaInfo("Duct", "Creates a Speckle duct")]
     public Duct(Line baseLine, double width, double height, double diameter, double velocity = 0)
     {
@@ -31,7 +39,6 @@ namespace Objects.BuiltElements
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitDuct : Duct
   {
     public string family { get; set; }
@@ -42,10 +49,23 @@ namespace Objects.BuiltElements.Revit
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-    public RevitDuct()
-    {
-    }
+    public RevitDuct() { }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit duct
+    /// </summary>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="baseLine"></param>
+    /// <param name="systemName"></param>
+    /// <param name="systemType"></param>
+    /// <param name="level"></param>
+    /// <param name="width"></param>
+    /// <param name="height"></param>
+    /// <param name="diameter"></param>
+    /// <param name="velocity"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
     [SchemaInfo("RevitDuct", "Creates a Revit duct")]
     public RevitDuct(string family, string type, Line baseLine, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, List<Parameter> parameters = null)
     {
@@ -62,5 +82,4 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
     }
   }
-
 }

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -23,12 +23,10 @@ namespace Objects.BuiltElements
       this.elements = elements;
     }
   }
-
 }
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitFloor : Floor
   {
     public string family { get; set; }
@@ -37,9 +35,7 @@ namespace Objects.BuiltElements.Revit
     public bool structural { get; set; }
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
-    public RevitFloor()
-    {
-    }
+    public RevitFloor() { }
 
     [SchemaInfo("RevitFloor", "Creates a Revit floor by outline and level")]
     public RevitFloor(string family, string type, ICurve outline,

--- a/Objects/Objects/BuiltElements/Level.cs
+++ b/Objects/Objects/BuiltElements/Level.cs
@@ -14,6 +14,12 @@ namespace Objects.BuiltElements
 
     public Level() { }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Speckle level
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="elevation"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="elevation"/> param</remarks>
     [SchemaInfo("Level", "Creates a Speckle level")]
     public Level(string name, double elevation)
     {
@@ -25,19 +31,23 @@ namespace Objects.BuiltElements
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitLevel : Level
   {
     public bool createView { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
-
     public bool referenceOnly { get; set; }
 
     public RevitLevel() { }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit level
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="elevation"></param>
+    /// <param name="createView"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="elevation"/> param</remarks>
     [SchemaInfo("Create level", "Creates a new Revit level unless one with the same elevation already exists")]
     public RevitLevel(
       [SchemaParamInfo("Level name. NOTE: updating level name is not supported")] string name,

--- a/Objects/Objects/BuiltElements/Opening.cs
+++ b/Objects/Objects/BuiltElements/Opening.cs
@@ -58,17 +58,33 @@ namespace Objects.BuiltElements.Revit
     /// <param name="outline"></param>
     /// <param name="bottomLevel"></param>
     /// <param name="topLevel"></param>
-    /// <param name="height"></param>
     /// <param name="parameters"></param>
-    /// <remarks>Assign units when using this constructor due to <paramref name="height"/> param</remarks>
-    [SchemaInfo("RevitShaft", "Creates a Revit shaft")]
-    public RevitShaft(ICurve outline, Level bottomLevel, Level topLevel, double height, List<Parameter> parameters = null)
+    [SchemaInfo("RevitShaft", "Creates a Revit shaft from a bottom and top level")]
+    public RevitShaft(ICurve outline, Level bottomLevel, Level topLevel, List<Parameter> parameters = null)
     {
       this.outline = outline;
       this.bottomLevel = bottomLevel;
       this.topLevel = topLevel;
+      this.parameters = parameters;
+    }
+
+    /*
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit shaft
+    /// </summary>
+    /// <param name="outline"></param>
+    /// <param name="bottomLevel"></param>
+    /// <param name="height"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="height"/> param</remarks>
+    [SchemaInfo("RevitShaft", "Creates a Revit shaft from a bottom level and height")]
+    public RevitShaft(ICurve outline, Level bottomLevel, double height, List<Parameter> parameters = null)
+    {
+      this.outline = outline;
+      this.bottomLevel = bottomLevel;
       this.height = height;
       this.parameters = parameters;
     }
+    */
   }
 }

--- a/Objects/Objects/BuiltElements/Opening.cs
+++ b/Objects/Objects/BuiltElements/Opening.cs
@@ -23,15 +23,11 @@ namespace Objects.BuiltElements
 
 namespace Objects.BuiltElements.Revit
 {
-
   public class RevitOpening : Opening
   {
     //public string family { get; set; }
-
     //public string type { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
     public RevitOpening() { }
@@ -51,21 +47,28 @@ namespace Objects.BuiltElements.Revit
   public class RevitShaft : RevitOpening
   {
     public Level bottomLevel { get; set; }
-
     public Level topLevel { get; set; }
-
     public double height { get; set; }
 
     public RevitShaft() { }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit shaft
+    /// </summary>
+    /// <param name="outline"></param>
+    /// <param name="bottomLevel"></param>
+    /// <param name="topLevel"></param>
+    /// <param name="height"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="height"/> param</remarks>
     [SchemaInfo("RevitShaft", "Creates a Revit shaft")]
-    public RevitShaft(ICurve outline, Level bottomLevel, Level topLevel, List<Parameter> parameters = null)
+    public RevitShaft(ICurve outline, Level bottomLevel, Level topLevel, double height, List<Parameter> parameters = null)
     {
       this.outline = outline;
       this.bottomLevel = bottomLevel;
       this.topLevel = topLevel;
+      this.height = height;
       this.parameters = parameters;
     }
   }
-
 }

--- a/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
+++ b/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
@@ -9,18 +9,12 @@ namespace Objects.BuiltElements.Revit
   {
     public string type { get; set; }
     public string family { get; set; }
-
     public List<Point> basePoints { get; set; }
-
     public bool flipped { get; set; }
-
     public string elementId { get; set; }
-
     public List<Parameter> parameters { get; set; }
 
-    public AdaptiveComponent()
-    {
-    }
+    public AdaptiveComponent() { }
 
     [SchemaInfo("AdaptiveComponent", "Creates a Revit adaptive component by points")]
     public AdaptiveComponent(string type, string family, List<Point> basePoints, bool flipped = false, List<Parameter> parameters = null)

--- a/Objects/Objects/BuiltElements/Revit/BuildingPad.cs
+++ b/Objects/Objects/BuiltElements/Revit/BuildingPad.cs
@@ -13,7 +13,6 @@ namespace Objects.BuiltElements.Revit
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-
     public BuildingPad() { }
 
 

--- a/Objects/Objects/BuiltElements/Revit/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Revit/DirectShape.cs
@@ -8,20 +8,12 @@ namespace Objects.BuiltElements.Revit
   public class DirectShape : Base
   {
     public string name { get; set; }
-
     public RevitCategory category { get; set; }
-
     public List<Base> baseGeometries { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
-
-    public DirectShape()
-    {
-
-    }
+    public DirectShape() { }
 
     /// <summary>
     ///  Constructs a new <see cref="DirectShape"/> instance given a list of <see cref="Base"/> objects.

--- a/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
+++ b/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
@@ -8,30 +8,20 @@ namespace Objects.BuiltElements.Revit
   public class FamilyInstance : Base
   {
     public Point basePoint { get; set; }
-
     public string family { get; set; }
-
     public string type { get; set; }
     public string category { get; set; }
     public Level level { get; set; }
-
     public double rotation { get; set; }
-
     public bool facingFlipped { get; set; }
-
     public bool handFlipped { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
     [DetachProperty]
     public List<Base> elements { get; set; }
 
-    public FamilyInstance()
-    {
-
-    }
+    public FamilyInstance() { }
 
     [SchemaInfo("FamilyInstance", "Creates a Revit family instance")]
     public FamilyInstance(Point basePoint, string family, string type, Level level,

--- a/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
+++ b/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
@@ -12,6 +12,7 @@ namespace Objects.BuiltElements.Revit.Curve
     public string elementId { get; set; }
 
     public ModelCurve() { }
+
     [SchemaInfo("ModelCurve", "Creates a Revit model curve")]
     public ModelCurve(ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
     {
@@ -26,10 +27,10 @@ namespace Objects.BuiltElements.Revit.Curve
     public ICurve baseCurve { get; set; }
     public string lineStyle { get; set; }
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
     public DetailCurve() { }
+
     [SchemaInfo("DetailCurve", "Creates a Revit detail curve")]
     public DetailCurve(ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
     {
@@ -42,13 +43,11 @@ namespace Objects.BuiltElements.Revit.Curve
   public class RoomBoundaryLine : Base
   {
     public ICurve baseCurve { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
     public string elementId { get; set; }
 
-    public RoomBoundaryLine()
-    { }
+    public RoomBoundaryLine() { }
+
     [SchemaInfo("RoomBoundaryLine", "Creates a Revit room boundary line")]
     public RoomBoundaryLine(ICurve baseCurve, List<Parameter> parameters = null)
     {

--- a/Objects/Objects/BuiltElements/Revit/RevitRailing.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitRailing.cs
@@ -12,11 +12,8 @@ namespace Objects.BuiltElements.Revit
     public Level level { get; set; }
     public Polycurve path { get; set; }
     public bool flipped { get; set; }
-
     public string elementId { get; set; }
-
     public List<Parameter> parameters { get; set; }
-
 
     public RevitRailing() { }
 
@@ -28,7 +25,5 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
       this.flipped = flipped;
     }
-
-
   }
 }

--- a/Objects/Objects/BuiltElements/Revit/RevitStair.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitStair.cs
@@ -13,7 +13,7 @@ namespace Objects.BuiltElements.Revit
     public Level topLevel { get; set; }
     public double riserHeight { get; set; }
     public int risersNumber { get; set; }
-    public double treradDepth { get; set; }
+    public double treadDepth { get; set; }
     public int treadsNumber { get; set; }
     public double baseElevation { get; set; }
     public double topElevation { get; set; }
@@ -26,10 +26,7 @@ namespace Objects.BuiltElements.Revit
     public List<RevitStairSupport> supports { get; set; }
     public string elementId { get; set; }
 
-
     public RevitStair() { }
-
-
   }
 
   public class RevitStairRun : Base
@@ -49,11 +46,8 @@ namespace Objects.BuiltElements.Revit
     public double extensionBelowTreadBase { get; set; }
     public double height { get; set; }
     public string runStyle { get; set; }
-
-
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
-
 
     public RevitStairRun() { }
   }
@@ -69,7 +63,6 @@ namespace Objects.BuiltElements.Revit
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-
     public RevitStairLanding() { }
   }
 
@@ -79,7 +72,6 @@ namespace Objects.BuiltElements.Revit
     public string type { get; set; }
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
-
 
     public RevitStairSupport() { }
   }

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -37,9 +37,7 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     public string elementId { get; set; }
     public Level level { get; set; }
 
-    public RevitRoof()
-    {
-    }
+    public RevitRoof() { }
   }
 
   public class RevitExtrusionRoof : RevitRoof
@@ -48,11 +46,20 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     public double end { get; set; }
     public Line referenceLine { get; set; }
 
-    public RevitExtrusionRoof()
-    {
+    public RevitExtrusionRoof() { }
 
-    }
-
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit extrusion roof
+    /// </summary>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="start"></param>
+    /// <param name="end"></param>
+    /// <param name="referenceLine"></param>
+    /// <param name="level"></param>
+    /// <param name="elements"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="start"/> and <paramref name="end"/> params</remarks>
     [SchemaInfo("RevitExtrusionRoof", "Creates a Revit roof by extruding a curve")]
     public RevitExtrusionRoof(string family, string type, double start, double end, Line referenceLine, Level level,
       List<Base> elements = null,
@@ -67,7 +74,6 @@ namespace Objects.BuiltElements.Revit.RevitRoof
       this.referenceLine = referenceLine;
       this.elements = elements;
     }
-
   }
 
   public class RevitFootprintRoof : RevitRoof
@@ -75,10 +81,21 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     public RevitLevel cutOffLevel { get; set; }
     public double? slope { get; set; }
 
-    public RevitFootprintRoof()
-    {
+    public RevitFootprintRoof() { }
 
-    }
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit footprint roof
+    /// </summary>
+    /// <param name="outline"></param>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="level"></param>
+    /// <param name="cutOffLevel"></param>
+    /// <param name="slope"></param>
+    /// <param name="voids"></param>
+    /// <param name="elements"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="slope"/> param</remarks>
     [SchemaInfo("RevitFootprintRoof", "Creates a Revit roof by outline")]
     public RevitFootprintRoof(ICurve outline, string family, string type, Level level, RevitLevel cutOffLevel = null, double slope = 0, List<ICurve> voids = null,
       List<Base> elements = null,
@@ -95,5 +112,4 @@ namespace Objects.BuiltElements.Revit.RevitRoof
       this.elements = elements;
     }
   }
-
 }

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -86,19 +86,6 @@ namespace Objects.BuiltElements.Revit.RevitRoof
 
     public RevitFootprintRoof() { }
 
-    /// <summary>
-    /// SchemaBuilder constructor for a Revit footprint roof
-    /// </summary>
-    /// <param name="outline"></param>
-    /// <param name="family"></param>
-    /// <param name="type"></param>
-    /// <param name="level"></param>
-    /// <param name="cutOffLevel"></param>
-    /// <param name="slope"></param>
-    /// <param name="voids"></param>
-    /// <param name="elements"></param>
-    /// <param name="parameters"></param>
-    /// <remarks>Assign units when using this constructor due to <paramref name="slope"/> param</remarks>
     [SchemaInfo("RevitFootprintRoof", "Creates a Revit roof by outline")]
     public RevitFootprintRoof(ICurve outline, string family, string type, Level level, RevitLevel cutOffLevel = null, double slope = 0, List<ICurve> voids = null,
       List<Base> elements = null,

--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -18,7 +18,7 @@ namespace Objects.BuiltElements
     public Point center { get; set; }
     public List<ICurve> voids { get; set; } = new List<ICurve>();
     public ICurve outline { get; set; }
-    public Room() { }
 
+    public Room() { }
   }
 }

--- a/Objects/Objects/BuiltElements/Topography.cs
+++ b/Objects/Objects/BuiltElements/Topography.cs
@@ -10,6 +10,7 @@ namespace Objects.BuiltElements
   public class Topography : Base
   {
     public Mesh baseGeometry { get; set; } = new Mesh();
+
     public Topography() { }
 
     [SchemaInfo("Topography", "Creates a Speckle topography")]
@@ -25,12 +26,9 @@ namespace Objects.BuiltElements.Revit
   public class RevitTopography : Topography
   {
     public string elementId { get; set; }
-
     public List<Parameter> parameters { get; set; }
-    public RevitTopography()
-    {
 
-    }
+    public RevitTopography() { }
 
     [SchemaInfo("RevitTopography", "Creates a Revit topography")]
     public RevitTopography(Mesh baseGeometry, List<Parameter> parameters = null)
@@ -39,5 +37,4 @@ namespace Objects.BuiltElements.Revit
       this.parameters = parameters;
     }
   }
-
 }

--- a/Objects/Objects/BuiltElements/View.cs
+++ b/Objects/Objects/BuiltElements/View.cs
@@ -21,6 +21,7 @@ namespace Objects.BuiltElements
     public Vector forwardDirection { get; set; }
     //public double zoom { get; set; }
     public bool isOrthogonal { get; set; } = false;
+
     public View3D() { }
   }
 
@@ -28,6 +29,7 @@ namespace Objects.BuiltElements
   {
     //public Point topLeft { get; set; }
     //public Point bottomRight { get; set; }
+
     public View2D() { }
   }
 }

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -15,6 +15,13 @@ namespace Objects.BuiltElements
 
     public Wall() { }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Speckle wall
+    /// </summary>
+    /// <param name="height"></param>
+    /// <param name="baseLine"></param>
+    /// <param name="elements"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="height"/> param</remarks>
     [SchemaInfo("Wall", "Creates a Speckle wall")]
     public Wall(double height, ICurve baseLine,
       [SchemaParamInfo("Any nested elements that this wall might have")] List<Base> elements = null)
@@ -38,15 +45,26 @@ namespace Objects.BuiltElements.Revit
     public bool structural { get; set; }
     public Level level { get; set; }
     public Level topLevel { get; set; }
-
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-    public RevitWall()
-    {
+    public RevitWall() { }
 
-    }
-
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit wall
+    /// </summary>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="baseLine"></param>
+    /// <param name="level"></param>
+    /// <param name="topLevel"></param>
+    /// <param name="baseOffset"></param>
+    /// <param name="topOffset"></param>
+    /// <param name="flipped"></param>
+    /// <param name="structural"></param>
+    /// <param name="elements"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="baseOffset"/> and <paramref name="topOffset"/> params</remarks>
     [SchemaInfo("Wall by curve and levels", "Creates a Revit wall with a top and base level.")]
     public RevitWall(string family, string type,
       ICurve baseLine, Level level, Level topLevel, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
@@ -66,6 +84,21 @@ namespace Objects.BuiltElements.Revit
       this.parameters = parameters;
     }
 
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit wall
+    /// </summary>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="baseLine"></param>
+    /// <param name="level"></param>
+    /// <param name="height"></param>
+    /// <param name="baseOffset"></param>
+    /// <param name="topOffset"></param>
+    /// <param name="flipped"></param>
+    /// <param name="structural"></param>
+    /// <param name="elements"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="height"/>, <paramref name="baseOffset"/>, and <paramref name="topOffset"/> params</remarks>
     [SchemaInfo("Wall by curve and height", "Creates an unconnected Revit wall.")]
     public RevitWall(string family, string type,
       ICurve baseLine, Level level, double height, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
@@ -90,19 +123,13 @@ namespace Objects.BuiltElements.Revit
   {
     public string family { get; set; }
     public string type { get; set; }
-
     public Surface surface { get; set; }
     public Level level { get; set; }
-
     public LocationLine locationLine { get; set; }
-
     public List<Parameter> parameters { get; set; }
     public string elementId { get; set; }
 
-    public RevitFaceWall()
-    {
-
-    }
+    public RevitFaceWall() { }
 
     [SchemaInfo("Wall by face", "Creates a Revit wall from a surface.")]
     public RevitFaceWall(string family, string type,


### PR DESCRIPTION
## Description

Adds xml comments to builtelements constructors that expect units due to length props. Also includes:
- reformatting for consistency
- minor typo fix in stair property spelling and ceiling schema name
- commented template for a new revit shaft constructor using bottomlevel and height (in addition to current constructor using bottom and top levels)

- Fixes #319

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Sent a shaft from GH to Revit

- [ ] Tests not required
- [ ] Manual Tests (what did you do?)

