### PR TITLE
Update schemabuilder behavior for Rhino and GH

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -222,7 +222,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
           bool changedLayerNames = false;
 
           // create a commit layer prefix: all nested layers will be concatenated with this
-          var layerPrefix = DesktopUI.Utils.Formatting.CommitLayer(stream.name, state.Branch.name, id);
+          var layerPrefix = DesktopUI.Utils.Formatting.CommitInfo(stream.name, state.Branch.name, id);
 
           // give converter a way to access the commit info
           Doc.UserData.Add("commit", layerPrefix);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -502,7 +502,7 @@ namespace ConnectorGrasshopper.Ops
           var message = _MessageInput.get_FirstItem(true).Value;
           if (message == "")
           {
-            message = "Grasshopper push.";
+            message = $"Pushed {TotalObjectCount} elements from Grasshopper.";
           }
 
           var prevCommits = ((SendComponent)Parent).OutputWrappers;

--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -251,7 +251,7 @@ namespace SpeckleRhino
       };
 
       // get commit layer name 
-      var commitLayerName = Speckle.DesktopUI.Utils.Formatting.CommitLayer(stream.name, state.Branch.name, commitId);
+      var commitLayerName = Speckle.DesktopUI.Utils.Formatting.CommitInfo(stream.name, state.Branch.name, commitId);
 
       // give converter a way to access the base commit layer name
       RhinoDoc.ActiveDoc.Notes += "%%%" + commitLayerName;
@@ -358,7 +358,12 @@ namespace SpeckleRhino
           Layer bakeLayer = Doc.GetLayer(layerPath, true);
           if (bakeLayer != null)
           {
-            if (Doc.Objects.Add(convertedRH, new ObjectAttributes { LayerIndex = bakeLayer.Index }) == Guid.Empty)
+            var attributes = new ObjectAttributes { LayerIndex = bakeLayer.Index };
+            string schema = obj["SpeckleSchema"] as string;
+            if (schema != null)
+              attributes.SetUserString("SpeckleSchema", schema);
+
+            if (Doc.Objects.Add(convertedRH, attributes) == Guid.Empty)
               state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}."));
           }
           else
@@ -440,10 +445,7 @@ namespace SpeckleRhino
             }
 
             foreach (var key in obj.Attributes.GetUserStrings().AllKeys)
-            {
-              // TODO: check if this is a SchemaBuilder key and maybe omit?
-              converted[key] = obj.Attributes.GetUserString(key);
-            }
+                converted[key] = obj.Attributes.GetUserString(key);
 
             if (obj is InstanceObject)
               containerName = "Blocks";

--- a/DesktopUI/DesktopUI/Utils/Helpers.cs
+++ b/DesktopUI/DesktopUI/Utils/Helpers.cs
@@ -145,7 +145,7 @@ namespace Speckle.DesktopUI.Utils
       return num != 1 ? "s" : "";
     }
 
-    public static string CommitLayer(string stream, string branch, string commitId)
+    public static string CommitInfo(string stream, string branch, string commitId)
     {
       string formatted = $"{stream}[ {branch} @ {commitId} ]";
       string clean = Regex.Replace(formatted, @"[^\u0000-\u007F]+", string.Empty).Trim(); // remove emojis and trim :( 

--- a/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
+++ b/DesktopUI/DesktopUI/Utils/SelectionFilter.cs
@@ -17,7 +17,7 @@ namespace Speckle.DesktopUI.Utils
   {
 
     /// <summary>
-    /// User friendly name displaied in the UI
+    /// User friendly name displayed in the UI
     /// </summary>
     string Name { get; set; }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -190,6 +190,10 @@ namespace Objects.Converter.Revit
 
     public object ConvertToNative(Base @object)
     {
+      // schema check
+      Base speckleSchema = @object["SpeckleSchema"] as Base;
+       @object = (speckleSchema != null) ? speckleSchema : @object ;
+
       switch (@object)
       {
         //geometry

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -191,8 +191,15 @@ namespace Objects.Converter.Revit
     public object ConvertToNative(Base @object)
     {
       // schema check
-      Base speckleSchema = @object["SpeckleSchema"] as Base;
-       @object = (speckleSchema != null) ? speckleSchema : @object ;
+      var speckleSchema = @object["@SpeckleSchema"] as Base;
+      if (speckleSchema != null) 
+      {
+        // find self referential prop and set value to @object if it is null (happens when sent from gh)
+        var objProp = speckleSchema.GetInstanceMembers().Where(o => !o.GetType().IsEnum).Where(o => !Utilities.IsSimpleType(o.GetType())).First();
+        if (speckleSchema[objProp.Name] == null)
+          speckleSchema[objProp.Name] = @object;
+        @object = speckleSchema;
+      }
 
       switch (@object)
       {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -64,22 +64,15 @@ namespace Objects.Converter.RhinoGh
     {
       RenderMaterial material = null;
       Base @base = null;
+      Base schema = null;
       if (@object is RhinoObject ro)
       {
         material = GetMaterial(ro);
-        // special case for rhino objects that have a `SpeckleSchema` attribute
-        // this will change in the near future
-        if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null)
-        {
-          @base = ConvertToSpeckleBE(ro);
-          if (@base != null)
-          {
-            @base["renderMaterial"] = material;
-            return @base;
-          }
-        }
-        //conversion to built elem failed, revert to just send the base geom
-        if (!(@object is InstanceObject))
+        
+        if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
+          schema = ConvertToSpeckleBE(ro);
+
+        if (!(@object is InstanceObject)) // block instance check
           @object = ro.Geometry;
       }
 
@@ -169,6 +162,12 @@ namespace Objects.Converter.RhinoGh
 
       if (material != null)
         @base["renderMaterial"] = material;
+
+      if (schema != null)
+      {
+        schema["renderMaterial"] = material;
+        @base["@SpeckleSchema"] = schema;
+      }
 
       return @base;
     }


### PR DESCRIPTION
## Description

Updates schemabuilder behavior in Rhino and GH by attaching BuiltElement as a prop.

GH:
 - CreateSchemaObject output is now the defining param input converted to Base, with the generated BuiltElement attached as a prop.
 - The `defining param` is the first input geometry param. This will register as a null value in the detached BuiltElement prop.
 - If no `defining param` is found, the output will be the generated BuiltElement (old functionality)
 - When a CSO object is converted back to GH, only the `defining param` will be converted

Rhino:
 - SpeckleSchema user attribute string will attach generated BuiltElement as a prop, same as GH
 - When a schema object is converted back into Rhino, the original geometry will be received *with* the SpeckleSchema user attribute string

Revit:
 - Adds a check on ConvertToNative for an attached SpeckleSchema property. Handles case where when sent from GH, the `defining prop` value of the BuiltElement object is null.

Fixes #441 
Fixes #366 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: updated BuiltElements test files and tested Rhino -> Revit -> Rhino, GH -> Revit -> GH

## Docs

- No updates needed

