### PR TITLE
fix(revit): check for cancellation when converting

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -103,6 +103,13 @@ namespace Speckle.ConnectorRevit.UI
           // needs to be set for openings in floors and roofs to work
           converter.SetContextObjects(flattenedObjects.Select(x => new ApplicationPlaceholderObject { applicationId = x.applicationId, NativeObject = x }).ToList());
           var newPlaceholderObjects = ConvertReceivedObjects(flattenedObjects, converter, state);
+          // receive was cancelled by user
+          if ( newPlaceholderObjects == null )
+          {
+            converter.ConversionErrors.Add(new Exception("fatal error: receive cancelled by user"));
+            t.RollBack();
+            return;
+          }
 
           DeleteObjects(previouslyReceiveObjects, newPlaceholderObjects);
 
@@ -169,6 +176,12 @@ namespace Speckle.ConnectorRevit.UI
 
       foreach (var @base in objects)
       {
+        if ( state.CancellationTokenSource.Token.IsCancellationRequested )
+        {
+          placeholders = null;
+          break;
+        }
+
         try
         {
           conversionProgressDict["Conversion"]++;


### PR DESCRIPTION
## Description

Let users cancel the receive during conversion. We were previously not checking for cancellation while objects were being converted. This checks and rolls back the commit if cancellation was requested.

- Fixes issue reported by Alan

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

-  Manual tests in Revit with the stream Alan reported 

## Docs

- No updates needed


