### PR TITLE
fix(revit):disallowing column joins

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -91,6 +91,8 @@ namespace Objects.Converter.Revit
       if (revitColumn == null && isLineBased)
       {
         revitColumn = Doc.Create.NewFamilyInstance(baseLine, familySymbol, level, structuralType);
+        StructuralFramingUtils.DisallowJoinAtEnd(revitColumn, 0);
+        StructuralFramingUtils.DisallowJoinAtEnd(revitColumn, 1);
       }
 
       //try with a point based column


### PR DESCRIPTION
## Description

Disallows joins on column ends

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: sent some columns from rhino

## Docs

- No updates needed

