### PR TITLE
fix(desktopui): catch when adding stream offline

### DIFF
--- a/DesktopUI/DesktopUI/Streams/StreamCreateDialogView.xaml
+++ b/DesktopUI/DesktopUI/Streams/StreamCreateDialogView.xaml
@@ -59,7 +59,7 @@
       </DataTemplate>
     </ResourceDictionary>
   </UserControl.Resources>
-  <Grid Margin="24,0,24,36">
+  <Grid Margin="24 0">
     <Grid.RowDefinitions>
       <RowDefinition x:Name="CloseButtonRow"
         Height="Auto" />
@@ -183,7 +183,7 @@
           Grid.Column="1"
           Margin="8"
           HorizontalAlignment="Right"
-          md:ShadowAssist.ShadowDepth="Depth4"
+          md:ShadowAssist.ShadowDepth="Depth2"
           Command="{s:Action AddSimpleStream}"
           CommandParameter="2"
           Content="{md:PackIcon Kind=Plus,
@@ -193,10 +193,12 @@
         <Separator Grid.Row="1"
           Visibility="{Binding HasSearchResults, Converter={x:Static s:BoolToVisibilityConverter.Instance}}" />
         <ItemsControl Grid.Row="2"
+          Margin="0 0 0 36"
           ItemTemplate="{StaticResource StreamCardTemplate}"
           ItemsSource="{Binding StreamSearchResults, Mode=OneWay, UpdateSourceTrigger=Default}" />
+
+        <md:Snackbar MessageQueue="{Binding Notifications}" Margin="0 0 0 -36"/>
       </Grid>
     </ScrollViewer>
-    <md:Snackbar MessageQueue="{Binding Notifications}" />
   </Grid>
 </UserControl>

--- a/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
@@ -233,7 +233,15 @@ namespace Speckle.DesktopUI.Streams
       }
       catch (Exception e)
       {
-        await client.StreamDelete(StreamToCreate.id);
+        try
+        {
+          await client.StreamDelete(StreamToCreate.id);
+        }
+        catch
+        {
+          // POKEMON! (server is prob down)
+        }
+
         Log.CaptureException(e);
         Notifications.Enqueue($"Error: {e.Message}");
       }


### PR DESCRIPTION
## Description

- catch exception when adding a stream and the server appears to be offline

- Fixes #377

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests in standalone and rhino 

## Docs

- No updates needed


