### PR TITLE
fix(autocad/rhino): arc and polycurve conversions fixes

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -242,6 +242,9 @@ namespace Speckle.ConnectorAutocadCivil.UI
           int count = 0;
           var commitObjs = FlattenCommitObject(commitObject, converter, layerPrefix, state, ref count);
 
+          // open model space block table record for write
+          BlockTableRecord btr = (BlockTableRecord)tr.GetObject(Doc.Database.CurrentSpaceId, OpenMode.ForWrite);
+
           foreach (var commitObj in commitObjs)
           {
             // create the object's bake layer if it doesn't already exist
@@ -258,7 +261,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
                 if (!cleanName.Equals(layerName))
                   changedLayerNames = true;
 
-                if (!convertedEntity.Append(cleanName, tr))
+                if (!convertedEntity.Append(cleanName, tr, btr))
                   state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}."));
               }
               else

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -78,7 +78,7 @@ public static string AutocadAppName = Applications.Autocad2022;
     /// </summary>
     /// <param name="entity"></param>
     /// <param name="tr"></param>
-    public static bool Append(this Entity entity, string layer, Transaction tr)
+    public static bool Append(this Entity entity, string layer, Transaction tr, BlockTableRecord btr)
     {
       Document Doc = Application.DocumentManager.MdiActiveDocument;
       
@@ -86,9 +86,6 @@ public static string AutocadAppName = Applications.Autocad2022;
       {
         try
         {
-          // open blocktable record for editing
-          BlockTableRecord btr = (BlockTableRecord)tr.GetObject(Doc.Database.CurrentSpaceId, OpenMode.ForWrite);
-
           entity.Layer = layer;
           btr.AppendEntity(entity);
           tr.AddNewlyCreatedDBObject(entity, true);
@@ -97,6 +94,10 @@ public static string AutocadAppName = Applications.Autocad2022;
         {
           return false;
         }
+      }
+      else
+      {
+        entity.Layer = layer;
       }
       return true;
     }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -251,8 +251,29 @@ namespace Objects.Converter.AutocadCivil
       var segments = new List<ICurve>();
       var exploded = new DBObjectCollection();
       polyline.Explode(exploded);
+      Point3d previousPoint = new Point3d();
       for (int i = 0; i < exploded.Count; i++)
-        segments.Add((ICurve)ConvertToSpeckle(exploded[i]));
+      {
+        var segment = (exploded[i] as AcadDB.Curve).GetGeCurve();
+
+        if (i == 0 && exploded.Count > 1)
+        {
+          // get the connection point to the next segment - this is necessary since imported polycurves might have segments in different directions
+          var connectionPoint = new Point3d();
+          var nextSegment = (exploded[i+1] as AcadDB.Curve).GetGeCurve();
+          if (nextSegment.StartPoint.IsEqualTo(segment.StartPoint) || nextSegment.StartPoint.IsEqualTo(segment.EndPoint))
+            connectionPoint = nextSegment.StartPoint;
+          else
+            connectionPoint = nextSegment.EndPoint;
+          previousPoint = connectionPoint;
+          segment = GetCorrectSegmentDirection(segment, connectionPoint, true, out Point3d otherPoint);
+        }
+        else
+        {
+          segment = GetCorrectSegmentDirection(segment, previousPoint, false, out previousPoint);
+        }
+        segments.Add(CurveToSpeckle(segment));
+      }
       polycurve.segments = segments;
 
       polycurve.length = polyline.Length;
@@ -266,18 +287,27 @@ namespace Objects.Converter.AutocadCivil
 
       // extract segments
       var segments = new List<ICurve>();
+      Point3d previousPoint = new Point3d();
       for (int i = 0; i < polyline.NumberOfVertices; i++)
       {
-        SegmentType type = polyline.GetSegmentType(i);
-        switch (type)
+        var segment = GetSegmentByType(polyline, i);
+        if (i == 0 && polyline.NumberOfVertices > 1)
         {
-          case SegmentType.Line:
-            segments.Add(LineToSpeckle(polyline.GetLineSegmentAt(i)));
-            break;
-          case SegmentType.Arc:
-            segments.Add(ArcToSpeckle(polyline.GetArcSegmentAt(i)));
-            break;
+          // get the connection point to the next segment
+          var connectionPoint = new Point3d();
+          var nextSegment = GetSegmentByType(polyline, i + 1);
+          if (nextSegment.StartPoint.IsEqualTo(segment.StartPoint) || nextSegment.StartPoint.IsEqualTo(segment.EndPoint))
+            connectionPoint = nextSegment.StartPoint;
+          else
+            connectionPoint = nextSegment.EndPoint;
+          previousPoint = connectionPoint;
+          segment = GetCorrectSegmentDirection(segment, connectionPoint, true, out Point3d otherPoint);
         }
+        else
+        {
+          segment = GetCorrectSegmentDirection(segment, previousPoint, false, out previousPoint);
+        }
+        segments.Add(CurveToSpeckle(segment));
       }
       polycurve.segments = segments;
 
@@ -285,6 +315,42 @@ namespace Objects.Converter.AutocadCivil
       polycurve.bbox = BoxToSpeckle(polyline.GeometricExtents, true);
 
       return polycurve;
+    }
+
+    private Curve3d GetSegmentByType(AcadDB.Polyline polyline, int i)
+    {
+      SegmentType type = polyline.GetSegmentType(i);
+      switch (type)
+      {
+        case SegmentType.Line:
+          return polyline.GetLineSegmentAt(i);
+        case SegmentType.Arc:
+          return polyline.GetArcSegmentAt(i);
+        default:
+          return null;
+      }
+    }
+
+    private Curve3d GetCorrectSegmentDirection (Curve3d segment, Point3d connectionPoint, bool isFirstSegment, out Point3d nextPoint) // note sometimes curve3d may not have endpoints
+    {
+      nextPoint = segment.EndPoint;
+
+      if (connectionPoint == null)
+        return segment;
+
+      bool reverseDirection = false; 
+      if (isFirstSegment)
+      {
+        reverseDirection = (segment.StartPoint.IsEqualTo(connectionPoint)) ? true : false;
+        if (reverseDirection) nextPoint = segment.StartPoint;
+      }  
+      else
+      {
+        reverseDirection = (segment.StartPoint.IsEqualTo(connectionPoint)) ? false : true;
+        if (reverseDirection) nextPoint = segment.StartPoint;
+      }
+        
+      return (reverseDirection) ? segment.GetReverseParameterCurve() : segment;
     }
 
     // polylines can only support curve segments of type circular arc
@@ -1083,6 +1149,7 @@ namespace Objects.Converter.AutocadCivil
           }
           blockId = blckTbl.Add(btr);
           tr.AddNewlyCreatedDBObject(btr, true);
+          blckTbl.Dispose();
         }
         tr.Commit();
       }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -350,24 +350,18 @@ namespace Objects.Converter.AutocadCivil
     {
       var u = units ?? ModelUnits;
 
-      if (curve.IsPlanar(out AC.Plane pln))
+      // note: some curve3ds may not have endpoints! Not sure what contexts this may occur in, might cause issues later.
+      switch (curve)
       {
-        if (curve.IsPeriodic(out double period) && curve.IsClosed())
-        { }
-
-        if (curve.IsLinear(out Line3d line)) // this removes endpoint info! need to create line here instead of using LineToSpeckle
-        {
-          var startParam = line.GetParameterOf(curve.StartPoint);
-          var endParam = line.GetParameterOf(curve.EndPoint);
-          var _line = new Line(PointToSpeckle(curve.StartPoint, u), PointToSpeckle(curve.EndPoint, u), u);
-          _line.length = line.GetLength(startParam, endParam, tolerance);
-          _line.domain = IntervalToSpeckle(curve.GetInterval());
-          _line.bbox = BoxToSpeckle(curve.OrthoBoundBlock);
-          return _line;
-        }
+        case Line3d line:
+          return LineToSpeckle(line);
+        case LineSegment3d line:
+          return LineToSpeckle(line);
+        case CircularArc3d arc:
+          return ArcToSpeckle(arc);
+        default:
+          return NurbsToSpeckle(curve as NurbCurve3d);
       }
-
-      return NurbsToSpeckle(curve as NurbCurve3d);
     }
 
     public Surface SurfaceToSpeckle(AC.NurbSurface surface, string units = null)

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -160,8 +160,11 @@ public static string AutocadAppName = Applications.Autocad2022;
         //case Surface o: // TODO: NOT TESTED
         //  return SurfaceToNative(o);
 
-        //case Brep o: // TODO: NOT TESTED
-        //  return BrepToNativeDB(o);
+        case Brep o:
+          if (o.displayMesh != null)
+            return MeshToNativeDB(o.displayMesh);
+          else
+            return null;
 
         //case Mesh o: // unstable, do not use for now
         //  return MeshToNativeDB(o);
@@ -333,6 +336,8 @@ public static string AutocadAppName = Applications.Autocad2022;
         case Polyline _:
         case Polycurve _:
         case Curve _:
+        case Brep _:
+        case Mesh _:
 
         case BlockDefinition _:
         case BlockInstance _:

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -157,7 +157,8 @@ public static string AutocadAppName = Applications.Autocad2022;
         case Curve o:
           return CurveToNativeDB(o);
 
-        //case Surface o: // TODO: NOT TESTED
+          /*
+        //case Surface o: 
         //  return SurfaceToNative(o);
 
         case Brep o:
@@ -168,6 +169,7 @@ public static string AutocadAppName = Applications.Autocad2022;
 
         //case Mesh o: // unstable, do not use for now
         //  return MeshToNativeDB(o);
+        */
 
         case BlockInstance o:
           return BlockInstanceToNativeDB(o, out BlockReference refernce);
@@ -336,8 +338,8 @@ public static string AutocadAppName = Applications.Autocad2022;
         case Polyline _:
         case Polycurve _:
         case Curve _:
-        case Brep _:
-        case Mesh _:
+        //case Brep _:
+        //case Mesh _:
 
         case BlockDefinition _:
         case BlockInstance _:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Geometry.cs
@@ -272,6 +272,10 @@ namespace Objects.Converter.RhinoGh
       RH.Arc arc = new RH.Arc(PlaneToNative(a.plane), ScaleToNative((double)a.radius, a.units), (double)a.angleRadians);
       arc.StartAngle = (double)a.startAngle;
       arc.EndAngle = (double)a.endAngle;
+      if (!arc.IsValid) // try with different method if not valid
+      {
+        arc = new RH.Arc(PointToNative(a.startPoint).Location, PointToNative(a.midPoint).Location, PointToNative(a.endPoint).Location);
+      }
       var myArc = new ArcCurve(arc);
 
       if (a.domain != null)


### PR DESCRIPTION
## Description

Two fixes: 

Large arcs where not being correctly converted from acad to rhino due to differing angle conventions. Added alternative method in Rhino to create an arc from start, end, and midpoint in the case of failure to convert with existing method.

Manually imported dwgs in Autocad appear correct in modelspace, but polycurve segments may not be all aligned in the same direction resulting in incorrect conversion when sent to speckle. Now the autocad converter contains a segment direction check.

- Fixes #504 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: sent standard geo file back and forth

## Docs

- No updates needed


