### PR TITLE
RH: Add applicationId to Speckle Schema objects

### DIFF
--- a/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/UI/ConnectorBindingsRhino.cs
@@ -513,7 +513,14 @@ namespace SpeckleRhino
         conversionProgressDict["Conversion"]++;
         UpdateProgress(conversionProgressDict, state.Progress);
 
+        // set application ids, also set for speckle schema base object if it exists
         converted.applicationId = applicationId;
+        if (converted["@SpeckleSchema"] != null)
+        {
+          var newSchemaBase = converted["@SpeckleSchema"] as Base;
+          newSchemaBase.applicationId = applicationId;
+          converted["@SpeckleSchema"] = newSchemaBase;
+        }
 
         objCount++;
       }


### PR DESCRIPTION
## Description

Adds applicationId to schemabuilder objects before send. This is for updating functionality in Revit.

- Fixes #619

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests

## Docs

- No updates needed

