### PR TITLE
feat(gh): Added fancy rendered state tags, no more pixels!!

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Conversion\Convert.ToNativeAsync.cs" />
     <Compile Include="Extras\Speckle.IGH_Goo.cs" />
     <Compile Include="Extras\SpeckleBaseParam.cs" />
+    <Compile Include="Extras\SpeckleStateTag.cs" />
     <Compile Include="Extras\SpeckleStreamParam.cs" />
     <Compile Include="Extras\TreeBuilder.cs" />
     <Compile Include="Extras\Utilities.cs" />

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using GH_IO.Serialization;
 using Grasshopper.GUI.Canvas;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
+
 
 namespace ConnectorGrasshopper.Extras
 {
@@ -24,7 +26,8 @@ namespace ConnectorGrasshopper.Extras
         {
           tags.Add(new OptionalStateTag());
         }
-        if(!Detachable)
+
+        if (!Detachable)
           tags.Add(new DetachedStateTag());
         if (Access == GH_ParamAccess.list)
           tags.Add(new ListAccesStateTag());
@@ -43,18 +46,18 @@ namespace ConnectorGrasshopper.Extras
         base.AppendAdditionalMenuItems(menu);
         return;
       }
-      
+
       Menu_AppendSeparator(menu);
 
       var listAccessToggle = Menu_AppendItem(
-        menu, 
-        "List Access", 
-        (s, e) => SetAccess(Access == GH_ParamAccess.list ? GH_ParamAccess.item : GH_ParamAccess.list), 
+        menu,
+        "List Access",
+        (s, e) => SetAccess(Access == GH_ParamAccess.list ? GH_ParamAccess.item : GH_ParamAccess.list),
         true,
         Access == GH_ParamAccess.list);
       listAccessToggle.ToolTipText = "Set this parameter as a List. If disabled, defaults to item access.";
       listAccessToggle.Image = Properties.Resources.StateTag_List;
-      
+
       var optionalToggle = Menu_AppendItem(
         menu,
         "Optional",
@@ -64,16 +67,16 @@ namespace ConnectorGrasshopper.Extras
         Optional);
       optionalToggle.ToolTipText = "Set this parameter as optional.";
       optionalToggle.Image = Properties.Resources.StateTag_Optional;
-      
+
       var detachToggle = Menu_AppendItem(
-        menu, 
-        "Do Not Detach", 
+        menu,
+        "Do Not Detach",
         (s, e) => SetDetach(!Detachable),
-        true, 
+        true,
         Detachable == false);
       detachToggle.ToolTipText = "Set this key as not detachable.";
       detachToggle.Image = Properties.Resources.StateTag_Detach;
-      
+
       Menu_AppendSeparator(menu);
 
       base.AppendAdditionalMenuItems(menu);
@@ -129,22 +132,4 @@ namespace ConnectorGrasshopper.Extras
     }
   }
 
-  public class OptionalStateTag: GH_StateTag
-  {
-    public override string Description => "Determines if a parameter is optional";
-    public override string Name => "Optional";
-    public override Bitmap Icon => Properties.Resources.StateTag_Optional_Large;
-  }
-  public class DetachedStateTag: GH_StateTag
-  {
-    public override string Description => "This property will not be detached";
-    public override string Name => "Do not detach";
-    public override Bitmap Icon => Properties.Resources.StateTag_Detach_Large;
-  }
-  public class ListAccesStateTag: GH_StateTag
-  {
-    public override string Description => "This parameter is set to List access";
-    public override string Name => "List Access";
-    public override Bitmap Icon => Properties.Resources.StateTag_List_Large;
-  }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStateTag.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStateTag.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using Grasshopper.GUI.Canvas;
+using Grasshopper.Kernel;
+
+namespace ConnectorGrasshopper.Extras
+{
+  public class OptionalStateTag : SpeckleStateTag
+  {
+    public override string Description => "Determines if a parameter is optional";
+    public override string Name => "Optional";
+    public override Bitmap Icon => Properties.Resources.StateTag_Optional;
+    public override bool Crossed => false;
+    public override string Letter => "?";
+  }
+
+  public class DetachedStateTag : SpeckleStateTag
+  {
+    public override string Description => "This property will not be detached";
+    public override string Name => "Do not detach";
+    public override Bitmap Icon => Properties.Resources.StateTag_Detach;
+    public override bool Crossed => true;
+    public override string Letter => "D";
+  }
+
+  public class ListAccesStateTag : SpeckleStateTag
+  {
+    public override string Description => "This parameter is set to List access";
+    public override string Name => "List Access";
+    public override Bitmap Icon => Properties.Resources.StateTag_List;
+    public override bool Crossed => false;
+    public override string Letter => "L";
+  }
+
+  public abstract class SpeckleStateTag : GH_StateTag
+  {
+    public override string Description { get; }
+    public override string Name { get; }
+    public override Bitmap Icon { get; }
+    
+    public abstract bool Crossed { get; }
+    
+    public abstract string Letter { get; }
+
+    public override void Render(Graphics graphics)
+    {
+      if (GH_Canvas.ZoomFadeLow < 5)
+        return;
+      
+      RenderSpeckleTagBlankIcon(graphics);
+      RenderSpeckleTagContents(graphics);
+      if (Crossed)
+        RenderRedDiagonalLine(graphics);
+      
+    }
+
+    public void RenderSpeckleTagBlankIcon(Graphics graphics)
+    {
+      int zoomFadeLow = GH_Canvas.ZoomFadeLow;
+      Rectangle stage = Stage;
+      --stage.Width;
+      --stage.Height;
+      stage.Inflate(-1, -1);
+      var roundedRectangle1 = GH_CapsuleRenderEngine.CreateRoundedRectangle(stage, 2);
+      stage.Inflate(-1, -1);
+      var roundedRectangle2 = GH_CapsuleRenderEngine.CreateRoundedRectangle(stage, 1);
+      var linearGradientBrush1 = new LinearGradientBrush(stage, Color.FromArgb(zoomFadeLow, 240, 240, 240),
+        Color.FromArgb(zoomFadeLow, 185, 185, 185), LinearGradientMode.Vertical);
+      var linearGradientBrush2 = new LinearGradientBrush(stage, Color.FromArgb(0, Color.White),
+        Color.FromArgb(Convert.ToInt32((double) zoomFadeLow * 0.8), Color.White), LinearGradientMode.Vertical);
+      linearGradientBrush1.WrapMode = WrapMode.TileFlipXY;
+      linearGradientBrush2.WrapMode = WrapMode.TileFlipXY;
+      Pen pen1 = new Pen(Color.FromArgb(zoomFadeLow, 10, 107, 252));
+      Pen pen2 = new Pen(linearGradientBrush2);
+      graphics.FillPath(linearGradientBrush1, roundedRectangle1);
+      // if (drawCallBack != null)
+      //   drawCallBack(graphics, (double) zoomFadeLow);
+      graphics.DrawPath(pen1, roundedRectangle1);
+      graphics.DrawPath(pen2, roundedRectangle2);
+      pen1.Dispose();
+      pen2.Dispose();
+      linearGradientBrush1.Dispose();
+      linearGradientBrush2.Dispose();
+      roundedRectangle1.Dispose();
+      roundedRectangle2.Dispose();
+    }
+    public void RenderSpeckleTagContents(Graphics graphics)
+    {
+      var p = new GraphicsPath();
+      p.AddString(Letter, FontFamily.GenericMonospace, 1, Stage.Height - 2,
+        new Point(Stage.Location.X + 1, this.Stage.Location.Y), null);
+      
+      LinearGradientBrush blueGradient = new LinearGradientBrush(Stage, Color.FromArgb(100, 10, 107, 252),
+        Color.FromArgb(Convert.ToInt32((double) GH_Canvas.ZoomFadeLow), Color.FromArgb(0, 10, 107, 252)),
+        LinearGradientMode.Vertical);
+      
+      graphics.FillPath(blueGradient, p);
+      blueGradient.Dispose();
+      p.Dispose();
+    }
+    public void RenderRedDiagonalLine(Graphics graphics)
+    {
+      var stage = Stage;
+      --stage.Height;
+      --stage.Width;
+      var offX = 3;
+      var offY = 4;
+      var ptA = new Point(stage.Location.X + stage.Width - offX, stage.Location.Y + offY);
+      var ptB = new Point(stage.Location.X + offX, stage.Location.Y + stage.Height - offY);
+      var g = new GraphicsPath();
+      g.AddLine(ptA, ptB);
+      var redPen = new Pen(Color.Firebrick);
+      graphics.DrawLine(redPen, ptA, ptB);
+      redPen.Dispose();
+      g.Dispose();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Refactored all state tag code into a `SpeckleStateTag` class, and derived the following:
- ListAccessStateTag
- DetachStateTag
- OptionalStateTag
These represent the small icons appearing at the side of the parameter name.

Implemented custom `Render` function to get nice Speckle style colors. 


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. 

- [x] Tests not required

