### PR TITLE
fix(revit): better base point transformation for XYZ vectors, improved views

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -585,6 +585,7 @@ namespace Objects.Converter.Revit
       public double Y { get; set; } = 0;
       public double Z { get; set; } = 0;
       public double Angle { get; set; } = 0;
+      public Transform TotalTransform { get; set; }
     }
 
     ////////////////////////////////////////////////
@@ -619,12 +620,17 @@ namespace Objects.Converter.Revit
           }
           else
           {
+            var x = bp.get_Parameter(BuiltInParameter.BASEPOINT_EASTWEST_PARAM).AsDouble();
+            var y = bp.get_Parameter(BuiltInParameter.BASEPOINT_NORTHSOUTH_PARAM).AsDouble();
+            var z = bp.get_Parameter(BuiltInParameter.BASEPOINT_ELEVATION_PARAM).AsDouble();
+            var angle = bp.get_Parameter(BuiltInParameter.BASEPOINT_ANGLETON_PARAM).AsDouble();
             _basePoint = new BetterBasePoint
             {
-              X = bp.get_Parameter(BuiltInParameter.BASEPOINT_EASTWEST_PARAM).AsDouble(),
-              Y = bp.get_Parameter(BuiltInParameter.BASEPOINT_NORTHSOUTH_PARAM).AsDouble(),
-              Z = bp.get_Parameter(BuiltInParameter.BASEPOINT_ELEVATION_PARAM).AsDouble(),
-              Angle = bp.get_Parameter(BuiltInParameter.BASEPOINT_ANGLETON_PARAM).AsDouble()
+              X = x,
+              Y = y,
+              Z = z,
+              Angle = angle,
+              TotalTransform = Transform.CreateRotation(XYZ.BasisZ, angle).Multiply(Transform.CreateTranslation(new XYZ(0 - x, 0 - y, 0 - z)))
             };
           }
         }
@@ -637,8 +643,11 @@ namespace Objects.Converter.Revit
     /// </summary>
     /// <param name="p"></param>
     /// <returns></returns>
-    public XYZ ToExternalCoordinates(XYZ p)
+    public XYZ ToExternalCoordinates(XYZ p, bool isPoint)
     {
+      return (isPoint) ? BasePoint.TotalTransform.OfPoint(p) : BasePoint.TotalTransform.OfVector(p);
+
+      /*
       p = new XYZ(p.X - BasePoint.X, p.Y - BasePoint.Y, p.Z - BasePoint.Z);
       //rotation
       double centX = (p.X * Math.Cos(-BasePoint.Angle)) - (p.Y * Math.Sin(-BasePoint.Angle));
@@ -647,6 +656,7 @@ namespace Objects.Converter.Revit
       XYZ newP = new XYZ(centX, centY, p.Z);
 
       return newP;
+      */
     }
 
     /// <summary>
@@ -654,8 +664,11 @@ namespace Objects.Converter.Revit
     /// </summary>
     /// <param name="p"></param>
     /// <returns></returns>
-    public XYZ ToInternalCoordinates(XYZ p)
+    public XYZ ToInternalCoordinates(XYZ p, bool isPoint)
     {
+      return (isPoint) ? BasePoint.TotalTransform.Inverse.OfPoint(p) : BasePoint.TotalTransform.Inverse.OfVector(p);
+
+      /*
       //rotation
       double centX = (p.X * Math.Cos(BasePoint.Angle)) - (p.Y * Math.Sin(BasePoint.Angle));
       double centY = (p.X * Math.Sin(BasePoint.Angle)) + (p.Y * Math.Cos(BasePoint.Angle));
@@ -663,6 +676,7 @@ namespace Objects.Converter.Revit
       XYZ newP = new XYZ(centX + BasePoint.X, centY + BasePoint.Y, p.Z + BasePoint.Z);
 
       return newP;
+      */
     }
     #endregion
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -47,14 +47,15 @@ namespace Objects.Converter.Revit
     public XYZ PointToNative(Point pt)
     {
       var revitPoint = new XYZ(ScaleToNative(pt.x, pt.units), ScaleToNative(pt.y, pt.units), ScaleToNative(pt.z, pt.units));
-      var intPt = ToInternalCoordinates(revitPoint);
+      var intPt = ToInternalCoordinates(revitPoint, true);
       return intPt;
     }
 
     public Point PointToSpeckle(XYZ pt, string units = null)
     {
       var u = units ?? ModelUnits;
-      var extPt = ToExternalCoordinates(pt);
+      var extPt = ToExternalCoordinates(pt, true);
+
       var pointToSpeckle = new Point(
         u == Units.None ? extPt.X : ScaleToSpeckle(extPt.X),
         u == Units.None ? extPt.Y : ScaleToSpeckle(extPt.Y),
@@ -97,7 +98,7 @@ namespace Objects.Converter.Revit
     public Vector VectorToSpeckle(XYZ pt, string units = null)
     {
       var u = units ?? ModelUnits;
-      var extPt = ToExternalCoordinates(pt);
+      var extPt = ToExternalCoordinates(pt, false);
       var pointToSpeckle = new Vector(
         u == Units.None ? extPt.X : ScaleToSpeckle(extPt.X),
         u == Units.None ? extPt.Y : ScaleToSpeckle(extPt.Y),
@@ -109,7 +110,7 @@ namespace Objects.Converter.Revit
     public XYZ VectorToNative(Vector pt)
     {
       var revitVector = new XYZ(ScaleToNative(pt.x, pt.units), ScaleToNative(pt.y, pt.units), ScaleToNative(pt.z, pt.units));
-      var intV = ToInternalCoordinates(revitVector);
+      var intV = ToInternalCoordinates(revitVector, false);
       return intV;
     }
 
@@ -647,7 +648,7 @@ namespace Objects.Converter.Revit
         for (var v = 0; v < controlPointCountV; v++)
         {
           var pt = controlPoints[uOffset + v];
-          var extPt = ToExternalCoordinates(pt);
+          var extPt = ToExternalCoordinates(pt, true);
           if (surface.IsRational)
           {
             var w = weights[uOffset + v];

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
@@ -52,8 +52,8 @@ namespace Objects.Converter.Revit
         speckleView = new View3D
         {
           origin = PointToSpeckle(rv3d.Origin),
-          forwardDirection = new Geometry.Vector(forward.X, forward.Y, forward.Z, "none"),
-          upDirection = new Geometry.Vector(up.X, up.Y, up.Z, "none"),
+          forwardDirection = VectorToSpeckle(forward, Speckle.Core.Kits.Units.None),
+          upDirection = VectorToSpeckle(up, Speckle.Core.Kits.Units.None),
           //target = target,
           isOrthogonal = !rv3d.IsPerspective,
           boundingBox = BoxToSpeckle(rv3d.CropBox)


### PR DESCRIPTION
## Description

Revit XYZ class can be points or vectors: in the case of a transformed base point (translation, angle from north), the ToInternalCoordinates() and ToExternalCoordinates() was working properly but not for vectors. This was resulting in faulty view conversions where camera location was correct but direction was incorrect.

1.  Added TotalTransform property to BetterBasePoint class
2.  Modified Point and Vector conversions to use TotalTransform
3.  Fixed View conversions to use Point and Vector conversions for all props

- Fixes #559

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: sent sample arch and structure file from Revit with views, some light additional testing with current test streams 

## Docs

- No updates needed


