### PR TITLE
fix(gh): Removed preprocessor directives!

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper.sln
+++ b/ConnectorGrasshopper/ConnectorGrasshopper.sln
@@ -50,10 +50,10 @@ Global
 		{9103058A-0D20-49AA-B053-01548DD66D16}.Debug along Revit|Any CPU.ActiveCfg = Debug along Revit|Any CPU
 		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug along Revit|Any CPU.ActiveCfg = Debug along Revit|Any CPU
 		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug along Revit|Any CPU.Build.0 = Debug along Revit|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.ActiveCfg = Debug Grasshopper|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.Build.0 = Debug Grasshopper|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.ActiveCfg = Release Grasshopper|Any CPU
-		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.Build.0 = Release Grasshopper|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C73D5B6D-4A65-4CF8-8F36-9B78C17D92D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -372,13 +372,11 @@ namespace Objects.Converter.RhinoGh
         case RH.Brep _:
         case NurbsSurface _:
           return true;
-        
-#if !GRASSHOPPER
+        // TODO: This types are not supported in GH!
         case ViewInfo _:
         case InstanceDefinition _:
         case InstanceObject _:
           return true;
-#endif
 
         default:
 
@@ -407,7 +405,8 @@ namespace Objects.Converter.RhinoGh
         case Brep _:
         case Surface _:
           return true;
-#if !GRASSHOPPER
+        
+        //TODO: This types are not supported in GH!
         case Pointcloud _:
         case ModelCurve _:
         case DirectShape _:
@@ -415,7 +414,6 @@ namespace Objects.Converter.RhinoGh
         case BlockDefinition _:
         case BlockInstance _:
           return true;
-#endif
         
         default:
           return false;


### PR DESCRIPTION
Removes `GRASSHOPPER` preprocessor directive for now.