### PR TITLE
Claire/arc conversion fixes

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -30,6 +30,8 @@ namespace Objects.Converter.AutocadCivil
     {
       return null;
     }
+
+    // alignments
   }
 }
 #endif

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -185,7 +185,12 @@ namespace Objects.Converter.AutocadCivil
     }
     public CircularArc3d ArcToNative(Arc arc)
     {
-      return new CircularArc3d(PointToNative(arc.startPoint), PointToNative(arc.midPoint), PointToNative(arc.endPoint));
+      var _arc = new CircularArc3d(PointToNative(arc.startPoint), PointToNative(arc.midPoint), PointToNative(arc.endPoint));
+
+      _arc.SetAxes(VectorToNative(arc.plane.normal), VectorToNative(arc.plane.xdir));
+      _arc.SetAngles((double)arc.startAngle, (double)arc.endAngle);
+
+      return _arc;
     }
 
     // Curve


### PR DESCRIPTION
## Description
Fixes bug where some clockwise arcs sent from Rhino were not being correctly converted to native in autocad due to differing conventions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: updated standard file with additional arc conditions and sent back and forth between autocad and rhino

## Docs

- No updates needed

