### PR TITLE
rhino(fix): better column and beam conversions

### DIFF
--- a/ConnectorRhino/ConnectorRhino/SchemaBuilder/SchemaObjectFilter.cs
+++ b/ConnectorRhino/ConnectorRhino/SchemaBuilder/SchemaObjectFilter.cs
@@ -123,7 +123,9 @@ namespace SpeckleRhino
           {
             Curve crv = obj.Geometry as Curve; // assumes this has already been filtered for linearity
             double angleRad = Vector3d.VectorAngle(crv.PointAtEnd - crv.PointAtStart, Vector3d.ZAxis);
-            if (angleRad < Math.PI/4)
+            if (angleRad > Math.PI / 2)
+              angleRad = Math.PI - angleRad;
+            if (angleRad < Math.PI / 4)
               return true;
           }
           catch { }
@@ -133,6 +135,8 @@ namespace SpeckleRhino
           {
             Curve crv = obj.Geometry as Curve; // assumes this has already been filtered for linearity
             double angleRad = Vector3d.VectorAngle(crv.PointAtEnd - crv.PointAtStart, Vector3d.ZAxis);
+            if (angleRad > Math.PI / 2)
+              angleRad = Math.PI - angleRad;
             if (angleRad >= Math.PI / 4)
               return true;
           }

--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -319,7 +319,10 @@ namespace SpeckleRhino
             }
           }
           if (!foundConvertibleMember && count == totalMembers) // this was an unsupported geo
+          {
+            // try to get displaymesh instead
             state.Errors.Add(new Exception($"Receiving {@base.speckle_type} objects is not supported. Object {@base.id} not baked."));
+          }
           return objects;
         }
       }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
@@ -69,16 +69,6 @@ namespace Objects.Converter.RhinoGh
       return floor;
     }
 
-    public Ceiling BrepToSpeckleCeiling(RH.Brep brep)
-    {
-      Ceiling ceiling = null;
-      var extCurves = GetSurfaceBrepEdges(brep, getExterior: true); // extract outline
-      var intCurves = GetSurfaceBrepEdges(brep, getInterior: true); // extract voids
-      if (extCurves != null)
-        ceiling = new Ceiling(extCurves[0], intCurves) { units = ModelUnits };
-      return ceiling;
-    }
-
     public Roof BrepToSpeckleRoof(RH.Brep brep)
     {
       Roof roof = null;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -194,9 +194,6 @@ namespace Objects.Converter.RhinoGh
             case "Floor":
               return BrepToSpeckleFloor(o);
 
-            case "Ceiling":
-              return BrepToSpeckleCeiling(o);
-
             case "Roof":
               return BrepToSpeckleRoof(o);
 
@@ -216,6 +213,9 @@ namespace Objects.Converter.RhinoGh
         case RH.Extrusion o:
           switch (schema)
           {
+            case "FaceWall":
+              return BrepToFaceWall(o.ToBrep(), args);
+
             case "DirectShape":
               return ExtrusionToDirectShape(o, args);
 


### PR DESCRIPTION
## Description

Improves the beams and columns builtelements conversion logic slightly by accounting for "flipped" endpoints. Also removes deprecated ceiling methods.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- Will be updated ASAP (remove ceiling from supported conversions)

