### PR TITLE
fix(revit): resolve failing unit tests

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -106,11 +106,7 @@ namespace Objects.Converter.Revit
             continue;
           }
 
-          if (!CanConvertToNative(obj))
-          {
-            ConversionErrors.Add(new Exception($"Skipping not supported type: {obj.speckle_type}"));
-            continue;
-          }
+          if (!CanConvertToNative(obj)) continue;
 
           try
           {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -20,7 +20,7 @@ namespace Objects.Converter.Revit
         throw new Speckle.Core.Logging.SpeckleException("Only line based Beams are currently supported.");
       }
 
-      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn); ;
+      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn);
       var baseLine = CurveToNative(speckleColumn.baseLine).get_Item(0);
 
       // If the start point elevation is higher than the end point elevation, reverse the line.
@@ -91,8 +91,11 @@ namespace Objects.Converter.Revit
       if (revitColumn == null && isLineBased)
       {
         revitColumn = Doc.Create.NewFamilyInstance(baseLine, familySymbol, level, structuralType);
-        StructuralFramingUtils.DisallowJoinAtEnd(revitColumn, 0);
-        StructuralFramingUtils.DisallowJoinAtEnd(revitColumn, 1);
+        if ( revitColumn.Symbol.Family.FamilyPlacementType == FamilyPlacementType.CurveDrivenStructural )
+        {
+          StructuralFramingUtils.DisallowJoinAtEnd(revitColumn, 0);
+          StructuralFramingUtils.DisallowJoinAtEnd(revitColumn, 1);
+        }
       }
 
       //try with a point based column

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
@@ -49,7 +49,7 @@ namespace Objects.Converter.Revit
             var bottomLevel = LevelToNative(rs.bottomLevel);
             var topLevel = LevelToNative(rs.topLevel);
             revitOpening = Doc.Create.NewOpening(bottomLevel, topLevel, baseCurves);
-            TrySetParam(revitOpening, BuiltInParameter.WALL_USER_HEIGHT_PARAM, rs.height);
+            TrySetParam(revitOpening, BuiltInParameter.WALL_USER_HEIGHT_PARAM, rs.height, rs.units);
 
             break;
           }

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/BeamTests.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/BeamTests.cs
@@ -45,7 +45,7 @@ namespace ConverterRevitTests
 
     [Fact]
     [Trait("Beam", "ToNativeUpdates")]
-    public void WallToNativeUpdates()
+    public void BeamToNativeUpdates()
     {
       SpeckleToNativeUpdates<DB.FamilyInstance>(AssertFamilyInstanceEqual);
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/ColumnTests.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/ColumnTests.cs
@@ -43,7 +43,7 @@ namespace ConverterRevitTests
 
     [Fact]
     [Trait("Column", "ToNativeUpdates")]
-    public void WallToNativeUpdates()
+    public void ColumnToNativeUpdates()
     {
       SpeckleToNativeUpdates<DB.FamilyInstance>(AssertFamilyInstanceEqual);
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/SpeckleConversionTest.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/SpeckleConversionTest.cs
@@ -229,26 +229,31 @@ namespace ConverterRevitTests
       if (expecedParam == null)
         return;
 
-      if (expecedParam.StorageType == StorageType.Double)
+      switch ( expecedParam.StorageType )
       {
-        Assert.Equal(expecedParam.AsDouble(), actual.get_Parameter(param).AsDouble(), 4);
-      }
-      else if (expecedParam.StorageType == StorageType.Integer)
-      {
-        Assert.Equal(expecedParam.AsInteger(), actual.get_Parameter(param).AsInteger());
-      }
-      else if (expecedParam.StorageType == StorageType.String)
-      {
-        Assert.Equal(expecedParam.AsString(), actual.get_Parameter(param).AsString());
-      }
-      else if (expecedParam.StorageType == StorageType.ElementId)
-      {
-        var e1 = fixture.SourceDoc.GetElement(expecedParam.AsElementId());
-        var e2 = fixture.NewDoc.GetElement(actual.get_Parameter(param).AsElementId());
-        if (e1 is Level l1 && e2 is Level l2)
-          Assert.Equal(l1.Elevation, l2.Elevation, 3);
-        else if (e1 != null && e2 != null)
-          Assert.Equal(e1.Name, e2.Name);
+        case StorageType.Double:
+          Assert.Equal(expecedParam.AsDouble(), actual.get_Parameter(param).AsDouble(), 4);
+          break;
+        case StorageType.Integer:
+          Assert.Equal(expecedParam.AsInteger(), actual.get_Parameter(param).AsInteger());
+          break;
+        case StorageType.String:
+          Assert.Equal(expecedParam.AsString(), actual.get_Parameter(param).AsString());
+          break;
+        case StorageType.ElementId:
+        {
+          var e1 = fixture.SourceDoc.GetElement(expecedParam.AsElementId());
+          var e2 = fixture.NewDoc.GetElement(actual.get_Parameter(param).AsElementId());
+          if (e1 is Level l1 && e2 is Level l2)
+            Assert.Equal(l1.Elevation, l2.Elevation, 3);
+          else if (e1 != null && e2 != null)
+            Assert.Equal(e1.Name, e2.Name);
+          break;
+        }
+        case StorageType.None:
+          break;
+        default:
+          throw new ArgumentOutOfRangeException();
       }
     }
   }

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/SpeckleConversionTest.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/SpeckleConversionTest.cs
@@ -107,8 +107,8 @@ namespace ConverterRevitTests
           {
             resEls.AddRange(apls);
             flatSpkElems.Add(el);
-            if (el["elements"] != null)
-              flatSpkElems.AddRange(el["elements"] as List<Base>);
+            if ( el[ "elements" ] == null ) continue;
+            flatSpkElems.AddRange(( el[ "elements" ] as List<Base> ).Where(b => converter.CanConvertToNative(b)));
           }
           else
           {


### PR DESCRIPTION
## Description

- unconnected shaft openings are getting the correct height (previously we were not passing units, so this was not getting scaled)
- slanted columns checked if curve driven before trying to mess with endpoints 
  - errors no longer thrown on receive of slanted columns
- support [stacked walls](https://latest.speckle.dev/streams/0c6ad366c4/objects/c07a424ffad5837c5bc927fc3eee9046)
  - previously, stacked wall members were not being converted so nothing showed up in the viewer and receiving back would just be a regular wall
  - now wall members are added to `elements` list of host wall
- remove unsupported exception for hosted elements
- exclude nonconverted nested elements in tests 
  - was throwing errors bc flat list of elements was longer than the list of converted elements
- smol typo fixes and refactoring

NOTE: does not address the failing brep tests (unclear to me if we just leave them or if @AlanRynne wants to make any adjustments / update the boat test file?)

- Fixes #496 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Unit/Integration Tests: all xunit tests now pass (except for the brep ones that are unrelated)
- Manual Tests: sent full built elements test file (see [commit](https://latest.speckle.dev/streams/0c6ad366c4/commits/81eb49625d))

## Docs

- No updates needed

