### PR TITLE
fix(objects): fixes scaling issue related from brep serialisation optimisations

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -695,6 +695,7 @@ namespace Objects.Converter.RhinoGh
     public Brep BrepToSpeckle(RH.Brep brep, string units = null)
     {
       var tol = RhinoDoc.ActiveDoc.ModelAbsoluteTolerance;
+      //tol = 0;
       var u = units ?? ModelUnits;
       brep.Repair(tol); //should maybe use ModelAbsoluteTolerance ?
       foreach (var f in brep.Faces)

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -107,6 +107,7 @@ namespace Objects.Geometry
       get
       {
         var list = new List<double>();
+        list.Add(Units.GetEncodingFromUnit(units));
         foreach (var vertex in Vertices)
         {
           list.AddRange(vertex.ToList());
@@ -117,9 +118,10 @@ namespace Objects.Geometry
       {
         if (value != null)
         {
-          for (int i = 0; i < value.Count; i += 3)
+          var units = Units.GetUnitFromEncoding(value[0]);
+          for (int i = value.Count %3 == 0 ? 0 : 1; i < value.Count; i += 3)
           {
-            Vertices.Add(new Point(value[i], value[i + 1], value[i + 2]));
+            Vertices.Add(new Point(value[i], value[i + 1], value[i + 2], units));
           }
         }
       }
@@ -243,6 +245,7 @@ namespace Objects.Geometry
     [OnDeserialized]
     internal void OnDeserialized(StreamingContext context)
     {
+      Surfaces.ForEach(s => s.units = units);
       Edges.ForEach(e => e.Brep = this);
       Loops.ForEach(l => l.Brep = this);
       Trims.ForEach(t => t.Brep = this);

--- a/Objects/Objects/Geometry/Surface.cs
+++ b/Objects/Objects/Geometry/Surface.cs
@@ -90,6 +90,7 @@ namespace Objects.Geometry
       list.AddRange(knotsU);
       list.AddRange(knotsV);
 
+      list.Add(Units.GetEncodingFromUnit(units));
       list.Insert(0, list.Count);
 
       return list;
@@ -115,7 +116,9 @@ namespace Objects.Geometry
       srf.pointData = list.GetRange(14, pointCount);
       srf.knotsU = list.GetRange(14 + pointCount, knotsUCount);
       srf.knotsV = list.GetRange(14 + pointCount + knotsUCount, knotsVCount);
-
+      
+      var u = list[list.Count - 1];
+      srf.units = Units.GetUnitFromEncoding(u);
       return srf;
     }
   }


### PR DESCRIPTION
two issues were at hand: 
- surfaces came through with wrong units (defaulted to meteres)
- vertices had no units

## Description

- Fixes unlogged issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

Received claire's amazing stadium in a variety of doc units in rhino. 

## Docs

- No updates needed


