### PR TITLE
feat(autocad): handles surface to speckle conversions as mesh

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -225,11 +225,11 @@ public static string AutocadAppName = Applications.Autocad2022;
         case AcadDB.Polyline2d o:
           return PolycurveToSpeckle(o);
 
-        case PlaneSurface o:
-          return SurfaceToSpeckle(o);
+        case Region o:
+          return RegionToSpeckle(o);
 
-         case AcadDB.NurbSurface o:
-           return SurfaceToSpeckle(o);
+        case AcadDB.Surface o:
+          return SurfaceToSpeckle(o);
 
         case AcadDB.PolyFaceMesh o:
           return MeshToSpeckle(o);
@@ -287,9 +287,9 @@ public static string AutocadAppName = Applications.Autocad2022;
             case AcadDB.Polyline _:
             case AcadDB.Polyline2d _:
             case AcadDB.Polyline3d _:
-            case AcadDB.PlaneSurface _:
-            case AcadDB.NurbSurface _:
+            case AcadDB.Surface _:
             case AcadDB.PolyFaceMesh _:
+            case AcadDB.Region _:
             case SubDMesh _:
             case Solid3d _:
               return true;


### PR DESCRIPTION
## Description

Sends surfaces to Speckle as meshes, since breps are not yet supported in autocad.
Also adds region conversions to mesh.

- Fixes #425 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: sending standard geometry files from autocad 

## Docs

- No updates needed

