### PR TITLE
fix(rhino): converts display mesh for builtelements

### DIFF
--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -298,6 +298,8 @@ namespace SpeckleRhino
           List<string> props = @base.GetDynamicMembers().ToList();
           if (@base.GetMembers().ContainsKey("displayMesh")) // add display mesh to member list if it exists
             props.Add("displayMesh");
+          else if (@base.GetMembers().ContainsKey("displayValue"))
+            props.Add("displayValue");
           int totalMembers = props.Count;
 
           foreach (var prop in props)


### PR DESCRIPTION
## Description

Tries to convert the displayMesh or displayValue if it exists and the Base conversion is not supported. Also includes fix for dangling issue (failure to bake "bad" geometry) by adding a warning and no longer creating layers on failure.

- Fixes #442 
- Fixes #340 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: received sample architecture file from Revit

## Docs

- No updates needed


