### PR TITLE
feat(objects,rhino): added pointcloud  and pointcloud conversions

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -91,6 +91,9 @@ namespace Objects.Converter.RhinoGh
         case Rhino.Geometry.Point o:
           @base = PointToSpeckle(o);
           break;
+        case PointCloud o:
+          @base = PointcloudToSpeckle(o);
+          break;
         case Vector3d o:
           @base = VectorToSpeckle(o);
           break;
@@ -258,6 +261,9 @@ namespace Objects.Converter.RhinoGh
         case Point o:
           return PointToNative(o);
 
+        case Pointcloud o:
+          return PointcloudToNative(o);
+
         case Vector o:
           return VectorToNative(o);
 
@@ -349,6 +355,9 @@ namespace Objects.Converter.RhinoGh
         case Rhino.Geometry.Point _:
           return true;
 
+        case PointCloud _:
+          return true;
+
         case Vector3d _:
           return true;
 
@@ -427,7 +436,10 @@ namespace Objects.Converter.RhinoGh
     {
       switch (@object)
       {
-        case Point _:
+        case Point _ :
+          return true;
+
+        case Pointcloud _:
           return true;
 
         case Vector _:

--- a/Objects/Objects/Geometry/Pointcloud.cs
+++ b/Objects/Objects/Geometry/Pointcloud.cs
@@ -1,0 +1,40 @@
+﻿using Speckle.Newtonsoft.Json;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System.Collections.Generic;
+
+namespace Objects.Geometry
+{
+  public class Pointcloud : Base, IHasBoundingBox
+  {
+
+    [DetachProperty]
+    [Chunkable(31250)]
+    public List<double> points { get; set; } = new List<double>();
+
+    [DetachProperty]
+    [Chunkable(62500)]
+    public List<int> colors { get; set; } = new List<int>();
+
+    [DetachProperty]
+    [Chunkable(62500)]
+    public List<double> sizes { get; set; } = new List<double>();
+
+    public Box bbox { get; set; }
+
+    public Pointcloud()
+    {
+    }
+
+    public IEnumerable<Point> GetPoints()
+    {
+      if (points.Count % 3 != 0) throw new Speckle.Core.Logging.SpeckleException("Array malformed: length%3 != 0.");
+
+      Point[] pts = new Point[points.Count / 3];
+      var asArray = points.ToArray();
+      for (int i = 2, k = 0; i < points.Count; i += 3)
+        pts[k++] = new Point(asArray[i - 2], asArray[i - 1], asArray[i], units);
+      return pts;
+    }
+  }
+}

--- a/Objects/Objects/Objects.csproj
+++ b/Objects/Objects/Objects.csproj
@@ -8,7 +8,7 @@
     <Authors>Speckle</Authors>
     <Company>Speckle</Company>
     <Product>Objects</Product>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Objects is the default object model for Speckle</Description>
     <PackageTags>speckle objects</PackageTags>


### PR DESCRIPTION
## Description

Adds a `Pointcloud` class to Objects. 
- Based on researching cad, unity, unreal, three.js, and PCL, current implementation includes points (all), colors (all), and sizes ( three.js, unity, unreal). Autocad api does not support pointcloud creation, and afaik neither does Revit. Ignores the ordered/unordered categorization from PCL for now.

Adds `Pointcloud` conversions for RhinoGh converter.
- Conversion adds a custom prop for point normals

Includes minor refactoring, removes unnecessary double array to point helper methods in the RhinoGh converter.

Fixes #367
Fixes #338 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: pointcloud conversions to/from Rhino https://latest.speckle.dev/streams/dc5e51ffd4/commits/e387efa5a6

## Docs

- Will be updated ASAP

