### PR TITLE
feat(rhino & acad): adds hatch conversions

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -609,21 +609,17 @@ namespace Objects.Converter.AutocadCivil
 
       return _hatch;
     }
-    public AcadDB.Hatch HatchToNative(Hatch hatch)
+    public AcadDB.Hatch HatchToNativeDB(Hatch hatch)
     {
       var _hatch = new AcadDB.Hatch();
 
-      _hatch.PatternAngle = hatch.rotation;
-      _hatch.PatternScale = hatch.scale;
-      _hatch.SetHatchPattern(HatchPatternType.PreDefined, hatch.pattern);
-
-      // handle curves
       var curveIds = new ObjectIdCollection();
       using (Transaction tr = Doc.TransactionManager.StartTransaction())
       {
         BlockTable blckTbl = tr.GetObject(Doc.Database.BlockTableId, OpenMode.ForRead) as BlockTable;
         BlockTableRecord modelSpaceRecord = (BlockTableRecord)tr.GetObject(blckTbl[BlockTableRecord.ModelSpace], AcadDB.OpenMode.ForWrite);
 
+        // convert curves
         foreach (var curve in hatch.curves)
         {
           var converted = CurveToNativeDB(curve);
@@ -642,6 +638,11 @@ namespace Objects.Converter.AutocadCivil
 
         // insert loops
         _hatch.AppendLoop((int)HatchLoopTypes.Default, curveIds);
+
+        // set props
+        _hatch.SetHatchPattern(HatchPatternType.PreDefined, hatch.pattern);
+        _hatch.PatternAngle = hatch.rotation;
+        _hatch.PatternScale = hatch.scale;
 
         tr.Commit();
       }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -33,6 +33,10 @@ namespace Objects.Converter.AutocadCivil
     {
       return new double[ ] { pt.X, pt.Y, pt.Z };
     }
+    public double[] PointToArray(Point2d pt)
+    {
+      return new double[] { pt.X, pt.Y, 0 };
+    }
     public Point3d[ ] PointListToNative(IEnumerable<double> arr, string units)
     {
       var enumerable = arr.ToList();
@@ -49,6 +53,10 @@ namespace Objects.Converter.AutocadCivil
       return points;
     }
     public double[ ] PointsToFlatArray(IEnumerable<Point3d> points)
+    {
+      return points.SelectMany(pt => PointToArray(pt)).ToArray();
+    }
+    public double[] PointsToFlatArray(IEnumerable<Point2d> points)
     {
       return points.SelectMany(pt => PointToArray(pt)).ToArray();
     }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -143,6 +143,9 @@ public static string AutocadAppName = Applications.Autocad2022;
         case Ellipse o:
           return EllipseToNativeDB(o);
 
+        case Hatch o:
+          return HatchToNativeDB(o);
+
         case Polyline o:
           return PolylineToNativeDB(o);
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -12,6 +12,7 @@ using Brep = Objects.Geometry.Brep;
 using Circle = Objects.Geometry.Circle;
 using Curve = Objects.Geometry.Curve;
 using Ellipse = Objects.Geometry.Ellipse;
+using Hatch = Objects.Other.Hatch;
 using Interval = Objects.Primitive.Interval;
 using Line = Objects.Geometry.Line;
 using Mesh = Objects.Geometry.Mesh;
@@ -214,6 +215,9 @@ public static string AutocadAppName = Applications.Autocad2022;
         case AcadDB.Ellipse o:
           @base = EllipseToSpeckle(o);
           break;
+        case AcadDB.Hatch o:
+          @base = HatchToSpeckle(o);
+          break;
         case AcadDB.Spline o:
           @base = SplineToSpeckle(o);
           break;
@@ -292,6 +296,7 @@ public static string AutocadAppName = Applications.Autocad2022;
             case AcadDB.Arc _:
             case AcadDB.Circle _:
             case AcadDB.Ellipse _:
+            case AcadDB.Hatch _:
             case AcadDB.Spline _:
             case AcadDB.Polyline _:
             case AcadDB.Polyline2d _:
@@ -345,6 +350,7 @@ public static string AutocadAppName = Applications.Autocad2022;
         case Arc _:
         case Circle _:  
         case Ellipse _:
+        case Hatch _:
         case Polyline _:
         case Polycurve _:
         case Curve _:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Other.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BlockDefinition = Objects.Other.BlockDefinition;
 using BlockInstance = Objects.Other.BlockInstance;
+using Hatch = Objects.Other.Hatch;
 using Point = Objects.Geometry.Point;
 using RH = Rhino.DocObjects;
 using Rhino;
@@ -20,6 +21,32 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
+    public Rhino.Geometry.Hatch HatchToNative(Hatch hatch)
+    {
+      var curves = hatch.curves.Select(o => CurveToNative(o));
+      var pattern = Doc.HatchPatterns.FindName(hatch.pattern);
+      if (pattern != null)
+      {
+        var hatches = Rhino.Geometry.Hatch.Create(curves, pattern.Index, hatch.rotation, hatch.scale, 0.001);
+        return hatches.First();
+      }
+      else return null;
+    }
+    public Hatch HatchToSpeckle(Rhino.Geometry.Hatch hatch)
+    {
+      var _hatch = new Hatch();
+
+      var curves = hatch.Get3dCurves(true).ToList();
+      curves.AddRange(hatch.Get3dCurves(false));
+      _hatch.color = 
+      _hatch.curves = curves.Select(o => CurveToSpeckle(o)).ToList();
+      _hatch.scale = hatch.PatternScale;
+      _hatch.pattern = Doc.HatchPatterns.ElementAt(hatch.PatternIndex).Name;
+      _hatch.rotation = hatch.PatternRotation;
+
+      return _hatch;
+    }
+
     public BlockDefinition BlockDefinitionToSpeckle(RH.InstanceDefinition definition)
     {
       var geometry = new List<Base>();

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -17,6 +17,7 @@ using Circle = Objects.Geometry.Circle;
 using Curve = Objects.Geometry.Curve;
 using DirectShape = Objects.BuiltElements.Revit.DirectShape;
 using Ellipse = Objects.Geometry.Ellipse;
+using Hatch = Objects.Other.Hatch;
 using Interval = Objects.Primitive.Interval;
 using Line = Objects.Geometry.Line;
 using Mesh = Objects.Geometry.Mesh;
@@ -136,6 +137,9 @@ namespace Objects.Converter.RhinoGh
           break;
         case RH.Box o:
           @base = BoxToSpeckle(o);
+          break;
+        case RH.Hatch o:
+          @base = HatchToSpeckle(o);
           break;
         case RH.Mesh o:
           @base = MeshToSpeckle(o);
@@ -271,6 +275,9 @@ namespace Objects.Converter.RhinoGh
         case Vector o:
           return VectorToNative(o);
 
+        case Hatch o:
+          return HatchToNative(o);
+
         case Interval o:
           return IntervalToNative(o);
 
@@ -361,6 +368,7 @@ namespace Objects.Converter.RhinoGh
         case UVInterval _:
         case RH.Line _:
         case LineCurve _:
+        case Rhino.Geometry.Hatch _:
         case RH.Plane _:
         case Rectangle3d _:
         case RH.Circle _:
@@ -405,6 +413,7 @@ namespace Objects.Converter.RhinoGh
         case Polyline _:
         case Polycurve _:
         case Curve _:
+        case Hatch _:
         case Box _:
         case Mesh _:
         case Brep _:

--- a/Objects/Objects/Other/Hatch.cs
+++ b/Objects/Objects/Other/Hatch.cs
@@ -1,0 +1,22 @@
+﻿using Speckle.Core.Models;
+using Speckle.Core.Kits;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+
+namespace Objects.Other
+{
+  /// <summary>
+  /// Hatch class for Rhino and AutoCAD
+  /// </summary>
+  public class Hatch : Base
+  {
+    public List<ICurve> curves { get; set; }
+    public string pattern { get; set; }
+    public double scale { get; set; } = 1;
+    public double rotation { get; set; } = 0; // relative angle
+
+    public Hatch() { }
+  }
+}


### PR DESCRIPTION
## Description

Adds hatch conversions to Rhino and Autocad:

- Hatch base class added to Objects: includes curves, pattern name, scale, and rotation
- Hatch conversions added to rhino and autocad converters
- If hatch name isn't found, will use default solid hatch instead

- Fixes #551 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sent standard test files between rhino and autocad

## Docs

- Will be updated ASAP

