### PR TITLE
fix(Rhino,Autocad): error handling

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhino.csproj
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhino.csproj
@@ -52,6 +52,7 @@
     <Compile Include="SchemaBuilder\SchemaObjectFilter.cs" />
     <Compile Include="UI\ConnectorBindingsRhino.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj">
@@ -81,7 +82,6 @@
       Erase "$(TargetPath)"
     </PostBuildEvent>
   </PropertyGroup>
-
   <Target Name="Clean">
     <RemoveDir Directories="$(TargetDir);$(AppData)\McNeel\Rhinoceros\6.0\Plug-ins\SpeckleRhino2 (8dd5f30b-a13d-4a24-abdc-3e05c8c87143);$(AppData)\McNeel\Rhinoceros\7.0\Plug-ins\SpeckleRhino2 (8dd5f30b-a13d-4a24-abdc-3e05c8c87143)" />
   </Target>

--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -196,7 +196,6 @@ namespace SpeckleRhino
         return null;
       }
 
-
       converter.SetContextDocument(Doc);
 
       var stream = await state.Client.StreamGet(state.Stream.id);
@@ -249,156 +248,84 @@ namespace SpeckleRhino
       };
 
       // get commit layer name 
-      var layerName = Speckle.DesktopUI.Utils.Formatting.CommitLayer(stream.name, state.Branch.name, commitId);
-
-      var existingLayer = Doc.Layers.FindName(layerName);
+      var commitLayerName = Speckle.DesktopUI.Utils.Formatting.CommitLayer(stream.name, state.Branch.name, commitId);
+      var existingLayer = Doc.Layers.FindName(commitLayerName);
       if (existingLayer != null)
-      {
         Doc.Layers.Purge(existingLayer.Id, false);
-      }
-      var layerIndex = Doc.Layers.Add(layerName, System.Drawing.Color.Blue);
 
-      if (layerIndex == -1)
+      // flatten the commit object to retrieve children objs
+      var commitObjs = FlattenCommitObject(commitObject, converter, commitLayerName, state);
+
+      foreach (var commitObj in commitObjs)
       {
-        RaiseNotification($"Could not create layer {layerName} to bake objects into.");
-        state.Errors.Add(new Exception($"Could not create layer {layerName} to bake objects into."));
-        return state;
+        Base obj = commitObj.Item1;
+        string layerPath = commitObj.Item2;
+        
+        var converted = converter.ConvertToNative(obj) as Rhino.Geometry.GeometryBase;
+        if (converted != null)
+        {
+          Layer bakeLayer = Doc.GetLayer(layerPath, true);
+          if (bakeLayer != null)
+            Doc.Objects.Add(converted, new ObjectAttributes { LayerIndex = bakeLayer.Index });
+          else
+            state.Errors.Add(new Exception($"could not create layer {layerPath} to bake objects into."));
+        }
+        else
+          state.Errors.Add(new Exception($"Failed to convert object {obj.id} of type {obj.speckle_type}."));
+            
+        updateProgressAction?.Invoke();
       }
-      currentRootLayerName = layerName;
-      HandleAndConvert(commitObject, converter, Doc.Layers.FindIndex(layerIndex), state);
 
       Doc.Views.Redraw();
-
       Doc.EndUndoRecord(undoRecord);
 
       return state;
     }
 
-    /// <summary>
-    /// Used to hold in state for the handle and convert function below.
-    /// </summary>
-    private string currentRootLayerName;
-
-    private void HandleAndConvert(object obj, ISpeckleConverter converter, Layer layer, StreamState state, Action updateProgressAction = null)
+    // Recurses through the commit object and flattens it. Returns list of Base objects with their bake layers
+    private List<Tuple<Base, string>> FlattenCommitObject(object obj, ISpeckleConverter converter, string layer, StreamState state)
     {
-      Layer myLayer = null;
+      var objects = new List<Tuple<Base, string>>();
 
-      // The rhino layer api is a bit sucky, hence the result below. It probably can be cleaned up and optimised.
-      if (!layer.HasIndex || layer.Index == -1)
+      if (obj is Base @base)
       {
-        // Try and recreate layer structure if coming from Rhino.
-        if (layer.Name.Contains("::") || layer.FullPath.Contains("::"))
+        if (converter.CanConvertToNative(@base))
         {
-          var layers = layer.Name.Split(new string[] { "::" }, StringSplitOptions.RemoveEmptyEntries);
-          var ancestors = new List<Layer>();
-          var currentPath = currentRootLayerName;
-          foreach (var linkName in layers)
-          {
-            currentPath += $"::{linkName}";
-            var existingIndex = Doc.Layers.FindByFullPath(currentPath, -1);
-            if (existingIndex != -1)
-            {
-              ancestors.Add(Doc.Layers[existingIndex]);
-            }
-            else
-            {
-              var newLayer = new Layer() { Color = System.Drawing.Color.AliceBlue, Name = linkName };
-              if (ancestors.Count != 0)
-              {
-                newLayer.ParentLayerId = ancestors.Last().Id;
-              }
-              else
-              {
-                newLayer.ParentLayerId = layer.ParentLayerId;
-              }
-              var newIndex = Doc.Layers.Add(newLayer);
-              ancestors.Add(Doc.Layers[newIndex]);
-            }
-
-            layer = ancestors.Last();
-          }
+          objects.Add(new Tuple<Base, string>(@base, layer));
+          return objects;
         }
         else
         {
-          var index = Doc.Layers.Add(layer);
-          if (index == -1) // it means it exists already, and we're returning to a previously created higher level layer.
-          {
-            var fullPath = "";
-            if (layer.ParentLayerId != null)
-            {
-              var parent = Doc.Layers.FindId(layer.ParentLayerId);
-              fullPath += parent.FullPath + "::" + layer.Name;
-            }
-            var existingLayerIndex = Doc.Layers.FindByFullPath(fullPath, true);
-            layer.Index = Doc.Layers.FindIndex(existingLayerIndex).Index;
-          }
-          else
-          {
-            layer.Index = index;
-          }
-        }
-      }
+          if (@base.GetDynamicMembers().Count() == 0) // this was an unsupported geo
+            state.Errors.Add(new Exception($"Recieving {@base.speckle_type} objects is not supported. Object {@base.id} not baked."));
 
-      layer = Doc.Layers.FindIndex(layer.Index);
-
-      if (obj is Base baseItem)
-      {
-        if (converter.CanConvertToNative(baseItem))
-        {
-          var converted = converter.ConvertToNative(baseItem) as Rhino.Geometry.GeometryBase;
-          if (converted != null)
+          foreach (var prop in @base.GetDynamicMembers())
           {
-            Doc.Objects.Add(converted, new ObjectAttributes { LayerIndex = layer.Index });
-          }
-          else
-          {
-            state.Errors.Add(new Exception($"Failed to convert object {baseItem.id} of type {baseItem.speckle_type}."));
-          }
-          updateProgressAction?.Invoke();
-          return;
-        }
-        else
-        {
+            // get bake layer name
+            string objLayerName = prop.StartsWith("@") ? prop.Remove(0, 1) : prop;
+            string rhLayerName = $"{layer}{Layer.PathSeparator}{objLayerName}";
 
-          foreach (var prop in baseItem.GetDynamicMembers())
-          {
-            var value = baseItem[prop];
-            string layerName;
-            if (prop.StartsWith("@"))
-            {
-              layerName = prop.Remove(0, 1);
-            }
-            else
-            {
-              layerName = prop;
-            }
-
-            var subLayer = new Layer() { ParentLayerId = layer.Id, Color = System.Drawing.Color.Gray, Name = $"{layerName}" };
-            HandleAndConvert(value, converter, subLayer, state, updateProgressAction);
+            objects.AddRange(FlattenCommitObject(@base[prop], converter, rhLayerName, state));
           }
-
-          return;
+          return objects;
         }
       }
 
       if (obj is List<object> list)
       {
-
         foreach (var listObj in list)
-        {
-          HandleAndConvert(listObj, converter, layer, state, updateProgressAction);
-        }
-        return;
+          objects.AddRange(FlattenCommitObject(listObj, converter, layer, state));
+        return objects;
       }
 
       if (obj is IDictionary dict)
       {
         foreach (DictionaryEntry kvp in dict)
-        {
-          HandleAndConvert(kvp.Value, converter, layer, state, updateProgressAction);
-        }
-        return;
+          objects.AddRange(FlattenCommitObject(kvp.Value, converter, layer, state));
+        return objects;
       }
+
+      return objects;
     }
 
     #endregion
@@ -477,17 +404,17 @@ namespace SpeckleRhino
           converted[key] = obj.Attributes.GetUserString(key);
         }
 
-        var layerName = Doc.Layers[obj.Attributes.LayerIndex].FullPath; // sep is ::
-        string cleanLayerName = RemoveInvalidDynamicPropChars(layerName);
-        if (!cleanLayerName.Equals(layerName))
+        var layerPath = Doc.Layers[obj.Attributes.LayerIndex].FullPath; // sep is ::
+        string cleanLayerPath = RemoveInvalidDynamicPropChars(layerPath);
+        if (!cleanLayerPath.Equals(layerPath))
           renamedlayers = true;
 
-        if (commitObj[$"@{cleanLayerName}"] == null)
+        if (commitObj[$"@{cleanLayerPath}"] == null)
         {
-          commitObj[$"@{cleanLayerName}"] = new List<Base>();
+          commitObj[$"@{cleanLayerPath}"] = new List<Base>();
         }
 
-        ((List<Base>)commitObj[$"@{cleanLayerName}"]).Add(converted);
+        ((List<Base>)commitObj[$"@{cleanLayerPath}"]).Add(converted);
 
         objCount++;
       }
@@ -568,18 +495,14 @@ namespace SpeckleRhino
           objs = Doc.Objects.Where(obj => obj.Visible).Select(obj => obj.Id.ToString()).ToList();
           break;
         case ListSelectionFilter f:
-          foreach (var layerName in f.Selection)
+          foreach (var layerPath in f.Selection)
           {
-            int layerIndex = Doc.Layers.FindByFullPath(layerName, -1);
-            if (layerIndex >= 0)
+            Layer layer = Doc.GetLayer(layerPath);
+            if (layer != null && layer.IsVisible)
             {
-              Layer layer = Doc.Layers.FindIndex(layerIndex);
-              if (layer.IsVisible)
-              {
-                var layerObjs = Doc.Objects.FindByLayer(layer)?.Select(o => o.Id.ToString());
-                if (layerObjs != null)
-                  objs.AddRange(layerObjs);
-              }
+              var layerObjs = Doc.Objects.FindByLayer(layer)?.Select(o => o.Id.ToString());
+              if (layerObjs != null)
+                objs.AddRange(layerObjs);
             }
           }
           break;

--- a/ConnectorRhino/ConnectorRhino/Utils.cs
+++ b/ConnectorRhino/ConnectorRhino/Utils.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Speckle.Core.Kits;
+
+using Rhino;
+using Rhino.DocObjects;
+
+namespace SpeckleRhino
+{
+  public static class Utils
+  {
+    #region extension methods
+    /// <summary>
+    /// Finds a layer from its full path
+    /// </summary>
+    /// <param name="doc"></param>
+    /// <param name="path">Full path of layer</param>
+    /// <param name="MakeIfNull">Create the layer if it doesn't already exist</param>
+    /// <returns>Null on failure</returns>
+    public static Layer GetLayer(this RhinoDoc doc, string path, bool MakeIfNull = false)
+    {
+      int index = doc.Layers.FindByFullPath(path, RhinoMath.UnsetIntIndex);
+      Layer layer = doc.Layers.FindIndex(index);
+      if (layer == null && MakeIfNull)
+      {
+        var layerNames = path.Split(new string[] { Layer.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+
+        Layer parent = null;
+        string currentLayerPath = string.Empty;
+        Layer currentLayer = null;
+        for (int i = 0; i < layerNames.Length; i++)
+        {
+          currentLayerPath = (i == 0) ? layerNames[i] : $"{currentLayerPath}{Layer.PathSeparator}{layerNames[i]}";
+          currentLayer = doc.GetLayer(currentLayerPath);
+          if (currentLayer == null)
+            currentLayer = MakeLayer(doc, layerNames[i], parent);
+          if (currentLayer == null)
+            break;
+          parent = currentLayer;
+        }
+        layer = currentLayer;
+      }
+      return layer;
+    } 
+    #endregion
+
+    #region internal methods
+    private static Layer MakeLayer(RhinoDoc doc, string name, Layer parentLayer = null)
+    {
+      Layer newLayer = new Layer() { Color = System.Drawing.Color.AliceBlue, Name = name };
+      if (parentLayer != null)
+        newLayer.ParentLayerId = parentLayer.Id;
+      int newIndex = doc.Layers.Add(newLayer);
+      if ( newIndex < 0)
+        return null;
+      else
+        return doc.Layers.FindIndex(newIndex);
+    }
+    #endregion
+  }
+}

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
@@ -22,12 +22,6 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
-    /*
-    public RH.Curve ModelCurveToNative(RV.Curve.ModelCurve curve)
-    {
-      return new RH.Curve();
-    }
-    */
 
     public Column CurveToSpeckleColumn(RH.Curve curve)
     {
@@ -103,11 +97,6 @@ namespace Objects.Converter.RhinoGh
       string type = "Default";
       try { family = args[0]; type = args[1]; } catch { }
       return new RV.RevitFaceWall(family, type, BrepToSpeckle(brep), null) { units = ModelUnits };
-    }
-
-    public object DirectShapeToNative(RV.DirectShape shape)
-    {
-      return new object();
     }
 
     public RV.DirectShape BrepToDirectShape(RH.Brep brep, string[] args)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
@@ -22,6 +22,13 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
+    /*
+    public RH.Curve ModelCurveToNative(RV.Curve.ModelCurve curve)
+    {
+      return new RH.Curve();
+    }
+    */
+
     public Column CurveToSpeckleColumn(RH.Curve curve)
     {
       return new Column((ICurve)ConvertToSpeckle(curve)) { units = ModelUnits };
@@ -96,6 +103,11 @@ namespace Objects.Converter.RhinoGh
       string type = "Default";
       try { family = args[0]; type = args[1]; } catch { }
       return new RV.RevitFaceWall(family, type, BrepToSpeckle(brep), null) { units = ModelUnits };
+    }
+
+    public object DirectShapeToNative(RV.DirectShape shape)
+    {
+      return new object();
     }
 
     public RV.DirectShape BrepToDirectShape(RH.Brep brep, string[] args)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -14,10 +14,12 @@ using Box = Objects.Geometry.Box;
 using Brep = Objects.Geometry.Brep;
 using Circle = Objects.Geometry.Circle;
 using Curve = Objects.Geometry.Curve;
+using DirectShape = Objects.BuiltElements.Revit.DirectShape;
 using Ellipse = Objects.Geometry.Ellipse;
 using Interval = Objects.Primitive.Interval;
 using Line = Objects.Geometry.Line;
 using Mesh = Objects.Geometry.Mesh;
+using ModelCurve = Objects.BuiltElements.Revit.Curve.ModelCurve;
 using Plane = Objects.Geometry.Plane;
 using Point = Objects.Geometry.Point;
 using Polyline = Objects.Geometry.Polyline;
@@ -291,12 +293,18 @@ namespace Objects.Converter.RhinoGh
           // Brep conversion should always fallback to mesh if it fails.
           var b = BrepToNative(o);
           if (b == null)
-            return MeshToNative(o.displayMesh);
+            return (o.displayMesh != null) ? MeshToNative(o.displayMesh) : null;
           else
             return b;
 
         case Surface o:
           return SurfaceToNative(o);
+
+        case ModelCurve o:
+          return CurveToNative(o.baseCurve);
+
+        case DirectShape o:
+          return (o.displayMesh != null) ? MeshToNative(o.displayMesh) : null;
 
         default:
           throw new NotSupportedException();
@@ -438,6 +446,12 @@ namespace Objects.Converter.RhinoGh
           return true;
 
         case Surface _:
+          return true;
+
+        case ModelCurve _:
+          return true;
+
+        case DirectShape _:
           return true;
 
         default:

--- a/Objects/Objects/BuiltElements/Revit/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Revit/DirectShape.cs
@@ -5,15 +5,18 @@ using System.Collections.Generic;
 
 namespace Objects.BuiltElements.Revit
 {
-  public class DirectShape : Base
+  public class DirectShape : Base , IDisplayMesh
   {
     public string name { get; set; }
     public RevitCategory category { get; set; }
+    public List<Parameter> parameters { get; set; }
+    public string elementId { get; set; }
 
     [DetachProperty]
     public List<Base> baseGeometries { get; set; }
-    public List<Parameter> parameters { get; set; }
-    public string elementId { get; set; }
+
+    [DetachProperty]
+    public Mesh displayMesh { get; set; }
 
     public DirectShape() { }
 


### PR DESCRIPTION
## Description

Rhino:
  - Refactored receiving commit obj logic and layer creation
  - Fixed bug that created bake layers even if no objects where converted (empty layers currently still will be created if base is successfully converted but not successfully added to doc)
  - Added correct warnings for failure to bake supported and unsupported objects with no dynamic props
  - Added  `ModelCurve` (basecurve) and `DirectShape` (displaymesh) ConvertToNative handling

Autocad:
  - Added correct warnings for failure to bake unsupported objects with no dynamic props

Objects:
  - DirectShape class now inheriting from `IDisplayMesh`

Fixes #341 
Fixes #342
Fixes #347 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Rhino:
Tested receiving Rhino test streams for Standard Geometry, BuiltElement Geometry, and Edge Case Geometry
Tested receiving Revit test stream for Standard Geometry

Autocad:
Tested receiving Rhino test streams for Standard Geometry

- Unit/Integration Tests
- Manual Tests

## Docs

- No updates needed
