### PR TITLE
feat(autocad,rhino): convert nested blocks

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -167,7 +167,7 @@ public static string AutocadAppName = Applications.Autocad2022;
         //  return MeshToNativeDB(o);
 
         case BlockInstance o:
-          return BlockInstanceToNativeDB(o);
+          return BlockInstanceToNativeDB(o, out BlockReference refernce);
 
         case BlockDefinition o:
           return BlockDefinitionToNativeDB(o);
@@ -326,41 +326,15 @@ public static string AutocadAppName = Applications.Autocad2022;
       switch (@object)
       {
         case Point _:
-          return true;
-
         case Line _:
-          return true;
-
         case Arc _:
-          return true;
-
-        case Circle _:
-          return true;
-
+        case Circle _:  
         case Ellipse _:
-          return true;
-
         case Polyline _:
-          return true;
-
         case Polycurve _:
-          return true;
-
         case Curve _:
-          return true;
-
-        case Surface _:
-          return false;
-
-        case Brep _:
-          return false;
-
-        case Mesh _:
-          return false;
 
         case BlockDefinition _:
-          return true;
-
         case BlockInstance _:
           return true;
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Other.cs
@@ -67,7 +67,18 @@ namespace Objects.Converter.RhinoGh
       {
         if (CanConvertToNative(geo))
         {
-          var converted = ConvertToNative(geo) as GeometryBase;
+          GeometryBase converted = null;
+          switch (geo)
+          {
+            case BlockInstance _:
+              var instance = (InstanceObject)ConvertToNative(geo);
+              converted = instance.Geometry;
+              Doc.Objects.Delete(instance);
+              break;
+            default:
+              converted = (GeometryBase)ConvertToNative(geo);
+              break;
+          }
           if (converted == null)
             continue;
           var layerName = $"{commitInfo}{Layer.PathSeparator}{geo["Layer"] as string}";
@@ -88,7 +99,8 @@ namespace Objects.Converter.RhinoGh
       if (definitionIndex < 0)
         return null;
 
-      return Doc.InstanceDefinitions[definitionIndex];
+      var blockDefinition = Doc.InstanceDefinitions[definitionIndex];
+      return blockDefinition;
     }
 
     // Rhino convention seems to order the origin of the vector space last instead of first

--- a/Objects/Objects/Geometry/Polyline.cs
+++ b/Objects/Objects/Geometry/Polyline.cs
@@ -14,6 +14,10 @@ namespace Objects.Geometry
     [DetachProperty]
     [Chunkable(31250)]
     public List<double> value { get; set; } = new List<double>();
+
+    /// <summary>
+    /// If true, do not add the last point to the value list. Polyline first and last points should be unique.
+    /// </summary>
     public bool closed { get; set; }
     public Interval domain { get; set; }
     public Box bbox { get; set; }


### PR DESCRIPTION
## Description

Adds Nested Block conversions for autocad and rhino.
Also includes a minor polyline fix in autocad: polyline conversions were changed in rhino to add last point of closed polylines, had to update autocad conversions to match. Added comment in Objects Polyline class to prevent confusion in the future

- Part of #466 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sent autocad and rhino test files in all permutations between eachother.
 **Note** During testing, Rhino->Rhino standard file had a trimmed surface edge error 👇
![image](https://user-images.githubusercontent.com/16748799/118007632-37306a80-b344-11eb-865a-af7a3c1c0e7b.png)


## Docs

- Will be updated ASAP

