### PR TITLE
Claire/revit block conversion

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -260,6 +260,10 @@ namespace Objects.Converter.Revit
           UpdateParameter(o);
           return null;
 
+        // other
+        case Other.BlockInstance o:
+          return BlockInstanceToNative(o);
+
         default:
           return null;
       }
@@ -424,6 +428,10 @@ namespace Objects.Converter.Revit
           return true;
 
         case BER.ParameterUpdater _:
+          return true;
+
+        // other
+        case Other.BlockInstance _:
           return true;
 
         default:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertAdaptiveComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertBeam.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertBrace.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertBlock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertRevitElement.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\FreeformElement.cs" />

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using Autodesk.Revit.DB;
+using ConverterRevitShared.Revit;
+using Objects.Geometry;
+using Speckle.Core.Logging;
+using Speckle.Core.Models;
+using DB = Autodesk.Revit.DB;
+using DirectShape = Objects.BuiltElements.Revit.DirectShape;
+using Mesh = Objects.Geometry.Mesh;
+using Parameter = Objects.BuiltElements.Revit.Parameter;
+using BlockInstance = Objects.Other.BlockInstance;
+using BlockDefinition = Objects.Other.BlockDefinition;
+
+namespace Objects.Converter.Revit
+{
+  public partial class ConverterRevit
+  {
+    public List<ApplicationPlaceholderObject> BlockInstanceToNative(BlockInstance instance)
+    {
+      // Get or make family from block definition
+      FamilySymbol familySymbol = new FilteredElementCollector(Doc)
+        .OfClass(typeof(Family))
+        .OfType<Family>()
+        .FirstOrDefault(f => f.Name.Equals("SpeckleBlock_" + instance.blockDefinition.name))
+        ?.GetFamilySymbolIds()
+        .Select(id => Doc.GetElement(id))
+        .OfType<FamilySymbol>()
+        .FirstOrDefault(null);
+
+      if (familySymbol == null)
+        familySymbol = BlockDefinitionToNative(instance.blockDefinition);
+
+      // base point
+      var basePoint = PointToNative(instance.insertionPoint);
+
+      FamilyInstance _instance = Doc.Create.NewFamilyInstance(basePoint, familySymbol, DB.Structure.StructuralType.NonStructural);
+
+      Doc.Regenerate();
+
+      // transform
+      if (MatrixDecompose(instance.transform, out double rotation))
+      {
+        try
+        {
+          // some point based families don't have a rotation, so keep this in a try catch
+          if (rotation != (_instance.Location as LocationPoint).Rotation)
+          {
+            var axis = DB.Line.CreateBound(new XYZ(basePoint.X, basePoint.Y, 0), new XYZ(basePoint.X, basePoint.Y, 1000));
+            (_instance.Location as LocationPoint).Rotate(axis, rotation - (_instance.Location as LocationPoint).Rotation);
+          }
+        }
+        catch { }
+
+      }
+
+      SetInstanceParameters(_instance, instance);
+
+      var placeholders = new List<ApplicationPlaceholderObject>()
+      {
+        new ApplicationPlaceholderObject
+        {
+        applicationId = instance.applicationId,
+        ApplicationGeneratedId = _instance.UniqueId,
+        NativeObject = _instance
+        }
+      };
+
+      return placeholders;
+    }
+
+    private FamilySymbol BlockDefinitionToNative(BlockDefinition definition)
+    {
+      // convert definition geometry to native
+      var solids = new List<DB.Solid>();
+      var curves = new List<DB.Curve>();
+      foreach (var geometry in definition.geometry)
+      {
+        switch (geometry)
+        {
+          case Brep brep:
+            try
+            {
+              var solid = BrepToNative(geometry as Brep);
+              solids.Add(solid);
+            }
+            catch (Exception e)
+            {
+              ConversionErrors.Add(new SpeckleException($"Could not convert block {definition.id} BREP to native, falling back to mesh representation.", e));
+              var brepMeshSolids = MeshToNative(brep.displayMesh, DB.TessellatedShapeBuilderTarget.Solid, DB.TessellatedShapeBuilderFallback.Abort)
+                  .Select(m => m as DB.Solid);
+              solids.AddRange(brepMeshSolids);
+            }
+            break;
+          case Mesh mesh:
+            var meshSolids = MeshToNative(mesh, DB.TessellatedShapeBuilderTarget.Solid, DB.TessellatedShapeBuilderFallback.Abort)
+                .Select(m => m as DB.Solid);
+            solids.AddRange(meshSolids);
+            break;
+          case Geometry.Curve curve:
+            try
+            {
+              var modelCurve = CurveToNative(geometry as Objects.Geometry.Curve);
+              curves.Add(modelCurve);
+            }
+            catch (Exception e)
+            {
+              ConversionErrors.Add(new SpeckleException($"Could not convert block {definition.id} CURVE to native.", e));
+            }
+            break;
+        }
+      }
+
+      var tempPath = CreateBlockFamily(solids, curves, definition.name);
+      Doc.LoadFamily(tempPath, new FamilyLoadOption(), out var fam);
+      var symbol = Doc.GetElement(fam.GetFamilySymbolIds().First()) as DB.FamilySymbol;
+      symbol.Activate();
+      try
+      {
+        File.Delete(tempPath);
+      }
+      catch
+      {
+      }
+
+      return symbol;
+    }
+
+    private bool MatrixDecompose(double[] m, out double rotation)
+    {
+      var matrix = new Matrix4x4(
+        (float)m[0], (float)m[1], (float)m[2], (float)m[3],
+        (float)m[4], (float)m[5], (float)m[6], (float)m[7],
+        (float)m[8], (float)m[9], (float)m[10], (float)m[11],
+        (float)m[12], (float)m[13], (float)m[14], (float)m[15]);
+
+      if (Matrix4x4.Decompose(matrix, out Vector3 _scale, out Quaternion _rotation, out Vector3 _translation))
+      {
+        rotation = Math.Acos(_rotation.W) * 2;
+        return true;
+      }
+      else
+      {
+        rotation = 0;
+        return false;
+      }
+    }
+
+    private string CreateBlockFamily(List<DB.Solid> solids, List<DB.Curve> curves, string name)
+    {
+      // create a family to represent a block definition
+      var famPath = Path.Combine(Doc.Application.FamilyTemplatePath, @"English\Metric Generic Model.rft");
+      if (!File.Exists(famPath))
+      {
+        throw new Exception($"Could not find file Metric Generic Model.rft - {famPath}");
+      }
+
+      var famDoc = Doc.Application.NewFamilyDocument(famPath);
+      using (DB.Transaction t = new DB.Transaction(famDoc, "Create Block Geometry Elements"))
+      {
+        t.Start();
+
+        solids.ForEach(o => { DB.FreeFormElement.Create(famDoc, o); });
+        curves.ForEach(o => { famDoc.FamilyCreate.NewModelCurve(o, NewSketchPlaneFromCurve(o)); });
+
+        t.Commit();
+      }
+
+      var famName = "SpeckleBlock_" + name;
+      string tempFamilyPath = Path.Combine(Path.GetTempPath(), famName + ".rfa");
+      var so = new DB.SaveAsOptions();
+      so.OverwriteExistingFile = true;
+      famDoc.SaveAs(tempFamilyPath, so);
+      famDoc.Close();
+
+      return tempFamilyPath;
+    }
+  }
+}

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
@@ -39,7 +39,7 @@ namespace Objects.Converter.Revit
       while (curveEnumerator.MoveNext() && curveEnumerator.Current != null)
       {
         var baseCurve = curveEnumerator.Current as Curve;
-        DB.ModelCurve revitCurve = Doc.Create.NewModelCurve(baseCurve, NewSketchPlaneFromCurve(baseCurve));
+        DB.ModelCurve revitCurve = Doc.Create.NewModelCurve(baseCurve, NewSketchPlaneFromCurve(baseCurve, Doc));
 
         var lineStyles = revitCurve.GetLineStyleIds();
         var lineStyleId = lineStyles.FirstOrDefault(x => Doc.GetElement(x).Name == speckleCurve.lineStyle);
@@ -71,7 +71,7 @@ namespace Objects.Converter.Revit
       while (curveEnumerator.MoveNext() && curveEnumerator.Current != null)
       {
         var curve = curveEnumerator.Current as DB.Curve;
-        DB.ModelCurve revitCurve = Doc.Create.NewModelCurve(curve, NewSketchPlaneFromCurve(curve));
+        DB.ModelCurve revitCurve = Doc.Create.NewModelCurve(curve, NewSketchPlaneFromCurve(curve, Doc));
         placeholders.Add(new ApplicationPlaceholderObject() { applicationId = (speckleLine as Base).applicationId, ApplicationGeneratedId = revitCurve.UniqueId, NativeObject = revitCurve });
       }
 
@@ -149,7 +149,7 @@ namespace Objects.Converter.Revit
 
       try
       {
-        var res = Doc.Create.NewRoomBoundaryLines(NewSketchPlaneFromCurve(baseCurve.get_Item(0)), baseCurve, Doc.ActiveView).get_Item(0);
+        var res = Doc.Create.NewRoomBoundaryLines(NewSketchPlaneFromCurve(baseCurve.get_Item(0), Doc), baseCurve, Doc.ActiveView).get_Item(0);
         return new ApplicationPlaceholderObject()
         { applicationId = speckleCurve.applicationId, ApplicationGeneratedId = res.UniqueId, NativeObject = res };
       }
@@ -169,7 +169,7 @@ namespace Objects.Converter.Revit
     /// </summary>
     /// <param name="curve">Curve to get plane from</param>
     /// <returns>Plane of the curve</returns>
-    private SketchPlane NewSketchPlaneFromCurve(DB.Curve curve)
+    private SketchPlane NewSketchPlaneFromCurve(DB.Curve curve, Document doc)
     {
       XYZ startPoint = curve.GetEndPoint(0);
       XYZ endPoint = curve.GetEndPoint(1);
@@ -212,7 +212,7 @@ namespace Objects.Converter.Revit
         plane = DB.Plane.CreateByThreePoints(startPoint, new XYZ(0, 0, 0), endPoint);
       }
 
-      return SketchPlane.Create(Doc, plane);
+      return SketchPlane.Create(doc, plane);
     }
     private DB.Plane CreatePlane(XYZ basis, XYZ startPoint)
     {


### PR DESCRIPTION
## Description

Add ToNative `Block` conversions to Revit as `Generic Families`.  No need for a ToSpeckle method - will be exported as families.
A few notes to improve the conversions:

- Family template path is hardcoded and unreliable (eg users who have multiple language packs installed have a different .rft path). This is also an issue for freeform element conversions
- Family template used should be based off of main doc units (currently set to metric always)
- Unit conversions are borked because conversions are referencing main doc units instead of family doc units. This is also an issue for freeform element conversions
- May need to look into multiple axis rotations in the future (currently only handling z axis rotations)
- Need to figure out how to store commit info in main doc to retrieve and use as a block name prefix in the converter, otherwise old family rfas will be used in the case of blocks with the same name

Fixes #436 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: received standard file from Rhino, including blocks

## Docs

- Will be updated ASAP

