### PR TITLE
bug(revit): fix crash on sending directshapes

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -124,6 +124,7 @@ namespace Objects.Converter.Revit
       var l = new Line { units = u };
       l.start = PointToSpeckle(line.GetEndPoint(0), u);
       l.end = PointToSpeckle(line.GetEndPoint(1), u);
+      l.domain = new Interval(line.GetEndParameter(0), line.GetEndParameter(1));
 
       l.length = ScaleToSpeckle(line.Length);
       return l;
@@ -186,6 +187,7 @@ namespace Objects.Converter.Revit
       a.startPoint = PointToSpeckle(start, u);
       a.midPoint = PointToSpeckle(mid, u);
       a.length = ScaleToSpeckle(arc.Length);
+      a.domain = new Interval(arc.GetEndParameter(0), arc.GetEndParameter(1));
 
       return a;
     }
@@ -225,6 +227,7 @@ namespace Objects.Converter.Revit
           trim,
           u);
         ellipseToSpeckle.length = ScaleToSpeckle(ellipse.Length);
+        ellipseToSpeckle.domain = new Interval(0, 1);
         return ellipseToSpeckle;
       }
     }
@@ -247,7 +250,7 @@ namespace Objects.Converter.Revit
       speckleCurve.rational = revitCurve.isRational;
       speckleCurve.closed = RevitVersionHelper.IsCurveClosed(revitCurve);
       speckleCurve.units = units ?? ModelUnits;
-      //speckleCurve.domain = new Interval(revitCurve.StartParameter(), revitCurve.EndParameter());
+      speckleCurve.domain = new Interval(revitCurve.GetEndParameter(0), revitCurve.GetEndParameter(1));
       speckleCurve.length = ScaleToSpeckle(revitCurve.Length);
       var coords = revitCurve.Tessellate().SelectMany(xyz => PointToSpeckle(xyz, units).ToList()).ToArray();
       speckleCurve.displayValue = new Polyline(coords, units);
@@ -601,6 +604,9 @@ namespace Objects.Converter.Revit
 
       result.degreeU = surface.DegreeU;
       result.degreeV = surface.DegreeV;
+
+      result.domainU = new Interval(0, 1);
+      result.domainV = new Interval(0, 1);
 
       var knotsU = surface.GetKnotsU().ToList();
       var knotsV = surface.GetKnotsV().ToList();

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -32,9 +32,12 @@ namespace Objects.Geometry
       get
       {
         var list = new List<double>();
-        foreach(var srf in Surfaces)
+        if (Surfaces != null)
         {
-          list.AddRange(srf.ToList());
+          foreach (var srf in Surfaces)
+          {
+            list.AddRange(srf.ToList());
+          }
         }
         return list;
       }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -74,7 +74,7 @@ namespace Objects.Geometry
       var list = new List<double>();
       list.AddRange(start.ToList());
       list.AddRange(end.ToList());
-      list.Add( domain.start ?? 0);
+      list.Add(domain.start ?? 0);
       list.Add(domain.end ?? 1);
       list.Add(Units.GetEncodingFromUnit(units));
       list.Insert(0, CurveTypeEncoding.Line);


### PR DESCRIPTION
## Description

Revit was crashing when sending Standard geometry. This was caused by missing domain props on various curves during surface conversion, creating a null exception in .ToList() methods in Objects.

- Fixes #494 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: standard geometry file sending without crash now

## Docs

- No updates needed

