### PR TITLE
fix(gh): CSO not recomputing on input rename

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ComponentCategories.cs" />
     <Compile Include="Conversion\Convert.ToSpeckleAsync.cs" />
     <Compile Include="Conversion\Serialisation.SerialiseObject.cs" />
+    <Compile Include="Extras\DebounceDispatcher.cs" />
     <Compile Include="Extras\GenericAccessParam.cs" />
     <Compile Include="Conversion\Convert.ToNativeAsync.cs" />
     <Compile Include="Extras\Speckle.IGH_Goo.cs" />

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/DebounceDispatcher.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/DebounceDispatcher.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Windows.Threading;
+
+namespace ConnectorGrasshopper.Extras
+{
+/// <summary>
+/// Provides Debounce() and Throttle() methods.
+/// Use these methods to ensure that events aren't handled too frequently.
+/// 
+/// Throttle() ensures that events are throttled by the interval specified.
+/// Only the last event in the interval sequence of events fires.
+/// 
+/// Debounce() fires an event only after the specified interval has passed
+/// in which no other pending event has fired. Only the last event in the
+/// sequence is fired.
+/// </summary>
+public class DebounceDispatcher
+{
+    private DispatcherTimer timer;
+    private DateTime timerStarted { get; set; } = DateTime.UtcNow.AddYears(-1);
+
+    /// <summary>
+    /// Debounce an event by resetting the event timeout every time the event is 
+    /// fired. The behavior is that the Action passed is fired only after events
+    /// stop firing for the given timeout period.
+    /// 
+    /// Use Debounce when you want events to fire only after events stop firing
+    /// after the given interval timeout period.
+    /// 
+    /// Wrap the logic you would normally use in your event code into
+    /// the  Action you pass to this method to debounce the event.
+    /// Example: https://gist.github.com/RickStrahl/0519b678f3294e27891f4d4f0608519a
+    /// </summary>
+    /// <param name="interval">Timeout in Milliseconds</param>
+    /// <param name="action">Action<object> to fire when debounced event fires</object></param>
+    /// <param name="param">optional parameter</param>
+    /// <param name="priority">optional priorty for the dispatcher</param>
+    /// <param name="disp">optional dispatcher. If not passed or null CurrentDispatcher is used.</param>        
+    public void Debounce(int interval, Action<object> action,
+        object param = null,
+        DispatcherPriority priority = DispatcherPriority.ApplicationIdle,
+        Dispatcher disp = null)
+    {
+        // kill pending timer and pending ticks
+        timer?.Stop();
+        timer = null;
+
+        if (disp == null)
+            disp = Dispatcher.CurrentDispatcher;
+
+        // timer is recreated for each event and effectively
+        // resets the timeout. Action only fires after timeout has fully
+        // elapsed without other events firing in between
+        timer = new DispatcherTimer(TimeSpan.FromMilliseconds(interval), priority, (s, e) =>
+        {
+            if (timer == null)
+                return;
+
+            timer?.Stop();
+            timer = null;
+            action.Invoke(param);
+        }, disp);
+
+        timer.Start();
+    }
+
+    /// <summary>
+    /// This method throttles events by allowing only 1 event to fire for the given
+    /// timeout period. Only the last event fired is handled - all others are ignored.
+    /// Throttle will fire events every timeout ms even if additional events are pending.
+    /// 
+    /// Use Throttle where you need to ensure that events fire at given intervals.
+    /// </summary>
+    /// <param name="interval">Timeout in Milliseconds</param>
+    /// <param name="action">Action<object> to fire when debounced event fires</object></param>
+    /// <param name="param">optional parameter</param>
+    /// <param name="priority">optional priorty for the dispatcher</param>
+    /// <param name="disp">optional dispatcher. If not passed or null CurrentDispatcher is used.</param>
+    public void Throttle(int interval, Action<object> action,
+        object param = null,
+        DispatcherPriority priority = DispatcherPriority.ApplicationIdle,
+        Dispatcher disp = null)
+    {
+        // kill pending timer and pending ticks
+        timer?.Stop();
+        timer = null;
+
+        if (disp == null)
+            disp = Dispatcher.CurrentDispatcher;
+
+        var curTime = DateTime.UtcNow;
+
+        // if timeout is not up yet - adjust timeout to fire 
+        // with potentially new Action parameters           
+        if (curTime.Subtract(timerStarted).TotalMilliseconds < interval)
+            interval -= (int) curTime.Subtract(timerStarted).TotalMilliseconds;
+
+        timer = new DispatcherTimer(TimeSpan.FromMilliseconds(interval), priority, (s, e) =>
+        {
+            if (timer == null)
+                return;
+
+            timer?.Stop();
+            timer = null;
+            action.Invoke(param);
+        }, disp);
+
+        timer.Start();
+        timerStarted = curTime;            
+    }
+}
+}

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
@@ -240,9 +240,28 @@ namespace ConnectorGrasshopper.Objects
     {
     }
 
+    private DebounceDispatcher nicknameChangeDebounce = new DebounceDispatcher();
+
     public override void AddedToDocument(GH_Document document)
     {
-      base.AddedToDocument(document);
+      base.AddedToDocument(document); // This would set the converter already.
+      Params.ParameterChanged += (sender, args) =>
+      {
+        if (args.ParameterSide != GH_ParameterSide.Input) return;
+        switch (args.OriginalArguments.Type)
+        {
+          case GH_ObjectEventType.NickName:
+            // This means the user is typing characters, debounce until it stops for 400ms before expiring the solution.
+            // Prevents UI from locking too soon while writing new names for inputs.
+            args.Parameter.Name = args.Parameter.NickName;
+            nicknameChangeDebounce.Debounce(400, (e) => ExpireSolution(true));
+            break;
+          case GH_ObjectEventType.NickNameAccepted:
+            args.Parameter.Name = args.Parameter.NickName;
+            ExpireSolution(true);
+            break;
+        }
+      };
     }
   }
 }


### PR DESCRIPTION
Create speckle object node was not properly recomputing when the input name was changed.

Added `DebounceDispatcher` for dependency free `Debounce`. Needed to prevent us from expiring the solution on every character typed.

Current behaviour is:
- If you start writing on an input text field, `ExpireSolution` call will be debounced until no call has been invoked for 400ms.
- If you press enter, this is considered a `NickName Accepted` event, and we'll recompute directly, no debouncing.