### PR TITLE
fix(desktopui): handle commit deleted event

### DIFF
--- a/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.Events.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Speckle.Core.Api;
 using Speckle.Core.Api.SubscriptionModels;
-using Speckle.Core.Models;
 using Stylet;
 
 namespace Speckle.DesktopUI.Utils
@@ -121,12 +121,17 @@ namespace Speckle.DesktopUI.Utils
       var binfo = Branches.FirstOrDefault(b => b.name == info.branchName);
       var cinfo = binfo.commits.items.FirstOrDefault(c => c.id == info.id);
 
-      if (Branch.name == info.branchName)
-      {
-        Branch = binfo;
-      }
-
       ServerUpdateSummary = $"{cinfo.authorName} sent new data on branch {info.branchName}: {info.message}";
+      ServerUpdates = true;
+    }
+
+    private async void HandleCommitDeleted(object sender, CommitInfo info)
+    {
+      Branches = await Client.StreamGetBranches(Stream.id);
+
+      if ( IsSenderCard ) return;
+
+      ServerUpdateSummary = $"Commit {info.id} has been deleted";
       ServerUpdates = true;
     }
 

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -508,7 +508,7 @@ namespace Speckle.DesktopUI.Utils
 
       Client.OnStreamUpdated += HandleStreamUpdated;
       Client.OnCommitCreated += HandleCommitCreated;
-      Client.OnCommitDeleted += HandleCommitCreated;
+      Client.OnCommitDeleted += HandleCommitDeleted;
       Client.OnCommitUpdated += HandleCommitUpdated;
       // BUG: due to subs bug, these all have to be handled by fetching new list from server
       Client.OnBranchCreated += HandleBranchCreated;


### PR DESCRIPTION
previously, commit created and deleted were handled by the same event
as the handler just updates the branches.

however, we now show a notification with info on the event.
branch name is only returned on commit created, so a diff handler is
now needed for commit deleted. this is the fix!

tested manually in both Rhino & Revit

closes #371