### PR TITLE
feat(core): updates Sentry, downgrades gh and rhino deps to 6.33

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -215,6 +215,7 @@
   <ItemGroup>
     <PackageReference Include="Grasshopper">
       <Version>6.33.20343.16431</Version>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="GrasshopperAsyncComponent">
       <Version>0.2.1</Version>

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitAsyncComponentBase.cs
@@ -8,7 +8,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using GrasshopperAsyncComponent;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
@@ -7,7 +7,7 @@ using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;

--- a/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
+++ b/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
@@ -51,7 +51,7 @@ namespace ConnectorRevit.Revit
           _converter.ConversionErrors.Clear();
           _converter.ConversionErrors.Add(new Exception("Objects failed to bake due to fatal error: " + t));
           // logging the error
-          var exception = new Speckle.Core.Logging.SpeckleException("Revit commit failed: " + t, e, level: Sentry.Protocol.SentryLevel.Warning);
+          var exception = new Speckle.Core.Logging.SpeckleException("Revit commit failed: " + t, e, level: Sentry.SentryLevel.Warning);
           return FailureProcessingResult.ProceedWithCommit;
         }
       }

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhino.csproj
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhino.csproj
@@ -70,10 +70,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RhinoCommon" Version="6.31.20315.17001" />
+    <PackageReference Include="RhinoCommon" Version="6.33.20343.16431">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="RhinoWindows" Version="6.31.20315.17001" />
     <PackageReference Include="Stub.System.Data.SQLite.Core.NetFramework" Version="1.0.113.3" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.6" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.7" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Logging;
 
 namespace Speckle.Core.Api

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Branch.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Logging;
 using Speckle.Core.Api.SubscriptionModels;
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Commit.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Logging;
 using Speckle.Core.Api.SubscriptionModels;
 

--- a/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
+++ b/Core/Core/Api/GraphQL/Client.Subscriptions.Stream.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Logging;
 using Speckle.Core.Api.SubscriptionModels;
 

--- a/Core/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Core/Api/Operations/Operations.Receive.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
@@ -52,7 +52,7 @@ namespace Speckle.Core.Api
     {
       Log.AddBreadcrumb("Receive");
 
-      var(serializer, settings) = GetSerializerInstance();
+      var (serializer, settings) = GetSerializerInstance();
 
       var localProgressDict = new ConcurrentDictionary<string, int>();
       var internalProgressAction = GetInternalProgressAction(localProgressDict, onProgressAction);
@@ -82,7 +82,7 @@ namespace Speckle.Core.Api
       }
       else if (remoteTransport == null)
       {
-        throw new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it.", level : SentryLevel.Error);
+        throw new SpeckleException($"Could not find specified object using the local transport, and you didn't provide a fallback remote from which to pull it.", level: SentryLevel.Error);
       }
 
       // If we've reached this stage, it means that we didn't get a local transport hit on our object, so we will proceed to get it from the provided remote transport. 

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Sentry;
-using Sentry.Protocol;
+using Sentry;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;

--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -32,7 +32,7 @@
   <Choose>
     <When Condition="$([MSBuild]::IsOsPlatform('Windows')) Or $([MSBuild]::IsOsPlatform('Linux')) ">
       <ItemGroup>
-        <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.6" />
+        <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.7" />
       </ItemGroup>
     </When>
     <When Condition="$([MSBuild]::IsOsPlatform('OSX'))">
@@ -42,10 +42,10 @@
     </When>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="GraphQL.Client" Version="3.2.1" />
+    <PackageReference Include="GraphQL.Client" Version="3.2.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Piwik.Tracker" Version="3.0.0" />
-    <PackageReference Include="Sentry" Version="2.1.8" />
+    <PackageReference Include="Sentry" Version="3.2.0" />
     <PackageReference Include="Speckle.Newtonsoft.Json" Version="12.0.3.1">
       <Aliases></Aliases>
     </PackageReference>

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -19,7 +19,7 @@ namespace Speckle.Core.Credentials
       get
       {
         if (serverInfo == null || userInfo == null)
-          throw new SpeckleException("Incomplete account info: cannot generate id.", level: Sentry.Protocol.SentryLevel.Error);
+          throw new SpeckleException("Incomplete account info: cannot generate id.", level: Sentry.SentryLevel.Error);
         return Speckle.Core.Models.Utilities.hashString(serverInfo.url + userInfo.email);
       }
     }

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -97,7 +97,7 @@ namespace Speckle.Core.Credentials
         var firstAccount = GetAccounts().FirstOrDefault();
         if (firstAccount == null)
         {
-          Log.CaptureException(new SpeckleException("No Speckle accounts found. Visit the Speckle web app to create one."), level: Sentry.Protocol.SentryLevel.Info);
+          Log.CaptureException(new SpeckleException("No Speckle accounts found. Visit the Speckle web app to create one."), level: Sentry.SentryLevel.Info);
         }
         return firstAccount;
       }

--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -99,7 +99,7 @@ namespace Speckle.Core.Kits
     /// <param name="kitFolderLocation"></param>
     public static void Initialize(string kitFolderLocation)
     {
-      if (_initialized)throw new SpeckleException("The kit manager has already been initialised. Make sure you call this method earlier in your code!", level : Sentry.Protocol.SentryLevel.Warning);
+      if (_initialized)throw new SpeckleException("The kit manager has already been initialised. Make sure you call this method earlier in your code!", level : Sentry.SentryLevel.Warning);
 
       KitsFolder = kitFolderLocation;
       Load();

--- a/Core/Core/Logging/Log.cs
+++ b/Core/Core/Logging/Log.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Sentry;
-using Sentry.Protocol;
+
 
 namespace Speckle.Core.Logging
 {
@@ -21,7 +21,7 @@ namespace Speckle.Core.Logging
       //TODO: set DSN & env in CI/CD pipeline
       SentrySdk.Init(o =>
       {
-        o.Dsn = new Dsn("https://f29ec716d14d4121bb2a71c4f3ef7786@o436188.ingest.sentry.io/5396846");
+        o.Dsn = "https://f29ec716d14d4121bb2a71c4f3ef7786@o436188.ingest.sentry.io/5396846";
         o.Environment = "dev";
         o.Debug = true;
         o.Release = "SpeckleCore@" + Assembly.GetExecutingAssembly().GetName().Version.ToString();
@@ -29,14 +29,14 @@ namespace Speckle.Core.Logging
 
       SentrySdk.ConfigureScope(scope =>
       {
-        scope.User = new User {Id = Setup.SUUID,};
+        scope.User = new User { Id = Setup.SUUID, };
         scope.SetTag("hostApplication", Setup.HostApplication);
       });
     }
 
     public static Log Instance()
     {
-      if ( _instance == null )
+      if (_instance == null)
       {
         _instance = new Log();
       }
@@ -71,9 +71,9 @@ namespace Speckle.Core.Logging
       {
         s.Level = level;
 
-        if ( extra != null )
+        if (extra != null)
           s.SetExtras(extra);
-        if ( e is AggregateException aggregate )
+        if (e is AggregateException aggregate)
           aggregate.InnerExceptions.ToList().ForEach(ex => SentrySdk.CaptureException(e));
         else
           SentrySdk.CaptureException(e);

--- a/Core/Core/Logging/SpeckleException.cs
+++ b/Core/Core/Logging/SpeckleException.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using GraphQL;
-using Sentry.Protocol;
+using Sentry;
 
 namespace Speckle.Core.Logging
 {
@@ -13,13 +13,13 @@ namespace Speckle.Core.Logging
     {
     }
 
-    public SpeckleException(string message, bool log = true, SentryLevel level = SentryLevel.Info ) : base(message)
+    public SpeckleException(string message, bool log = true, SentryLevel level = SentryLevel.Info) : base(message)
     {
       if (log)
         Log.CaptureException(this, level);
     }
 
-    public SpeckleException(string message, GraphQLError[ ] errors, bool log = true,
+    public SpeckleException(string message, GraphQLError[] errors, bool log = true,
       SentryLevel level = SentryLevel.Info) : base(message)
     {
       GraphQLErrors = errors.Select(error => new KeyValuePair<string, object>("error", error.Message)).ToList();

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -171,7 +171,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          throw new SpeckleException("Cannot resolve reference, no transport is defined.", level : Sentry.Protocol.SentryLevel.Error);
+          throw new SpeckleException("Cannot resolve reference, no transport is defined.", level : Sentry.SentryLevel.Error);
         }
 
         if (str != null && str != "")
@@ -181,7 +181,7 @@ namespace Speckle.Core.Serialisation
         }
         else
         {
-          throw new SpeckleException("Cannot resolve reference. The provided transport could not find it.", level : Sentry.Protocol.SentryLevel.Error);
+          throw new SpeckleException("Cannot resolve reference. The provided transport could not find it.", level : Sentry.SentryLevel.Error);
         }
       }
 

--- a/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
+++ b/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
@@ -295,13 +295,13 @@ namespace Speckle.Core.Serialisation
       var myAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(ass => ass.GetName().Name == pieces[1]);
       if (myAssembly == null)
       {
-        throw new SpeckleException("Could not load abstract object's assembly.", level : Sentry.Protocol.SentryLevel.Error);
+        throw new SpeckleException("Could not load abstract object's assembly.", level : Sentry.SentryLevel.Error);
       }
 
       var myType = myAssembly.GetType(pieces[0]);
       if (myType == null)
       {
-        throw new SpeckleException("Could not load abstract object's assembly.", level : Sentry.Protocol.SentryLevel.Error);
+        throw new SpeckleException("Could not load abstract object's assembly.", level : Sentry.SentryLevel.Error);
       }
 
       cachedAbstractTypes[assemblyQualifiedName] = myType;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.csproj
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grasshopper" Version="6.34.21034.7001" />
-    <PackageReference Include="RhinoCommon" Version="6.34.21034.7001" />
+    <PackageReference Include="Grasshopper" Version="6.33.20343.16431" />
+    <PackageReference Include="RhinoCommon" Version="6.33.20343.16431" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Objects/Objects/ObjectsKit.cs
+++ b/Objects/Objects/ObjectsKit.cs
@@ -84,7 +84,7 @@ namespace Objects
         }
         else
         {
-          throw new SpeckleException($"Converter for {app} was not found in kit {basePath}", level: Sentry.Protocol.SentryLevel.Warning);
+          throw new SpeckleException($"Converter for {app} was not found in kit {basePath}", level: Sentry.SentryLevel.Warning);
         }
 
       }


### PR DESCRIPTION
## Description

- Updates sentry dependency, it now no longer depends on Newtonsoft.Json, yay!

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Quick tests in Revit & Rhino

## Docs

- No updates needed

