### PR TITLE
added handler for blocks from external references

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -1151,6 +1151,8 @@ namespace Objects.Converter.AutocadCivil
         definition = BlockRecordToSpeckle(btr);
         tr.Commit();
       }
+      if (definition == null)
+        return null;
 
       var instance = new BlockInstance()
       {
@@ -1206,6 +1208,10 @@ namespace Objects.Converter.AutocadCivil
 
     public BlockDefinition BlockRecordToSpeckle (BlockTableRecord record)
     {
+      // skip if this is from an external reference
+      if (record.IsFromExternalReference)
+        return null;
+
       // get geometry
       var geometry = new List<Base>();
       using (Transaction tr = Doc.TransactionManager.StartTransaction())


### PR DESCRIPTION
Previously resulted in application crash if attempting to send a block from external reference


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests 

## Docs

- No updates needed
