### PR TITLE
refactor(tests): move server info to fixtures

### DIFF
--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -7,17 +7,10 @@ using Speckle.Core.Models;
 using Speckle.Core.Transports;
 using Tests;
 
-////////////////////////////////////////////////////////////////////////////
-/// NOTE:                                                                ///
-/// These tests don't run without a server running locally.              ///
-/// Check out https://github.com/specklesystems/server for               ///
-/// more info on the server.                                             ///
-////////////////////////////////////////////////////////////////////////////
 namespace TestsIntegration
 {
   public class Api
   {
-    public ServerInfo testServer;
     public Account firstUserAccount, secondUserAccount;
 
     public Client myClient;
@@ -32,10 +25,8 @@ namespace TestsIntegration
     [OneTimeSetUp]
     public void Setup()
     {
-      testServer = new ServerInfo { url = "https://latest.speckle.dev", name = "TestServer" };
-
-      firstUserAccount = Fixtures.SeedUser(testServer);
-      secondUserAccount = Fixtures.SeedUser(testServer);
+      firstUserAccount = Fixtures.SeedUser();
+      secondUserAccount = Fixtures.SeedUser();
 
       myClient = new Client(firstUserAccount);
       myServerTransport = new ServerTransport(firstUserAccount, null);

--- a/Core/IntegrationTests/Fixtures.cs
+++ b/Core/IntegrationTests/Fixtures.cs
@@ -14,7 +14,9 @@ namespace TestsIntegration
 {
   public static class Fixtures
   {
-    public static Account SeedUser(ServerInfo server)
+    public static readonly ServerInfo Server = new ServerInfo { url = "https://latest.speckle.dev", name = "Test Server" };
+    
+    public static Account SeedUser()
     {
       var seed = Guid.NewGuid().ToString().ToLower();
       var user = new Dictionary<string, string>();
@@ -22,7 +24,7 @@ namespace TestsIntegration
       user["password"] = "12ABC3456789DEF0GHO";
       user["name"] = $"{seed.Substring(0, 5)} Name";
 
-      var registerRequest = (HttpWebRequest)WebRequest.Create($"{server.url}/auth/local/register?challenge=challengingchallenge");
+      var registerRequest = (HttpWebRequest)WebRequest.Create($"{Server.url}/auth/local/register?challenge=challengingchallenge");
       registerRequest.Method = "POST";
       registerRequest.ContentType = "application/json";
       registerRequest.AllowAutoRedirect = false;
@@ -55,7 +57,7 @@ namespace TestsIntegration
         }
       }
 
-      var tokenRequest = (HttpWebRequest)WebRequest.Create($"{server.url}/auth/token");
+      var tokenRequest = (HttpWebRequest)WebRequest.Create($"{Server.url}/auth/token");
       tokenRequest.Method = "POST";
       tokenRequest.ContentType = "application/json";
 
@@ -85,8 +87,8 @@ namespace TestsIntegration
         deserialised = JsonConvert.DeserializeObject<Dictionary<string, string>>(text);
       }
 
-      var acc = new Account { token = deserialised["token"], userInfo = new UserInfo { id = user["name"], email = user["email"] }, serverInfo = server };
-      var client = new Speckle.Core.Api.Client(acc);
+      var acc = new Account { token = deserialised["token"], userInfo = new UserInfo { id = user["name"], email = user["email"] }, serverInfo = Server };
+      var client = new Client(acc);
 
       var user1 = client.UserGet().Result;
       acc.userInfo.id = user1.id;

--- a/Core/IntegrationTests/Subscriptions/Branches.cs
+++ b/Core/IntegrationTests/Subscriptions/Branches.cs
@@ -11,7 +11,6 @@ namespace TestsIntegration.Subscriptions
   public class Branches
   {
     public Client client;
-    public ServerInfo testServer;
     public Account testUserAccount;
 
     private BranchInfo BranchCreatedInfo;
@@ -23,8 +22,7 @@ namespace TestsIntegration.Subscriptions
     [OneTimeSetUp]
     public void Setup()
     {
-      testServer = new ServerInfo { url = "https://testing.speckle.dev", name = "TestServer" };
-      testUserAccount = Fixtures.SeedUser(testServer);
+      testUserAccount = Fixtures.SeedUser();
       client = new Client(testUserAccount);
     }
 

--- a/Core/IntegrationTests/Subscriptions/Commits.cs
+++ b/Core/IntegrationTests/Subscriptions/Commits.cs
@@ -16,7 +16,6 @@ namespace TestsIntegration.Subscriptions
   public class Commits
   {
     public Client client;
-    public ServerInfo testServer;
     public Account testUserAccount;
 
     private CommitInfo CommitCreatedInfo;
@@ -29,8 +28,7 @@ namespace TestsIntegration.Subscriptions
     [OneTimeSetUp]
     public void Setup()
     {
-      testServer = new ServerInfo { url = "https://testing.speckle.dev", name = "TestServer" };
-      testUserAccount = Fixtures.SeedUser(testServer);
+      testUserAccount = Fixtures.SeedUser();
       client = new Client(testUserAccount);
       myServerTransport = new ServerTransport(testUserAccount, null);
     }

--- a/Core/IntegrationTests/Subscriptions/Streams.cs
+++ b/Core/IntegrationTests/Subscriptions/Streams.cs
@@ -11,7 +11,6 @@ namespace TestsIntegration.Subscriptions
   public class Streams
   {
     public Client client;
-    public ServerInfo testServer;
     public Account testUserAccount;
 
     private StreamInfo StreamAddedInfo;
@@ -22,8 +21,7 @@ namespace TestsIntegration.Subscriptions
     [OneTimeSetUp]
     public void Setup()
     {
-      testServer = new ServerInfo { url = "https://testing.speckle.dev", name = "TestServer" };
-      testUserAccount = Fixtures.SeedUser(testServer);
+      testUserAccount = Fixtures.SeedUser();
       client = new Client(testUserAccount);
     }
 


### PR DESCRIPTION
## Description

Refactor tests to use our new testing server. Also extracts the individual `testServer` definitions and consolidates them to one place - fixtures. `SeedUser` no longer takes server as an argument and just uses the server defined in the fixtures.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Unit/Integration Tests (which?)

NOTE: cannot merge this right now as tests fail when using `https://latest.speckle.dev` despite working with `https://testing.speckle.dev`. this is because the register post request returns a 400 error on `latest`
