### PR TITLE
fix(revit): use displayvalue for failed curves

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -297,6 +297,7 @@ namespace Objects.Converter.Revit
             speckleKnots.Insert(0, speckleKnots[0]);
             speckleKnots.Add(speckleKnots[speckleKnots.Count - 1]);
           }
+
           //var knots = speckleKnots.GetRange(0, pts.Count + speckleCurve.degree + 1);
           var curve = NurbSpline.CreateCurve(speckleCurve.degree, speckleKnots, pts, weights);
           return curve;
@@ -311,6 +312,7 @@ namespace Objects.Converter.Revit
       }
       catch (Exception e)
       {
+        if ( e is Autodesk.Revit.Exceptions.ArgumentException ) throw e; // prob a closed, periodic curve
         return null;
       }
     }


### PR DESCRIPTION
## Description

[the offending curves](https://latest.speckle.dev/streams/0c6ad366c4/commits/2290a4a5c1)

helps deal with the following issues:
- revit api doesn't support closed periodic curves
  (ty claire for help, boo autodesk for sucking)
- non-planar nurbs aren't supported

fixes #497

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

![working curves (sorta)](https://user-images.githubusercontent.com/7717434/121711975-168a3a80-cad3-11eb-9d69-3861b1ae9d5c.png)

- Unit/Integration Tests: all xunit tests pass with this + the revit fixes PR that is pending (#556)
- Manual Test: receive standard geometry file from revit

## Docs

- No updates needed
