### PR TITLE
Feat: add render material support for schemabuilder

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -128,6 +128,8 @@ namespace ConnectorGrasshopper
     {
       // get property name and value
       Type propType = param.ParameterType;
+      if (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(Nullable<>))
+        propType = Nullable.GetUnderlyingType(propType);
 
       string propName = param.Name;
       object propValue = param;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -152,6 +152,8 @@ namespace ConnectorGrasshopper
 
       newInputParam.Description = $"({propType.Name}) {d}";
       newInputParam.Optional = param.IsOptional;
+      if (param.IsOptional)
+        newInputParam.SetPersistentData(param.DefaultValue);
 
       // check if input needs to be a list or item access
       bool isCollection = typeof(System.Collections.IEnumerable).IsAssignableFrom(propType) && propType != typeof(string) && !propType.Name.ToLower().Contains("dictionary");

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectDialog.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectDialog.cs
@@ -226,7 +226,10 @@ namespace ConnectorGrasshopper
         {
           var inputDesc = p.GetCustomAttribute<SchemaParamInfo>();
           var d = inputDesc != null ? $": {inputDesc.Description}" : "";
-          description += $"\n- {p.Name} ({p.ParameterType.Name}){d}";
+          var type = p.ParameterType;
+          if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            type = Nullable.GetUnderlyingType(type);
+          description += $"\n- {p.Name} ({type.Name}){d}";
           if (p.IsOptional)
           {
             var def = p.DefaultValue == null ? "null" : p.DefaultValue.ToString();

--- a/Objects/Objects/Other/RenderMaterial.cs
+++ b/Objects/Objects/Other/RenderMaterial.cs
@@ -1,4 +1,5 @@
 ﻿using Speckle.Core.Models;
+using Speckle.Core.Kits;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -17,17 +18,22 @@ namespace Objects.Other
   public class RenderMaterial : Base
   {
     public string name { get; set; }
-
     public double opacity { get; set; } = 1;
-
     public double metalness { get; set; } = 0;
-
     public double roughness { get; set; } = 1;
-
     public int diffuse { get; set; } = Color.LightGray.ToArgb();
-
     public int emissive { get; set; } = Color.Black.ToArgb();
 
     public RenderMaterial() { }
+
+    [SchemaInfo("RenderMaterial", "Creates a render material.")]
+    public RenderMaterial(double opacity = 1, double metalness = 0, double roughness = 1, Color? diffuse = null, Color? emissive = null)
+    {
+      this.opacity = opacity;
+      this.metalness = metalness;
+      this.roughness = roughness;
+      this.diffuse = (diffuse.HasValue) ? diffuse.Value.ToArgb() : Color.LightGray.ToArgb();
+      this.emissive = (emissive.HasValue) ? emissive.Value.ToArgb() : Color.Black.ToArgb();
+    }
   }
 }


### PR DESCRIPTION
## Description

Render material support for schemabuilder:
-  Objects: Added schemabuilder constructor. Constructor uses `System.Color` for diffuse and emissive props and converts to int internally to make GH component easier to use.
-  GH: Added default value to Create Schema Object optional params
-  GH: Added Nullable type checking for descriptive type text

Fixes #315

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sent [rendermaterial from gh](https://latest.speckle.dev/streams/dc5e51ffd4/commits/c51c1c0919) and created a few other [schemabuilder objects with render material](https://latest.speckle.dev/streams/dc5e51ffd4/commits/f76972e2d3)

## Docs

- No updates needed

