### PR TITLE
feat(acad civil): additional conversions

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
@@ -63,10 +63,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ModPlus.AutoCAD.API.2021">
-      <Version>1.0.0</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="Speckle.AutoCAD.API">
+      <Version>2021.0.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />

--- a/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
@@ -53,9 +53,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Speckle.AutoCAD.API">
-      <Version>2022.0.0.2</Version>
+      <Version>2022.0.0.3</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
@@ -66,15 +66,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Civil3D2021.Base">
-      <Version>1.0.0</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="Speckle.AutoCAD.API">
+      <Version>2021.0.0.3</Version>
     </PackageReference>
-    <PackageReference Include="ModPlus.AutoCAD.API.2021">
-      <Version>1.0.0</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="Speckle.Civil3D.API">
+      <Version>2021.0.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />

--- a/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
@@ -56,14 +56,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Speckle.AutoCAD.API">
-      <Version>2022.0.0.2</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+      <Version>2022.0.0.3</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Civil3D.API">
-      <Version>2022.0.0.1</Version>
+      <Version>2022.0.0.3</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2021/ConverterAutocad2021.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2021/ConverterAutocad2021.csproj
@@ -25,7 +25,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="ModPlus.AutoCAD.API.2021" Version="1.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" Version="2021.0.0.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,13 +38,6 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="acdbmgdbrep">
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2021\acdbmgdbrep.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2021/ConverterAutocad2021.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2021/ConverterAutocad2021.csproj
@@ -40,6 +40,13 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="acdbmgdbrep">
+      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2021\acdbmgdbrep.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />
 
 </Project>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
@@ -40,6 +40,13 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="acdbmgdbrep">
+      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2022\acdbmgdbrep.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
@@ -25,7 +25,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="ModPlus.AutoCAD.API.2022" Version="1.0.0" />
+    <PackageReference Include="Speckle.AutoCAD.API" Version="2022.0.0.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,13 +38,6 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="acdbmgdbrep">
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2022\acdbmgdbrep.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -1,13 +1,17 @@
 ﻿#if (CIVIL2021 || CIVIL2022)
 using System.Collections.Generic;
+using System.Linq;
 
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.Civil.ApplicationServices;
 using CivilDB = Autodesk.Civil.DatabaseServices;
+using Acad = Autodesk.AutoCAD.Geometry;
 
 using Interval = Objects.Primitive.Interval;
 using Polycurve = Objects.Geometry.Polycurve;
+using Curve = Objects.Geometry.Curve;
 using Brep = Objects.Geometry.Brep;
+using Mesh = Objects.Geometry.Mesh;
 
 namespace Objects.Converter.AutocadCivil
 {
@@ -42,15 +46,166 @@ namespace Objects.Converter.AutocadCivil
     // alignments
     public Curve AlignmentToSpeckle(CivilDB.Alignment alignment)
     {
-      var baseCurve = alignment.BaseCurve;
-      return null;
+      var curve = CurveToSpeckle(alignment.BaseCurve, ModelUnits) as Curve;
+      curve["name"] = alignment.DisplayName;
+      curve["description"] = alignment.Description;
+      try{
+      curve["startStation"] = alignment.StartingStation;
+      curve["endStation"] = alignment.EndingStation;
+      }
+      catch{}
+      return curve;
     }
 
-    // 3D solids
-    //public Brep SolidToSpeckle(Solid3d solid)
-    //{
-    //return null;
-    //}
+    // profiles
+    public Curve ProfileToSpeckle(CivilDB.Profile profile)
+    {
+      var curve = CurveToSpeckle(profile.BaseCurve, ModelUnits) as Curve;
+      curve["name"] = profile.DisplayName;
+      curve["description"] = profile.Description;
+      curve["profileType"] = profile.ProfileType.ToString();
+      try{
+      curve["startStation"] = profile.StartingStation;
+      curve["endStation"] = profile.EndingStation;
+      curve["offset"] = profile.Offset;
+      }
+      catch{}
+
+      return curve;
+    }
+
+    // surfaces
+    public Mesh SurfaceToSpeckle(CivilDB.TinSurface surface)
+    {
+      Mesh mesh = null;
+
+      // output vars
+      var _vertices = new List<Acad.Point3d>();
+      var _faces = new List<int[]>();
+
+      foreach (var triangle in surface.GetTriangles(false))
+      {
+        // get vertices
+        var faceIndices = new List<int>();
+        foreach (var vertex in new List<CivilDB.TinSurfaceVertex>() {triangle.Vertex1, triangle.Vertex2, triangle.Vertex3})
+        {
+          if (!_vertices.Contains(vertex.Location))
+          {
+            faceIndices.Add(_vertices.Count);
+            _vertices.Add(vertex.Location);
+          }
+          else
+          {
+            faceIndices.Add(_vertices.IndexOf(vertex.Location));
+          }
+          vertex.Dispose();
+        }
+
+        // get face
+        _faces.Add(new int[] { 0, faceIndices[0], faceIndices[1], faceIndices[2] });
+
+        triangle.Dispose();
+      }
+
+      var vertices = PointsToFlatArray(_vertices);
+      var faces = _faces.SelectMany(o => o).ToArray();
+      mesh = new Mesh(vertices, faces);
+      mesh.units = ModelUnits;
+      mesh.bbox = BoxToSpeckle(surface.GeometricExtents);
+
+      // add tin surface props
+      mesh["name"] = surface.DisplayName;
+      mesh["description"] = surface.Description;
+
+      return mesh;
+    }
+
+    public Mesh SurfaceToSpeckle(CivilDB.GridSurface surface)
+    {
+      Mesh mesh = null;
+
+      // output vars
+      var _vertices = new List<Acad.Point3d>();
+      var _faces = new List<int[]>();
+
+      foreach (var cell in surface.GetCells(false))
+      {
+        // get vertices
+        var faceIndices = new List<int>();
+        foreach (var vertex in new List<CivilDB.GridSurfaceVertex>() {cell.BottomLeftVertex, cell.BottomRightVertex, cell.TopLeftVertex, cell.TopRightVertex})
+        {
+          if (!_vertices.Contains(vertex.Location))
+          {
+            faceIndices.Add(_vertices.Count);
+            _vertices.Add(vertex.Location);
+          }
+          else
+          {
+            faceIndices.Add(_vertices.IndexOf(vertex.Location));
+          }
+          vertex.Dispose();
+        }
+
+        // get face
+        _faces.Add(new int[] { 1, faceIndices[0], faceIndices[1], faceIndices[2], faceIndices[3] });
+
+        cell.Dispose();
+      }
+
+      var vertices = PointsToFlatArray(_vertices);
+      var faces = _faces.SelectMany(o => o).ToArray();
+      mesh = new Mesh(vertices, faces);
+      mesh.units = ModelUnits;
+      mesh.bbox = BoxToSpeckle(surface.GeometricExtents);
+
+      // add grid surface props
+      mesh["name"] = surface.DisplayName;
+      mesh["description"] = surface.Description;
+
+      return mesh;
+    }
+
+    // structures
+    public Mesh StructureToSpeckle(CivilDB.Structure structure)
+    {
+      var mesh = SolidToSpeckle(structure.Solid3dBody);
+
+      // assign additional structure props
+      mesh["@baseCurve"] = CurveToSpeckle(structure.BaseCurve, ModelUnits) as Curve;
+      mesh["name"] = structure.DisplayName;
+      mesh["description"] = structure.Description;
+      mesh["connectedPipes"] = structure.ConnectedPipesCount;
+      mesh["@location"] = PointToSpeckle(structure.Location, ModelUnits);
+      try{
+      mesh["station"] = structure.Station;
+      }
+      catch{}
+      mesh["network"] = structure.NetworkName;
+
+      return mesh;
+    }
+
+    // pipes
+    public Mesh PipeToSpeckle(CivilDB.Pipe pipe)
+    {
+      var mesh = SolidToSpeckle(pipe.Solid3dBody);
+
+      // assign additional structure props
+      mesh["@baseCurve"] = CurveToSpeckle(pipe.BaseCurve, ModelUnits) as Curve;
+      mesh["name"] = pipe.DisplayName;
+      mesh["description"] = pipe.Description;
+      mesh["flowDirection"] = pipe.FlowDirection.ToString();
+      mesh["flowRate"] = pipe.FlowRate;
+      mesh["network"] = pipe.NetworkName;
+      try{
+      mesh["startStation"] = pipe.StartStation;
+      mesh["endStation"] = pipe.EndStation;
+      mesh["startOffset"] = pipe.StartOffset;
+      mesh["endOffset"] = pipe.EndOffset;
+      }
+      catch{}
+      return mesh;
+    }
   }
 }
 #endif

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -5,7 +5,9 @@ using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.Civil.ApplicationServices;
 using CivilDB = Autodesk.Civil.DatabaseServices;
 
+using Interval = Objects.Primitive.Interval;
 using Polycurve = Objects.Geometry.Polycurve;
+using Brep = Objects.Geometry.Brep;
 
 namespace Objects.Converter.AutocadCivil
 {
@@ -24,6 +26,12 @@ namespace Objects.Converter.AutocadCivil
         segments.Add((ICurve)ConvertToSpeckle(exploded[i]));
       polycurve.segments = segments;
 
+      // TODO: additional params to attach
+      var points = featureLine.GetPoints(Autodesk.Civil.FeatureLinePointType.AllPoints);
+      var grade = new Interval(featureLine.MinGrade, featureLine.MaxGrade);
+      var elevation = new Interval(featureLine.MinElevation, featureLine.MaxElevation);
+      var name = featureLine.DisplayName;
+
       return polycurve;
     }
     public CivilDB.FeatureLine FeatureLineToNative(Polycurve polycurve)
@@ -32,6 +40,17 @@ namespace Objects.Converter.AutocadCivil
     }
 
     // alignments
+    public Curve AlignmentToSpeckle(CivilDB.Alignment alignment)
+    {
+      var baseCurve = alignment.BaseCurve;
+      return null;
+    }
+
+    // 3D solids
+    //public Brep SolidToSpeckle(Solid3d solid)
+    //{
+    //return null;
+    //}
   }
 }
 #endif

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -205,9 +205,11 @@ namespace Objects.Converter.AutocadCivil
     // Arc
     public Arc ArcToSpeckle(CircularArc3d arc)
     {
+      var interval = arc.GetInterval();
       var _arc = new Arc(PlaneToSpeckle(arc.GetPlane()), arc.Radius, arc.StartAngle, arc.EndAngle, Math.Abs(arc.EndAngle - arc.StartAngle), ModelUnits);
       _arc.startPoint = PointToSpeckle(arc.StartPoint);
       _arc.endPoint = PointToSpeckle(arc.EndPoint);
+      _arc.midPoint = PointToSpeckle(arc.EvaluatePoint((interval.UpperBound - interval.LowerBound) / 2));
       _arc.domain = IntervalToSpeckle(arc.GetInterval());
       _arc.length = arc.GetLength(arc.GetParameterOf(arc.StartPoint), arc.GetParameterOf(arc.EndPoint), tolerance);
       _arc.bbox = BoxToSpeckle(arc.OrthoBoundBlock);

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -242,11 +242,23 @@ public static string AutocadAppName = Applications.Autocad2022;
           return BlockRecordToSpeckle(o);
 
 #if (CIVIL2021 || CIVIL2022)
+        case CivilDB.Alignment o:
+          return AlignmentToSpeckle(o);
+
         case CivilDB.FeatureLine o:
           return FeatureLineToSpeckle(o);
 
         case CivilDB.Structure o:
-          return SolidToSpeckle(o.Solid3dBody);
+          return StructureToSpeckle(o);
+
+        case CivilDB.Pipe o:
+          return PipeToSpeckle(o);
+
+        case CivilDB.Profile o:
+          return ProfileToSpeckle(o);
+
+        case CivilDB.TinSurface o:
+          return SurfaceToSpeckle(o);
 #endif
 
         default:
@@ -284,6 +296,10 @@ public static string AutocadAppName = Applications.Autocad2022;
 #if (CIVIL2021 || CIVIL2022)
             case CivilDB.FeatureLine _:
             case CivilDB.Structure _:
+            case CivilDB.Alignment _:
+            case CivilDB.Pipe _:
+            case CivilDB.Profile _:
+            case CivilDB.TinSurface _:
               return true;
 #endif
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -232,6 +232,9 @@ public static string AutocadAppName = Applications.Autocad2022;
         case SubDMesh o:
           return MeshToSpeckle(o);
 
+        case Solid3d o:
+          return SolidToSpeckle(o);
+
         case BlockReference o:
           return BlockReferenceToSpeckle(o);
 
@@ -241,6 +244,9 @@ public static string AutocadAppName = Applications.Autocad2022;
 #if (CIVIL2021 || CIVIL2022)
         case CivilDB.FeatureLine o:
           return FeatureLineToSpeckle(o);
+
+        case CivilDB.Structure o:
+          return SolidToSpeckle(o.Solid3dBody);
 #endif
 
         default:
@@ -256,81 +262,46 @@ public static string AutocadAppName = Applications.Autocad2022;
           switch (o)
           {
             case DBPoint _:
-              return true;
-
             case AcadDB.Line _:
-              return true;
-
             case AcadDB.Arc _:
-              return true;
-
             case AcadDB.Circle _:
-              return true;
-
             case AcadDB.Ellipse _:
-              return true;
-
             case AcadDB.Spline _:
-              return true;
-
             case AcadDB.Polyline _:
-              return true;
-
             case AcadDB.Polyline2d _:
-              return true;
-
             case AcadDB.Polyline3d _:
-              return true;
-
             case AcadDB.PlaneSurface _:
-              return true;
-
             case AcadDB.NurbSurface _:
-              return true;
-
             case AcadDB.PolyFaceMesh _:
-              return true;
-
             case SubDMesh _:
+            case Solid3d _:
               return true;
 
             case BlockReference _:
-              return true;
-
             case BlockTableRecord _:
               return true;
+
+#if (CIVIL2021 || CIVIL2022)
+            case CivilDB.FeatureLine _:
+            case CivilDB.Structure _:
+              return true;
+#endif
 
             default:
               return false;
           }
 
         case Acad.Geometry.Point3d _:
-          return true;
-
         case Acad.Geometry.Vector3d _:
-          return true;
-
         case Acad.Geometry.Plane _:
-          return true;
-
         case Acad.Geometry.Line3d _:
-          return true;
-
         case Acad.Geometry.LineSegment3d _:
-          return true;
-
         case Acad.Geometry.CircularArc3d _:
-          return true;
-
         case Acad.Geometry.Curve3d _:
           return true;
 
-        case Acad.Geometry.NurbSurface _:
-          return false;
-
         default:
           return false;
-
       }
     }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
@@ -42,6 +42,13 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="acdbmgdbrep">
+      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2021\acdbmgdbrep.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />
 
 </Project>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
@@ -20,12 +20,6 @@
     <Copyright>Copyright (c) AEC Systems Ltd</Copyright>
   </PropertyGroup>
 
-
-  <ItemGroup>
-    <PackageReference Include="Civil3D2021.Base" Version="1.0.0" />
-    <PackageReference Include="ModPlus.AutoCAD.API.2021" Version="1.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
@@ -43,10 +37,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="acdbmgdbrep">
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2021\acdbmgdbrep.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
+    <PackageReference Include="Speckle.AutoCAD.API" Version="2021.0.0.3" />
+    <PackageReference Include="Speckle.Civil3D.API" Version="2021.0.0.3" />
   </ItemGroup>
 
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
@@ -26,11 +26,6 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="ModPlus.AutoCAD.API.2022" Version="1.0.0" />
-    <PackageReference Include="Speckle.Civil3D.API" Version="2022.0.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
   </ItemGroup>
@@ -43,10 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="acdbmgdbrep">
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2022\acdbmgdbrep.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
+    <PackageReference Include="Speckle.AutoCAD.API" Version="2022.0.0.3" />
+    <PackageReference Include="Speckle.Civil3D.API" Version="2022.0.0.3" />
   </ItemGroup>
 
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
@@ -42,6 +42,13 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="acdbmgdbrep">
+      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2022\acdbmgdbrep.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />
 
 </Project>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -1051,14 +1051,15 @@ namespace Objects.Converter.RhinoGh
         points.Count, points[0].Count);
 
       // Set knot vectors
-      for (int i = 0; i < surface.knotsU.Count; i++)
+      var correctUKnots = GetCorrectKnots(surface.knotsU, surface.countU, surface.degreeU);
+      for (int i = 0; i < correctUKnots.Count; i++)
       {
-        result.KnotsU[i] = surface.knotsU[i];
+        result.KnotsU[i] = correctUKnots[i];
       }
-
-      for (int i = 0; i < surface.knotsV.Count; i++)
+      var correctVKnots = GetCorrectKnots(surface.knotsV, surface.countV, surface.degreeV);
+      for (int i = 0; i < correctVKnots.Count; i++)
       {
-        result.KnotsV[i] = surface.knotsV[i];
+        result.KnotsV[i] = correctVKnots[i];
       }
 
       // Set control points
@@ -1116,6 +1117,18 @@ namespace Objects.Converter.RhinoGh
       result.bbox = BoxToSpeckle(new RH.Box(surface.GetBoundingBox(true)), u);
 
       return result;
+    }
+
+    private List<double> GetCorrectKnots(List<double> knots, int controlPointCount, int degree)
+    {
+      var correctKnots = knots;
+      if (knots.Count == controlPointCount + degree + 1)
+      {
+        correctKnots.RemoveAt(0);
+        correctKnots.RemoveAt(correctKnots.Count - 1);
+      }
+
+      return correctKnots;
     }
   }
 }

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -263,7 +263,7 @@ namespace Objects.Geometry
     None = 0,
     Inward = -1,
     Outward = 1,
-    Unkown = 2
+    Unknown = 2
   }
 
   /// <summary>


### PR DESCRIPTION
## Description

Adds TinSurface, GridSurface, Alignment, Profile, Structure, and Pipe conversions to Speckle.

All are sent as Meshes or Curves with attached props.

- Fixes #439 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sending elements from autocad to rhino, checking for previous functionality by sending & receiving standard test file geometry

## Docs

- Will be updated ASAP

