### PR TITLE
refactor(revit): better failure warning

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
+++ b/ConnectorRevit/ConnectorRevit/Revit/ErrorEater.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Autodesk.Revit.DB;
@@ -27,7 +27,7 @@ namespace ConnectorRevit.Revit
       var failedElements = new List<ElementId>();
       // Inside event handler, get all warnings
       failList = failuresAccessor.GetFailureMessages();
-      foreach (FailureMessageAccessor failure in failList)
+      foreach ( FailureMessageAccessor failure in failList )
       {
         // check FailureDefinitionIds against ones that you want to dismiss, 
         //FailureDefinitionId failID = failure.GetFailureDefinitionId();
@@ -38,20 +38,25 @@ namespace ConnectorRevit.Revit
         _converter.ConversionErrors.Add(new Exception(t));
 
         var s = failure.GetSeverity();
-        if (s == FailureSeverity.Warning) continue;
+        if ( s == FailureSeverity.Warning ) continue;
         try
         {
           failuresAccessor.ResolveFailure(failure);
         }
-        catch (Exception e)
+        catch ( Exception e )
         {
           // currently, the whole commit is rolled back. this should be investigated further at a later date
           // to properly proceed with commit
           failedElements.AddRange(failure.GetFailingElementIds());
           _converter.ConversionErrors.Clear();
-          _converter.ConversionErrors.Add(new Exception("Objects failed to bake due to fatal error: " + t));
+          _converter.ConversionErrors.Add(new Exception(
+            "Objects failed to bake due to a fatal error!\n" +
+            "This is likely due to scaling issues - please ensure you've set the correct units on your objects or remove any invalid objects.\n\n" +
+            "Revit error: " + t));
           // logging the error
-          var exception = new Speckle.Core.Logging.SpeckleException("Revit commit failed: " + t, e, level: Sentry.SentryLevel.Warning);
+          var exception =
+            new Speckle.Core.Logging.SpeckleException("Revit commit failed: " + t, e,
+              level: Sentry.SentryLevel.Warning);
           return FailureProcessingResult.ProceedWithCommit;
         }
       }


### PR DESCRIPTION
## Description

Example problematic stream [here](https://latest.speckle.dev/streams/27bcb1c57b).

This issue is being laid to rest for now. All I've done is improve the error message so the user knows what is likely the problem (units).

- Fixes #299 

**log:**
Tried subtransactions as per ADN's suggestion, but found out that failures are _not_ processed when committing subtransactions - the event isn't fired until the parent transaction is committed. This means wrapping all element conversions in subtransactions and rolling back the ones that failed isn't an option.

Another thing you can do is collect the element ids for the failing elements, roll back the whole commit, then re-do the transaction without those elements. However, after discussing w teo we decided this was not ideal as 1. element ids will be different when the conversion is creating new elements and 2. it's a pretty hacky solution even in the cases it would work (only update streams).

Doing a transaction group with a new transaction for each element is also not an option as this causes a _huge_ degradation in performance (eg 15 min vs 1 min).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests in revit

## Docs

- No updates needed

