### PR TITLE
Dim/cancellation

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -104,10 +104,6 @@
     <Compile Include="Conversion\Serialisation.DeserializeObject.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GrasshopperAsyncComponent\GrasshopperAsyncComponent\GrasshopperAsyncComponent.csproj">
-      <Project>{695d2b91-ddb6-416e-8a99-dde6253da7aa}</Project>
-      <Name>GrasshopperAsyncComponent</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Core\Core\Core.csproj">
       <Project>{b4d98d2c-e5da-463e-bf6c-68e9b77c72f3}</Project>
       <Name>Core</Name>
@@ -218,7 +214,7 @@
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="GrasshopperAsyncComponent">
-      <Version>0.2.1</Version>
+      <Version>1.2.2</Version>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations">
       <Version>4.7.0</Version>

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -11,6 +11,7 @@ using Grasshopper;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Rhino.Geometry;
+using System.Threading;
 
 namespace ConnectorGrasshopper.Extras
 {
@@ -18,14 +19,22 @@ namespace ConnectorGrasshopper.Extras
   {
     public static List<object> DataTreeToNestedLists(GH_Structure<IGH_Goo> dataInput, ISpeckleConverter converter, Action OnConversionProgress = null)
     {
+      return DataTreeToNestedLists(dataInput, converter, CancellationToken.None, OnConversionProgress);
+    }
+
+    public static List<object> DataTreeToNestedLists(GH_Structure<IGH_Goo> dataInput, ISpeckleConverter converter, CancellationToken cancellationToken, Action OnConversionProgress = null)
+    {
       var output = new List<object>();
       for (var i = 0; i < dataInput.Branches.Count; i++)
       {
+        if (cancellationToken.IsCancellationRequested) return output;
+
         var path = dataInput.Paths[i].Indices.ToList();
         var leaves = new List<object>(); 
         
         foreach(var goo in dataInput.Branches[i])
         {
+        if (cancellationToken.IsCancellationRequested) return output;
           OnConversionProgress?.Invoke();
           leaves.Add(TryConvertItemToSpeckle(goo, converter));
         }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -212,11 +212,15 @@ namespace ConnectorGrasshopper.Ops
       }
 
       Menu_AppendSeparator(menu);
-      Menu_AppendItem(menu, "Cancel", (s, e) =>
+
+      if (CurrentComponentState == "receiving")
       {
-        CurrentComponentState = "expired";
-        RequestCancellation();
-      });
+        Menu_AppendItem(menu, "Cancel Receive", (s, e) =>
+        {
+          CurrentComponentState = "expired";
+          RequestCancellation();
+        });
+      }
 
       base.AppendAdditionalComponentMenuItems(menu);
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -211,6 +211,13 @@ namespace ConnectorGrasshopper.Ops
           "To enable automatic receiving, you need to input a stream rather than a specific commit.";
       }
 
+      Menu_AppendSeparator(menu);
+      Menu_AppendItem(menu, "Cancel", (s, e) =>
+      {
+        CurrentComponentState = "expired";
+        RequestCancellation();
+      });
+
       base.AppendAdditionalComponentMenuItems(menu);
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -181,11 +181,14 @@ namespace ConnectorGrasshopper.Ops
       }
       Menu_AppendSeparator(menu);
 
-      Menu_AppendItem(menu, "Cancel", (s, e) =>
+      if (CurrentComponentState == "sending")
       {
-        CurrentComponentState = "expired";
-        RequestCancellation();
-      });
+        Menu_AppendItem(menu, "Cancel Send", (s, e) =>
+        {
+          CurrentComponentState = "expired";
+          RequestCancellation();
+        });
+      }
 
       base.AppendAdditionalComponentMenuItems(menu);
     }
@@ -342,6 +345,7 @@ namespace ConnectorGrasshopper.Ops
         {
           ReportProgress("Conversion", convertedCount++ / (double)DataInput.DataCount);
         });
+
         if ( convertedCount == 0 )
         {
           RuntimeMessages.Add(( GH_RuntimeMessageLevel.Error, "Zero objects converted successfully. Send stopped." ));

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -179,6 +179,13 @@ namespace ConnectorGrasshopper.Ops
             (s, e) => System.Diagnostics.Process.Start($"{ow.ServerUrl}/streams/{ow.StreamId}/commits/{ow.CommitId}"));
         }
       }
+      Menu_AppendSeparator(menu);
+
+      Menu_AppendItem(menu, "Cancel", (s, e) =>
+      {
+        CurrentComponentState = "expired";
+        RequestCancellation();
+      });
 
       base.AppendAdditionalComponentMenuItems(menu);
     }
@@ -331,7 +338,7 @@ namespace ConnectorGrasshopper.Ops
 
         // Note: this method actually converts the objects to speckle too
         int convertedCount = 0;
-        var converted = Utilities.DataTreeToNestedLists(DataInput, ((SendComponent)Parent).Converter, () =>
+        var converted = Utilities.DataTreeToNestedLists(DataInput, ((SendComponent)Parent).Converter, CancellationToken, () =>
         {
           ReportProgress("Conversion", convertedCount++ / (double)DataInput.DataCount);
         });


### PR DESCRIPTION
## Description

- Fixes #79
- Fixes #213 

## Type of change

### Bug fix (non-breaking change which fixes an issue) re #213: 

Not sure if this is a bug fix, or enhancement, but the component now behaves in a way that's more simple to reason about. The only downside is that it will not be able to set lists as values, but that's a weird case for grasshopper anyway. Should sort out @iltabe's use case. 

### New feature (non-breaking change which adds functionality) re #79:

If the component is sending or receiving, a right-click option will show to cancel the current send and receive. This required:
- some extra legwork in the AsyncComponent base (nuget finally updated) to expose `RequestCancellation` method
- some extra legwork in the `DataTreeToNestedLists` func to allow cancellation during conversion (added wrapper, so that prev usage is not broken)

## How has this been tested?

- Manual Tests in Grasshopper. 
  - Received and sent stuff and cancelled things in between, then re-received/sent to make sure flow is not broken. 
  - ESO object (re #213): behaviour seems consistent. 

## Docs

- No updates needed / will update ASAP (a small section on send/receive cancellation would be nice)


