### PR TITLE
feat(desktopui): make commit message ui more prominent

### DIFF
--- a/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
@@ -636,7 +636,7 @@
                     Opacity="0.5" />
                   <TextBox Grid.Column="0"
                     Margin="20,0,20,20"
-                    md:HintAssist.HelperText="Commit message - keep track of changes made and the reasons behind them"
+                    md:HintAssist.HelperText="Commit message - keep track of changes made. Defaults to 'Pushed X elements'"
                     md:TextBlockAssist.AutoToolTip="False"
                     s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
                     PreviewKeyDown="{s:Action SendWithCommitMessage}"

--- a/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsView.xaml
@@ -1,15 +1,15 @@
 ﻿<UserControl x:Class="Speckle.DesktopUI.Streams.AllStreamsView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:Speckle.DesktopUI.Streams"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
-             xmlns:s="https://github.com/canton7/Stylet"
-             xmlns:utils="clr-namespace:Speckle.DesktopUI.Utils"
-             d:DesignHeight="450"
-             d:DesignWidth="600"
-             mc:Ignorable="d">
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:local="clr-namespace:Speckle.DesktopUI.Streams"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+  xmlns:s="https://github.com/canton7/Stylet"
+  xmlns:utils="clr-namespace:Speckle.DesktopUI.Utils"
+  d:DesignHeight="450"
+  d:DesignWidth="600"
+  mc:Ignorable="d">
   <UserControl.Resources>
     <ResourceDictionary>
 
@@ -20,14 +20,14 @@
       <!--#region Branch Swapping Button (Sender/Receiver shared)-->
       <ControlTemplate x:Key="BranchButton">
         <Button x:Name="BranchButton"
-                Width="auto"
-                Padding="10,0"
-                HorizontalAlignment="Left"
-                local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
-                md:ButtonAssist.CornerRadius="3"
-                ContextMenuService.Placement="Bottom"
-                FontSize="12"
-                Style="{StaticResource MaterialDesignFlatButton}">
+          Width="auto"
+          Padding="10,0"
+          HorizontalAlignment="Left"
+          local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
+          md:ButtonAssist.CornerRadius="3"
+          ContextMenuService.Placement="Bottom"
+          FontSize="12"
+          Style="{StaticResource MaterialDesignFlatButton}">
           <Button.ToolTip>
             <TextBlock>
               <Run Text="Current branch is" />
@@ -42,39 +42,39 @@
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <md:PackIcon Grid.Column="0"
-                         Margin="0,0,0,0"
-                         HorizontalAlignment="Left"
-                         Kind="SourceBranch" />
+              Margin="0,0,0,0"
+              HorizontalAlignment="Left"
+              Kind="SourceBranch" />
             <TextBlock Grid.Column="1"
-                       Margin="4,0"
-                       FontWeight="Normal"
-                       Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext.Branch.name}" />
+              Margin="4,0"
+              FontWeight="Normal"
+              Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext.Branch.name}" />
           </Grid>
           <Button.Resources>
             <local:BindingProxy x:Key="Proxy"
-                                Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
+              Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
           </Button.Resources>
           <Button.ContextMenu>
             <ContextMenu FontSize="12"
-                         ItemsSource="{Binding BranchContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+              ItemsSource="{Binding BranchContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
               <ContextMenu.ItemTemplate>
                 <DataTemplate>
                   <Grid Background="Transparent"
-                        ToolTip="{Binding Tooltip}">
+                    ToolTip="{Binding Tooltip}">
                     <Grid.InputBindings>
                       <MouseBinding Command="{s:Action SwitchBranch}"
-                                    CommandParameter="{Binding CommandArgument}"
-                                    Gesture="LeftClick" />
+                        CommandParameter="{Binding CommandArgument}"
+                        Gesture="LeftClick" />
                     </Grid.InputBindings>
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="20" />
                       <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <md:PackIcon Grid.Column="0"
-                                 Kind="{Binding Icon.Kind}" />
+                      Kind="{Binding Icon.Kind}" />
                     <TextBlock Grid.Column="1"
-                               Text="{Binding Branch.name}"
-                               TextAlignment="Left" />
+                      Text="{Binding Branch.name}"
+                      TextAlignment="Left" />
                   </Grid>
                 </DataTemplate>
               </ContextMenu.ItemTemplate>
@@ -87,30 +87,25 @@
       <!--#region Sender Selection/Filters Button (Sender)-->
       <ControlTemplate x:Key="SelectionButton">
         <Button x:Name="SelectionButton"
-                MinWidth="120"
-                Padding="5"
-                HorizontalAlignment="Left"
-                local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="true"
-                md:ButtonAssist.CornerRadius="3"
-                FontSize="12"
-                FontWeight="Normal">
+          MinWidth="120"
+          Padding="5"
+          HorizontalAlignment="Left"
+          local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="true"
+          md:ButtonAssist.CornerRadius="3"
+          FontSize="12"
+          FontWeight="Normal">
           <Button.Style>
             <Style BasedOn="{StaticResource MaterialDesignRaisedButton}"
-                   TargetType="Button">
+              TargetType="Button">
               <Style.Triggers>
-                <DataTrigger Binding="{Binding SendDisabled}"
-                             Value="True">
-                  <Setter Property="md:ShadowAssist.ShadowDepth"
-                          Value="Depth3" />
-                </DataTrigger>
                 <DataTrigger Binding="{Binding SendEnabled}"
-                             Value="True">
+                  Value="True">
                   <Setter Property="Background"
-                          Value="Transparent" />
+                    Value="Transparent" />
                   <Setter Property="BorderBrush"
-                          Value="Transparent" />
+                    Value="Transparent" />
                   <Setter Property="Foreground"
-                          Value="{StaticResource PrimaryHueMidBrush}" />
+                    Value="{StaticResource PrimaryHueMidBrush}" />
                 </DataTrigger>
               </Style.Triggers>
             </Style>
@@ -118,7 +113,7 @@
           <Button.ToolTip>
             <TextBlock>
               <Run FontWeight="Bold"
-                   Text="{Binding ObjectSelectionTooltipText, Mode=OneWay}" />
+                Text="{Binding ObjectSelectionTooltipText, Mode=OneWay}" />
               <LineBreak />
               <Run Text="Click to change." />
             </TextBlock>
@@ -129,23 +124,23 @@
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <md:PackIcon Grid.Column="0"
-                         Kind="{Binding ObjectSelectionButtonIcon.Kind}" />
+              Kind="{Binding ObjectSelectionButtonIcon.Kind}" />
             <TextBlock Grid.Column="2"
-                       Margin="5,2"
-                       FontWeight="Normal">
+              Margin="5,2"
+              FontWeight="Normal">
               <Run Text="{Binding ObjectSelectionButtonText, Mode=OneWay}" />
             </TextBlock>
           </Grid>
           <Button.Resources>
             <local:BindingProxy x:Key="Proxy"
-                                Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+              Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}}" />
           </Button.Resources>
           <Button.ContextMenu>
             <ContextMenu FontSize="12">
               <MenuItem Command="{s:Action ShowStreamUpdateObjectsDialog}"
-                        CommandParameter="{Binding}"
-                        ToolTip="A filter will run automatically and dynamically select elements that match when sending."
-                        Visibility="{Binding AppHasFilters, Converter={StaticResource BooleanToVisibilityConverter}}">
+                CommandParameter="{Binding}"
+                ToolTip="A filter will run automatically and dynamically select elements that match when sending."
+                Visibility="{Binding AppHasFilters, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <MenuItem.Icon>
                   <md:PackIcon Kind="FilterList" />
                 </MenuItem.Icon>
@@ -159,7 +154,7 @@
               <Separator Visibility="{Binding AppHasFilters, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
               <MenuItem Command="{s:Action SetObjectSelection}"
-                        CommandParameter="{Binding}">
+                CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Clears any existing objects, and sets the current selected ones.</Run>
@@ -169,7 +164,7 @@
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
                   <md:PackIcon Foreground="Green"
-                               Kind="AddCircle" />
+                    Kind="AddCircle" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -179,7 +174,7 @@
               </MenuItem>
 
               <MenuItem Command="{s:Action AddObjectSelection}"
-                        CommandParameter="{Binding}">
+                CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Adds the currently selected objects to the existing list. Does not clear old ones.</Run>
@@ -189,7 +184,7 @@
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
                   <md:PackIcon Foreground="{StaticResource PrimaryHueLightBrush}"
-                               Kind="AddCircle" />
+                    Kind="AddCircle" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -199,7 +194,7 @@
               </MenuItem>
 
               <MenuItem Command="{s:Action RemoveObjectSelection}"
-                        CommandParameter="{Binding}">
+                CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Removes the selected objects.</Run>
@@ -209,7 +204,7 @@
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
                   <md:PackIcon Foreground="IndianRed"
-                               Kind="MinusCircle" />
+                    Kind="MinusCircle" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -219,7 +214,7 @@
               </MenuItem>
 
               <MenuItem Command="{s:Action ClearObjectSelection}"
-                        CommandParameter="{Binding}">
+                CommandParameter="{Binding}">
                 <MenuItem.ToolTip>
                   <TextBlock>
                     <Run>Removes all selected objects.</Run>
@@ -229,7 +224,7 @@
                 </MenuItem.ToolTip>
                 <MenuItem.Icon>
                   <md:PackIcon Foreground="OrangeRed"
-                               Kind="RemoveCircleMultiple" />
+                    Kind="RemoveCircleMultiple" />
                 </MenuItem.Icon>
                 <MenuItem.Header>
                   <TextBlock>
@@ -247,14 +242,14 @@
       <!--#region Commit Swapping Button (Receiver)-->
       <ControlTemplate x:Key="CommitSwappingButton">
         <Button x:Name="CommitSwappingButton"
-                Width="auto"
-                Padding="0"
-                HorizontalAlignment="Left"
-                local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
-                md:ButtonAssist.CornerRadius="3"
-                ContextMenuService.Placement="Bottom"
-                FontSize="12"
-                Style="{StaticResource MaterialDesignFlatButton}">
+          Width="auto"
+          Padding="0"
+          HorizontalAlignment="Left"
+          local:ContextMenuLeftClickBehavior.IsLeftClickEnabled="True"
+          md:ButtonAssist.CornerRadius="3"
+          ContextMenuService.Placement="Bottom"
+          FontSize="12"
+          Style="{StaticResource MaterialDesignFlatButton}">
           <Button.ToolTip>
             <TextBlock>
               <Run Text="Current commit is" />
@@ -269,29 +264,29 @@
               <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <md:PackIcon Grid.Column="0"
-                         Margin="0,0,0,0"
-                         HorizontalAlignment="Left"
-                         Kind="SourceCommit" />
+              Margin="0,0,0,0"
+              HorizontalAlignment="Left"
+              Kind="SourceCommit" />
             <TextBlock Grid.Column="1"
-                       Margin="3,1,14,1"
-                       FontWeight="Normal"
-                       Text="{Binding Commit.id}" />
+              Margin="3,1,14,1"
+              FontWeight="Normal"
+              Text="{Binding Commit.id}" />
           </Grid>
           <Button.Resources>
             <local:BindingProxy x:Key="Proxy"
-                                Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
+              Data="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=DataContext}" />
           </Button.Resources>
           <Button.ContextMenu>
             <ContextMenu FontSize="12"
-                         ItemsSource="{Binding CommitContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+              ItemsSource="{Binding CommitContextMenuItems, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
               <ContextMenu.ItemTemplate>
                 <DataTemplate>
                   <StackPanel>
                     <Grid Margin="0,0">
                       <Grid.InputBindings>
                         <MouseBinding Command="{s:Action SwitchCommit}"
-                                      CommandParameter="{Binding CommandArgument}"
-                                      Gesture="LeftClick" />
+                          CommandParameter="{Binding CommandArgument}"
+                          Gesture="LeftClick" />
                       </Grid.InputBindings>
                       <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="10" />
@@ -302,17 +297,17 @@
                         <RowDefinition Height="Auto" />
                       </Grid.RowDefinitions>
                       <md:PackIcon Grid.Row="0"
-                                   Grid.Column="0"
-                                   Margin="-20,0,0,0"
-                                   HorizontalAlignment="Left"
-                                   Kind="{Binding Icon.Kind}" />
+                        Grid.Column="0"
+                        Margin="-20,0,0,0"
+                        HorizontalAlignment="Left"
+                        Kind="{Binding Icon.Kind}" />
                       <TextBlock Grid.Row="0"
-                                 Grid.Column="1"
-                                 TextAlignment="Left">
+                        Grid.Column="1"
+                        TextAlignment="Left">
                         <Run Text="{Binding MainText}" />
                         <!--<Run Text="-" />-->
                         <Run FontWeight="Bold"
-                             Text="{Binding SecondaryText}" />
+                          Text="{Binding SecondaryText}" />
                       </TextBlock>
                     </Grid>
                   </StackPanel>
@@ -335,42 +330,42 @@
           <!--#region Disabled Card (no account)-->
 
           <md:Card Grid.Row="0"
-                   Width="Auto"
-                   Margin="12,10,12,10"
-                   Panel.ZIndex="100"
-                   md:ShadowAssist.ShadowDepth="Depth0"
-                   Opacity=".9"
-                   UniformCornerRadius="8"
-                   Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
+            Width="Auto"
+            Margin="12,10,12,10"
+            Panel.ZIndex="100"
+            md:ShadowAssist.ShadowDepth="Depth0"
+            Opacity=".9"
+            UniformCornerRadius="8"
+            Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
 
             <Grid Margin="16"
-                  Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
-              <StackPanel Margin="8"
-                          Grid.ColumnSpan="2"
-                          HorizontalAlignment="Center"
-                          VerticalAlignment="Center">
+              Visibility="{Binding Client, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
+              <StackPanel Grid.ColumnSpan="2"
+                Margin="8"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
                 <TextBlock FontSize="14"
-                           Text="No local account for server:"
-                           TextWrapping="Wrap" />
+                  Text="No local account for server:"
+                  TextWrapping="Wrap" />
                 <TextBlock Margin="0,4"
-                           FontFamily="Consolas"
-                           Text="{Binding ServerUrl}"
-                           TextWrapping="Wrap" />
+                  FontFamily="Consolas"
+                  Text="{Binding ServerUrl}"
+                  TextWrapping="Wrap" />
                 <TextBlock
                   Text="Please ensure you have an account for this server and have added it to the Speckle Manager"
                   TextWrapping="Wrap" />
               </StackPanel>
               <Button Width="28"
-                      Height="28"
-                      HorizontalAlignment="Right"
-                      VerticalAlignment="Top"
-                      md:RippleAssist.ClipToBounds="True"
-                      Command="{s:Action RemoveDisabledStream}"
-                      CommandParameter="{Binding}"
-                      Content="{md:PackIcon Kind=TrashCanOutline,
-                                          Size=16}"
-                      Style="{StaticResource MaterialDesignIconButton}"
-                      ToolTip="Remove this stream" />
+                Height="28"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                md:RippleAssist.ClipToBounds="True"
+                Command="{s:Action RemoveDisabledStream}"
+                CommandParameter="{Binding}"
+                Content="{md:PackIcon Kind=TrashCanOutline,
+                                      Size=16}"
+                Style="{StaticResource MaterialDesignIconButton}"
+                ToolTip="Remove this stream" />
 
             </Grid>
           </md:Card>
@@ -379,28 +374,28 @@
           <!--#endregion-->
 
           <md:Card Grid.Row="0"
-                   Width="Auto"
-                   Margin="12,10,12,10"
-                   UniformCornerRadius="8">
+            Width="Auto"
+            Margin="12,10,12,10"
+            UniformCornerRadius="8">
             <md:Card.Style>
               <Style>
                 <Style.Triggers>
                   <DataTrigger Binding="{Binding ServerUpdates}"
-                               Value="True">
+                    Value="True">
                     <Setter Property="md:ShadowAssist.ShadowDepth"
-                            Value="Depth5" />
+                      Value="Depth5" />
                   </DataTrigger>
                   <DataTrigger Binding="{Binding ServerUpdates}"
-                               Value="False">
+                    Value="False">
                     <Setter Property="md:ShadowAssist.ShadowDepth"
-                            Value="Depth1" />
+                      Value="Depth1" />
                   </DataTrigger>
                 </Style.Triggers>
               </Style>
             </md:Card.Style>
             <StackPanel>
               <Grid x:Name="CardGrid"
-                    Margin="16">
+                Margin="16">
                 <Grid.RowDefinitions>
                   <RowDefinition Height="Auto" />
                   <RowDefinition Height="Auto" />
@@ -410,7 +405,7 @@
                 <!--#region Card Header-->
 
                 <Grid Name="StreamCardTitle"
-                      Grid.Row="0">
+                  Grid.Row="0">
                   <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -422,29 +417,29 @@
                   </Grid.ColumnDefinitions>
 
                   <WrapPanel Grid.Row="0"
-                             Grid.Column="0">
+                    Grid.Column="0">
                     <TextBlock Grid.Column="0"
-                               VerticalAlignment="Center"
-                               Style="{StaticResource MaterialDesignHeadline4TextBlock}"
-                               TextWrapping="Wrap">
+                      VerticalAlignment="Center"
+                      Style="{StaticResource MaterialDesignHeadline4TextBlock}"
+                      TextWrapping="Wrap">
                       <Hyperlink Command="{s:Action ShowStreamInfo}"
-                                 CommandParameter="{Binding}"
-                                 ToolTip="Open stream details page.">
+                        CommandParameter="{Binding}"
+                        ToolTip="Open stream details page.">
                         <TextBlock FontSize="20"
-                                   Text="{Binding Stream.name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                          Text="{Binding Stream.name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                       </Hyperlink>
                     </TextBlock>
                   </WrapPanel>
 
                   <ToggleButton Grid.Row="0"
-                                Grid.Column="2"
-                                Width="28"
-                                Height="28"
-                                Command="{s:Action SwapState}"
-                                CommandParameter="{Binding}"
-                                IsEnabled="{Binding RoleIsReviewer, Converter={StaticResource InverseBooleanConverter}}"
-                                Style="{StaticResource MaterialDesignWhiteToggleButton}"
-                                ToolTipService.ShowOnDisabled="True">
+                    Grid.Column="2"
+                    Width="28"
+                    Height="28"
+                    Command="{s:Action SwapState}"
+                    CommandParameter="{Binding}"
+                    IsEnabled="{Binding RoleIsReviewer, Converter={StaticResource InverseBooleanConverter}}"
+                    Style="{StaticResource MaterialDesignWhiteToggleButton}"
+                    ToolTipService.ShowOnDisabled="True">
                     <ToggleButton.ToolTip>
                       <StackPanel Orientation="Vertical">
                         <TextBlock
@@ -475,17 +470,17 @@
                   </ToggleButton>
 
                   <Button Grid.Row="0"
-                          Grid.Column="1"
-                          Width="28"
-                          Height="28"
-                          HorizontalAlignment="Right"
-                          md:RippleAssist.ClipToBounds="True"
-                          Command="{s:Action OpenStreamInWeb}"
-                          CommandParameter="{Binding}"
-                          Content="{md:PackIcon Kind=OpenInNew,
+                    Grid.Column="1"
+                    Width="28"
+                    Height="28"
+                    HorizontalAlignment="Right"
+                    md:RippleAssist.ClipToBounds="True"
+                    Command="{s:Action OpenStreamInWeb}"
+                    CommandParameter="{Binding}"
+                    Content="{md:PackIcon Kind=OpenInNew,
                                           Size=16}"
-                          Style="{StaticResource MaterialDesignIconButton}"
-                          ToolTip="Open this stream in the browser" />
+                    Style="{StaticResource MaterialDesignIconButton}"
+                    ToolTip="Open this stream in the browser" />
                   <!--<StackPanel Orientation="Horizontal"
                               Grid.Row="1"
                               Grid.Column="0"
@@ -502,10 +497,10 @@
 
                 <!--  Stream Card Sender Actions  -->
                 <Grid Name="StreamCardSenderActions"
-                      Grid.Row="1"
-                      Margin="0,30,0,0"
-                      IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
-                      Visibility="{Binding IsSenderCard, Converter={StaticResource BooleanToVisibilityConverter}}">
+                  Grid.Row="1"
+                  Margin="0,30,0,0"
+                  IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
+                  Visibility="{Binding IsSenderCard, Converter={StaticResource BooleanToVisibilityConverter}}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
@@ -518,127 +513,64 @@
 
                   <!--  The Objects button  -->
                   <Control Grid.Column="1"
-                           Template="{StaticResource SelectionButton}" />
+                    Template="{StaticResource SelectionButton}" />
 
                   <!--  The Send Button  -->
                   <Button x:Name="SendButton"
-                          Grid.Column="2"
-                          Width="120"
-                          HorizontalAlignment="Right"
-                          md:ButtonAssist.CornerRadius="3"
-                          md:ShadowAssist.ShadowDepth="Depth3"
-                          Command="{s:Action Send}"
-                          CommandParameter="{Binding}"
-                          ContextMenuService.Placement="Center"
-                          IsEnabled="{Binding SendEnabled}">
+                    Grid.Column="2"
+                    Width="120"
+                    HorizontalAlignment="Right"
+                    md:ButtonAssist.CornerRadius="3"
+                    Command="{s:Action Send}"
+                    CommandParameter="{Binding}"
+                    ContextMenuService.Placement="Center"
+                    IsEnabled="{Binding SendEnabled}">
                     <Button.ToolTip>
                       <TextBlock>
-                        <Run>Send to Specke: either the selected objects, or the ones picked up by the filter.</Run>
-                        <!--<LineBreak />
-                        <Run FontWeight="Bold">Right click this button to set a commit message before sending.</Run>-->
+                        <Run>Send to Speckle: either the selected objects, or the ones picked up by the filter.</Run>
                       </TextBlock>
                     </Button.ToolTip>
                     <Button.Resources>
                       <local:BindingProxy x:Key="Proxy"
-                                          Data="{Binding}" />
+                        Data="{Binding}" />
                     </Button.Resources>
-                    <!--<Button.ContextMenu>
-                      <ContextMenu>
-                        <MenuItem>
-                          <MenuItem.Template>
-                            <ControlTemplate>
-                              <Grid>
-                                <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="*" />
-                                  <ColumnDefinition Width="30" />
-                                </Grid.ColumnDefinitions>
-                                <md:PackIcon
-                                  Grid.Column="1"
-                                  Margin="0,10,0,10"
-                                  Kind="MessageAdd"
-                                  Opacity="0.5" />
-                                <TextBox
-                                  Grid.Column="0"
-                                  Width="200"
-                                  Margin="4"
-                                  md:HintAssist.HelperText="Commit message (press enter to send)"
-                                  md:TextBlockAssist.AutoToolTip="False"
-                                  s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
-                                  PreviewKeyDown="{s:Action SendWithCommitMessage}"
-                                  Text="{Binding Path=Data.CommitMessage, Source={StaticResource Proxy}}"
-                                  ToolTip="A commit message helps keep track of the changes made, and the reasons behind them." />
-                              </Grid>
-                            </ControlTemplate>
-                          </MenuItem.Template>
-                        </MenuItem>
-                      </ContextMenu>
-                    </Button.ContextMenu>-->
                     <Grid>
                       <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                       </Grid.ColumnDefinitions>
                       <Image Grid.Column="0"
-                             Width="32"
-                             Height="32"
-                             Margin="-10,0,5,0"
-                             HorizontalAlignment="Left"
-                             VerticalAlignment="Center"
-                             Source="/SpeckleDesktopUI;Component/Resources/SenderWhite@32.png" />
+                        Width="32"
+                        Height="32"
+                        Margin="-10,0,5,0"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Source="/SpeckleDesktopUI;Component/Resources/SenderWhite@32.png" />
                       <TextBlock Grid.Column="1"
-                                 HorizontalAlignment="Center"
-                                 VerticalAlignment="Center"
-                                 Text="Send" />
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Text="Send" />
                     </Grid>
                   </Button>
 
-                  <md:PopupBox Grid.Column="3"
-                               IsEnabled="{Binding SendEnabled}"
-                               StaysOpen="True">
-                    <md:PopupBox.ToolTip>
-                      <TextBlock>
-                        <Run>Send data with a commit message.</Run>
-                      </TextBlock>
-                    </md:PopupBox.ToolTip>
-                    <MenuItem Margin="10">
-                      <MenuItem.Resources>
-                        <local:BindingProxy x:Key="Proxy"
-                                            Data="{Binding}" />
-                      </MenuItem.Resources>
-                      <MenuItem.Template>
-                        <ControlTemplate>
-                          <Grid>
-                            <Grid.ColumnDefinitions>
-                              <ColumnDefinition Width="*" />
-                              <ColumnDefinition Width="30" />
-                            </Grid.ColumnDefinitions>
-                            <md:PackIcon Grid.Column="1"
-                                         Margin="0,10,0,10"
-                                         Kind="MessageAdd"
-                                         Opacity="0.5" />
-                            <TextBox Grid.Column="0"
-                                     Width="200"
-                                     Margin="4"
-                                     md:HintAssist.HelperText="Commit message (press enter to send)"
-                                     md:TextBlockAssist.AutoToolTip="False"
-                                     s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
-                                     PreviewKeyDown="{s:Action SendWithCommitMessage}"
-                                     Text="{Binding Path=Data.CommitMessage, Source={StaticResource Proxy}}"
-                                     ToolTip="A commit message helps keep track of the changes made, and the reasons behind them." />
-                          </Grid>
-                        </ControlTemplate>
-                      </MenuItem.Template>
-                    </MenuItem>
-                  </md:PopupBox>
+                  <ToggleButton x:Name="CommitMessageExpanded"
+                    Grid.Column="3"
+                    Margin="8,5,0,0"
+                    Foreground="{DynamicResource MaterialDesignBody}"
+                    IsEnabled="{Binding SendEnabled}"
+                    IsChecked="{Binding CommitExpanderChecked}"
+                    Style="{StaticResource MaterialDesignExpanderToggleButton}"
+                    ToolTip="Add a commit message" />
+
                 </Grid>
                 <!--#endregion-->
 
                 <!--#region Stream Card Receiver Actions-->
                 <Grid x:Name="StreamCardReceiverActions"
-                      Grid.Row="1"
-                      Margin="0,30,0,0"
-                      IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
-                      Visibility="{Binding IsReceiverCard, Converter={StaticResource BooleanToVisibilityConverter}}">
+                  Grid.Row="1"
+                  Margin="0,30,0,0"
+                  IsEnabled="{Binding ShowProgressBar, Converter={StaticResource InverseBooleanConverter}}"
+                  Visibility="{Binding IsReceiverCard, Converter={StaticResource BooleanToVisibilityConverter}}">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
@@ -650,40 +582,68 @@
 
                   <!--  The commit button  -->
                   <Control Grid.Column="1"
-                           Template="{StaticResource CommitSwappingButton}" />
+                    Template="{StaticResource CommitSwappingButton}" />
 
                   <Button x:Name="ReceiveButton"
-                          Grid.Column="2"
-                          Width="120"
-                          HorizontalAlignment="Right"
-                          md:ButtonAssist.CornerRadius="3"
-                          Command="{s:Action Receive}"
-                          CommandParameter="{Binding}"
-                          IsEnabled="{Binding ReceiveEnabled}"
-                          Style="{StaticResource MaterialDesignRaisedButton}"
-                          ToolTip="Edit/Change Objects">
+                    Grid.Column="2"
+                    Width="120"
+                    HorizontalAlignment="Right"
+                    md:ButtonAssist.CornerRadius="3"
+                    Command="{s:Action Receive}"
+                    CommandParameter="{Binding}"
+                    IsEnabled="{Binding ReceiveEnabled}"
+                    Style="{StaticResource MaterialDesignRaisedButton}"
+                    ToolTip="Edit/Change Objects">
                     <Grid>
                       <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                       </Grid.ColumnDefinitions>
                       <Image Grid.Column="0"
-                             Width="32"
-                             Height="32"
-                             Margin="0,0,5,0"
-                             VerticalAlignment="Center"
-                             Source="/SpeckleDesktopUI;Component/Resources/ReceiverWhite@32.png" />
+                        Width="32"
+                        Height="32"
+                        Margin="0,0,5,0"
+                        VerticalAlignment="Center"
+                        Source="/SpeckleDesktopUI;Component/Resources/ReceiverWhite@32.png" />
 
                       <TextBlock Grid.Column="1"
-                                 HorizontalAlignment="Center"
-                                 VerticalAlignment="Center"
-                                 Text="Receive  " />
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Text="Receive  " />
                     </Grid>
                   </Button>
                 </Grid>
                 <!--#endregion-->
-
               </Grid>
+
+              <!--#region Commit Message-->
+              <md:Card Grid.Row="1"
+                Padding="5"
+                md:ShadowAssist.ShadowDepth="Depth0"
+                Visibility="{Binding IsChecked, ElementName=CommitMessageExpanded, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <md:Card.Resources>
+                  <local:BindingProxy x:Key="Proxy"
+                    Data="{Binding}" />
+                </md:Card.Resources>
+                <Grid>
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="30" />
+                  </Grid.ColumnDefinitions>
+                  <md:PackIcon Grid.Column="1"
+                    Margin="0,10,0,10"
+                    Kind="MessageAdd"
+                    Opacity="0.5" />
+                  <TextBox Grid.Column="0"
+                    Margin="20,0,20,20"
+                    md:HintAssist.HelperText="Commit message - keep track of changes made and the reasons behind them"
+                    md:TextBlockAssist.AutoToolTip="False"
+                    s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
+                    PreviewKeyDown="{s:Action SendWithCommitMessage}"
+                    Text="{Binding Path=Data.CommitMessage, Source={StaticResource Proxy}, Mode=TwoWay}" />
+                </Grid>
+              </md:Card>
+              <!--#endregion-->
 
               <!--#region Progress Bar-->
 
@@ -691,61 +651,61 @@
                 Visibility="{Binding Path=DataContext.ShowProgressBar, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Grid.Resources>
                   <local:BindingProxy x:Key="Proxy"
-                                      Data="{Binding}" />
+                    Data="{Binding}" />
                 </Grid.Resources>
                 <ProgressBar x:Name="ProgressBar"
-                             Grid.Column="0"
-                             Height="15"
-                             Margin="0,0"
-                             VerticalAlignment="Center"
-                             md:TransitionAssist.DisableTransitions="True"
-                             BorderBrush="Transparent"
-                             BorderThickness="0"
-                             IsIndeterminate="{Binding Path=DataContext.ProgressBarIsIndeterminate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                             Maximum="{Binding Path=DataContext.Progress.Maximum, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                             Minimum="0"
-                             Value="{Binding Path=DataContext.Progress.Value, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                  Grid.Column="0"
+                  Height="15"
+                  Margin="0,0"
+                  VerticalAlignment="Center"
+                  md:TransitionAssist.DisableTransitions="True"
+                  BorderBrush="Transparent"
+                  BorderThickness="0"
+                  IsIndeterminate="{Binding Path=DataContext.ProgressBarIsIndeterminate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                  Maximum="{Binding Path=DataContext.Progress.Maximum, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                  Minimum="0"
+                  Value="{Binding Path=DataContext.Progress.Value, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
                 <TextBlock Grid.Column="0"
-                           Height="10"
-                           Margin="20,0"
-                           HorizontalAlignment="Left"
-                           FontSize="9"
-                           Foreground="White"
-                           Opacity="0.7"
-                           Text="{Binding Path=DataContext.Progress.ProgressSummary, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                           TextAlignment="Center" />
+                  Height="10"
+                  Margin="20,0"
+                  HorizontalAlignment="Left"
+                  FontSize="9"
+                  Foreground="White"
+                  Opacity="0.7"
+                  Text="{Binding Path=DataContext.Progress.ProgressSummary, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
+                  TextAlignment="Center" />
                 <!--  TODO: Figure out how to make this nice  -->
                 <Button x:Name="Cancel"
-                        Grid.Column="0"
-                        Width="14"
-                        Height="15"
-                        Margin="0,0,20,0"
-                        HorizontalAlignment="Right"
-                        md:ButtonAssist.CornerRadius="3"
-                        s:View.ActionTarget="{Binding Source={StaticResource Proxy}, Path=Data}"
-                        Background="Transparent"
-                        BorderBrush="Transparent"
-                        BorderThickness="0"
-                        Command="{s:Action CancelSendOrReceive}"
-                        Content="{md:PackIcon Kind=Close,
+                  Grid.Column="0"
+                  Width="14"
+                  Height="15"
+                  Margin="0,0,20,0"
+                  HorizontalAlignment="Right"
+                  md:ButtonAssist.CornerRadius="3"
+                  s:View.ActionTarget="{Binding Source={StaticResource Proxy}, Path=Data}"
+                  Background="Transparent"
+                  BorderBrush="Transparent"
+                  BorderThickness="0"
+                  Command="{s:Action CancelSendOrReceive}"
+                  Content="{md:PackIcon Kind=Close,
                                         Size=12}"
-                        Style="{StaticResource MaterialDesignFloatingActionButton}"
-                        ToolTip="Cancel" />
+                  Style="{StaticResource MaterialDesignFloatingActionButton}"
+                  ToolTip="Cancel" />
               </Grid>
               <!--#endregion-->
 
               <!--#region Updates display-->
               <md:Card Grid.Row="1"
-                       Margin="0,0,0,0"
-                       Padding="5"
-                       Panel.ZIndex="1000"
-                       md:ShadowAssist.ShadowDepth="Depth0"
-                       Background="{StaticResource PrimaryHueDarkBrush}"
-                       UniformCornerRadius="0"
-                       Visibility="{Binding ServerUpdates, Converter={StaticResource BooleanToVisibilityConverter}}">
+                Margin="0,0,0,0"
+                Padding="5"
+                Panel.ZIndex="1000"
+                md:ShadowAssist.ShadowDepth="Depth0"
+                Background="{StaticResource PrimaryHueDarkBrush}"
+                UniformCornerRadius="0"
+                Visibility="{Binding ServerUpdates, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <md:Card.Resources>
                   <local:BindingProxy x:Key="Proxy"
-                                      Data="{Binding}" />
+                    Data="{Binding}" />
                 </md:Card.Resources>
                 <Grid Margin="10,5,10,0">
                   <Grid.ColumnDefinitions>
@@ -753,39 +713,39 @@
                     <ColumnDefinition Width="20" />
                   </Grid.ColumnDefinitions>
                   <TextBlock Grid.Column="0"
-                             Padding="4"
-                             FontSize="12"
-                             Foreground="White"
-                             Text="{Binding ServerUpdateSummary}"
-                             TextWrapping="Wrap" />
+                    Padding="4"
+                    FontSize="12"
+                    Foreground="White"
+                    Text="{Binding ServerUpdateSummary}"
+                    TextWrapping="Wrap" />
 
                   <Button Grid.Column="1"
-                          Width="20"
-                          Height="20"
-                          s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
-                          Background="White"
-                          BorderBrush="White"
-                          Command="{s:Action CloseUpdateNotification}"
-                          CommandParameter="{Binding}"
-                          Content="{md:PackIcon Kind=Close,
+                    Width="20"
+                    Height="20"
+                    s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
+                    Background="White"
+                    BorderBrush="White"
+                    Command="{s:Action CloseUpdateNotification}"
+                    CommandParameter="{Binding}"
+                    Content="{md:PackIcon Kind=Close,
                                           Size=10}"
-                          Foreground="Black"
-                          Style="{StaticResource MaterialDesignFloatingActionLightButton}"
-                          ToolTip="Close notification." />
+                    Foreground="Black"
+                    Style="{StaticResource MaterialDesignFloatingActionLightButton}"
+                    ToolTip="Close notification." />
                 </Grid>
               </md:Card>
               <!--#endregion-->
 
               <!--#region Error display-->
               <md:Card Grid.Row="1"
-                       Margin="0,0,0,0"
-                       Padding="5"
-                       Panel.ZIndex="1000"
-                       md:ShadowAssist.ShadowDepth="Depth0"
-                       Visibility="{Binding ShowErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
+                Margin="0,0,0,0"
+                Padding="5"
+                Panel.ZIndex="1000"
+                md:ShadowAssist.ShadowDepth="Depth0"
+                Visibility="{Binding ShowErrors, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <md:Card.Resources>
                   <local:BindingProxy x:Key="Proxy"
-                                      Data="{Binding}" />
+                    Data="{Binding}" />
                 </md:Card.Resources>
                 <Grid Margin="0,0,10,0">
                   <Grid.RowDefinitions>
@@ -798,44 +758,44 @@
                       <ColumnDefinition Width="20" />
                     </Grid.ColumnDefinitions>
                     <Expander Grid.Row="1"
-                              HorizontalAlignment="Stretch"
-                              md:ExpanderAssist.DownHeaderPadding="0"
-                              Background="Transparent"
-                              FontSize="12">
+                      HorizontalAlignment="Stretch"
+                      md:ExpanderAssist.DownHeaderPadding="0"
+                      Background="Transparent"
+                      FontSize="12">
                       <Expander.Header>
                         <TextBlock FontSize="12">Warnings</TextBlock>
                       </Expander.Header>
                       <TextBox MaxHeight="200"
-                               Margin="25,0,25,0"
-                               HorizontalAlignment="Stretch"
-                               Background="Transparent"
-                               BorderBrush="Transparent"
-                               Foreground="Gray"
-                               IsReadOnly="True"
-                               Style="{x:Null}"
-                               TextWrapping="Wrap"
-                               VerticalScrollBarVisibility="Visible">
+                        Margin="25,0,25,0"
+                        HorizontalAlignment="Stretch"
+                        Background="Transparent"
+                        BorderBrush="Transparent"
+                        Foreground="Gray"
+                        IsReadOnly="True"
+                        Style="{x:Null}"
+                        TextWrapping="Wrap"
+                        VerticalScrollBarVisibility="Visible">
                         <TextBox.Text>
                           <Binding Mode="OneWay"
-                                   Path="FormattedErrors" />
+                            Path="FormattedErrors" />
                         </TextBox.Text>
                       </TextBox>
                     </Expander>
                     <Button Grid.Column="1"
-                            Width="20"
-                            Height="20"
-                            Margin="0,13"
-                            VerticalAlignment="Top"
-                            s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
-                            Background="White"
-                            BorderBrush="White"
-                            Command="{s:Action CloseErrorNotification}"
-                            CommandParameter="{Binding}"
-                            Content="{md:PackIcon Kind=Close,
+                      Width="20"
+                      Height="20"
+                      Margin="0,13"
+                      VerticalAlignment="Top"
+                      s:View.ActionTarget="{Binding Data, Source={StaticResource Proxy}}"
+                      Background="White"
+                      BorderBrush="White"
+                      Command="{s:Action CloseErrorNotification}"
+                      CommandParameter="{Binding}"
+                      Content="{md:PackIcon Kind=Close,
                                             Size=10}"
-                            Foreground="Black"
-                            Style="{StaticResource MaterialDesignFloatingActionLightButton}"
-                            ToolTip="Close notification." />
+                      Foreground="Black"
+                      Style="{StaticResource MaterialDesignFloatingActionLightButton}"
+                      ToolTip="Close notification." />
                   </Grid>
 
 
@@ -863,30 +823,30 @@
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <ScrollViewer Grid.Row="0"
-                      Grid.Column="0"
-                      HorizontalAlignment="Stretch"
-                      VerticalAlignment="Stretch"
-                      HorizontalScrollBarVisibility="Disabled"
-                      VerticalScrollBarVisibility="Auto">
+          Grid.Column="0"
+          HorizontalAlignment="Stretch"
+          VerticalAlignment="Stretch"
+          HorizontalScrollBarVisibility="Disabled"
+          VerticalScrollBarVisibility="Auto">
           <ItemsControl Margin="0,10"
-                        ItemTemplate="{StaticResource StreamCardTemplate}"
-                        ItemsSource="{Binding StreamList, Mode=OneWay, UpdateSourceTrigger=Default}" />
+            ItemTemplate="{StaticResource StreamCardTemplate}"
+            ItemsSource="{Binding StreamList, Mode=OneWay, UpdateSourceTrigger=Default}" />
         </ScrollViewer>
         <StackPanel Grid.Row="0"
-                    Margin="58,30,58,0"
-                    Visibility="{Binding EmptyState, Converter={StaticResource BooleanToVisibilityConverter}}">
+          Margin="58,30,58,0"
+          Visibility="{Binding EmptyState, Converter={StaticResource BooleanToVisibilityConverter}}">
           <TextBlock FontSize="30"
-                     FontWeight="Light"
-                     Foreground="Gray"
-                     TextWrapping="Wrap">
+            FontWeight="Light"
+            Foreground="Gray"
+            TextWrapping="Wrap">
             Hello! Seems like you have no streams in this file.
           </TextBlock>
           <Separator Margin="0,20,300,20"
-                     Background="Gray" />
+            Background="Gray" />
           <TextBlock FontSize="20"
-                     FontWeight="Light"
-                     Foreground="Gray"
-                     TextWrapping="Wrap">
+            FontWeight="Light"
+            Foreground="Gray"
+            TextWrapping="Wrap">
             You can add or create a stream from the big friendly blue button in the lower right.
           </TextBlock>
         </StackPanel>
@@ -895,22 +855,22 @@
       <!--#region The BAB (Big Add Button)-->
       <Canvas>
         <Button x:Name="CreateStreamButton"
-                Canvas.Right="0"
-                Canvas.Bottom="0"
-                Width="60"
-                Height="60"
-                Margin="32"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Bottom"
-                md:ShadowAssist.ShadowDepth="Depth3"
-                Command="{s:Action ShowStreamCreateDialog}"
-                DockPanel.Dock="Bottom"
-                Style="{StaticResource FlatFloatingActionButton}"
-                ToolTip="Add a stream"
-                ToolTipService.Placement="Left">
+          Canvas.Right="0"
+          Canvas.Bottom="0"
+          Width="60"
+          Height="60"
+          Margin="32"
+          HorizontalAlignment="Right"
+          VerticalAlignment="Bottom"
+          md:ShadowAssist.ShadowDepth="Depth3"
+          Command="{s:Action ShowStreamCreateDialog}"
+          DockPanel.Dock="Bottom"
+          Style="{StaticResource FlatFloatingActionButton}"
+          ToolTip="Add a stream"
+          ToolTipService.Placement="Left">
           <Image Width="32"
-                 Height="32"
-                 Source="/SpeckleDesktopUI;Component/Resources/CreateStreamWhite@32.png" />
+            Height="32"
+            Source="/SpeckleDesktopUI;Component/Resources/CreateStreamWhite@32.png" />
         </Button>
       </Canvas>
       <!--#endregion-->

--- a/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/AllStreamsViewModel.cs
@@ -134,7 +134,13 @@ namespace Speckle.DesktopUI.Streams
       await DialogHost.Show(view, "RootDialogHost");
     }
 
-    public async void Send(StreamState state) => state.Send();
+    public async void Send(StreamState state)
+    {
+      if ( state.CommitExpanderChecked )
+        state.Send();
+      else
+        state.CommitExpanderChecked = true;
+    }
 
     public async void Receive(StreamState state) => state.Receive();
 

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -576,11 +576,7 @@ namespace Speckle.DesktopUI.Utils
     public bool CommitExpanderChecked
     {
       get => _commitExpanderChecked;
-      set
-      {
-        SetAndNotify(ref _commitExpanderChecked, value);
-        NotifyOfPropertyChange(nameof(CommitExpanderChecked));
-      }
+      set => SetAndNotify(ref _commitExpanderChecked, value);
     }
 
     public void SendWithCommitMessage(object sender, KeyEventArgs e)

--- a/DesktopUI/DesktopUI/Utils/StreamState.cs
+++ b/DesktopUI/DesktopUI/Utils/StreamState.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Controls;
 using System.Windows.Input;
 using MaterialDesignThemes.Wpf;
 using Speckle.Newtonsoft.Json;
@@ -570,12 +571,23 @@ namespace Speckle.DesktopUI.Utils
       Globals.HostBindings.PersistAndUpdateStreamInFile(this);
     }
 
+    private bool _commitExpanderChecked;
+
+    public bool CommitExpanderChecked
+    {
+      get => _commitExpanderChecked;
+      set
+      {
+        SetAndNotify(ref _commitExpanderChecked, value);
+        NotifyOfPropertyChange(nameof(CommitExpanderChecked));
+      }
+    }
+
     public void SendWithCommitMessage(object sender, KeyEventArgs e)
     {
-      if (e.Key == Key.Enter)
-      {
-        Send();
-      }
+      if ( e.Key != Key.Enter ) return;
+      CommitMessage = ( ( TextBox ) sender ).Text;
+      Send();
     }
 
     public async void Send()
@@ -652,6 +664,7 @@ namespace Speckle.DesktopUI.Utils
 
     public void SwapState()
     {
+      CommitExpanderChecked = false;
       IsSenderCard = !IsSenderCard;
       NotifyOfPropertyChange(nameof(CommitContextMenuItems));
       Globals.HostBindings.PersistAndUpdateStreamInFile(this);


### PR DESCRIPTION
## Description

make commit message ui more prominent to encourage usage!

![desktopui-commit-expander-new](https://user-images.githubusercontent.com/7717434/112671971-cfd55e80-8e5a-11eb-9c97-a38b70540221.gif)

- closes #314

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests in standalone ui and revit

## Docs

- No updates needed
