### PR TITLE
fix(desktopui): don't reload accts on toggle

### DIFF
--- a/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
@@ -95,7 +95,6 @@ namespace Speckle.DesktopUI.Streams
 
     public void ToggleAccountSelection()
     {
-      NotifyOfPropertyChange(nameof(Accounts));
       AccountSelectionVisibility = AccountSelectionVisibility == System.Windows.Visibility.Visible
         ? System.Windows.Visibility.Collapsed
         : System.Windows.Visibility.Visible;


### PR DESCRIPTION
in stream create dialog:
refreshing the accounts when toggling the accounts dropdown was
deselecting the selected acct. resetting it will always refresh the ui
which is an unpleasant experience, so i've opted to just take it out.
we have a refresh button and in theory the accts should reload anyway
if you close and reopen the dialog.

closes #474

also no acct issue here shouldn't crash anymore thanks to #480

## Type of change

- Bug fix (non-breaking change which fixes an issue)
## How has this been tested?

- Manual Tests 

## Docs

- No updates needed

