### PR TITLE
Dim/breps serialisation

### DIFF
--- a/Core/Core/Kits/Units.cs
+++ b/Core/Core/Kits/Units.cs
@@ -211,5 +211,39 @@ namespace Speckle.Core.Kits
 
       throw new SpeckleException($"Cannot understand what unit {unit} is.");
     }
+
+    public static int GetEncodingFromUnit(string unit)
+    {
+      switch (unit)
+      {
+        case Millimeters: return 1;
+        case Centimeters: return 2;
+        case Meters: return 3;
+        case Kilometers: return 4;
+        case Inches: return 5;
+        case Feet: return 6;
+        case Yards: return 7;
+        case Miles: return 8;
+      }
+
+      return 0;
+    }
+
+    public static string GetUnitFromEncoding(double unit)
+    {
+      switch (unit)
+      {
+        case 1: return Millimeters;
+        case 2: return Centimeters;
+        case 3: return Meters;
+        case 4: return Kilometers;
+        case 5: return Inches;
+        case 6: return Feet;
+        case 7: return Yards;
+        case 8: return Miles;
+      }
+
+      return None;
+    }
   }
 }

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -216,9 +216,10 @@ namespace Speckle.Core.Serialisation
 
         // first attempt to find a settable property, otherwise fall back to a dynamic set without type
         JsonProperty property = contract.Properties.GetClosestMatchProperty(jProperty.Name);
-
-        if (property != null && property.Writable && !property.Ignored)
+        
+        if (property != null && property.Writable)
         {
+
           if (type == typeof(Abstract) && property.PropertyName == "base")
           {
             var propertyValue = SerializationUtilities.HandleAbstractOriginalValue(jProperty.Value, ((JValue)jObject.GetValue("assemblyQualifiedName")).Value as string, serializer);

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -290,7 +290,7 @@ namespace Speckle.Core.Serialisation
     // the parent object being last. 
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
-      var xxxx = serializer.ReferenceLoopHandling;
+      writer.Formatting = serializer.Formatting;
       if (CancellationToken.IsCancellationRequested)
       {
         return; // Check for cancellation
@@ -459,7 +459,7 @@ namespace Speckle.Core.Serialisation
 
         if ((DetachLineage.Count == 0 || DetachLineage[DetachLineage.Count - 1]) && WriteTransports != null && WriteTransports.Count != 0)
         {
-          var objString = jo.ToString();
+          var objString = jo.ToString(writer.Formatting);
           var objId = jo["id"].Value<string>();
 
           OnProgressAction?.Invoke("S", 1);

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -312,8 +312,9 @@ namespace Speckle.Core.Serialisation
       if (value.GetType().IsPrimitive || value is string)
       {
         FirstEntry = false;
-        var t = JToken.FromObject(value); // bypasses this converter as we do not pass in the serializer
-        t.WriteTo(writer);
+        writer.WriteValue(value);
+        //var t = JToken.FromObject(value); // bypasses this converter as we do not pass in the serializer
+        //t.WriteTo(writer);
         return;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/BrepTests.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/BrepTests.cs
@@ -29,7 +29,6 @@ namespace ConverterRevitTests
       _testOutputHelper = testOutputHelper;
       this.fixture = fixture;
     }
-    public static string TestFolder => @"Y:\Documents\Speckle\speckle-sharp\Objects\Converters\ConverterRevit\TestModels\";
     
     [Theory]
     [Trait("Brep", "ToNative")]
@@ -51,7 +50,7 @@ namespace ConverterRevitTests
     {
     
       // Read and obtain `base` object.
-      var contents = System.IO.File.ReadAllText(TestFolder + fileName);
+      var contents = System.IO.File.ReadAllText(Globals.GetTestModel(fileName));
       var converter = new ConverterRevit();
       var @base = Operations.Deserialize(contents);
       

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -694,7 +694,7 @@ namespace Objects.Converter.RhinoGh
     /// <returns></returns>
     public Brep BrepToSpeckle(RH.Brep brep, string units = null)
     {
-      var tol = 0.0;
+      var tol = RhinoDoc.ActiveDoc.ModelAbsoluteTolerance;
       var u = units ?? ModelUnits;
       brep.Repair(tol); //should maybe use ModelAbsoluteTolerance ?
       foreach (var f in brep.Faces)
@@ -768,8 +768,8 @@ namespace Objects.Converter.RhinoGh
           spcklBrep,
           edge.EdgeCurveIndex,
           edge.TrimIndices(),
-          edge.StartVertex.VertexIndex,
-          edge.EndVertex.VertexIndex,
+          edge.StartVertex?.VertexIndex ?? -1,
+          edge.EndVertex?.VertexIndex ?? -1,
           edge.ProxyCurveIsReversed,
           IntervalToSpeckle(edge.Domain)
         )).ToList();
@@ -922,65 +922,6 @@ namespace Objects.Converter.RhinoGh
 
       return myExtrusion;
     }
-
-    //  Curve profile = null;
-    //  try
-    //  {
-    //    var toNativeMethod = extrusion.Profile.GetType().GetMethod( "ToNative" );
-    //    profile = ( Curve ) toNativeMethod.Invoke( extrusion.Profile, new object[ ] { extrusion.Profile } );
-    //    if ( new string[ ] { "Polyline", "Polycurve" }.Contains( extrusion.Profile.Type ) )
-    //      try
-    //      {
-    //        var IsClosed = extrusion.Profile.GetType().GetProperty( "IsClosed" ).GetValue( extrusion.Profile, null ) as bool?;
-    //        if ( IsClosed != true )
-    //        {
-    //          profile.Reverse();
-    //        }
-    //      }
-    //      catch { }
-
-    //    //switch ( extrusion.Profile )
-    //    //{
-    //    //  case SpeckleCore.SpeckleCurve curve:
-    //    //    profile = curve.ToNative();
-    //    //    break;
-    //    //  case SpeckleCore.SpecklePolycurve polycurve:
-    //    //    profile = polycurve.ToNative();
-    //    //    if ( !profile.IsClosed )
-    //    //      profile.Reverse();
-    //    //    break;
-    //    //  case SpeckleCore.SpecklePolyline polyline:
-    //    //    profile = polyline.ToNative();
-    //    //    if ( !profile.IsClosed )
-    //    //      profile.Reverse();
-    //    //    break;
-    //    //  case SpeckleCore.SpeckleArc arc:
-    //    //    profile = arc.ToNative();
-    //    //    break;
-    //    //  case SpeckleCore.SpeckleCircle circle:
-    //    //    profile = circle.ToNative();
-    //    //    break;
-    //    //  case SpeckleCore.SpeckleEllipse ellipse:
-    //    //    profile = ellipse.ToNative();
-    //    //    break;
-    //    //  case SpeckleCore.SpeckleLine line:
-    //    //    profile = line.ToNative();
-    //    //    break;
-    //    //  default:
-    //    //    profile = null;
-    //    //    break;
-    //    //}
-    //  }
-    //  catch { }
-    //  var x = new Extrusion();
-
-    //  if ( profile == null ) return null;
-
-    //  var myExtrusion = Extrusion.Create( profile.ToNurbsCurve(), ( double ) extrusion.Length, ( bool ) extrusion.Capped );
-
-    //  myExtrusion.UserDictionary.ReplaceContentsWith( extrusion.Properties.ToNative() );
-    //  return myExtrusion;
-    //}
 
     // Proper explosion of polycurves:
     // (C) The Rutten David https://www.grasshopper3d.com/forum/topics/explode-closed-planar-curve-using-rhinocommon

--- a/Objects/Objects/Geometry/Arc.cs
+++ b/Objects/Objects/Geometry/Arc.cs
@@ -51,5 +51,37 @@ namespace Objects.Geometry
       this.applicationId = applicationId;
       this.units = units;
     }
+
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+      list.Add(radius ?? 0);
+      list.Add(startAngle ?? 0);
+      list.Add(endAngle ?? 0);
+      list.Add(angleRadians ?? 0);
+      list.Add(domain.start ?? 0);
+      list.Add(domain.end ?? 0);
+
+      list.AddRange(plane.ToList());
+
+      list.Add(Units.GetEncodingFromUnit(units));
+      list.Insert(0, CurveTypeEncoding.Arc);
+      list.Insert(0, list.Count);
+      return list;
+    }
+
+    public static Arc FromList(List<double> list)
+    {
+      var arc = new Arc();
+
+      arc.radius = list[2];
+      arc.startAngle = list[3];
+      arc.endAngle = list[4];
+      arc.angleRadians = list[5];
+      arc.domain = new Interval(list[6], list[7]);
+      arc.plane = Plane.FromList(list.GetRange(8, 12));
+      arc.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+      return arc;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -23,30 +23,99 @@ namespace Objects.Geometry
     /// <summary>
     /// Gets or sets the list of surfaces in this <see cref="Brep"/> instance.
     /// </summary>
-    [DetachProperty]
-    [Chunkable(200)]
+    [JsonIgnore]
     public List<Surface> Surfaces { get; set; }
+    public List<double> SurfacesValue
+    {
+      get
+      {
+        var list = new List<double>();
+        foreach(var srf in Surfaces)
+        {
+          list.AddRange(srf.ToList());
+        }
+        return list;
+      }
+      set
+      {
+        if (value == null) return;
+        var list = new List<Surface>();
+        var done = false;
+        var currentIndex = 0;
+        while(!done)
+        {
+          var len = (int)value[currentIndex];
+          list.Add(Surface.FromList(value.GetRange(currentIndex + 1, len)));
+          currentIndex += len + 1;
+          done = currentIndex >= value.Count;
+        }
+        Surfaces = list;
+      }
+    }
 
     /// <summary>
     /// Gets or sets the list of 3-dimensional curves in this <see cref="Brep"/> instance.
     /// </summary>
-    [DetachProperty]
-    [Chunkable(200)]
+    [JsonIgnore]
     public List<ICurve> Curve3D { get; set; }
+    public List<double> Curve3DValues
+    {
+      get
+      {
+        return CurveArrayEncodingExtensions.ToArray(Curve3D);
+      }
+      set
+      {
+        if (value != null)
+          Curve3D = CurveArrayEncodingExtensions.FromArray(value);
+      }
+    }
 
     /// <summary>
     /// Gets or sets the list of 2-dimensional UV curves in this <see cref="Brep"/> instance.
     /// </summary>
-    [DetachProperty]
-    [Chunkable(200)]
+    [JsonIgnore]
     public List<ICurve> Curve2D { get; set; }
+    public List<double> Curve2DValues
+    {
+      get
+      {
+        return CurveArrayEncodingExtensions.ToArray(Curve2D);
+      }
+      set
+      {
+        if (value != null)
+          Curve2D = CurveArrayEncodingExtensions.FromArray(value);
+      }
+    }
 
     /// <summary>
     /// Gets or sets the list of vertices in this <see cref="Brep"/> instance.
     /// </summary>
-    [DetachProperty]
-    [Chunkable(5000)]
+    [JsonIgnore]
     public List<Point> Vertices { get; set; }
+    public List<double> VerticesValue
+    {
+      get
+      {
+        var list = new List<double>();
+        foreach (var vertex in Vertices)
+        {
+          list.AddRange(vertex.ToList());
+        }
+        return list;
+      }
+      set
+      {
+        if (value != null)
+        {
+          for (int i = 0; i < value.Count; i += 3)
+          {
+            Vertices.Add(new Point(value[i], value[i + 1], value[i + 2]));
+          }
+        }
+      }
+    }
 
     /// <summary>
     /// Gets or sets the list of edges in this <see cref="Brep"/> instance.
@@ -65,9 +134,50 @@ namespace Objects.Geometry
     /// <summary>
     /// Gets or sets the list of UV trim segments for each surface in this <see cref="Brep"/> instance.
     /// </summary>
-    [DetachProperty]
-    [Chunkable(5000)]
+    [JsonIgnore]
     public List<BrepTrim> Trims { get; set; }
+    public List<int> TrimsValue
+    {
+      get
+      {
+        List<int> list = new List<int>();
+        foreach(var trim in Trims)
+        {
+          list.Add(trim.EdgeIndex);
+          list.Add(trim.StartIndex);
+          list.Add(trim.EndIndex);
+          list.Add(trim.FaceIndex);
+          list.Add(trim.LoopIndex);
+          list.Add(trim.CurveIndex);
+          list.Add(trim.IsoStatus);
+          list.Add((int)trim.TrimType);
+          list.Add(trim.IsReversed ? 1 : 0);
+        }
+        return list;
+      }
+      set
+      {
+        if (value == null) return;
+        var list = new List<BrepTrim>();
+        for(int i = 0; i < value.Count; i+=9)
+        {
+          var trim = new BrepTrim()
+          {
+            EdgeIndex = value[i],
+            StartIndex = value[i + 1],
+            EndIndex = value[i + 2],
+            FaceIndex = value[i + 3],
+            LoopIndex = value[i + 4],
+            CurveIndex = value[i + 5],
+            IsoStatus = value[i + 6],
+            TrimType = (BrepTrimType)value[i + 7],
+            IsReversed = value[i + 8] == 1
+          };
+          list.Add(trim);
+        }
+        Trims = list;
+      }
+    }
 
     /// <summary>
     /// Gets or sets the list of faces in this <see cref="Brep"/> instance.
@@ -205,7 +315,6 @@ namespace Objects.Geometry
   {
     [JsonIgnore] public Brep Brep { get; set; }
     public int EdgeIndex { get; set; }
-
     public int StartIndex { get; set; }
     public int EndIndex { get; set; }
     public int FaceIndex { get; set; }

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -25,6 +25,8 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<Surface> Surfaces { get; set; }
+    [DetachProperty]
+    [Chunkable(31250)]
     public List<double> SurfacesValue
     {
       get
@@ -58,6 +60,8 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<ICurve> Curve3D { get; set; }
+    [DetachProperty]
+    [Chunkable(31250)]
     public List<double> Curve3DValues
     {
       get
@@ -76,6 +80,8 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<ICurve> Curve2D { get; set; }
+    [DetachProperty]
+    [Chunkable(31250)]
     public List<double> Curve2DValues
     {
       get
@@ -94,6 +100,8 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<Point> Vertices { get; set; }
+    [DetachProperty]
+    [Chunkable(31250)]
     public List<double> VerticesValue
     {
       get
@@ -136,6 +144,8 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<BrepTrim> Trims { get; set; }
+    [DetachProperty]
+    [Chunkable(62500)]
     public List<int> TrimsValue
     {
       get

--- a/Objects/Objects/Geometry/Circle.cs
+++ b/Objects/Objects/Geometry/Circle.cs
@@ -1,6 +1,7 @@
 ﻿using Objects.Primitive;
 using Speckle.Core.Models;
 using Speckle.Core.Kits;
+using System.Collections.Generic;
 
 namespace Objects.Geometry
 {
@@ -30,6 +31,31 @@ namespace Objects.Geometry
       this.radius = radius;
       this.applicationId = applicationId;
       this.units = units;
+    }
+
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+
+      list.Add(radius ?? 0);
+      list.Add(domain.start ?? 0);
+      list.Add(domain.end ?? 1);
+      list.AddRange(plane.ToList());
+
+      list.Add(Units.GetEncodingFromUnit(units));
+      list.Insert(0, CurveTypeEncoding.Circle);
+      list.Insert(0, list.Count);
+      return list;
+    }
+
+    public static Circle FromList(List<double> list)
+    {
+      var circle = new Circle();
+      circle.radius = list[2];
+      circle.domain = new Interval(list[3], list[4]);
+      circle.plane = Plane.FromList(list.GetRange(5, 12));
+      circle.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+      return circle;
     }
   }
 }

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -20,21 +20,21 @@ namespace Objects.Geometry
     public bool rational { get; set; }
 
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(31250)]
     public List<double> points { get; set; }
 
     /// <summary>
     /// Gets or sets the weights for this <see cref="Curve"/>. Use a default value of 1 for unweighted points.
     /// </summary>
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(31250)]
     public List<double> weights { get; set; }
 
     /// <summary>
     /// Gets or sets the knots for this <see cref="Curve"/>. Count should be equal to <see cref="points"/> count + <see cref="degree"/> + 1.
     /// </summary>
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(31250)]
     public List<double> knots { get; set; }
 
     public Interval domain { get; set; }

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -68,5 +68,54 @@ namespace Objects.Geometry
         pts[k++] = new Point(asArray[i - 2], asArray[i - 1], asArray[i], units);
       return pts;
     }
+
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+      var curve = this;
+      list.Add(curve.degree); // 0
+      list.Add(curve.periodic ? 1 : 0); // 1
+      list.Add(curve.rational ? 1 : 0); // 2
+      list.Add(curve.closed ? 1 : 0); // 3
+      list.Add((double)curve.domain.start); // 4 
+      list.Add((double)curve.domain.end); // 5
+
+      list.Add(curve.points.Count); // 6
+      list.Add(curve.weights.Count); // 7
+      list.Add(curve.knots.Count); // 8
+
+      list.AddRange(curve.points); // 9 onwards
+      list.AddRange(curve.weights);
+      list.AddRange(curve.knots);
+
+      list.Add(Units.GetEncodingFromUnit(units));
+      list.Insert(0, CurveTypeEncoding.Curve);
+      list.Insert(0, list.Count);
+      return list;
+    }
+
+    public static Curve FromList(List<double> list)
+    {
+      if (list[0] != list.Count - 1) throw new Exception($"Incorrect length. Expected {list[0]}, got {list.Count}.");
+      if (list[1] != CurveTypeEncoding.Curve) throw new Exception($"Wrong curve type. Expected {CurveTypeEncoding.Curve}, got {list[1]}.");
+
+      var curve = new Curve();
+      curve.degree = (int)list[2];
+      curve.periodic = list[3] == 1;
+      curve.rational = list[4] == 1;
+      curve.closed = list[5] == 1;
+      curve.domain = new Interval(list[6], list[7]);
+
+      var pointsCount = (int)list[8];
+      var weightsCount = (int)list[9];
+      var knotsCount = (int)list[10];
+
+      curve.points = list.GetRange(11, pointsCount);
+      curve.weights = list.GetRange(11 + pointsCount, weightsCount);
+      curve.knots = list.GetRange(11 + pointsCount + weightsCount, knotsCount);
+
+      curve.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+      return curve;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Ellipse.cs
+++ b/Objects/Objects/Geometry/Ellipse.cs
@@ -87,5 +87,34 @@ namespace Objects.Geometry
       this.applicationId = applicationId;
       this.units = units;
     }
+
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+      list.Add(firstRadius ?? 0);
+      list.Add(secondRadius ?? 0);
+      list.Add(domain.start ?? 0);
+      list.Add(domain.end ?? 0);
+
+      list.AddRange(plane.ToList());
+
+      list.Add(Units.GetEncodingFromUnit(units));
+      list.Insert(0, CurveTypeEncoding.Ellipse);
+      list.Insert(0, list.Count);
+      return list;
+    }
+
+    public static Ellipse FromList(List<double> list)
+    {
+      var ellipse = new Ellipse();
+
+      ellipse.firstRadius = list[2];
+      ellipse.secondRadius = list[3];
+      ellipse.domain = new Interval(list[4], list[5]);
+
+      ellipse.plane = Plane.FromList(list.GetRange(6, 12));
+      ellipse.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+      return ellipse;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -69,6 +69,27 @@ namespace Objects.Geometry
       this.units = units;
     }
 
-    public List<double> ToList() => start.ToList().Concat(end.ToList()).ToList();
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+      list.AddRange(start.ToList());
+      list.AddRange(end.ToList());
+      list.Add( domain.start ?? 0);
+      list.Add(domain.end ?? 1);
+      list.Add(Units.GetEncodingFromUnit(units));
+      list.Insert(0, CurveTypeEncoding.Line);
+      list.Insert(0, list.Count);
+      return list;
+    }
+
+    public static Line FromList(List<double> list)
+    {
+      var line = new Line();
+      line.start = Point.FromList(list.GetRange(2, 3));
+      line.end = Point.FromList(list.GetRange(5, 3));
+      line.domain = new Interval(list[8], list[9]);
+      line.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+      return line;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -10,19 +10,19 @@ namespace Objects.Geometry
   public class Mesh : Base, IHasBoundingBox, IHasVolume, IHasArea
   {
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(31250)]
     public List<double> vertices { get; set; } = new List<double>();
 
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(62500)]
     public List<int> faces { get; set; } = new List<int>();
 
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(62500)]
     public List<int> colors { get; set; } = new List<int>();
 
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(31250)]
     public List<double> textureCoordinates { get; set; } = new List<double>();
 
     public Box bbox { get; set; }

--- a/Objects/Objects/Geometry/Plane.cs
+++ b/Objects/Objects/Geometry/Plane.cs
@@ -30,5 +30,29 @@ namespace Objects.Geometry
       this.applicationId = applicationId;
       this.units = units;
     }
+
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+
+      list.AddRange(origin.ToList());
+      list.AddRange(normal.ToList());
+      list.AddRange(xdir.ToList());
+      list.AddRange(ydir.ToList());
+
+      return list;
+    }
+
+    public static Plane FromList(List<double> list)
+    {
+      var plane = new Plane();
+
+      plane.origin = Point.FromList(list.GetRange(0, 3));
+      plane.normal = Vector.FromList(list.GetRange(3, 3));
+      plane.xdir = Vector.FromList(list.GetRange(6, 3));
+      plane.ydir = Vector.FromList(list.GetRange(9, 3));
+
+      return plane;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Point.cs
+++ b/Objects/Objects/Geometry/Point.cs
@@ -48,7 +48,9 @@ namespace Objects.Geometry
     public double y { get; set; }
 
     public double z { get; set; }
-    
-    public List<double> ToList() => new List<double>() {x, y, z};
+
+    public List<double> ToList() => new List<double>() { x, y, z };
+
+    public static Point FromList(List<double> list) => new Point(list[0], list[1], list[2]);
   }
 }

--- a/Objects/Objects/Geometry/Polycurve.cs
+++ b/Objects/Objects/Geometry/Polycurve.cs
@@ -57,5 +57,35 @@ namespace Objects.Geometry
 
       return polycurve;
     }
+
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+      list.Add(closed ? 1 : 0);
+      list.Add(domain.start ?? 0);
+      list.Add(domain.end ?? 1);
+
+      var crvs = CurveArrayEncodingExtensions.ToArray(segments);
+      list.Add(crvs.Count);
+      list.AddRange(crvs);
+
+      list.Add(Units.GetEncodingFromUnit(units));
+      list.Insert(0, CurveTypeEncoding.PolyCurve);
+      list.Insert(0, list.Count);
+
+      return list;
+    }
+
+    public static Polycurve FromList(List<double> list)
+    {
+      var polycurve = new Polycurve();
+      polycurve.closed = list[2] == 1;
+      polycurve.domain = new Interval(list[3], list[4]);
+
+      var temp = list.GetRange(6, (int)list[5]);
+      polycurve.segments = CurveArrayEncodingExtensions.FromArray(temp);
+      polycurve.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+      return polycurve;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Polyline.cs
+++ b/Objects/Objects/Geometry/Polyline.cs
@@ -12,7 +12,7 @@ namespace Objects.Geometry
   public class Polyline : Base, ICurve, IHasArea, IHasBoundingBox, IConvertible
   {
     [DetachProperty]
-    [Chunkable(20000)]
+    [Chunkable(31250)]
     public List<double> value { get; set; } = new List<double>();
     public bool closed { get; set; }
     public Interval domain { get; set; }

--- a/Objects/Objects/Geometry/Polyline.cs
+++ b/Objects/Objects/Geometry/Polyline.cs
@@ -45,6 +45,32 @@ namespace Objects.Geometry
       }
     }
 
+    public List<double> ToList()
+    {
+      var list = new List<double>();
+      list.Add(closed ? 1 : 0); // 2
+      list.Add(domain.start ?? 0); // 3
+      list.Add(domain.end ?? 1); // 4
+      list.Add(value.Count); // 5
+      list.AddRange(value); // 6 onwards
+
+      list.Add(Units.GetEncodingFromUnit(units));
+      list.Insert(0, CurveTypeEncoding.Polyline); // 1
+      list.Insert(0, list.Count); // 0
+      return list;
+    }
+
+    public static Polyline FromList(List<double> list)
+    {
+      var polyline = new Polyline();
+      polyline.closed = list[2] == 1;
+      polyline.domain = new Interval(list[3], list[4]);
+      var pointCount = (int)list[5];
+      polyline.value = list.GetRange(6, pointCount);
+      polyline.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+      return polyline;
+    }
+
     object IConvertible.ToType(Type conversionType, IFormatProvider provider)
     {
       if (conversionType == typeof(Polycurve))

--- a/Objects/Objects/Geometry/Surface.cs
+++ b/Objects/Objects/Geometry/Surface.cs
@@ -8,18 +8,32 @@ namespace Objects.Geometry
   //TODO: to finish
   public class Surface : Base, IHasBoundingBox, IHasArea
   {
-    public int degreeU { get; set; }
-    public int degreeV { get; set; }
-    public bool rational { get; set; }
+    public int degreeU { get; set; } //
+    public int degreeV { get; set; } //
+    public bool rational { get; set; } // 
     public double area { get; set; }
+    public List<double> pointData { get; set; } //
+    public int countU { get; set; } //
+    public int countV { get; set; } // 
+    public Box bbox { get; set; } // ignore 
+    public List<double> knotsU { get; set; } //
+    public List<double> knotsV { get; set; } //
+    public Interval domainU { get; set; } //
+    public Interval domainV { get; set; } //
+    public bool closedU { get; set; } //
+    public bool closedV { get; set; } //
 
-    // TODO: Rewrite this to be store as a list<double>
-    public List<double> pointData { get; set; }
+    public Surface()
+    {
+      this.applicationId = null;
+      this.pointData = new List<double>();
+    }
 
-    public int countU { get; set; }
-    public int countV { get; set; }
-    
-    public Box bbox { get; set; }
+    public Surface(string units = Units.Meters, string applicationId = null)
+    {
+      this.applicationId = applicationId;
+      this.units = units;
+    }
 
     public List<List<ControlPoint>> GetControlPoints()
     {
@@ -37,6 +51,7 @@ namespace Objects.Geometry
 
       return matrix;
     }
+    
     public void SetControlPoints(List<List<ControlPoint>> value)
     {
       List<double> data = new List<double>();
@@ -52,26 +67,56 @@ namespace Objects.Geometry
       pointData = data;
     }
 
-    public List<double> knotsU { get; set; }
-    public List<double> knotsV { get; set; }
-    public Interval domainU { get; set; }
-
-    public Interval domainV { get; set; }
-
-    public bool closedU { get; set; }
-    public bool closedV { get; set; }
-
-    public Surface()
+    public List<double> ToList()
     {
-      this.applicationId = null;
-      this.pointData = new List<double>();
+      var list = new List<double>();
+      list.Add(degreeU);
+      list.Add(degreeV);
+      list.Add(countU);
+      list.Add(countV);
+      list.Add(rational ? 1 : 0);
+      list.Add(closedU ? 1 : 0);
+      list.Add(closedV ? 1 : 0);
+      list.Add(domainU.start ?? 0);
+      list.Add(domainU.end ?? 1);
+      list.Add(domainV.start ?? 0);
+      list.Add(domainV.end ?? 1); // [0] 10
+
+      list.Add(pointData.Count); // 11
+      list.Add(knotsU.Count); // 12
+      list.Add(knotsV.Count); // 13
+
+      list.AddRange(pointData);
+      list.AddRange(knotsU);
+      list.AddRange(knotsV);
+
+      list.Insert(0, list.Count);
+
+      return list;
     }
 
-    public Surface(string units = Units.Meters, string applicationId = null)
+    public static Surface FromList(List<double> list)
     {
-      this.applicationId = applicationId;
-      this.units = units;
-    }
+      var srf = new Surface();
+      srf.degreeU = (int)list[0];
+      srf.degreeV = (int)list[1];
+      srf.countU = (int)list[2];
+      srf.countV = (int)list[3];
+      srf.rational = list[4] == 1;
+      srf.closedU = list[5] == 1;
+      srf.closedV = list[6] == 1;
+      srf.domainU = new Interval() { start = list[7], end = list[8] }; 
+      srf.domainV = new Interval() { start = list[9], end = list[10] };
 
+      var pointCount = (int)list[11];
+      var knotsUCount = (int)list[12];
+      var knotsVCount = (int)list[13];
+
+      srf.pointData = list.GetRange(14, pointCount);
+      srf.knotsU = list.GetRange(14 + pointCount, knotsUCount);
+      srf.knotsV = list.GetRange(14 + pointCount + knotsUCount, knotsVCount);
+
+      return srf;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Vector.cs
+++ b/Objects/Objects/Geometry/Vector.cs
@@ -47,6 +47,13 @@ namespace Objects.Geometry
       this.units = units;
     }
 
+    public List<double> ToList()
+    {
+      return new List<double>() { x, y, z };
+    }
+
+    public static Vector FromList(List<double> list) => new Vector(list[0], list[1], list[2]);
+
     public double x
     {
       get;

--- a/Objects/Objects/Utils/EncodingOptimisations.cs
+++ b/Objects/Objects/Utils/EncodingOptimisations.cs
@@ -1,0 +1,74 @@
+﻿using Objects.Geometry;
+using Objects.Primitive;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Objects
+{
+  public static class CurveTypeEncoding
+  {
+    public const double Arc = 0;
+    public const double Circle = 1;
+    public const double Curve = 2;
+    public const double Ellipse = 3;
+    public const double Line = 4;
+    public const double Polyline = 5;
+    public const double PolyCurve = 6;
+  }
+
+  public static class CurveArrayEncodingExtensions
+  {
+
+    public static List<double> ToArray(List<ICurve> curves)
+    {
+      var list = new List<double>();
+      foreach(var curve in curves)
+      {
+        switch (curve)
+        {
+          case Arc a: list.AddRange(a.ToList()); break;
+          case Circle c: list.AddRange(c.ToList()); break;
+          case Curve c: list.AddRange(c.ToList()); break;
+          case Ellipse e: list.AddRange(e.ToList()); break;
+          case Line l: list.AddRange(l.ToList()); break;
+          case Polycurve p: list.AddRange(p.ToList()); break;
+          case Polyline p: list.AddRange(p.ToList()); break;
+          default: throw new Exception($"Unkown curve type: {curve.GetType()}.");
+        }
+      }
+
+      return list;
+    }
+
+    public static List<ICurve> FromArray(List<double> list)
+    {
+      var curves = new List<ICurve>();
+      if (list.Count == 0) return curves;
+      var done = false;
+      var currentIndex = 0;
+      
+      while(!done)
+      {
+        var itemLength = (int) list[currentIndex];
+        var item = list.GetRange(currentIndex, itemLength + 1);
+
+        switch(item[1])
+        {
+          case CurveTypeEncoding.Arc: curves.Add(Arc.FromList(item)); break;
+          case CurveTypeEncoding.Circle: curves.Add(Circle.FromList(item)); break;
+          case CurveTypeEncoding.Curve: curves.Add(Curve.FromList(item)); break;
+          case CurveTypeEncoding.Ellipse: curves.Add(Ellipse.FromList(item)); break;
+          case CurveTypeEncoding.Line: curves.Add(Line.FromList(item)); break;
+          case CurveTypeEncoding.Polyline: curves.Add(Polyline.FromList(item)); break;
+          case CurveTypeEncoding.PolyCurve: curves.Add(Polycurve.FromList(item)); break;
+        }
+
+        currentIndex += itemLength + 1;
+        done = currentIndex >= list.Count;
+      }
+      return curves;
+    }
+
+  }
+}


### PR DESCRIPTION
## Description

- Fixes #407 (improves) 

## Type of change

Squeezed:
- 3x-5x speed increase in serialising and deserialising breps by optimising the object model. 
- ~2x size decrease in brep size (post-gzip)

This change is backwards compatible, e.g. old breps should deserialise and convert. 

New breps being sent out will now have props stored in typed lists for speed efficency, but on deserialisation the old properties will be re-populated and can be used for actual conversion work. 

Also fixes a small issue in brep to speckle conversion from Rhino, whereby an invalid brep with null edge vertices would crash. 

## How has this been tested?

Manual Tests: 
- [x] sent breps back and forth in Rhino
- [x] received old breps in Rhino and Gh
- [x] checked out new breps in the browser
- [x] xunit brep tests in Revit (backwards compatibility, as test files are based on old serialisation routines):

![image](https://user-images.githubusercontent.com/7696515/113290851-1a872880-92ea-11eb-9d0e-c6f5500f0ea4.png)

(not sure if these were passing or not previously, but the stack traces don't point to any deserialization/serialisation woes)

- [x] standard geometry testing file as per checklist
- [x] edge case geometry testing file 

