### PR TITLE
fix(revit): add support for feet and fractional inches

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -56,9 +56,9 @@ namespace Objects.Converter.Revit
         return Speckle.Core.Kits.Units.Centimeters;
       else if (typeId == UnitTypeId.Meters.TypeId)
         return Speckle.Core.Kits.Units.Meters;
-      else if (typeId == UnitTypeId.Inches.TypeId)
+      else if (typeId == UnitTypeId.Inches.TypeId || typeId == UnitTypeId.FractionalInches.TypeId)
         return Speckle.Core.Kits.Units.Inches;
-      else if (typeId == UnitTypeId.Feet.TypeId)
+      else if (typeId == UnitTypeId.Feet.TypeId || typeId == UnitTypeId.FeetFractionalInches.TypeId)
         return Speckle.Core.Kits.Units.Feet;
 
       throw new Exception("The current Unit System is unsupported.");
@@ -162,6 +162,10 @@ namespace Objects.Converter.Revit
           return Speckle.Core.Kits.Units.Inches;
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
+        case DisplayUnitType.DUT_FEET_FRACTIONAL_INCHES:
+          return Speckle.Core.Kits.Units.Feet;
+        case DisplayUnitType.DUT_FRACTIONAL_INCHES:
+          return Speckle.Core.Kits.Units.Inches;
         default:
           throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
       }


### PR DESCRIPTION
## Description

Adds support for:

- feet and fractional inches
- fractional inches

Note: did not require any changes in core - all internal unit conversions are thankfully handled by revit

- Fixes #482

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: sent revit models in above units and tested against the same models sent in meters 

## Docs

- No updates needed

