### PR TITLE
fix(core): fixes #356 and prevents dupes dynamic properties (detached…

### DIFF
--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -31,6 +31,48 @@ namespace Tests
       //Assert.Throws<Exception>(() => { @base["id"] = "Testing"; });
     }
 
+    [Test(Description = "Checks if detachable properties are set and retrieved correctly")]
+    public void DetachableProperties()
+    {
+      var sample = new SampleObject();
+
+      // New non-detached prop created 
+      sample["attached"] = "A";
+
+      // Update value of non-detached prop
+      sample["@attached"] = "B";
+
+      Assert.AreEqual("B", sample["attached"]);
+      Assert.AreEqual("B", sample["@attached"]);
+
+      // New detached prop created 
+      sample["@detached"] = "A";
+
+      // Update value of detached prop
+      sample["detached"] = "B";
+
+      Assert.AreEqual("B", sample["detached"]);
+      Assert.AreEqual("B", sample["@detached"]);
+
+      // non-detached prop set 
+      sample.attachedProp = new SampleProp { name = "Mario" };
+
+      // Update value of non-detached prop
+      ((SampleProp)sample["@attachedProp"]).name = "Giovanni";
+
+      Assert.AreEqual("Giovanni", ((SampleProp)sample["attachedProp"]).name);
+
+      // non-detached prop set 
+      sample.detachedProp = new SampleProp { name = "Luca" };
+
+      // Update value of non-detached prop
+      ((SampleProp)sample["@detachedProp"]).name = "Mirco";
+
+      Assert.AreEqual("Mirco", ((SampleProp)sample["detachedProp"]).name);
+
+
+    }
+
     [Test]
     public void CountDynamicChunkables()
     {
@@ -84,7 +126,17 @@ namespace Tests
       [DetachProperty]
       public double[] arr { get; set; }
 
+      [DetachProperty]
+      public SampleProp detachedProp { get; set; }
+
+      public SampleProp attachedProp { get; set; }
+
       public SampleObject() { }
+    }
+
+    public class SampleProp
+    {
+      public string name { get; set; }
     }
   }
 }

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -70,6 +70,13 @@ namespace Tests
 
       Assert.AreEqual("Mirco", ((SampleProp)sample["detachedProp"]).name);
 
+      sample["crazyProp"] = "Test1";
+
+      Assert.AreEqual("Test1", sample.crazyProp);
+
+      sample["@crazyProp"] = "Test2";
+
+      Assert.AreEqual("Test2", sample.crazyProp);
 
     }
 
@@ -130,6 +137,8 @@ namespace Tests
       public SampleProp detachedProp { get; set; }
 
       public SampleProp attachedProp { get; set; }
+
+      public string @crazyProp { get; set; }
 
       public SampleObject() { }
     }

--- a/Core/Tests/TestKit.cs
+++ b/Core/Tests/TestKit.cs
@@ -98,7 +98,7 @@ namespace Tests
     [DetachProperty]
     [Chunkable(2500)]
     public List<Tabletop> Tables { get; set; } = new List<Tabletop>();
-  
+
     public FakeMesh() { }
   }
 


### PR DESCRIPTION
## Description

-  fixes #356 and prevents dupes dynamic properties (detached and non detached) to exist

For dynamic props, now the logic is that a prop becomes `detached` or `non detached` the first time it's created. Afterwards, it can be either accessed with `base["@prop"]` or `base["prop"]` equally.

For typed props, they can now be accessed with `base["@prop"]` or `base["prop"]` equally whether they are detached or not.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- New tests were made

## Docs

- Will be updated ASAP

