### PR TITLE
bug(core): improve stream wrapper uri parsing logic

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStreamParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStreamParam.cs
@@ -70,7 +70,6 @@ namespace ConnectorGrasshopper.Extras
     public override bool CastFrom(object source)
     {
       var t = source.GetType();
-      var tt = t;
 
       if(source is GH_String ghStr)
       {
@@ -81,7 +80,7 @@ namespace ConnectorGrasshopper.Extras
         }
         catch
         {
-          return false;
+          throw;
         }
       }
 

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -118,11 +118,6 @@ namespace Speckle.Core.Credentials
       Uri uri = new Uri(streamUrl);
       ServerUrl = uri.GetLeftPart(UriPartial.Authority);
 
-      if (uri.Segments.Length < 3)
-      {
-        throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.");
-      }
-
       switch (uri.Segments.Length)
       {
         case 3: // ie http://speckle.server/streams/8fecc9aa6d
@@ -158,6 +153,9 @@ namespace Speckle.Core.Credentials
           }
 
           break;
+
+        default:
+          throw new SpeckleException($"Cannot parse {uri} into a stream wrapper class.");
       }
     }
 


### PR DESCRIPTION
- Previously: only throwing exception for uri count < 3. Now throws `SpeckleException` in all cases of incorrect uri segment count (anything other than 3 or 5).
- `GH_SpeckleStream` class throws `SpeckleException` on failure to cast string to stream instead of returning false on cast method.

Fixes #329

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: tested with Grasshopper Stream Details component

![image](https://user-images.githubusercontent.com/16748799/112065048-e7ab9a80-8b5b-11eb-8739-524712186b9a.png)

## Docs

- No updates needed

