### PR TITLE
feat(desktopui): the pin is back baby! 📌📍

### DIFF
--- a/DesktopUI/DesktopUI/RootView.xaml
+++ b/DesktopUI/DesktopUI/RootView.xaml
@@ -18,6 +18,7 @@
   Closing="{s:Action OnClosing}"
   FontFamily="{md:MaterialDesignFont}"
   Icon="Resources/s2block.ico"
+  Topmost="{Binding IsPinned, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
   TextElement.FontSize="13"
   TextElement.FontWeight="Normal"
   TextElement.Foreground="{DynamicResource MaterialDesignBody}"
@@ -46,7 +47,17 @@
         Background="{DynamicResource MaterialDesignCardBackground}"
         DockPanel.Dock="Top">
         <DockPanel>
-          <ToggleButton x:Name="MenuToggleButton"
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto"/>
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+          <ToggleButton Grid.Column="0" x:Name="MenuToggleButton"
+
             Width="30"
             Height="30"
             Margin="12,0,0,0"
@@ -59,25 +70,70 @@
             Content="{Binding  MainButtonIcon}"
             IsChecked="{Binding MainButton_Checked}"
             Style="{StaticResource MaterialDesignFloatingActionDarkButton}" />
-          <TextBlock Margin="12,0,0,0"
+
+          <TextBlock Grid.Column="1" Margin="12,0,0,0"
             VerticalAlignment="Center"
             FontSize="20"
             Style="{StaticResource MaterialDesignHeadline3TextBlock}"
             Text="{Binding ViewName, Converter={StaticResource StringToUpperConverter}}" />
-          <Button Width="30"
+
+          <ToggleButton Grid.Column="3"
+            Width="25"
+            Height="25"
+            Margin="0 0 4 0 "
+            VerticalAlignment="Center"
+            Background="Transparent"
+            Foreground="Gray"
+            IsChecked="{Binding IsPinned, Mode=TwoWay}">
+            <ToggleButton.Style>
+              <Style TargetType="ToggleButton" BasedOn="{StaticResource
+                MaterialDesignActionToggleButton}">
+                <Style.Triggers>
+                  <Trigger Property="IsChecked"
+                    Value="True">
+                    <Setter Property="ToolTip"
+                      Value="Unpin this window from top" />
+                  </Trigger>
+                  <Trigger Property="IsChecked"
+                    Value="False">
+                    <Setter Property="ToolTip"
+                      Value="Pin this window to top" />
+                  </Trigger>
+                </Style.Triggers>
+              </Style>
+            </ToggleButton.Style>
+
+            <ToggleButton.Content>
+              <md:PackIcon Kind="Pin"
+                Width="16"
+                Height="16"
+                RenderTransformOrigin=".5,.5">
+                <md:PackIcon.RenderTransform>
+                  <RotateTransform Angle="45" />
+                </md:PackIcon.RenderTransform>
+              </md:PackIcon>
+            </ToggleButton.Content>
+            <md:ToggleButtonAssist.OnContent>
+              <md:PackIcon Kind="Pin"
+                Width="16"
+                Height="16"/>
+            </md:ToggleButtonAssist.OnContent>
+          </ToggleButton>
+
+          <Button Grid.Column="4" Width="30"
             Height="30"
             Margin="0 0 12 0 "
             md:ShadowAssist.ShadowDepth="Depth0"
             Background="Transparent"
             BorderBrush="Transparent"
             VerticalAlignment="Center"
-            HorizontalAlignment="Right"
             Foreground="Gray"
             Content="{md:PackIcon Kind=Refresh}"
             Command="{s:Action RefreshActiveView}"
             ToolTip="Refresh streams and local accounts"
             Style="{StaticResource MaterialDesignFloatingActionDarkButton}" />
 
+          </Grid>
         </DockPanel>
       </md:Card>
       <!--#endregion-->

--- a/DesktopUI/DesktopUI/RootViewModel.cs
+++ b/DesktopUI/DesktopUI/RootViewModel.cs
@@ -45,6 +45,14 @@ namespace Speckle.DesktopUI
       set => SetAndNotify(ref _mainButton_Checked, value);
     }
 
+    private bool _isPinned = true;
+
+    public bool IsPinned
+    {
+      get => _isPinned;
+      set => SetAndNotify(ref _isPinned, value);
+    }
+
     public readonly Dictionary<string, IScreen> Pages = new Dictionary<string, IScreen>();
 
     public RootViewModel(IWindowManager windowManager, IEventAggregator events, IViewModelFactory viewModelFactory, ConnectorBindings bindings)

--- a/DesktopUI/DesktopUI/Settings/SettingsView.xaml
+++ b/DesktopUI/DesktopUI/Settings/SettingsView.xaml
@@ -170,7 +170,6 @@
                 <TextBlock Margin="0,0,8,0">
                   <md:PackIcon Kind="WhiteBalanceSunny" />
                 </TextBlock>
-                <!--  TODO figure out why this isn't changing the theme  -->
                 <ToggleButton x:Name="DarkModeToggleButton"
                   Command="{s:Action ToggleTheme}"
                   IsChecked="{Binding DarkMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />


### PR DESCRIPTION
## Description

it's back 🥳

![unpinned state](https://user-images.githubusercontent.com/7717434/124248848-2b2e8100-db1b-11eb-9ca0-f35b17ecaa6d.png)

![pinned state](https://user-images.githubusercontent.com/7717434/124248868-308bcb80-db1b-11eb-8f08-fd5b5a066de0.png)

- Fixes #584 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests in Revit & Rhino

## Docs

- No updates needed


