### PR TITLE
fix(core): resolves merge conflicts

### DIFF
--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -414,6 +414,9 @@ namespace Speckle.Core.Serialisation
               int.TryParse(match.Groups[match.Groups.Count - 1].Value, out chunkSize);
               serializer.Context = new StreamingContext(StreamingContextStates.Other,
                 chunkSize > 0 ? new Chunkable(chunkSize) : new Chunkable());
+            } else
+            {
+              serializer.Context = new StreamingContext();
             }
           }
           else
@@ -444,6 +447,8 @@ namespace Speckle.Core.Serialisation
 
           // Pop detach lineage. If you don't get this, remember this thing moves ONLY FORWARD, DEPTH FIRST
           DetachLineage.RemoveAt(DetachLineage.Count - 1);
+          // Refresh the streaming context to remove chunking flag
+          serializer.Context = new StreamingContext();
         }
 
         // Check if we actually have any transports present that would warrant a 

--- a/Core/Core/Serialisation/BaseObjectSerializer.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializer.cs
@@ -522,15 +522,24 @@ namespace Speckle.Core.Serialisation
           {
             if (i == maxCount)
             {
-              chunkList.Add(currChunk);
+              if(currChunk.data.Count!=0)
+              {
+                chunkList.Add(currChunk);
+              }
+
               currChunk = new DataChunk();
               i = 0;
             }
             currChunk.data.Add(arrValue);
             i++;
           }
-          chunkList.Add(currChunk);
+
+          if (currChunk.data.Count != 0)
+          {
+            chunkList.Add(currChunk);
+          }
           value = chunkList;
+
         }
 
         foreach (var arrValue in ((IEnumerable)value))

--- a/Core/Tests/SerializationTests.cs
+++ b/Core/Tests/SerializationTests.cs
@@ -229,16 +229,27 @@ namespace Tests
     [Test]
     public void EmptyListSerialisationTests()
     {
-      // NOTE: expected behaviour is that empty lists should serialize as empty lists. Don't ask me why, it's complicated. 
+      // NOTE: expected behaviour is that empty lists should serialize as empty lists. Don't ask why, it's complicated. 
       // Regarding chunkable empty lists, to prevent empty chunks, the expected behaviour is to have an empty lists, with no chunks inside.
       var test = new Base();
-      test["@(5)chunks"] = new List<object>();
-      test["bunks"] = new List<object>();
-      test["@funks"] = new List<object>();
 
+      test["@(5)emptyChunks"] = new List<object>();
+      test["emptyList"] = new List<object>();
+      test["@emptyDetachableList"] = new List<object>();
+
+      // Note: nested empty lists should be preserved. 
+      test["nestedList"] = new List<object>() { new List<object>() { new List<object>() } };
+      test["@nestedDetachableList"] = new List<object>() { new List<object>() { new List<object>() } };
+      
       var serialised = Operations.Serialize(test);
-      var hasProp = serialised.Contains("\"@(5)chunks\":[],\"bunks\":[],\"@funks\":[]");
-      Assert.AreEqual(hasProp, true);
+      var isCorrect =
+        serialised.Contains("\"@(5)emptyChunks\":[]") &&
+        serialised.Contains("\"emptyList\":[]") &&
+        serialised.Contains("\"@emptyDetachableList\":[]") &&
+        serialised.Contains("\"nestedList\":[[[]]]") &&
+        serialised.Contains("\"@nestedDetachableList\":[[[]]]");
+
+      Assert.AreEqual(isCorrect, true);
     }
 
   }

--- a/Core/Tests/SerializationTests.cs
+++ b/Core/Tests/SerializationTests.cs
@@ -226,5 +226,20 @@ namespace Tests
       Assert.AreEqual(deserialised.GetId(), mesh.GetId());
     }
 
+    [Test]
+    public void EmptyListSerialisationTests()
+    {
+      // NOTE: expected behaviour is that empty lists should serialize as empty lists. Don't ask me why, it's complicated. 
+      // Regarding chunkable empty lists, to prevent empty chunks, the expected behaviour is to have an empty lists, with no chunks inside.
+      var test = new Base();
+      test["@(5)chunks"] = new List<object>();
+      test["bunks"] = new List<object>();
+      test["@funks"] = new List<object>();
+
+      var serialised = Operations.Serialize(test);
+      var hasProp = serialised.Contains("\"@(5)chunks\":[],\"bunks\":[],\"@funks\":[]");
+      Assert.AreEqual(hasProp, true);
+    }
+
   }
 }


### PR DESCRIPTION
## Description

- Fixes #379, but for real now (wraps up the saga of #490 and #489)
- Fixes an potentially dangerous bug whereby if you had a chunkable list prop followed by a non-chunkable list prop, the second list would get chunked too - and any subsequent lists. It happened because the streaming context would not get cleared of the chunkable flag. Now ensuring this is happening, and the test for empty list serialisation should catch this if it's going to happen again. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Adds a new unit test which encodes the expected behaviour. 

## Docs

- No updates needed


