### PR TITLE
feat(logging): print unsupported units in errormsg

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -1,12 +1,10 @@
-﻿using Speckle.Core.Kits;
-using Speckle.Core.Models;
-
-using Objects.Other;
-
-using Autodesk.AutoCAD.DatabaseServices;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Text.RegularExpressions;
 using Autodesk.AutoCAD.Colors;
+using Autodesk.AutoCAD.DatabaseServices;
+using Objects.Other;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
 
 namespace Objects.Converter.AutocadCivil
 {
@@ -55,7 +53,7 @@ namespace Objects.Converter.AutocadCivil
         case UnitsValue.Miles:
           return Units.Miles;
         default:
-          throw new System.Exception("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{units}\" is unsupported.");
       }
     }
     #endregion
@@ -72,11 +70,11 @@ namespace Objects.Converter.AutocadCivil
         switch (entity.Color.ColorMethod)
         {
           case ColorMethod.ByLayer:
-            using (Transaction tr = Doc.Database.TransactionManager.StartTransaction())
+            using(Transaction tr = Doc.Database.TransactionManager.StartTransaction())
             {
               if (entity.LayerId.IsValid)
               {
-                var layer = tr.GetObject(entity.LayerId, OpenMode.ForRead) as LayerTableRecord;
+                var layer = tr.GetObject(entity.LayerId, OpenMode.ForRead)as LayerTableRecord;
                 color = layer.Color.ColorValue.ToArgb();
               }
               tr.Commit();
@@ -94,11 +92,11 @@ namespace Objects.Converter.AutocadCivil
         style.linetype = entity.Linetype;
         if (entity.Linetype == "BYLAYER")
         {
-          using (Transaction tr = Doc.Database.TransactionManager.StartTransaction())
+          using(Transaction tr = Doc.Database.TransactionManager.StartTransaction())
           {
             if (entity.LayerId.IsValid)
             {
-              var layer = tr.GetObject(entity.LayerId, OpenMode.ForRead) as LayerTableRecord;
+              var layer = tr.GetObject(entity.LayerId, OpenMode.ForRead)as LayerTableRecord;
               var linetype = (LinetypeTableRecord)tr.GetObject(layer.LinetypeObjectId, OpenMode.ForRead);
               style.linetype = linetype.Name;
             }
@@ -113,11 +111,11 @@ namespace Objects.Converter.AutocadCivil
           switch (entity.LineWeight)
           {
             case LineWeight.ByLayer:
-              using (Transaction tr = Doc.Database.TransactionManager.StartTransaction())
+              using(Transaction tr = Doc.Database.TransactionManager.StartTransaction())
               {
                 if (entity.LayerId.IsValid)
                 {
-                  var layer = tr.GetObject(entity.LayerId, OpenMode.ForRead) as LayerTableRecord;
+                  var layer = tr.GetObject(entity.LayerId, OpenMode.ForRead)as LayerTableRecord;
                   if (layer.LineWeight == LineWeight.ByLineWeightDefault || layer.LineWeight == LineWeight.ByBlock)
                     lineWeight = (int)LineWeight.LineWeight025;
                   else

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.Revit.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.Revit.cs
@@ -33,7 +33,7 @@ namespace Objects.Converter.Dynamo
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{type}\" is unsupported.");
       }
 
     }
@@ -78,7 +78,7 @@ namespace Objects.Converter.Dynamo
     //  else if (typeId == UnitTypeId.Feet.TypeId)
     //    return Speckle.Core.Kits.Units.Feet;
 
-    //  throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
+    //  throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{typeId}\" is unsupported.");
     //}
   }
 }

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.cs
@@ -42,7 +42,6 @@ namespace Objects.Converter.Dynamo
 
 #if !(REVIT2022)
 
-
     private DisplayUnitType _revitUnitsTypeId = DisplayUnitType.DUT_UNDEFINED;
     public DisplayUnitType RevitLengthTypeId
     {
@@ -72,7 +71,7 @@ namespace Objects.Converter.Dynamo
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{type}\" is unsupported.");
       }
 
     }
@@ -105,27 +104,18 @@ namespace Objects.Converter.Dynamo
       else if (typeId == UnitTypeId.Feet)
         return Speckle.Core.Kits.Units.Feet;
 
-      throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
+      throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{typeId}\" is unsupported.");
     }
 
 #endif
 
-
-
 #endif
-
-
 
     private double ScaleToNative(double value, string units)
     {
       var f = Speckle.Core.Kits.Units.GetConversionFactor(units, ModelUnits);
       return value * f;
     }
-
-
-
-
-
 
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -61,7 +61,7 @@ namespace Objects.Converter.Revit
       else if (typeId == UnitTypeId.Feet.TypeId || typeId == UnitTypeId.FeetFractionalInches.TypeId)
         return Speckle.Core.Kits.Units.Feet;
 
-      throw new Exception("The current Unit System is unsupported.");
+      throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{typeId}\" is unsupported.");
     }
 
     public string UnitsToNative(string units)
@@ -79,7 +79,7 @@ namespace Objects.Converter.Revit
         case Speckle.Core.Kits.Units.Feet:
           return UnitTypeId.Feet.TypeId;
         default:
-          throw new Exception("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{units}\" is unsupported.");
       }
     }
 #else
@@ -167,7 +167,7 @@ namespace Objects.Converter.Revit
         case DisplayUnitType.DUT_FRACTIONAL_INCHES:
           return Speckle.Core.Kits.Units.Inches;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{type}\" is unsupported.");
       }
 
     }
@@ -187,7 +187,7 @@ namespace Objects.Converter.Revit
         case Speckle.Core.Kits.Units.Feet:
           return DisplayUnitType.DUT_DECIMAL_FEET;
         default:
-          throw new Speckle.Core.Logging.SpeckleException("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{units}\" is unsupported.");
       }
     }
 #endif

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.Utils.cs
@@ -163,7 +163,7 @@ namespace Objects.Converter.RhinoGh
         case UnitSystem.Unset:
           return Units.Meters;
         default:
-          throw new System.Exception("The current Unit System is unsupported.");
+          throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{us}\" is unsupported.");
       }
     }
     #endregion


### PR DESCRIPTION
## Description

This should be a pretty innocuous change - just changing the error message you get in the connectors when the unit system isn't supported.

Here the units are none so it's just "" lol. Didn't really wanna add another case for this to minimise adding repeated code, but can do if desired. imho tho, "" conveys that there are no units p clearly.

![example when units are none](https://user-images.githubusercontent.com/7717434/124727297-7fb07280-df06-11eb-9294-70dc16cbb182.png)

- closes #601

## Type of change

- Bug fix 

## How has this been tested?

- Manual Tests in revit and rhino

## Docs

- No updates needed


