### PR TITLE
feat(autocadcivil): add 2022 projects

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -75,23 +75,36 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorRevit2019", "Conne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterRhinoGh", "Objects\Converters\ConverterRhinoGh\ConverterRhinoGh.csproj", "{1DD0275D-2E11-43E6-B495-996D7183BB3B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorAutocad2022", "ConnectorAutocadCivil\ConnectorAutocad2022\ConnectorAutocad2022.csproj", "{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorCivil2022", "ConnectorAutocadCivil\ConnectorCivil2022\ConnectorCivil2022.csproj", "{464F2220-D7D9-4D8C-BB3D-B93A1C603469}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterAutocad2022", "Objects\Converters\ConverterAutocadCivil\ConverterAutocad2022\ConverterAutocad2022.csproj", "{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterCivil2022", "Objects\Converters\ConverterAutocadCivil\ConverterCivil2022\ConverterCivil2022.csproj", "{8581B4BB-A8BC-4328-99FE-D18615AF2554}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{27a79aca-7ea8-4406-8bb8-216578cc3ab7}*SharedItemsImports = 4
 		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{2d0f9f8a-2e89-4780-978a-cd92d6d7b843}*SharedItemsImports = 13
 		Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{2dcd648d-dca5-4d2a-8b14-ad2cb85d24b0}*SharedItemsImports = 13
 		Objects\Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{3df12639-78b6-41b3-a046-a675035369be}*SharedItemsImports = 5
+		ConnectorAutocadCivil\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{464f2220-d7d9-4d8c-bb3d-b93a1c603469}*SharedItemsImports = 4
+		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{50bc1552-3e7e-4c77-ac3a-aa7c572dfe09}*SharedItemsImports = 5
 		ConnectorAutocadCivil\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{58a88f1a-7489-46d2-949d-2fc3f68c8d84}*SharedItemsImports = 4
 		Objects\Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{5bab09dc-b0fc-4004-9fd5-6496a9634071}*SharedItemsImports = 13
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{5fd0d810-03e9-4fd2-93e4-b1b51e5d82c5}*SharedItemsImports = 13
 		Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{77f660dd-302e-4e3e-94dd-29ec8d5b59a6}*SharedItemsImports = 5
 		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{78573adc-87a5-489f-8134-fb4a435a05f0}*SharedItemsImports = 5
+		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{8581b4bb-a8bc-4328-99fe-d18615af2554}*SharedItemsImports = 5
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{8a53b084-20d8-48f6-9591-9d53cfa74130}*SharedItemsImports = 4
 		Objects\Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{aacd5d91-99f1-4e69-b23b-e25239e5fb59}*SharedItemsImports = 5
+		Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{aacd5d91-99f1-4e69-b23b-e25239e5fb59}*SharedItemsImports = 5
 		ConnectorAutocadCivil\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{ad10c167-937f-4706-9eb5-c99f86c35e8f}*SharedItemsImports = 4
 		ConnectorAutocadCivil\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{b47492d9-2eda-4016-a930-7fa708c85c3d}*SharedItemsImports = 13
 		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{d9f443b5-c55b-4ad8-9c70-bc3d2be781be}*SharedItemsImports = 5
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{ef418256-8118-47b4-8386-a945946fb92d}*SharedItemsImports = 4
+		ConnectorAutocadCivil\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{ff1793e1-77f5-4a92-b3f2-6d8b104e479b}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -268,6 +281,38 @@ Global
 		{1DD0275D-2E11-43E6-B495-996D7183BB3B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1DD0275D-2E11-43E6-B495-996D7183BB3B}.Release|x64.ActiveCfg = Release|Any CPU
 		{1DD0275D-2E11-43E6-B495-996D7183BB3B}.Release|x64.Build.0 = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|x64.Build.0 = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|x64.ActiveCfg = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|x64.Build.0 = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|x64.Build.0 = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|Any CPU.Build.0 = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|x64.ActiveCfg = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|x64.Build.0 = Release|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Debug|x64.Build.0 = Debug|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Release|x64.ActiveCfg = Release|Any CPU
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09}.Release|x64.Build.0 = Release|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Debug|x64.Build.0 = Debug|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Release|x64.ActiveCfg = Release|Any CPU
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -305,6 +350,10 @@ Global
 		{8A53B084-20D8-48F6-9591-9D53CFA74130} = {42A86931-7497-4A34-B2FD-060231CD0A8F}
 		{EF418256-8118-47B4-8386-A945946FB92D} = {42A86931-7497-4A34-B2FD-060231CD0A8F}
 		{1DD0275D-2E11-43E6-B495-996D7183BB3B} = {4DE5ED81-2A55-4C23-A05F-3C9B9B06F85D}
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B} = {890F3257-FCC2-4ED8-9180-22B3641B494C}
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469} = {890F3257-FCC2-4ED8-9180-22B3641B494C}
+		{50BC1552-3E7E-4C77-AC3A-AA7C572DFE09} = {BE521908-7944-46F3-98BF-B47D34509934}
+		{8581B4BB-A8BC-4328-99FE-D18615AF2554} = {BE521908-7944-46F3-98BF-B47D34509934}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D43D91B-4F01-4A78-8250-CC6F9BD93A14}

--- a/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
@@ -65,6 +65,8 @@
   <ItemGroup>
     <PackageReference Include="ModPlus.AutoCAD.API.2021">
       <Version>1.0.0</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />

--- a/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Speckle.ConnectorAutocad</RootNamespace>
+    <AssemblyName>SpeckleConnectorAutocad</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(ProgramW6432)\Autodesk\AutoCAD 2022\acad.exe</StartProgram>
+    <!--these four make so that the SQLite.Interop.dll is copied in the after build target-->
+    <ContentSQLiteInteropFiles>true</ContentSQLiteInteropFiles>
+    <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
+    <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
+    <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;AUTOCAD2022</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ModPlus.AutoCAD.API.2022">
+      <Version>1.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Core\Core.csproj">
+      <Project>{3ad2c014-1eca-4a6b-bac4-30ce9a443a5b}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DesktopUI\DesktopUI\DesktopUI.csproj">
+      <Project>{a97c3046-2d55-4c49-ab40-a3c2194b82fa}</Project>
+      <Name>DesktopUI</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- POST BUILD EVENTS START -->
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+  <Target Name="Clean">
+    <RemoveDir Directories="$(TargetDir);$(AppData)\Autodesk\ApplicationPlugins\Speckle2AutoCAD2022" />
+  </Target>
+  <Target Name="AfterBuild">
+    <CallTarget Condition="'$(Configuration)' == 'Debug' AND '$(IsDesktopBuild)' == true" Targets="AfterBuildDebug" />
+    <!--<CallTarget Condition="'$(Configuration)' == 'Release'" Targets="AfterBuildRelease" />-->
+  </Target>
+  <Target Name="AfterBuildDebug">
+    <ItemGroup>
+      <SourceDLLs Include="$(TargetDir)\**\*.*" />
+    </ItemGroup>
+    <Copy DestinationFolder="$(AppData)\Autodesk\ApplicationPlugins\Speckle2AutoCAD2022\%(RecursiveDir)" SourceFiles="@(SourceDLLs)" />
+  </Target>
+  <!--<Target Name="AfterBuildRelease">
+  </Target>-->
+  <!--END-->
+</Project>

--- a/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
@@ -34,7 +34,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;AUTOCAD2022</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -52,8 +52,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ModPlus.AutoCAD.API.2022">
-      <Version>1.0.0</Version>
+    <PackageReference Include="Speckle.AutoCAD.API">
+      <Version>2022.0.0.2</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ConnectorAutocadCivil/ConnectorAutocad2022/Properties/AssemblyInfo.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocad2022/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ConnectorAutocad2022")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConnectorAutocad2022")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ff1793e1-77f5-4a92-b3f2-6d8b104e479b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil.sln
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil.sln
@@ -27,14 +27,30 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterCivil2021", "..\Ob
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorCivil2021", "ConnectorCivil2021\ConnectorCivil2021.csproj", "{AD10C167-937F-4706-9EB5-C99F86C35E8F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterAutocad2022", "..\Objects\Converters\ConverterAutocadCivil\ConverterAutocad2022\ConverterAutocad2022.csproj", "{D6731414-A695-4F89-AEA1-AE2141A1DAC1}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3AD2C014-1ECA-4A6B-BAC4-30CE9A443A5B} = {3AD2C014-1ECA-4A6B-BAC4-30CE9A443A5B}
+		{DE63379E-844A-47D9-AFDB-151A1888A912} = {DE63379E-844A-47D9-AFDB-151A1888A912}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterCivil2022", "..\Objects\Converters\ConverterAutocadCivil\ConverterCivil2022\ConverterCivil2022.csproj", "{575293FB-158C-4F91-ABC1-18B60F310B32}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorAutocad2022", "ConnectorAutocad2022\ConnectorAutocad2022.csproj", "{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorCivil2022", "ConnectorCivil2022\ConnectorCivil2022.csproj", "{464F2220-D7D9-4D8C-BB3D-B93A1C603469}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{2d0f9f8a-2e89-4780-978a-cd92d6d7b843}*SharedItemsImports = 13
 		..\Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{361b45eb-dc3f-42bb-93ee-21f31a05fa68}*SharedItemsImports = 5
+		ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{464f2220-d7d9-4d8c-bb3d-b93a1c603469}*SharedItemsImports = 4
+		..\Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{575293fb-158c-4f91-abc1-18b60f310b32}*SharedItemsImports = 5
 		ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{58a88f1a-7489-46d2-949d-2fc3f68c8d84}*SharedItemsImports = 4
 		..\Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{8cfc7609-f640-4683-bf13-fe144d3dc50b}*SharedItemsImports = 5
 		ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{ad10c167-937f-4706-9eb5-c99f86c35e8f}*SharedItemsImports = 4
 		ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{b47492d9-2eda-4016-a930-7fa708c85c3d}*SharedItemsImports = 13
+		..\Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{d6731414-a695-4f89-aea1-ae2141a1dac1}*SharedItemsImports = 5
+		ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems*{ff1793e1-77f5-4a92-b3f2-6d8b104e479b}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,6 +115,38 @@ Global
 		{AD10C167-937F-4706-9EB5-C99F86C35E8F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AD10C167-937F-4706-9EB5-C99F86C35E8F}.Release|x64.ActiveCfg = Release|Any CPU
 		{AD10C167-937F-4706-9EB5-C99F86C35E8F}.Release|x64.Build.0 = Release|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Debug|x64.Build.0 = Debug|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Release|x64.ActiveCfg = Release|Any CPU
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1}.Release|x64.Build.0 = Release|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Debug|x64.Build.0 = Debug|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Release|x64.ActiveCfg = Release|Any CPU
+		{575293FB-158C-4F91-ABC1-18B60F310B32}.Release|x64.Build.0 = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Debug|x64.Build.0 = Debug|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|x64.ActiveCfg = Release|Any CPU
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B}.Release|x64.Build.0 = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Debug|x64.Build.0 = Debug|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|Any CPU.Build.0 = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|x64.ActiveCfg = Release|Any CPU
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,6 +161,10 @@ Global
 		{2D0F9F8A-2E89-4780-978A-CD92D6D7B843} = {8AFDB1E6-D3E7-45EA-BCDC-F3554BDDEF1E}
 		{361B45EB-DC3F-42BB-93EE-21F31A05FA68} = {8AFDB1E6-D3E7-45EA-BCDC-F3554BDDEF1E}
 		{AD10C167-937F-4706-9EB5-C99F86C35E8F} = {A07071D5-E197-487D-B543-28639AC3C719}
+		{D6731414-A695-4F89-AEA1-AE2141A1DAC1} = {8AFDB1E6-D3E7-45EA-BCDC-F3554BDDEF1E}
+		{575293FB-158C-4F91-ABC1-18B60F310B32} = {8AFDB1E6-D3E7-45EA-BCDC-F3554BDDEF1E}
+		{FF1793E1-77F5-4A92-B3F2-6D8B104E479B} = {A07071D5-E197-487D-B543-28639AC3C719}
+		{464F2220-D7D9-4D8C-BB3D-B93A1C603469} = {A07071D5-E197-487D-B543-28639AC3C719}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DB7A654-4C09-4C9B-8CA1-01952811F527}

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using System.Collections;
-using System.Drawing;
 
 using Speckle.Newtonsoft.Json;
 using Speckle.Core.Models;
@@ -21,6 +20,7 @@ using AcadApp = Autodesk.AutoCAD.ApplicationServices;
 using AcadDb = Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
 using Autodesk.AutoCAD.ApplicationServices;
+using Autodesk.AutoCAD.Colors;
 
 using Stylet;
 using Autodesk.AutoCAD.DatabaseServices;
@@ -397,7 +397,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
           var _layer = new AcadDb.LayerTableRecord();
 
           // Assign the layer properties
-          _layer.Color = Autodesk.AutoCAD.Colors.Color.FromColor(Color.White);
+          _layer.Color = Autodesk.AutoCAD.Colors.Color.FromColorIndex(ColorMethod.ByColor, 7); // white
           _layer.Name = cleanName;
 
           // Append the new layer to the layer table and the transaction

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -18,8 +18,14 @@ namespace Speckle.ConnectorAutocadCivil
 #if AUTOCAD2021
     public static string AutocadAppName = Applications.Autocad2021;
     public static string AppName = "AutoCAD";
+#elif AUTOCAD2022
+public static string AutocadAppName = Applications.Autocad2022;
+    public static string AppName = "AutoCAD";
 #elif CIVIL2021
     public static string AutocadAppName = Applications.Civil2021;
+    public static string AppName = "Civil 3D";
+#elif CIVIL2022
+    public static string AutocadAppName = Applications.Civil2022;
     public static string AppName = "Civil 3D";
 #endif
     public static string invalidChars = @"<>/\:;""?*|=‘";

--- a/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
@@ -68,9 +68,13 @@
   <ItemGroup>
     <PackageReference Include="Civil3D2021.Base">
       <Version>1.0.0</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="ModPlus.AutoCAD.API.2021">
       <Version>1.0.0</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />

--- a/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{464F2220-D7D9-4D8C-BB3D-B93A1C603469}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Speckle.ConnectorCivil</RootNamespace>
+    <AssemblyName>SpeckleConnectorCivil</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(ProgramW6432)\Autodesk\AutoCAD 2022\acad.exe</StartProgram>
+    <StartArguments>
+      /ld "C:\Program Files\Autodesk\AutoCAD 2022\\AecBase.dbx"  /product "C3D" /language "en-US"
+    </StartArguments>
+    <!--these four make so that the SQLite.Interop.dll is copied in the after build target-->
+    <ContentSQLiteInteropFiles>true</ContentSQLiteInteropFiles>
+    <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
+    <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
+    <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;CIVIL2022</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;CIVIL2022</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ModPlus.AutoCAD.API.2022">
+      <Version>1.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="Speckle.Civil3D.API">
+      <Version>2022.0.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Core\Core.csproj">
+      <Project>{3ad2c014-1eca-4a6b-bac4-30ce9a443a5b}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DesktopUI\DesktopUI\DesktopUI.csproj">
+      <Project>{a97c3046-2d55-4c49-ab40-a3c2194b82fa}</Project>
+      <Name>DesktopUI</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- POST BUILD EVENTS START -->
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+  <Target Name="Clean">
+    <RemoveDir Directories="$(TargetDir);$(AppData)\Autodesk\ApplicationPlugins\Speckle2Civil3D2022" />
+  </Target>
+  <Target Name="AfterBuild">
+    <CallTarget Condition="'$(Configuration)' == 'Debug' AND '$(IsDesktopBuild)' == true" Targets="AfterBuildDebug" />
+    <!--<CallTarget Condition="'$(Configuration)' == 'Release'" Targets="AfterBuildRelease" />-->
+  </Target>
+  <Target Name="AfterBuildDebug">
+    <ItemGroup>
+      <SourceDLLs Include="$(TargetDir)\**\*.*" />
+    </ItemGroup>
+    <Copy DestinationFolder="$(AppData)\Autodesk\ApplicationPlugins\Speckle2Civil3D2022\%(RecursiveDir)" SourceFiles="@(SourceDLLs)" />
+  </Target>
+  <!--<Target Name="AfterBuildRelease">
+  </Target>-->
+  <!--END-->
+</Project>

--- a/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
@@ -55,11 +55,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ModPlus.AutoCAD.API.2022">
-      <Version>1.0.0</Version>
+    <PackageReference Include="Speckle.AutoCAD.API">
+      <Version>2022.0.0.2</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Speckle.Civil3D.API">
       <Version>2022.0.0.1</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ConnectorAutocadCivil/ConnectorCivil2022/Properties/AssemblyInfo.cs
+++ b/ConnectorAutocadCivil/ConnectorCivil2022/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ConnectorCivil2022")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConnectorCivil2022")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("464f2220-d7d9-4d8c-bb3d-b93a1c603469")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ConnectorAutocadCivil/README.md
+++ b/ConnectorAutocadCivil/README.md
@@ -16,10 +16,13 @@ Comprehensive developer and user documentation can be found in our:
 
 ### Requirements
 
-- AutoCAD 2021
-- Civil3D 2021 (optional)
 - A Speckle Server running (more on this below)
 - Speckle Manager (more on this below)
+
+#### Supported versions
+
+- AutoCAD: 2021, 2022
+- Civil3D: 2021, 2022
 
 ### Getting Started
 
@@ -35,7 +38,7 @@ The connector itself doesn't have features to manage your Speckle account - this
 
 We are currently exploring ways of streamlining AutoCAD add-in loading: for now, follow the steps below on *every* debug session ಠ_ಠ :
 
-- Start a Visual Studio debug session, and wait for your AutoCAD, Civil3D, or Civil3D as AutoCAD application to open
+- Start a Visual Studio debug session with the target connector as your startup project, and wait for your AutoCAD, Civil3D, or Civil3D as AutoCAD application to open
 - Enter `NETLOAD` in the command prompt
 - Navigate to and select the SpeckleConnectorAutocad.dll or SpeckleConnectorCivil.dll in the corresponding local repo Debug bin (ex: `speckle-sharp\ConnectorAutocadCivil\ConnectorCivil2021\bin\Debug`)
 - The Speckle connector should now appear in the Add-ins ribbon! Click this to get started, or enter `SPECKLE` in the command prompt.

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Objects.Converter.Autocad2022</AssemblyName>
+    <RootNamespace>Objects.Converter.Autocad</RootNamespace>
+    <DefineConstants>$(DefineConstants);AUTOCAD2022</DefineConstants>
+    <PackageId>Speckle.Objects.Converter.Autocad2022</PackageId>
+    <Authors>Speckle</Authors>
+    <Company>Speckle</Company>
+    <Product>Objects.Converter.Autocad2022</Product>
+    <Version>2.1.0</Version>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <Description>Converter for Autocad 2022</Description>
+    <PackageTags>speckle objects converter autocad</PackageTags>
+    <RepositoryUrl>https://github.com/specklesystems/speckle-sharp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageProjectUrl>https://speckle.systems/</PackageProjectUrl>
+    <Copyright>Copyright (c) AEC Systems Ltd</Copyright>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="ModPlus.AutoCAD.API.2022" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
+    <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\..\logo.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  </Target>
+
+  <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />
+
+</Project>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/Properties/launchSettings.json
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "ConverterAutocad2022": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Autodesk\\AutoCAD 2022\\acad.exe"
+    }
+  }
+}

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -1,4 +1,4 @@
-﻿#if CIVIL2021
+﻿#if (CIVIL2021 || CIVIL2022)
 using System.Collections.Generic;
 
 using Autodesk.AutoCAD.DatabaseServices;

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -25,7 +25,7 @@ using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 using Acad = Autodesk.AutoCAD;
 using AcadDB = Autodesk.AutoCAD.DatabaseServices;
-#if CIVIL2021
+#if (CIVIL2021 || CIVIL2022)
 using Civil = Autodesk.Civil;
 using CivilDB = Autodesk.Civil.DatabaseServices;
 #endif
@@ -37,8 +37,12 @@ namespace Objects.Converter.AutocadCivil
   {
 #if AUTOCAD2021
     public static string AutocadAppName = Applications.Autocad2021;
+#elif AUTOCAD2022
+public static string AutocadAppName = Applications.Autocad2022;
 #elif CIVIL2021
     public static string AutocadAppName = Applications.Civil2021;
+#elif CIVIL2022
+    public static string AutocadAppName = Applications.Civil2022;
 #endif
 
     #region ISpeckleConverter props
@@ -234,7 +238,7 @@ namespace Objects.Converter.AutocadCivil
         case BlockTableRecord o:
           return BlockRecordToSpeckle(o);
 
-#if CIVIL2021
+#if (CIVIL2021 || CIVIL2022)
         case CivilDB.FeatureLine o:
           return FeatureLineToSpeckle(o);
 #endif

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Objects.Converter.Civil2022</AssemblyName>
+    <RootNamespace>Objects.Converter.Civil</RootNamespace>
+    <DefineConstants>$(DefineConstants);CIVIL2022</DefineConstants>
+    <PackageId>Speckle.Objects.Converter.Civil2022</PackageId>
+    <Authors>Speckle</Authors>
+    <Company>Speckle</Company>
+    <Product>Objects.Converter.Civil2022</Product>
+    <Version>2.1.0</Version>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <Description>Converter for Civil3D 2022</Description>
+    <PackageTags>speckle objects converter civil3d</PackageTags>
+    <RepositoryUrl>https://github.com/specklesystems/speckle-sharp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageProjectUrl>https://speckle.systems/</PackageProjectUrl>
+    <Copyright>Copyright (c) AEC Systems Ltd</Copyright>
+  </PropertyGroup>
+
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="ModPlus.AutoCAD.API.2022" Version="1.0.0" />
+    <PackageReference Include="Speckle.Civil3D.API" Version="2022.0.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
+    <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\..\logo.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+  <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />
+
+</Project>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/Properties/launchSettings.json
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "ConverterCivil2022": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Autodesk\\AutoCAD 2022\\acad.exe"
+    }
+  }
+}

--- a/Objects/Objects.sln
+++ b/Objects/Objects.sln
@@ -41,13 +41,20 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterCivil2021", "Conve
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterRhinoGh", "Converters\ConverterRhinoGh\ConverterRhinoGh.csproj", "{85DAE0A6-47C1-41EB-947A-13E2DC1591BB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterAutocad2022", "Converters\ConverterAutocadCivil\ConverterAutocad2022\ConverterAutocad2022.csproj", "{156FF86C-8531-46D0-AA23-97DB326BC591}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterCivil2022", "Converters\ConverterAutocadCivil\ConverterCivil2022\ConverterCivil2022.csproj", "{2C68E80F-38F4-41D0-9B38-473031D1B541}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{0bcb32cf-a3cf-4a6a-a9f8-dfe5d85d608c}*SharedItemsImports = 5
 		Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{13f93c20-793c-4f2d-b836-68d7744063df}*SharedItemsImports = 5
+		Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{156ff86c-8531-46d0-aa23-97db326bc591}*SharedItemsImports = 5
+		Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{2c68e80f-38f4-41d0-9b38-473031d1b541}*SharedItemsImports = 5
 		Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{2d0f9f8a-2e89-4780-978a-cd92d6d7b843}*SharedItemsImports = 13
 		Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{2dcd648d-dca5-4d2a-8b14-ad2cb85d24b0}*SharedItemsImports = 13
 		Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{4f16a993-7d11-4565-a2a5-910899919e00}*SharedItemsImports = 5
+		Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{4f16a993-7d11-4565-a2a5-910899919e00}*SharedItemsImports = 5
 		Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{5bab09dc-b0fc-4004-9fd5-6496a9634071}*SharedItemsImports = 13
 		Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{bc110327-3c61-4c15-ae4c-daae7ca82a7b}*SharedItemsImports = 5
 		Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{bf5515b4-c97c-4fb9-9f93-1740d2b615b3}*SharedItemsImports = 5
@@ -102,6 +109,14 @@ Global
 		{85DAE0A6-47C1-41EB-947A-13E2DC1591BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{85DAE0A6-47C1-41EB-947A-13E2DC1591BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85DAE0A6-47C1-41EB-947A-13E2DC1591BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{156FF86C-8531-46D0-AA23-97DB326BC591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{156FF86C-8531-46D0-AA23-97DB326BC591}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{156FF86C-8531-46D0-AA23-97DB326BC591}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{156FF86C-8531-46D0-AA23-97DB326BC591}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C68E80F-38F4-41D0-9B38-473031D1B541}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C68E80F-38F4-41D0-9B38-473031D1B541}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C68E80F-38F4-41D0-9B38-473031D1B541}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C68E80F-38F4-41D0-9B38-473031D1B541}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -123,6 +138,8 @@ Global
 		{DD4ADD16-65F9-46E0-A610-2B7908A966B3} = {5419488F-6509-4F16-A342-BB2BE2689E00}
 		{13F93C20-793C-4F2D-B836-68D7744063DF} = {5419488F-6509-4F16-A342-BB2BE2689E00}
 		{85DAE0A6-47C1-41EB-947A-13E2DC1591BB} = {CCC09288-CE76-4FDB-B0C9-220112F88CD9}
+		{156FF86C-8531-46D0-AA23-97DB326BC591} = {5419488F-6509-4F16-A342-BB2BE2689E00}
+		{2C68E80F-38F4-41D0-9B38-473031D1B541} = {5419488F-6509-4F16-A342-BB2BE2689E00}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DA57EC2E-0A9E-4F59-B1F7-A65F76A74B74}


### PR DESCRIPTION
## Description

Adds 2022 projects for Autocad and Civil3D. Includes minor change of connector color method to be compatible in both 2021 and 2022 versions.

- Fixes #417 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sent and received standard geometry in 2022 connectors (autocad, civil, civil as autocad)

## Docs

- Have already been updated

