### PR TITLE
GH: 2.1.12 testing fixes

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper.sln
+++ b/ConnectorGrasshopper/ConnectorGrasshopper.sln
@@ -48,12 +48,12 @@ Global
 		{9103058A-0D20-49AA-B053-01548DD66D16}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9103058A-0D20-49AA-B053-01548DD66D16}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9103058A-0D20-49AA-B053-01548DD66D16}.Debug along Revit|Any CPU.ActiveCfg = Debug along Revit|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug along Revit|Any CPU.ActiveCfg = Debug along Revit|Any CPU
 		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug along Revit|Any CPU.Build.0 = Debug along Revit|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.ActiveCfg = Debug Grasshopper|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.Build.0 = Debug Grasshopper|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.ActiveCfg = Release Grasshopper|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.Build.0 = Release Grasshopper|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;GRASSHOPPER;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
@@ -115,6 +115,11 @@ namespace ConnectorGrasshopper.Conversion
         return;
       }
       
+      foreach (var error in Converter.ConversionErrors)
+      {
+        Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+      }
+      
       foreach (var (level, message) in RuntimeMessages)
       {
         Parent.AddRuntimeMessage(level, message);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToSpeckleAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToSpeckleAsync.cs
@@ -116,6 +116,11 @@ namespace ConnectorGrasshopper.Conversion
     {
       if (CancellationToken.IsCancellationRequested)return;
       
+      // Report all conversion errors as warnings
+      foreach (var error in Converter.ConversionErrors)
+      {
+        Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+      }
       
       foreach (var (level, message) in RuntimeMessages)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -237,12 +237,19 @@ namespace ConnectorGrasshopper.Extras
       {
         if (converter.CanConvertToNative(@base))
         {
-          var converted = converter.ConvertToNative(@base);
-          var geomgoo = GH_Convert.ToGoo(converted);
-          if (geomgoo != null) 
-            return geomgoo;
-          var goo = new GH_ObjectWrapper { Value = converted };
-          return goo;
+          try
+          {
+            var converted = converter.ConvertToNative(@base);
+            var geomgoo = GH_Convert.ToGoo(converted);
+            if (geomgoo != null) 
+              return geomgoo;
+            var goo = new GH_ObjectWrapper { Value = converted };
+            return goo;
+          }
+          catch (Exception e)
+          {
+            converter.ConversionErrors.Add(new Exception("Could not convert ${@base}", e));
+          }
         }
         if(recursive)
         {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -1,4 +1,4 @@
-﻿using Grasshopper.Kernel.Types;
+using Grasshopper.Kernel.Types;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -248,7 +248,7 @@ namespace ConnectorGrasshopper.Extras
           }
           catch (Exception e)
           {
-            converter.ConversionErrors.Add(new Exception("Could not convert ${@base}", e));
+            converter.ConversionErrors.Add(new Exception($"Could not convert {@base}", e));
           }
         }
         if(recursive)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectAsync.cs
@@ -200,6 +200,13 @@ namespace ConnectorGrasshopper.Objects
       // 👉 Checking for cancellation!
       if (CancellationToken.IsCancellationRequested) return;
 
+      // Report all conversion errors as warnings
+      if(Converter != null)
+        foreach (var error in Converter.ConversionErrors)
+        {
+          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+        }
+      
       foreach (var (level, message) in RuntimeMessages)
       {
         Parent.AddRuntimeMessage(level, message);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectByKeyValueAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectByKeyValueAsync.cs
@@ -181,7 +181,15 @@ namespace ConnectorGrasshopper.Objects
     {
       // 👉 Checking for cancellation!
       if (CancellationToken.IsCancellationRequested) return;
-
+      
+            
+      // Report all conversion errors as warnings
+      if(Converter != null)
+        foreach (var error in Converter.ConversionErrors)
+        {
+          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+        }
+      
       foreach (var (level, message) in RuntimeMessages)
       {
         Parent.AddRuntimeMessage(level, message);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectAsync.cs
@@ -178,6 +178,15 @@ namespace ConnectorGrasshopper.Objects
           DA.SetDataTree(indexOfOutputParam, ghStructure);
         }
       }
+
+            
+      // Report all conversion errors as warnings
+      if(Converter != null)
+        foreach (var error in Converter.ConversionErrors)
+        {
+          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+        }
+
       outputDict = null;
       (Parent as ExpandSpeckleObjectAsync).State = 0;
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectAsync.cs
@@ -179,14 +179,16 @@ namespace ConnectorGrasshopper.Objects
         }
       }
 
-            
       // Report all conversion errors as warnings
       if(Converter != null)
+      {
         foreach (var error in Converter.ConversionErrors)
         {
-          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+            error.Message + ": " + error.InnerException?.Message);
         }
-
+        Converter.ConversionErrors.Clear();
+      }
       outputDict = null;
       (Parent as ExpandSpeckleObjectAsync).State = 0;
 
@@ -194,6 +196,7 @@ namespace ConnectorGrasshopper.Objects
 
     public override void GetData(IGH_DataAccess DA, GH_ComponentParamServer Params)
     {
+      Parent.ClearRuntimeMessages();
       DA.GetDataTree(0, out speckleObjects);
       speckleObjects.Graft(GH_GraftMode.GraftAll);
       var names = Params.Output.Select(p => p.Name);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectAsync.cs
@@ -129,6 +129,13 @@ namespace ConnectorGrasshopper.Objects
       // 👉 Checking for cancellation!
       if (CancellationToken.IsCancellationRequested) return;
 
+      // Report all conversion errors as warnings
+      if(Converter != null)
+        foreach (var error in Converter.ConversionErrors)
+        {
+          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+        }
+      
       foreach (var (level, message) in RuntimeMessages)
       {
         Parent.AddRuntimeMessage(level, message);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyAsync.cs
@@ -101,6 +101,13 @@ namespace ConnectorGrasshopper.Objects
 
     public override void SetData(IGH_DataAccess DA)
     {
+      // Report all conversion errors as warnings
+      if(Converter != null)
+        foreach (var error in Converter.ConversionErrors)
+        {
+          Parent.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, error.Message + ": " + error.InnerException?.Message);
+        }
+      
       switch (value)
       {
         case null:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -371,13 +371,14 @@ namespace Objects.Converter.RhinoGh
         case RH.Extrusion _:
         case RH.Brep _:
         case NurbsSurface _:
-
+          return true;
+        
+#if !GRASSHOPPER
         case ViewInfo _:
-
         case InstanceDefinition _:
         case InstanceObject _:
-
           return true;
+#endif
 
         default:
 
@@ -390,7 +391,6 @@ namespace Objects.Converter.RhinoGh
       switch (@object)
       {
         case Point _ :
-        case Pointcloud _:
         case Vector _:
         case Interval _:
         case Interval2d _:
@@ -406,19 +406,18 @@ namespace Objects.Converter.RhinoGh
         case Mesh _:
         case Brep _:
         case Surface _:
-
+          return true;
+#if !GRASSHOPPER
+        case Pointcloud _:
         case ModelCurve _:
         case DirectShape _:
-
         case View3D _:
-
         case BlockDefinition _:
         case BlockInstance _:
-
           return true;
-
+#endif
+        
         default:
-
           return false;
       }
     }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Objects.Converter.Rhino</AssemblyName>
     <RootNamespace>Objects.Converter.RhinoGh</RootNamespace>
-    <Configurations>Debug;Release;Debug along Revit</Configurations>
+    <Configurations>Debug;Release;Debug along Revit;Debug Grasshopper;Release Grasshopper</Configurations>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <PackageId>Speckle.Objects.Converter.RhinoGh</PackageId>
     <Authors>Speckle</Authors>
@@ -21,6 +21,17 @@
     <Copyright>Copyright (c) AEC Systems Ltd</Copyright>
     <Platforms>AnyCPU</Platforms>
 
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug Grasshopper' ">
+    <DebugSymbols Condition=" '$(DebugSymbols)' == '' ">true</DebugSymbols>
+    <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
+    <DefineConstants>TRACE;GRASSHOPPER;</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release Grasshopper' ">
+    <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
+    <DefineConstants>TRACE;GRASSHOPPER;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Fixes testing issues:

- Added new GRASSHOPPER constant to distinguish between GH and Revit conversions.
- Prevented GH from converting DirectShapes, ModelCurves, Blocks and Views, which are not supported or would cause loss of data.
- Added conversion error reporting to conversion nodes. It was only reporting big fails.
- Added catch to `TryConvertItem` to prevent it from going 💥

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?): This issues where caught when doing the test for release 2.1.12, testing was done manually receiving from different apps.

## Docs

- No updates needed


