### PR TITLE
feat(rhino):  named view conversions

### DIFF
--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -360,6 +360,9 @@ namespace SpeckleRhino
         {
           state.Errors.Add(new Exception($"Failed to convert object {view.id} of type {view.speckle_type}."));
         }
+
+        // reset view to perspective
+        Doc.Views.ActiveView.ActiveViewport.SetProjection(DefinedViewportProjection.Perspective, null, true);
       }));
     }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
@@ -33,6 +33,7 @@ namespace Objects.Converter.RhinoGh
       _view.upDirection = VectorToSpeckle(view.Viewport.CameraUp);
       _view.forwardDirection = VectorToSpeckle(view.Viewport.CameraDirection);
       _view.origin = PointToSpeckle(view.Viewport.CameraLocation);
+      _view.target = PointToSpeckle(view.Viewport.TargetPoint);
       _view.isOrthogonal = (view.Viewport.IsParallelProjection) ? true : false;
       _view.units = ModelUnits;
 
@@ -52,6 +53,8 @@ namespace Objects.Converter.RhinoGh
 
       viewport.SetCameraLocation(PointToNative(view.origin).Location, true);
       viewport.SetCameraDirection(VectorToNative(view.forwardDirection), true);
+      if (view.target != null)
+        viewport.SetCameraTarget(PointToNative(view.target).Location, false);
       viewport.CameraUp = VectorToNative(view.upDirection);
       viewport.Name = view.name;
 
@@ -66,19 +69,11 @@ namespace Objects.Converter.RhinoGh
 
     private void AttachViewParams(Base speckleView, ViewInfo view)
     {
-      // target
-      speckleView["target"] = PointToSpeckle(view.Viewport.TargetPoint);
-
       // lens
       speckleView["lens"] = view.Viewport.Camera35mmLensLength;
     }
     private RhinoViewport SetViewParams(RhinoViewport viewport, Base speckleView)
     {
-      // target
-      var target = speckleView["target"] as Point;
-      if (target != null)
-        viewport.SetCameraTarget(PointToNative(target).Location, false);
-
       // lens
       var lens = speckleView["lens"] as double?;
       if (lens != null)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.BuiltElements.cs
@@ -46,23 +46,25 @@ namespace Objects.Converter.RhinoGh
     {
       RhinoView _view = Doc.Views.ActiveView;
       RhinoViewport viewport = _view.ActiveViewport;
-      if (view.isOrthogonal)
-        viewport.ChangeToParallelProjection(true);
-      else
-        viewport.ChangeToPerspectiveProjection(true, 50);
+      viewport.SetProjection(DefinedViewportProjection.Perspective, null, false);
 
-      viewport.SetCameraLocation(PointToNative(view.origin).Location, true);
-      viewport.SetCameraDirection(VectorToNative(view.forwardDirection), true);
       if (view.target != null)
-        viewport.SetCameraTarget(PointToNative(view.target).Location, false);
-      viewport.CameraUp = VectorToNative(view.upDirection);
+      {
+        viewport.SetCameraLocations(PointToNative(view.target).Location, PointToNative(view.origin).Location);
+      }
+      else
+      {
+        viewport.SetCameraLocation(PointToNative(view.origin).Location, true);
+        viewport.SetCameraDirection(VectorToNative(view.forwardDirection), true);
+        viewport.CameraUp = VectorToNative(view.upDirection);
+      }
       viewport.Name = view.name;
 
-      // set props
+      // set rhino view props if available
       SetViewParams(viewport, view);
 
-      // reset active view
-      _view.Redraw();
+      if (view.isOrthogonal)
+        viewport.ChangeToParallelProjection(true);
 
       return viewport;
     }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Utils.cs
@@ -1,17 +1,68 @@
-﻿using Objects;
+﻿using Grasshopper.Kernel.Types;
+using Objects.Geometry;
+using Objects.Primitive;
+using Objects.Other;
 using Rhino;
+using Rhino.Geometry;
+using Rhino.DocObjects;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
+    private RenderMaterial GetMaterial(RhinoObject o)
+    {
+      var material = o.GetMaterial(true);
+      var renderMaterial = new RenderMaterial();
+
+      // If it's a default material use the display color.
+      if (!material.HasId)
+      {
+        renderMaterial.diffuse = o.Attributes.DrawColor(Doc).ToArgb();
+        return renderMaterial;
+      }
+
+      // Otherwise, extract what properties we can. 
+      renderMaterial.name = material.Name;
+      renderMaterial.diffuse = material.DiffuseColor.ToArgb();
+      renderMaterial.emissive = material.EmissionColor.ToArgb();
+      renderMaterial.opacity = 1 - material.Transparency;
+      renderMaterial.metalness = material.Reflectivity;
+
+      if (material.Name.ToLower().Contains("glass") && renderMaterial.opacity == 0)
+      {
+        renderMaterial.opacity = 0.3;
+      }
+
+      return renderMaterial;
+    }
+
+    private string GetSchema(RhinoObject obj, out string[] args)
+    {
+      args = null;
+
+      // user string has format "DirectShape{[family], [type]}" if it is a directshape conversion
+      // otherwise, it is just the schema type name
+      string schema = obj.Attributes.GetUserString(SpeckleSchemaKey);
+
+      if (schema == null)
+        return null;
+
+      string[] parsedSchema = schema.Split(new char[] { '(', ')' }, StringSplitOptions.RemoveEmptyEntries);
+      if (parsedSchema.Length > 2) // there is incorrect formatting in the schema string!
+        return null;
+      if (parsedSchema.Length == 2)
+        args = parsedSchema[1].Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(o => o.Trim()).ToArray();
+      return parsedSchema[0].Trim();
+    }
+
+    #region Units
+
     /// <summary>
     /// Computes the Speckle Units of the current Document. The Rhino document is passed as a reference, so it will always be up to date.
     /// </summary>    
@@ -27,7 +78,6 @@ namespace Objects.Converter.RhinoGh
       var f = Units.GetConversionFactor(units, ModelUnits);
       return value * f;
     }
-
 
     private string UnitToSpeckle(UnitSystem us)
     {
@@ -90,11 +140,7 @@ namespace Objects.Converter.RhinoGh
         default:
           throw new System.Exception("The current Unit System is unsupported.");
       }
-
-
     }
-
-
-
+    #endregion
   }
 }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -3,6 +3,7 @@ using Objects.Geometry;
 using Objects.Primitive;
 using Rhino;
 using Rhino.Geometry;
+using Rhino.Display;
 using Rhino.DocObjects;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
@@ -23,6 +24,7 @@ using ModelCurve = Objects.BuiltElements.Revit.Curve.ModelCurve;
 using Plane = Objects.Geometry.Plane;
 using Point = Objects.Geometry.Point;
 using Polyline = Objects.Geometry.Polyline;
+using View3D = Objects.BuiltElements.View3D;
 
 using RH = Rhino.Geometry;
 
@@ -151,6 +153,9 @@ namespace Objects.Converter.RhinoGh
           break;
         case NurbsSurface o:
           @base = SurfaceToSpeckle(o);
+          break;
+        case ViewInfo o:
+          @base = ViewToSpeckle(o);
           break;
         default:
           throw new NotSupportedException();
@@ -306,6 +311,9 @@ namespace Objects.Converter.RhinoGh
         case DirectShape o:
           return (o.displayMesh != null) ? MeshToNative(o.displayMesh) : null;
 
+        case View3D o:
+          return ViewToNative(o);
+
         default:
           throw new NotSupportedException();
       }
@@ -452,6 +460,9 @@ namespace Objects.Converter.RhinoGh
           return true;
 
         case DirectShape _:
+          return true;
+
+        case View3D _:
           return true;
 
         default:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -1,9 +1,9 @@
 ﻿using Grasshopper.Kernel.Types;
 using Objects.Geometry;
 using Objects.Primitive;
+using Objects.Other;
 using Rhino;
 using Rhino.Geometry;
-using Rhino.Display;
 using Rhino.DocObjects;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
@@ -30,7 +30,6 @@ using RH = Rhino.Geometry;
 
 using Surface = Objects.Geometry.Surface;
 using Vector = Objects.Geometry.Vector;
-using Objects.Other;
 
 namespace Objects.Converter.RhinoGh
 {
@@ -468,53 +467,6 @@ namespace Objects.Converter.RhinoGh
         default:
           return false;
       }
-    }
-
-    private RenderMaterial GetMaterial(RhinoObject o)
-    {
-      var material = o.GetMaterial(true);
-      var renderMaterial = new RenderMaterial();
-
-      // If it's a default material use the display color.
-      if (!material.HasId)
-      {
-        renderMaterial.diffuse = o.Attributes.DrawColor(Doc).ToArgb();
-        return renderMaterial;
-      }
-
-      // Otherwise, extract what properties we can. 
-      renderMaterial.name = material.Name;
-      renderMaterial.diffuse = material.DiffuseColor.ToArgb();
-      renderMaterial.emissive = material.EmissionColor.ToArgb();
-
-      renderMaterial.opacity = 1 - material.Transparency;
-      renderMaterial.metalness = material.Reflectivity;
-
-      if (material.Name.ToLower().Contains("glass") && renderMaterial.opacity == 0)
-      {
-        renderMaterial.opacity = 0.3;
-      }
-
-      return renderMaterial;
-    }
-
-    private string GetSchema(RhinoObject obj, out string[] args)
-    {
-      args = null;
-
-      // user string has format "DirectShape{[family], [type]}" if it is a directshape conversion
-      // otherwise, it is just the schema type name
-      string schema = obj.Attributes.GetUserString(SpeckleSchemaKey);
-
-      if (schema == null)
-        return null;
-
-      string[] parsedSchema = schema.Split(new char[] { '(', ')' }, StringSplitOptions.RemoveEmptyEntries);
-      if (parsedSchema.Length > 2) // there is incorrect formatting in the schema string!
-        return null;
-      if (parsedSchema.Length == 2)
-        args = parsedSchema[1].Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(o => o.Trim()).ToArray();
-      return parsedSchema[0].Trim();
     }
   }
 }

--- a/Objects/Objects/BuiltElements/View.cs
+++ b/Objects/Objects/BuiltElements/View.cs
@@ -17,6 +17,7 @@ namespace Objects.BuiltElements
   public class View3D : View
   {
     public Point origin { get; set; }
+    public Point target { get; set; }
     public Vector upDirection { get; set; }
     public Vector forwardDirection { get; set; }
     public bool isOrthogonal { get; set; } = false;

--- a/Objects/Objects/BuiltElements/View.cs
+++ b/Objects/Objects/BuiltElements/View.cs
@@ -19,7 +19,6 @@ namespace Objects.BuiltElements
     public Point origin { get; set; }
     public Vector upDirection { get; set; }
     public Vector forwardDirection { get; set; }
-    //public double zoom { get; set; }
     public bool isOrthogonal { get; set; } = false;
 
     public View3D() { }


### PR DESCRIPTION
## Description

Adds named view conversions to Rhino:
- Added `Target` point prop to `View3d` Base class
- Added `Project Info` filter for Rhino to include named views, and included views in the `All` filter
- Uses a dispatcher for converting and baking named views since those operations require synchronous modifications to Rhino GUI. Otherwise causes issues if trying to bake with the Named Views Rhino panel open.
- Note: some named views have a different zoom after converting to native, though all properties match the original view. This is not dependent on projection type. Annoying but not essential to fix, just requires user to adjust zoom on the view

Fixes #390 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: Sent a few models with named views from Rhino to Rhino, and from Revit to Rhino

## Docs

- No updates needed

