### PR TITLE
Breaking Change: Revit parameter updates

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -302,16 +302,14 @@ namespace ConnectorGrasshopper
       try
       {
         schemaObject = SelectedConstructor.Invoke(cParamsValues.ToArray());
+        ((Base)schemaObject).applicationId = $"{Seed}-{SelectedConstructor.DeclaringType.FullName}-{DA.Iteration}";
+        ((Base)schemaObject).units = units;
       }
       catch (Exception e)
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
         return;
       }
-
-      var @base = ((Base)schemaObject).ShallowCopy();
-      @base.applicationId = $"{Seed}-{SelectedConstructor.DeclaringType.FullName}-{DA.Iteration}";
-      @base.units = units;
 
       // create commit obj from main geometry param and try to attach schema obj. use schema obj if no main geom param was found.
       Base commitObj = ((Base) schemaObject).ShallowCopy();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -285,16 +285,14 @@ namespace ConnectorGrasshopper
       try
       {
         schemaObject = SelectedConstructor.Invoke(cParamsValues.ToArray());
+        ((Base)schemaObject).applicationId = $"{Seed}-{SelectedConstructor.DeclaringType.FullName}-{DA.Iteration}";
+        ((Base)schemaObject).units = units;
       }
       catch (Exception e)
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
         return;
       }
-
-      var @base = ((Base) schemaObject).ShallowCopy();
-      @base.applicationId = $"{Seed}-{SelectedConstructor.DeclaringType.FullName}-{DA.Iteration}";
-      @base.units = units;
 
       // create commit obj from main geometry param and try to attach schema obj. use schema obj if no main geom param was found.
       Base commitObj = ((Base) schemaObject).ShallowCopy();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -208,7 +208,7 @@ public class ParameterSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("706f3fe9-f499-b07f-b682-febedbe38c9c");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Parameter.ctor(System.String,System.Object,System.String)","Objects.BuiltElements.Revit.Parameter");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Parameter.ctor(System.String,System.Object)","Objects.BuiltElements.Revit.Parameter");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -13,7 +13,7 @@ public class AdaptiveComponentSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("71420d27-62d1-f158-edab-a89e54604d76");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.AdaptiveComponent.ctor(System.String,System.String,System.Collections.Generic.List`1[Objects.Geometry.Point],System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.AdaptiveComponent");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.AdaptiveComponent.ctor(System.String,System.String,System.Collections.Generic.List`1[Objects.Geometry.Point],System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.AdaptiveComponent");
         base.AddedToDocument(document);
     }
 }
@@ -91,7 +91,7 @@ public class DetailCurveSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("4752d321-22cc-2d9e-dc6d-e3cf8e70c612");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.DetailCurve.ctor(Objects.ICurve,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.Curve.DetailCurve");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.DetailCurve.ctor(Objects.ICurve,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.DetailCurve");
         base.AddedToDocument(document);
     }
 }
@@ -104,7 +104,7 @@ public class DirectShapeSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("870d9670-cbf5-06d2-f371-e1e49212b063");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.DirectShape.ctor(System.String,Objects.BuiltElements.Revit.RevitCategory,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.DirectShape");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.DirectShape.ctor(System.String,Objects.BuiltElements.Revit.RevitCategory,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.DirectShape");
         base.AddedToDocument(document);
     }
 }
@@ -130,7 +130,7 @@ public class FamilyInstanceSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("266c4d84-3f2a-9129-565b-0ddb1e5bdac4");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FamilyInstance.ctor(Objects.Geometry.Point,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Boolean,System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.FamilyInstance");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FamilyInstance.ctor(Objects.Geometry.Point,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FamilyInstance");
         base.AddedToDocument(document);
     }
 }
@@ -156,7 +156,7 @@ public class FreeformElementSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("b24dc861-1c3c-a509-bc8b-560e9f7d503e");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(Speckle.Core.Models.Base,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.FreeformElement");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(Speckle.Core.Models.Base,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FreeformElement");
         base.AddedToDocument(document);
     }
 }
@@ -195,7 +195,7 @@ public class ModelCurveSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("7aa6e073-6783-8e7b-eec2-7b7bb0420db2");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.ModelCurve.ctor(Objects.ICurve,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.Curve.ModelCurve");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.ModelCurve.ctor(Objects.ICurve,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.ModelCurve");
         base.AddedToDocument(document);
     }
 }
@@ -221,7 +221,7 @@ public class ParameterUpdaterSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("c4f5fc69-58e1-59f6-4dac-e31b738f7254");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.ParameterUpdater.ctor(System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.ParameterUpdater");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.ParameterUpdater.ctor(System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.ParameterUpdater");
         base.AddedToDocument(document);
     }
 }
@@ -260,7 +260,7 @@ public class RevitBeamSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("6aba19f5-1b1c-8e0c-f063-2a7c91816b1c");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBeam.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitBeam");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBeam.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitBeam");
         base.AddedToDocument(document);
     }
 }
@@ -273,7 +273,7 @@ public class RevitBraceSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("a3a689dc-2ca5-d5be-a225-99a144768e7e");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBrace.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitBrace");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBrace.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitBrace");
         base.AddedToDocument(document);
     }
 }
@@ -286,7 +286,7 @@ public class RevitColumnSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("c243fe91-0103-bea1-34b7-3e8b39c8d0ec");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Double,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitColumn");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitColumn");
         base.AddedToDocument(document);
     }
 }
@@ -299,7 +299,7 @@ public class RevitColumn1SchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("bd9936e6-c75f-c0de-feb0-b801eff0e0ea");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitColumn");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitColumn");
         base.AddedToDocument(document);
     }
 }
@@ -312,7 +312,7 @@ public class RevitDuctSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("d7781536-e8a9-8aef-1b27-571584f8c4a3");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.Geometry.Line,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitDuct");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.Geometry.Line,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
         base.AddedToDocument(document);
     }
 }
@@ -325,7 +325,7 @@ public class RevitExtrusionRoofSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("707428ab-15b4-e7ec-a2cd-21154ff50c1b");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof.ctor(System.String,System.String,System.Double,System.Double,Objects.Geometry.Line,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof.ctor(System.String,System.String,System.Double,System.Double,Objects.Geometry.Line,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof");
         base.AddedToDocument(document);
     }
 }
@@ -338,7 +338,7 @@ public class RevitFaceWallSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("fc3927a7-0877-8137-a34e-ecd19a6f688c");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFaceWall.ctor(System.String,System.String,Objects.Geometry.Brep,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.LocationLine,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitFaceWall");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFaceWall.ctor(System.String,System.String,Objects.Geometry.Brep,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.LocationLine,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFaceWall");
         base.AddedToDocument(document);
     }
 }
@@ -351,7 +351,7 @@ public class RevitFloorSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("e6f17d4f-6c28-0d0f-2370-7b9c09a14fff");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFloor.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitFloor");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFloor.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFloor");
         base.AddedToDocument(document);
     }
 }
@@ -364,7 +364,7 @@ public class RevitFootprintRoofSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("b2f55d9f-7242-ee7e-c44a-24e34d5f6e3e");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof.ctor(Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.RevitLevel,System.Double,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof.ctor(Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.RevitLevel,System.Double,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof");
         base.AddedToDocument(document);
     }
 }
@@ -377,7 +377,7 @@ public class RevitLevelSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("5ef6e45c-00bd-f3b9-1cbf-6e9a902da7ab");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitLevel.ctor(System.String,System.Double,System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitLevel");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitLevel.ctor(System.String,System.Double,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitLevel");
         base.AddedToDocument(document);
     }
 }
@@ -403,7 +403,7 @@ public class RevitPipeSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("19700cd2-6310-c8b3-7ad5-954033702e52");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitPipe.ctor(System.String,System.String,Objects.Geometry.Line,System.Double,Objects.BuiltElements.Level,System.String,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitPipe");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitPipe.ctor(System.String,System.String,Objects.Geometry.Line,System.Double,Objects.BuiltElements.Level,System.String,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitPipe");
         base.AddedToDocument(document);
     }
 }
@@ -429,7 +429,7 @@ public class RevitShaftSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("00cdb2fd-ef75-107e-822c-3490cd359380");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitShaft.ctor(Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitShaft");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitShaft.ctor(Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitShaft");
         base.AddedToDocument(document);
     }
 }
@@ -442,7 +442,7 @@ public class RevitTopographySchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("f0840908-039e-b6d4-98de-8ed003dfd357");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitTopography.ctor(Objects.Geometry.Mesh,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitTopography");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitTopography.ctor(Objects.Geometry.Mesh,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitTopography");
         base.AddedToDocument(document);
     }
 }
@@ -455,7 +455,7 @@ public class RevitWallSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("fa1aef22-ddd5-01f4-887e-145ce21da247");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitWall");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWall");
         base.AddedToDocument(document);
     }
 }
@@ -468,7 +468,7 @@ public class RevitWall1SchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("bd2a0bb1-14f7-cd0a-76c4-2429412a5128");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitWall");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWall");
         base.AddedToDocument(document);
     }
 }
@@ -481,7 +481,7 @@ public class RevitWireSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("4045436b-0804-f0e1-a9f2-6217f4d8a45b");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWire.ctor(System.Collections.Generic.List`1[System.Double],System.String,System.String,Objects.BuiltElements.Level,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitWire");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWire.ctor(System.Collections.Generic.List`1[System.Double],System.String,System.String,Objects.BuiltElements.Level,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWire");
         base.AddedToDocument(document);
     }
 }
@@ -520,7 +520,7 @@ public class RoomBoundaryLineSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("2edade8a-5139-09be-4273-551f3ac476e2");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.RoomBoundaryLine.ctor(Objects.ICurve,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.Curve.RoomBoundaryLine");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.RoomBoundaryLine.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.RoomBoundaryLine");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -13,7 +13,7 @@ public class AdaptiveComponentSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("71420d27-62d1-f158-edab-a89e54604d76");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.AdaptiveComponent.ctor(System.String,System.String,System.Collections.Generic.List`1[Objects.Geometry.Point],System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.AdaptiveComponent");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.AdaptiveComponent.ctor(System.String,System.String,System.Collections.Generic.List`1[Objects.Geometry.Point],System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.AdaptiveComponent");
         base.AddedToDocument(document);
     }
 }
@@ -91,7 +91,7 @@ public class DetailCurveSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("4752d321-22cc-2d9e-dc6d-e3cf8e70c612");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.DetailCurve.ctor(Objects.ICurve,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.DetailCurve");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.DetailCurve.ctor(Objects.ICurve,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.Curve.DetailCurve");
         base.AddedToDocument(document);
     }
 }
@@ -104,7 +104,7 @@ public class DirectShapeSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("870d9670-cbf5-06d2-f371-e1e49212b063");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.DirectShape.ctor(System.String,Objects.BuiltElements.Revit.RevitCategory,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.DirectShape");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.DirectShape.ctor(System.String,Objects.BuiltElements.Revit.RevitCategory,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.DirectShape");
         base.AddedToDocument(document);
     }
 }
@@ -130,7 +130,7 @@ public class FamilyInstanceSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("266c4d84-3f2a-9129-565b-0ddb1e5bdac4");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FamilyInstance.ctor(Objects.Geometry.Point,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FamilyInstance");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FamilyInstance.ctor(Objects.Geometry.Point,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Boolean,System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.FamilyInstance");
         base.AddedToDocument(document);
     }
 }
@@ -156,7 +156,7 @@ public class FreeformElementSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("b24dc861-1c3c-a509-bc8b-560e9f7d503e");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(Speckle.Core.Models.Base,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FreeformElement");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(Speckle.Core.Models.Base,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.FreeformElement");
         base.AddedToDocument(document);
     }
 }
@@ -195,7 +195,7 @@ public class ModelCurveSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("7aa6e073-6783-8e7b-eec2-7b7bb0420db2");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.ModelCurve.ctor(Objects.ICurve,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.ModelCurve");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.ModelCurve.ctor(Objects.ICurve,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.Curve.ModelCurve");
         base.AddedToDocument(document);
     }
 }
@@ -221,7 +221,7 @@ public class ParameterUpdaterSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("c4f5fc69-58e1-59f6-4dac-e31b738f7254");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.ParameterUpdater.ctor(System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.ParameterUpdater");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.ParameterUpdater.ctor(System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.ParameterUpdater");
         base.AddedToDocument(document);
     }
 }
@@ -260,7 +260,7 @@ public class RevitBeamSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("6aba19f5-1b1c-8e0c-f063-2a7c91816b1c");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBeam.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitBeam");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBeam.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitBeam");
         base.AddedToDocument(document);
     }
 }
@@ -273,7 +273,7 @@ public class RevitBraceSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("a3a689dc-2ca5-d5be-a225-99a144768e7e");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBrace.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitBrace");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBrace.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitBrace");
         base.AddedToDocument(document);
     }
 }
@@ -286,7 +286,7 @@ public class RevitColumnSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("c243fe91-0103-bea1-34b7-3e8b39c8d0ec");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitColumn");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Double,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitColumn");
         base.AddedToDocument(document);
     }
 }
@@ -299,7 +299,7 @@ public class RevitColumn1SchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("bd9936e6-c75f-c0de-feb0-b801eff0e0ea");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitColumn");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitColumn");
         base.AddedToDocument(document);
     }
 }
@@ -312,7 +312,7 @@ public class RevitDuctSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("d7781536-e8a9-8aef-1b27-571584f8c4a3");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.Geometry.Line,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.Geometry.Line,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitDuct");
         base.AddedToDocument(document);
     }
 }
@@ -325,7 +325,7 @@ public class RevitExtrusionRoofSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("707428ab-15b4-e7ec-a2cd-21154ff50c1b");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof.ctor(System.String,System.String,System.Double,System.Double,Objects.Geometry.Line,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof.ctor(System.String,System.String,System.Double,System.Double,Objects.Geometry.Line,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof");
         base.AddedToDocument(document);
     }
 }
@@ -338,7 +338,7 @@ public class RevitFaceWallSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("fc3927a7-0877-8137-a34e-ecd19a6f688c");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFaceWall.ctor(System.String,System.String,Objects.Geometry.Brep,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.LocationLine,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFaceWall");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFaceWall.ctor(System.String,System.String,Objects.Geometry.Brep,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.LocationLine,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitFaceWall");
         base.AddedToDocument(document);
     }
 }
@@ -351,7 +351,7 @@ public class RevitFloorSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("e6f17d4f-6c28-0d0f-2370-7b9c09a14fff");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFloor.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFloor");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFloor.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitFloor");
         base.AddedToDocument(document);
     }
 }
@@ -364,7 +364,7 @@ public class RevitFootprintRoofSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("b2f55d9f-7242-ee7e-c44a-24e34d5f6e3e");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof.ctor(Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.RevitLevel,System.Double,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof.ctor(Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.RevitLevel,System.Double,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof");
         base.AddedToDocument(document);
     }
 }
@@ -377,7 +377,7 @@ public class RevitLevelSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("5ef6e45c-00bd-f3b9-1cbf-6e9a902da7ab");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitLevel.ctor(System.String,System.Double,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitLevel");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitLevel.ctor(System.String,System.Double,System.Boolean,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitLevel");
         base.AddedToDocument(document);
     }
 }
@@ -403,7 +403,7 @@ public class RevitPipeSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("19700cd2-6310-c8b3-7ad5-954033702e52");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitPipe.ctor(System.String,System.String,Objects.Geometry.Line,System.Double,Objects.BuiltElements.Level,System.String,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitPipe");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitPipe.ctor(System.String,System.String,Objects.Geometry.Line,System.Double,Objects.BuiltElements.Level,System.String,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitPipe");
         base.AddedToDocument(document);
     }
 }
@@ -429,7 +429,7 @@ public class RevitShaftSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("00cdb2fd-ef75-107e-822c-3490cd359380");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitShaft.ctor(Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitShaft");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitShaft.ctor(Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitShaft");
         base.AddedToDocument(document);
     }
 }
@@ -442,7 +442,7 @@ public class RevitTopographySchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("f0840908-039e-b6d4-98de-8ed003dfd357");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitTopography.ctor(Objects.Geometry.Mesh,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitTopography");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitTopography.ctor(Objects.Geometry.Mesh,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitTopography");
         base.AddedToDocument(document);
     }
 }
@@ -455,7 +455,7 @@ public class RevitWallSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("fa1aef22-ddd5-01f4-887e-145ce21da247");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWall");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitWall");
         base.AddedToDocument(document);
     }
 }
@@ -468,7 +468,7 @@ public class RevitWall1SchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("bd2a0bb1-14f7-cd0a-76c4-2429412a5128");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWall");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitWall");
         base.AddedToDocument(document);
     }
 }
@@ -481,7 +481,7 @@ public class RevitWireSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("4045436b-0804-f0e1-a9f2-6217f4d8a45b");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWire.ctor(System.Collections.Generic.List`1[System.Double],System.String,System.String,Objects.BuiltElements.Level,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWire");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWire.ctor(System.Collections.Generic.List`1[System.Double],System.String,System.String,Objects.BuiltElements.Level,System.String,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.RevitWire");
         base.AddedToDocument(document);
     }
 }
@@ -520,7 +520,7 @@ public class RoomBoundaryLineSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("2edade8a-5139-09be-4273-551f3ac476e2");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.RoomBoundaryLine.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.RoomBoundaryLine");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.RoomBoundaryLine.ctor(Objects.ICurve,Speckle.Core.Models.Base)","Objects.BuiltElements.Revit.Curve.RoomBoundaryLine");
         base.AddedToDocument(document);
     }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -312,12 +312,16 @@ namespace Objects.Converter.Revit
       var revitParameterById = revitParameters.ToDictionary(x => GetParamInternalName(x), x => x);
       var revitParameterByName = revitParameters.ToDictionary(x => x.Definition.Name, x => x);
 
-      //only loop params we can set and that actually exist on the revit element
+      // speckleParameters is a Base
+      // its member names will have for Key either a BuiltInName, GUID or Name of the parameter (depending onwhere it comes from)
+      // and as value the full Parameter object, that might come from Revit or SchemaBuilder
+      // We only loop params we can set and that actually exist on the revit element
       var filteredSpeckleParameters = speckleParameters.GetMembers()
+        .Where(x => revitParameterById.ContainsKey(x.Key) || revitParameterByName.ContainsKey(x.Key))
         .Select(x => x.Value)
         .Where(x => x is Parameter p)
         .Cast<Parameter>()
-        .Where(x => !x.isReadOnly && (revitParameterById.ContainsKey(x.applicationInternalName) || revitParameterByName.ContainsKey(x.name)));
+        .Where(x => !x.isReadOnly);
 
       foreach (var sp in filteredSpeckleParameters)
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -331,9 +331,18 @@ namespace Objects.Converter.Revit
           switch (rp.StorageType)
           {
             case StorageType.Double:
+              // This is meant for parameters that come from Revit
+              // as they might use a lot more unit types that Speckle doesn't currently support
               if (!string.IsNullOrEmpty(sp.applicationUnit))
               {
                 var val = RevitVersionHelper.ConvertToInternalUnits(sp);
+                rp.Set(val);
+              }
+              // Parameter comes form schema builder,
+              // doesn't have an applicationUnit but just units
+              else if (!string.IsNullOrEmpty(sp.units))
+              {
+                var val = ScaleToNative(Convert.ToDouble(sp.value), sp.units);
                 rp.Set(val);
               }
               else

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -147,21 +147,38 @@ namespace Objects.Converter.Revit
     /// potential conflicts when setting them back on the element</param>
     private void GetAllRevitParamsAndIds(Base speckleElement, DB.Element revitElement, List<string> exclusions = null)
     {
-      var parms = GetInstanceParams(revitElement, exclusions);
-      if (parms != null)
+      var instParams = GetInstanceParams(revitElement, exclusions);
+      var typeParams = speckleElement is Level ? null : GetTypeParams(revitElement);  //ignore type props of levels..!
+      var allParams = new Dictionary<string, Parameter>();
+
+      if (instParams != null)
+        instParams.ToList().ForEach(x => allParams.Add(x.Key, x.Value));
+
+      if (typeParams != null)
+        typeParams.ToList().ForEach(x => allParams.Add(x.Key, x.Value));
+
+      //sort by key
+      allParams = allParams.OrderBy(x => x.Key).ToDictionary(x => x.Key, x => x.Value);
+      Base paramBase = new Base();
+
+      foreach (var kv in allParams)
       {
-        speckleElement["parameters"] = parms;
+        try
+        {
+          paramBase[kv.Key] = kv.Value;
+        }
+        catch
+        {
+          //ignore
+        }
       }
 
-      var typeParams = GetTypeParams(revitElement);
-      if (typeParams != null && !(speckleElement is Level)) //ignore type props of levels..!
-      {
-        if ((List<Parameter>)speckleElement["parameters"] == null)
-          speckleElement["parameters"] = new List<Parameter>();
-        ((List<Parameter>)speckleElement["parameters"]).AddRange(typeParams);
 
-      }
 
+
+
+      if (paramBase.GetDynamicMembers().Any())
+        speckleElement["parameters"] = paramBase;
       speckleElement["elementId"] = revitElement.Id.ToString();
       speckleElement.applicationId = revitElement.UniqueId;
       speckleElement.units = ModelUnits;
@@ -169,23 +186,23 @@ namespace Objects.Converter.Revit
 
     //private List<string> alltimeExclusions = new List<string> { 
     //  "ELEM_CATEGORY_PARAM" };
-    private List<Parameter> GetInstanceParams(DB.Element element, List<string> exclusions)
+    private Dictionary<string, Parameter> GetInstanceParams(DB.Element element, List<string> exclusions)
     {
       return GetElementParams(element, false, exclusions);
     }
-    private List<Parameter> GetTypeParams(DB.Element element)
+    private Dictionary<string, Parameter> GetTypeParams(DB.Element element)
     {
       var elementType = Doc.GetElement(element.GetTypeId());
 
       if (elementType == null || elementType.Parameters == null)
       {
-        return new List<Parameter>();
+        return new Dictionary<string, Parameter>();
       }
       return GetElementParams(elementType, true);
 
     }
 
-    private List<Parameter> GetElementParams(DB.Element element, bool isTypeParameter = false, List<string> exclusions = null)
+    private Dictionary<string, Parameter> GetElementParams(DB.Element element, bool isTypeParameter = false, List<string> exclusions = null)
     {
       exclusions = (exclusions != null) ? exclusions : new List<string>();
 
@@ -196,7 +213,8 @@ namespace Objects.Converter.Revit
       //exclude parameters that failed to convert
       var speckleParameters = revitParameters.Select(x => ParameterToSpeckle(x, isTypeParameter))
         .Where(x => x != null);
-      return speckleParameters.OrderBy(x => x.name).ToList();
+
+      return speckleParameters.GroupBy(x => x.applicationId).Select(x => x.First()).ToDictionary(x => x.applicationId, x => x);
     }
 
     private T GetParamValue<T>(DB.Element elem, BuiltInParameter bip)
@@ -220,7 +238,7 @@ namespace Objects.Converter.Revit
         isShared = rp.IsShared,
         isReadOnly = rp.IsReadOnly,
         isTypeParameter = isTypeParameter,
-        revitUnitType = rp.GetUnityTypeString() //eg UT_Length
+        applicationUnitType = rp.GetUnityTypeString() //eg UT_Length
       };
 
       switch (rp.StorageType)
@@ -230,7 +248,7 @@ namespace Objects.Converter.Revit
           var val = rp.AsDouble();
           try
           {
-            sp.revitUnit = rp.GetDisplayUnityTypeString(); //eg DUT_MILLIMITERS, this can throw!
+            sp.applicationUnit = rp.GetDisplayUnityTypeString(); //eg DUT_MILLIMITERS, this can throw!
             sp.value = RevitVersionHelper.ConvertFromInternalUnits(val, rp);
           }
           catch
@@ -278,8 +296,8 @@ namespace Objects.Converter.Revit
       if (revitElement == null)
         return;
 
-      var speckleParameters = speckleElement["parameters"] as List<Parameter>;
-      if (speckleParameters == null || !speckleParameters.Any())
+      var speckleParameters = speckleElement["parameters"] as Base;
+      if (speckleParameters == null || speckleParameters.GetDynamicMemberNames().Count() == 0)
         return;
 
       // NOTE: we are using the ParametersMap here and not Parameters, as it's a much smaller list of stuff and 
@@ -295,8 +313,11 @@ namespace Objects.Converter.Revit
       var revitParameterByName = revitParameters.ToDictionary(x => x.Definition.Name, x => x);
 
       //only loop params we can set and that actually exist on the revit element
-      var filteredSpeckleParameters = speckleParameters.Where(x => !x.isReadOnly &&
-        (revitParameterById.ContainsKey(x.applicationId) || revitParameterByName.ContainsKey(x.name)));
+      var filteredSpeckleParameters = speckleParameters.GetMembers()
+        .Select(x => x.Value)
+        .Where(x => x is Parameter p)
+        .Cast<Parameter>()
+        .Where(x => !x.isReadOnly && (revitParameterById.ContainsKey(x.applicationId) || revitParameterByName.ContainsKey(x.name)));
 
       foreach (var sp in filteredSpeckleParameters)
       {
@@ -306,7 +327,7 @@ namespace Objects.Converter.Revit
           switch (rp.StorageType)
           {
             case StorageType.Double:
-              if (!string.IsNullOrEmpty(sp.revitUnit))
+              if (!string.IsNullOrEmpty(sp.applicationUnit))
               {
                 var val = RevitVersionHelper.ConvertToInternalUnits(sp);
                 rp.Set(val);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -138,7 +138,7 @@ namespace Objects.Converter.Revit
 
     #region ToSpeckle
     /// <summary>
-    /// Adds Instance and Type parameters, ElementId, ApplicationId and Units.
+    /// Adds Instance and Type parameters, ElementId, ApplicationInternalName and Units.
     /// </summary>
     /// <param name="speckleElement"></param>
     /// <param name="revitElement"></param>
@@ -214,7 +214,7 @@ namespace Objects.Converter.Revit
       var speckleParameters = revitParameters.Select(x => ParameterToSpeckle(x, isTypeParameter))
         .Where(x => x != null);
 
-      return speckleParameters.GroupBy(x => x.applicationId).Select(x => x.First()).ToDictionary(x => x.applicationId, x => x);
+      return speckleParameters.GroupBy(x => x.applicationInternalName).Select(x => x.First()).ToDictionary(x => x.applicationInternalName, x => x);
     }
 
     private T GetParamValue<T>(DB.Element elem, BuiltInParameter bip)
@@ -234,7 +234,7 @@ namespace Objects.Converter.Revit
       var sp = new Parameter
       {
         name = rp.Definition.Name,
-        applicationId = GetParamInternalName(rp),
+        applicationInternalName = GetParamInternalName(rp),
         isShared = rp.IsShared,
         isReadOnly = rp.IsReadOnly,
         isTypeParameter = isTypeParameter,
@@ -317,11 +317,11 @@ namespace Objects.Converter.Revit
         .Select(x => x.Value)
         .Where(x => x is Parameter p)
         .Cast<Parameter>()
-        .Where(x => !x.isReadOnly && (revitParameterById.ContainsKey(x.applicationId) || revitParameterByName.ContainsKey(x.name)));
+        .Where(x => !x.isReadOnly && (revitParameterById.ContainsKey(x.applicationInternalName) || revitParameterByName.ContainsKey(x.name)));
 
       foreach (var sp in filteredSpeckleParameters)
       {
-        var rp = revitParameterById.ContainsKey(sp.applicationId) ? revitParameterById[sp.applicationId] : revitParameterByName[sp.name];
+        var rp = revitParameterById.ContainsKey(sp.applicationInternalName) ? revitParameterById[sp.applicationInternalName] : revitParameterByName[sp.name];
         try
         {
           switch (rp.StorageType)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -156,7 +156,7 @@ namespace Objects.Converter.Revit
         revitAc.Name,
         category,
         geometries.ToList(),
-        new List<Parameter>()
+        new Base()
       );
       GetAllRevitParamsAndIds(speckleAc, revitAc);
       speckleAc["type"] = revitAc.Name;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -155,8 +155,7 @@ namespace Objects.Converter.Revit
       var speckleAc = new DirectShape(
         revitAc.Name,
         category,
-        geometries.ToList(),
-        new Base()
+        geometries.ToList()
       );
       GetAllRevitParamsAndIds(speckleAc, revitAc);
       speckleAc["type"] = revitAc.Name;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
@@ -27,10 +27,10 @@ namespace Objects.Converter.Revit
     public static double ConvertToInternalUnits(Objects.BuiltElements.Revit.Parameter parameter)
     {
 #if !(REVIT2022)
-      Enum.TryParse(parameter.revitUnit, out DisplayUnitType sourceUnit);
+      Enum.TryParse(parameter.applicationUnit, out DisplayUnitType sourceUnit);
       return UnitUtils.ConvertToInternalUnits(Convert.ToDouble(parameter.value), sourceUnit);
 #else
-      var sourceUnit = new ForgeTypeId(parameter.revitUnit);
+      var sourceUnit = new ForgeTypeId(parameter.applicationUnit);
       return UnitUtils.ConvertToInternalUnits(Convert.ToDouble(parameter.value), sourceUnit);
 #endif
     }

--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -37,12 +38,12 @@ namespace Objects.BuiltElements.Revit
     public RevitBeam() { }
 
     [SchemaInfo("RevitBeam", "Creates a Revit beam by curve and base level.", "Revit", "Structure")]
-    public RevitBeam(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, Base parameters = null)
+    public RevitBeam(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
       this.baseLine = baseLine;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.level = level;
     }
   }

--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -30,14 +30,14 @@ namespace Objects.BuiltElements.Revit
   {
     public string family { get; set; }
     public string type { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
     public Level level { get; set; }
 
     public RevitBeam() { }
 
     [SchemaInfo("RevitBeam", "Creates a Revit beam by curve and base level.", "Revit", "Structure")]
-    public RevitBeam(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, List<Parameter> parameters = null)
+    public RevitBeam(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, Base parameters = null)
     {
       this.family = family;
       this.type = type;

--- a/Objects/Objects/BuiltElements/Brace.cs
+++ b/Objects/Objects/BuiltElements/Brace.cs
@@ -30,14 +30,14 @@ namespace Objects.BuiltElements.Revit
   {
     public string family { get; set; }
     public string type { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
     public Level level { get; set; }
 
     public RevitBrace() { }
 
     [SchemaInfo("RevitBrace", "Creates a Revit brace by curve and base level.", "Revit", "Structure")]
-    public RevitBrace(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, List<Parameter> parameters = null)
+    public RevitBrace(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, Base parameters = null)
     {
       this.family = family;
       this.type = type;

--- a/Objects/Objects/BuiltElements/Brace.cs
+++ b/Objects/Objects/BuiltElements/Brace.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -37,12 +38,12 @@ namespace Objects.BuiltElements.Revit
     public RevitBrace() { }
 
     [SchemaInfo("RevitBrace", "Creates a Revit brace by curve and base level.", "Revit", "Structure")]
-    public RevitBrace(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, Base parameters = null)
+    public RevitBrace(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
       this.baseLine = baseLine;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.level = level;
     }
   }

--- a/Objects/Objects/BuiltElements/Ceiling.cs
+++ b/Objects/Objects/BuiltElements/Ceiling.cs
@@ -37,7 +37,7 @@ namespace Objects.BuiltElements.Revit
     public string type { get; set; }
     public Level level { get; set; }
     public double offset { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitCeiling() { }

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -63,7 +64,7 @@ namespace Objects.BuiltElements.Revit
       [SchemaParamInfo("Only the lower point of this line will be used as base point.")][SchemaMainParam] ICurve baseLine,
       Level level, Level topLevel,
       double baseOffset = 0, double topOffset = 0, bool structural = false,
-      double rotation = 0, Base parameters = null)
+      double rotation = 0, List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -73,19 +74,19 @@ namespace Objects.BuiltElements.Revit
       this.topOffset = topOffset;
       this.structural = structural;
       this.rotation = rotation;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.level = level;
     }
 
     [SchemaInfo("RevitColumn Slanted", "Creates a slanted Revit Column by curve.", "Revit", "Structure")]
-    public RevitColumn(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, bool structural = false, Base parameters = null)
+    public RevitColumn(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, bool structural = false, List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
       this.baseLine = baseLine;
       this.level = level;
       this.structural = structural;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -39,7 +39,7 @@ namespace Objects.BuiltElements.Revit
     public bool isSlanted { get; set; }
     public string family { get; set; }
     public string type { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitColumn() { }
@@ -63,7 +63,7 @@ namespace Objects.BuiltElements.Revit
       [SchemaParamInfo("Only the lower point of this line will be used as base point.")][SchemaMainParam] ICurve baseLine,
       Level level, Level topLevel,
       double baseOffset = 0, double topOffset = 0, bool structural = false,
-      double rotation = 0, List<Parameter> parameters = null)
+      double rotation = 0, Base parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -78,7 +78,7 @@ namespace Objects.BuiltElements.Revit
     }
 
     [SchemaInfo("RevitColumn Slanted", "Creates a slanted Revit Column by curve.", "Revit", "Structure")]
-    public RevitColumn(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, bool structural = false, List<Parameter> parameters = null)
+    public RevitColumn(string family, string type, [SchemaMainParam] ICurve baseLine, Level level, bool structural = false, Base parameters = null)
     {
       this.family = family;
       this.type = type;

--- a/Objects/Objects/BuiltElements/Duct.cs
+++ b/Objects/Objects/BuiltElements/Duct.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -70,7 +71,7 @@ namespace Objects.BuiltElements.Revit
     /// <param name="parameters"></param>
     /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
     [SchemaInfo("RevitDuct", "Creates a Revit duct", "Revit", "MEP")]
-    public RevitDuct(string family, string type, [SchemaMainParam] Line baseLine, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, Base parameters = null)
+    public RevitDuct(string family, string type, [SchemaMainParam] Line baseLine, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, List<Parameter> parameters = null)
     {
       this.baseLine = baseLine;
       this.family = family;
@@ -81,7 +82,7 @@ namespace Objects.BuiltElements.Revit
       this.velocity = velocity;
       this.systemName = systemName;
       this.systemType = systemType;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.level = level;
     }
   }

--- a/Objects/Objects/BuiltElements/Duct.cs
+++ b/Objects/Objects/BuiltElements/Duct.cs
@@ -49,7 +49,7 @@ namespace Objects.BuiltElements.Revit
     public string systemName { get; set; }
     public string systemType { get; set; }
     public Level level { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitDuct() { }
@@ -70,7 +70,7 @@ namespace Objects.BuiltElements.Revit
     /// <param name="parameters"></param>
     /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
     [SchemaInfo("RevitDuct", "Creates a Revit duct", "Revit", "MEP")]
-    public RevitDuct(string family, string type, [SchemaMainParam] Line baseLine, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, List<Parameter> parameters = null)
+    public RevitDuct(string family, string type, [SchemaMainParam] Line baseLine, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, Base parameters = null)
     {
       this.baseLine = baseLine;
       this.family = family;

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -37,7 +37,7 @@ namespace Objects.BuiltElements.Revit
     public string type { get; set; }
     public Level level { get; set; }
     public bool structural { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
     public RevitFloor() { }
 
@@ -45,7 +45,7 @@ namespace Objects.BuiltElements.Revit
     public RevitFloor(string family, string type, [SchemaMainParam] ICurve outline,
        Level level, bool structural = false, List<ICurve> voids = null,
       [SchemaParamInfo("Any nested elements that this floor might have")] List<Base> elements = null,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.family = family;
       this.type = type;

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -45,13 +46,13 @@ namespace Objects.BuiltElements.Revit
     public RevitFloor(string family, string type, [SchemaMainParam] ICurve outline,
        Level level, bool structural = false, List<ICurve> voids = null,
       [SchemaParamInfo("Any nested elements that this floor might have")] List<Base> elements = null,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
       this.level = level;
       this.structural = structural;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.outline = outline;
       this.voids = voids;
       this.elements = elements;

--- a/Objects/Objects/BuiltElements/Level.cs
+++ b/Objects/Objects/BuiltElements/Level.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Core.Kits;
+﻿using Objects.Utils;
+using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
@@ -53,12 +54,12 @@ namespace Objects.BuiltElements.Revit
       [SchemaParamInfo("Level name. NOTE: updating level name is not supported")] string name,
       [SchemaParamInfo("Level elevation. NOTE: updating level elevation is not supported, a new one will be created unless another level at the new elevation already exists.")] double elevation,
       [SchemaParamInfo("If true, it creates an associated view in Revit. NOTE: only used when creating a level for the first time")] bool createView,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.name = name;
       this.elevation = elevation;
       this.createView = createView;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.referenceOnly = false;
     }
 

--- a/Objects/Objects/BuiltElements/Level.cs
+++ b/Objects/Objects/BuiltElements/Level.cs
@@ -34,7 +34,7 @@ namespace Objects.BuiltElements.Revit
   public class RevitLevel : Level
   {
     public bool createView { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
     public bool referenceOnly { get; set; }
 
@@ -53,7 +53,7 @@ namespace Objects.BuiltElements.Revit
       [SchemaParamInfo("Level name. NOTE: updating level name is not supported")] string name,
       [SchemaParamInfo("Level elevation. NOTE: updating level elevation is not supported, a new one will be created unless another level at the new elevation already exists.")] double elevation,
       [SchemaParamInfo("If true, it creates an associated view in Revit. NOTE: only used when creating a level for the first time")] bool createView,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.name = name;
       this.elevation = elevation;

--- a/Objects/Objects/BuiltElements/Opening.cs
+++ b/Objects/Objects/BuiltElements/Opening.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -60,12 +61,12 @@ namespace Objects.BuiltElements.Revit
     /// <param name="topLevel"></param>
     /// <param name="parameters"></param>
     [SchemaInfo("RevitShaft", "Creates a Revit shaft from a bottom and top level", "Revit", "Architecture")]
-    public RevitShaft([SchemaMainParam] ICurve outline, Level bottomLevel, Level topLevel, Base parameters = null)
+    public RevitShaft([SchemaMainParam] ICurve outline, Level bottomLevel, Level topLevel, List<Parameter> parameters = null)
     {
       this.outline = outline;
       this.bottomLevel = bottomLevel;
       this.topLevel = topLevel;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
 
     /*
@@ -78,12 +79,12 @@ namespace Objects.BuiltElements.Revit
     /// <param name="parameters"></param>
     /// <remarks>Assign units when using this constructor due to <paramref name="height"/> param</remarks>
     [SchemaInfo("RevitShaft", "Creates a Revit shaft from a bottom level and height")]
-    public RevitShaft(ICurve outline, Level bottomLevel, double height, Base parameters = null)
+    public RevitShaft(ICurve outline, Level bottomLevel, double height, List<Parameter> parameters = null)
     {
       this.outline = outline;
       this.bottomLevel = bottomLevel;
       this.height = height;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
     */
   }

--- a/Objects/Objects/BuiltElements/Opening.cs
+++ b/Objects/Objects/BuiltElements/Opening.cs
@@ -27,7 +27,7 @@ namespace Objects.BuiltElements.Revit
   {
     //public string family { get; set; }
     //public string type { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitOpening() { }
@@ -60,7 +60,7 @@ namespace Objects.BuiltElements.Revit
     /// <param name="topLevel"></param>
     /// <param name="parameters"></param>
     [SchemaInfo("RevitShaft", "Creates a Revit shaft from a bottom and top level", "Revit", "Architecture")]
-    public RevitShaft([SchemaMainParam] ICurve outline, Level bottomLevel, Level topLevel, List<Parameter> parameters = null)
+    public RevitShaft([SchemaMainParam] ICurve outline, Level bottomLevel, Level topLevel, Base parameters = null)
     {
       this.outline = outline;
       this.bottomLevel = bottomLevel;
@@ -78,7 +78,7 @@ namespace Objects.BuiltElements.Revit
     /// <param name="parameters"></param>
     /// <remarks>Assign units when using this constructor due to <paramref name="height"/> param</remarks>
     [SchemaInfo("RevitShaft", "Creates a Revit shaft from a bottom level and height")]
-    public RevitShaft(ICurve outline, Level bottomLevel, double height, List<Parameter> parameters = null)
+    public RevitShaft(ICurve outline, Level bottomLevel, double height, Base parameters = null)
     {
       this.outline = outline;
       this.bottomLevel = bottomLevel;

--- a/Objects/Objects/BuiltElements/Pipe.cs
+++ b/Objects/Objects/BuiltElements/Pipe.cs
@@ -34,14 +34,14 @@ namespace Objects.BuiltElements.Revit
     public string type { get; set; }
     public string systemName { get; set; }
     public string systemType { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
     public Level level { get; set; }
 
     public RevitPipe() { }
 
     [SchemaInfo("RevitPipe", "Creates a Revit pipe", "Revit", "MEP")]
-    public RevitPipe(string family, string type, Line baseLine, double diameter, Level level,  string systemName = "", string systemType = "", List<Parameter> parameters = null)
+    public RevitPipe(string family, string type, Line baseLine, double diameter, Level level,  string systemName = "", string systemType = "", Base parameters = null)
     {
       this.family = family;
       this.type = type;

--- a/Objects/Objects/BuiltElements/Pipe.cs
+++ b/Objects/Objects/BuiltElements/Pipe.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 
@@ -41,7 +42,7 @@ namespace Objects.BuiltElements.Revit
     public RevitPipe() { }
 
     [SchemaInfo("RevitPipe", "Creates a Revit pipe", "Revit", "MEP")]
-    public RevitPipe(string family, string type, Line baseLine, double diameter, Level level,  string systemName = "", string systemType = "", Base parameters = null)
+    public RevitPipe(string family, string type, Line baseLine, double diameter, Level level,  string systemName = "", string systemType = "", List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -50,7 +51,7 @@ namespace Objects.BuiltElements.Revit
       this.systemName = systemName;
       this.systemType = systemType;
       this.level = level;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
+++ b/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
@@ -12,7 +12,7 @@ namespace Objects.BuiltElements.Revit
     public List<Point> basePoints { get; set; }
     public bool flipped { get; set; }
     public string elementId { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
 
     [DetachProperty]
     public Mesh displayMesh { get; set; }
@@ -20,7 +20,7 @@ namespace Objects.BuiltElements.Revit
     public AdaptiveComponent() { }
 
     [SchemaInfo("AdaptiveComponent", "Creates a Revit adaptive component by points", "Revit", "Families")]
-    public AdaptiveComponent(string type, string family, List<Point> basePoints, bool flipped = false, List<Parameter> parameters = null)
+    public AdaptiveComponent(string type, string family, List<Point> basePoints, bool flipped = false, Base parameters = null)
     {
       this.type = type;
       this.family = family;

--- a/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
+++ b/Objects/Objects/BuiltElements/Revit/AdaptiveComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -20,13 +21,13 @@ namespace Objects.BuiltElements.Revit
     public AdaptiveComponent() { }
 
     [SchemaInfo("AdaptiveComponent", "Creates a Revit adaptive component by points", "Revit", "Families")]
-    public AdaptiveComponent(string type, string family, List<Point> basePoints, bool flipped = false, Base parameters = null)
+    public AdaptiveComponent(string type, string family, List<Point> basePoints, bool flipped = false, List<Parameter> parameters = null)
     {
       this.type = type;
       this.family = family;
       this.basePoints = basePoints;
       this.flipped = flipped;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Revit/BuildingPad.cs
+++ b/Objects/Objects/BuiltElements/Revit/BuildingPad.cs
@@ -11,7 +11,7 @@ namespace Objects.BuiltElements.Revit
     public List<ICurve> voids { get; set; } = new List<ICurve>();
     public string type { get; set; }
     public Level level { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     [DetachProperty]

--- a/Objects/Objects/BuiltElements/Revit/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Revit/DirectShape.cs
@@ -9,7 +9,7 @@ namespace Objects.BuiltElements.Revit
   {
     public string name { get; set; }
     public RevitCategory category { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     [DetachProperty]
@@ -28,7 +28,7 @@ namespace Objects.BuiltElements.Revit
     /// <param name="baseGeometries">A list of base classes to represent the direct shape (only mesh and brep are allowed, anything else will be ignored.)</param>
     /// <param name="parameters">Optional Parameters for this instance.</param>
     [SchemaInfo("DirectShape by base geometries", "Creates a Revit DirectShape using a list of base geometry objects.", "Revit", "Families")]
-    public DirectShape(string name, RevitCategory category, List<Base> baseGeometries, List<Parameter> parameters = null)
+    public DirectShape(string name, RevitCategory category, List<Base> baseGeometries, Base parameters = null)
     {
       this.name = name;
       this.category = category;

--- a/Objects/Objects/BuiltElements/Revit/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Revit/DirectShape.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -28,12 +29,12 @@ namespace Objects.BuiltElements.Revit
     /// <param name="baseGeometries">A list of base classes to represent the direct shape (only mesh and brep are allowed, anything else will be ignored.)</param>
     /// <param name="parameters">Optional Parameters for this instance.</param>
     [SchemaInfo("DirectShape by base geometries", "Creates a Revit DirectShape using a list of base geometry objects.", "Revit", "Families")]
-    public DirectShape(string name, RevitCategory category, List<Base> baseGeometries, Base parameters = null)
+    public DirectShape(string name, RevitCategory category, List<Base> baseGeometries, List<Parameter> parameters = null)
     {
       this.name = name;
       this.category = category;
       this.baseGeometries = baseGeometries.FindAll(IsValidObject);
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
 
     public bool IsValidObject(Base @base) =>

--- a/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
+++ b/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -29,7 +30,7 @@ namespace Objects.BuiltElements.Revit
     [SchemaInfo("FamilyInstance", "Creates a Revit family instance", "Revit", "Families")]
     public FamilyInstance(Point basePoint, string family, string type, Level level,
       double rotation = 0, bool facingFlipped = false, bool handFlipped = false,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.basePoint = basePoint;
       this.family = family;
@@ -38,7 +39,7 @@ namespace Objects.BuiltElements.Revit
       this.rotation = rotation;
       this.facingFlipped = facingFlipped;
       this.handFlipped = handFlipped;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
+++ b/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
@@ -15,7 +15,7 @@ namespace Objects.BuiltElements.Revit
     public double rotation { get; set; }
     public bool facingFlipped { get; set; }
     public bool handFlipped { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     [DetachProperty]
@@ -29,7 +29,7 @@ namespace Objects.BuiltElements.Revit
     [SchemaInfo("FamilyInstance", "Creates a Revit family instance", "Revit", "Families")]
     public FamilyInstance(Point basePoint, string family, string type, Level level,
       double rotation = 0, bool facingFlipped = false, bool handFlipped = false,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.basePoint = basePoint;
       this.family = family;

--- a/Objects/Objects/BuiltElements/Revit/FreeformElement.cs
+++ b/Objects/Objects/BuiltElements/Revit/FreeformElement.cs
@@ -9,7 +9,7 @@ namespace Objects.BuiltElements.Revit
 {
   public class FreeformElement : Base , IDisplayMesh
   {
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     
     public string elementId { get; set; }
 
@@ -22,7 +22,7 @@ namespace Objects.BuiltElements.Revit
     public FreeformElement() { }
 
     [SchemaInfo("Freeform element", "Creates a Revit Freeform element using a Brep or a Mesh.", "Revit", "Families")]
-    public FreeformElement([SchemaMainParam] Base baseGeometry, List<Parameter> parameters = null)
+    public FreeformElement([SchemaMainParam] Base baseGeometry, Base parameters = null)
     {
       if (!IsValidObject(baseGeometry))
         throw new Exception("Freeform elements can only be created from BREPs or Meshes");

--- a/Objects/Objects/BuiltElements/Revit/FreeformElement.cs
+++ b/Objects/Objects/BuiltElements/Revit/FreeformElement.cs
@@ -4,6 +4,7 @@ using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Objects.Utils;
 
 namespace Objects.BuiltElements.Revit
 {
@@ -22,12 +23,12 @@ namespace Objects.BuiltElements.Revit
     public FreeformElement() { }
 
     [SchemaInfo("Freeform element", "Creates a Revit Freeform element using a Brep or a Mesh.", "Revit", "Families")]
-    public FreeformElement([SchemaMainParam] Base baseGeometry, Base parameters = null)
+    public FreeformElement([SchemaMainParam] Base baseGeometry, List<Parameter> parameters = null)
     {
       if (!IsValidObject(baseGeometry))
         throw new Exception("Freeform elements can only be created from BREPs or Meshes");
       this.baseGeometry = baseGeometry;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
     
     public bool IsValid() => IsValidObject(baseGeometry);

--- a/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
+++ b/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
@@ -8,13 +8,13 @@ namespace Objects.BuiltElements.Revit.Curve
   {
     public ICurve baseCurve { get; set; }
     public string lineStyle { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public ModelCurve() { }
 
     [SchemaInfo("ModelCurve", "Creates a Revit model curve", "Revit", "Curves")]
-    public ModelCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
+    public ModelCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, Base parameters = null)
     {
       this.baseCurve = baseCurve;
       this.lineStyle = lineStyle;
@@ -26,13 +26,13 @@ namespace Objects.BuiltElements.Revit.Curve
   {
     public ICurve baseCurve { get; set; }
     public string lineStyle { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public DetailCurve() { }
 
     [SchemaInfo("DetailCurve", "Creates a Revit detail curve", "Revit", "Curves")]
-    public DetailCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
+    public DetailCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, Base parameters = null)
     {
       this.baseCurve = baseCurve;
       this.lineStyle = lineStyle;
@@ -43,13 +43,13 @@ namespace Objects.BuiltElements.Revit.Curve
   public class RoomBoundaryLine : Base
   {
     public ICurve baseCurve { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RoomBoundaryLine() { }
 
     [SchemaInfo("RoomBoundaryLine", "Creates a Revit room boundary line", "Revit", "Curves")]
-    public RoomBoundaryLine([SchemaMainParam] ICurve baseCurve, List<Parameter> parameters = null)
+    public RoomBoundaryLine([SchemaMainParam] ICurve baseCurve, Base parameters = null)
     {
       this.baseCurve = baseCurve;
       this.parameters = parameters;

--- a/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
+++ b/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Core.Kits;
+﻿using Objects.Utils;
+using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
 
@@ -14,11 +15,11 @@ namespace Objects.BuiltElements.Revit.Curve
     public ModelCurve() { }
 
     [SchemaInfo("ModelCurve", "Creates a Revit model curve", "Revit", "Curves")]
-    public ModelCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, Base parameters = null)
+    public ModelCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
     {
       this.baseCurve = baseCurve;
       this.lineStyle = lineStyle;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 
@@ -32,11 +33,11 @@ namespace Objects.BuiltElements.Revit.Curve
     public DetailCurve() { }
 
     [SchemaInfo("DetailCurve", "Creates a Revit detail curve", "Revit", "Curves")]
-    public DetailCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, Base parameters = null)
+    public DetailCurve([SchemaMainParam] ICurve baseCurve, string lineStyle, List<Parameter> parameters = null)
     {
       this.baseCurve = baseCurve;
       this.lineStyle = lineStyle;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 
@@ -49,10 +50,10 @@ namespace Objects.BuiltElements.Revit.Curve
     public RoomBoundaryLine() { }
 
     [SchemaInfo("RoomBoundaryLine", "Creates a Revit room boundary line", "Revit", "Curves")]
-    public RoomBoundaryLine([SchemaMainParam] ICurve baseCurve, Base parameters = null)
+    public RoomBoundaryLine([SchemaMainParam] ICurve baseCurve, List<Parameter> parameters = null)
     {
       this.baseCurve = baseCurve;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Revit/Parameter.cs
+++ b/Objects/Objects/BuiltElements/Revit/Parameter.cs
@@ -30,12 +30,11 @@ namespace Objects.BuiltElements.Revit
     public Parameter() { }
 
     [SchemaInfo("Parameter", "A Revit instance parameter to set on an element", "Revit", "Families")]
-    public Parameter(string name, object value,
-      [SchemaParamInfo("The Revit BuiltInParameter name or GUID (for shared parameters), if defined it will prevail over the name")] string internalName = "")
+    public Parameter([SchemaParamInfo("The Revit display name, BuiltInParameter name or GUID (for shared parameters)")] string name, object value)
     {
       this.name = name;
       this.value = value;
-      this.applicationId = internalName;
+      this.applicationInternalName = name;
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Revit/Parameter.cs
+++ b/Objects/Objects/BuiltElements/Revit/Parameter.cs
@@ -6,12 +6,13 @@ using System.Text;
 
 namespace Objects.BuiltElements.Revit
 {
+  //note: its applicationId in Revit is the BuiltInName or GUID for shared parameter
   public class Parameter : Base
   {
     public string name { get; set; }
     public object value { get; set; }
-    public string revitUnitType { get; set; } //eg UnitType UT_Length
-    public string revitUnit { get; set; } //DisplayUnitType eg DUT_MILLIMITERS
+    public string applicationUnitType { get; set; } //eg UnitType UT_Length
+    public string applicationUnit { get; set; } //DisplayUnitType eg DUT_MILLIMITERS
 
     /// <summary>
     /// If True it's a Shared Parameter, in which case the ApplicationId field will contain this parameter GUID, 

--- a/Objects/Objects/BuiltElements/Revit/Parameter.cs
+++ b/Objects/Objects/BuiltElements/Revit/Parameter.cs
@@ -6,13 +6,14 @@ using System.Text;
 
 namespace Objects.BuiltElements.Revit
 {
-  //note: its applicationId in Revit is the BuiltInName or GUID for shared parameter
+  
   public class Parameter : Base
   {
     public string name { get; set; }
     public object value { get; set; }
     public string applicationUnitType { get; set; } //eg UnitType UT_Length
     public string applicationUnit { get; set; } //DisplayUnitType eg DUT_MILLIMITERS
+    public string applicationInternalName { get; set; } //BuiltInParameterName or GUID for shared parameter
 
     /// <summary>
     /// If True it's a Shared Parameter, in which case the ApplicationId field will contain this parameter GUID, 

--- a/Objects/Objects/BuiltElements/Revit/ParameterUpdater.cs
+++ b/Objects/Objects/BuiltElements/Revit/ParameterUpdater.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Core.Kits;
+﻿using Objects.Utils;
+using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
@@ -13,10 +14,10 @@ namespace Objects.BuiltElements.Revit
 
 
     [SchemaInfo("ParameterUpdater", "Updates parameters on a Revit element by id", "Revit", "Families")]
-    public ParameterUpdater([SchemaParamInfo("A Revit ElementId or UniqueId")] string id, Base parameters)
+    public ParameterUpdater([SchemaParamInfo("A Revit ElementId or UniqueId")] string id, List<Parameter> parameters)
     {
       this.revitId = id;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
 
     public ParameterUpdater()

--- a/Objects/Objects/BuiltElements/Revit/ParameterUpdater.cs
+++ b/Objects/Objects/BuiltElements/Revit/ParameterUpdater.cs
@@ -9,11 +9,11 @@ namespace Objects.BuiltElements.Revit
   public class ParameterUpdater : Base
   {
     public string revitId { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
 
 
     [SchemaInfo("ParameterUpdater", "Updates parameters on a Revit element by id", "Revit", "Families")]
-    public ParameterUpdater([SchemaParamInfo("A Revit ElementId or UniqueId")] string id, List<Parameter> parameters)
+    public ParameterUpdater([SchemaParamInfo("A Revit ElementId or UniqueId")] string id, Base parameters)
     {
       this.revitId = id;
       this.parameters = parameters;

--- a/Objects/Objects/BuiltElements/Revit/RevitElement.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitElement.cs
@@ -13,7 +13,7 @@ namespace Objects.BuiltElements.Revit
     public string family { get; set; }
     public string type { get; set; }
     public string category { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     [DetachProperty]

--- a/Objects/Objects/BuiltElements/Revit/RevitRailing.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitRailing.cs
@@ -13,7 +13,7 @@ namespace Objects.BuiltElements.Revit
     public Polycurve path { get; set; }
     public bool flipped { get; set; }
     public string elementId { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
 
     [DetachProperty]
     public Mesh displayMesh { get; set; }

--- a/Objects/Objects/BuiltElements/Revit/RevitStair.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitStair.cs
@@ -20,7 +20,7 @@ namespace Objects.BuiltElements.Revit
     public bool beginsWithRiser { get; set; }
     public double height { get; set; }
     public int numberOfStories { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public List<RevitStairRun> runs { get; set; }
     public List<RevitStairLanding> landings { get; set; }
     public List<RevitStairSupport> supports { get; set; }
@@ -49,7 +49,7 @@ namespace Objects.BuiltElements.Revit
     public double extensionBelowTreadBase { get; set; }
     public double height { get; set; }
     public string runStyle { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitStairRun() { }
@@ -63,7 +63,7 @@ namespace Objects.BuiltElements.Revit
     public double baseElevation { get; set; }
     public double thickness { get; set; }
     public Polycurve outline { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitStairLanding() { }
@@ -73,7 +73,7 @@ namespace Objects.BuiltElements.Revit
   {
     public string family { get; set; }
     public string type { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitStairSupport() { }

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -36,7 +36,7 @@ namespace Objects.BuiltElements.Revit.RevitRoof
   {
     public string family { get; set; }
     public string type { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
     public Level level { get; set; }
 
@@ -70,7 +70,7 @@ namespace Objects.BuiltElements.Revit.RevitRoof
       [SchemaParamInfo("Profile along which to extrude the roof")][SchemaMainParam] Line referenceLine,
       Level level,
       List<Base> elements = null,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -93,7 +93,7 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     [SchemaInfo("RevitFootprintRoof", "Creates a Revit roof by outline", "Revit", "Architecture")]
     public RevitFootprintRoof([SchemaMainParam] ICurve outline, string family, string type, Level level, RevitLevel cutOffLevel = null, double slope = 0, List<ICurve> voids = null,
       List<Base> elements = null,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.outline = outline;
       this.voids = voids;

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -70,11 +71,11 @@ namespace Objects.BuiltElements.Revit.RevitRoof
       [SchemaParamInfo("Profile along which to extrude the roof")][SchemaMainParam] Line referenceLine,
       Level level,
       List<Base> elements = null,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.level = level;
       this.start = start;
       this.end = end;
@@ -93,14 +94,14 @@ namespace Objects.BuiltElements.Revit.RevitRoof
     [SchemaInfo("RevitFootprintRoof", "Creates a Revit roof by outline", "Revit", "Architecture")]
     public RevitFootprintRoof([SchemaMainParam] ICurve outline, string family, string type, Level level, RevitLevel cutOffLevel = null, double slope = 0, List<ICurve> voids = null,
       List<Base> elements = null,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.outline = outline;
       this.voids = voids;
       this.family = family;
       this.type = type;
       this.slope = slope;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
       this.level = level;
       this.cutOffLevel = cutOffLevel;
       this.elements = elements;

--- a/Objects/Objects/BuiltElements/Topography.cs
+++ b/Objects/Objects/BuiltElements/Topography.cs
@@ -29,12 +29,12 @@ namespace Objects.BuiltElements.Revit
   public class RevitTopography : Topography
   {
     public string elementId { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
 
     public RevitTopography() { }
 
     [SchemaInfo("RevitTopography", "Creates a Revit topography", "Revit", "Architecture")]
-    public RevitTopography([SchemaMainParam] Mesh displayMesh, List<Parameter> parameters = null)
+    public RevitTopography([SchemaMainParam] Mesh displayMesh, Base parameters = null)
     {
       this.displayMesh = displayMesh;
       this.parameters = parameters;

--- a/Objects/Objects/BuiltElements/Topography.cs
+++ b/Objects/Objects/BuiltElements/Topography.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -34,10 +35,10 @@ namespace Objects.BuiltElements.Revit
     public RevitTopography() { }
 
     [SchemaInfo("RevitTopography", "Creates a Revit topography", "Revit", "Architecture")]
-    public RevitTopography([SchemaMainParam] Mesh displayMesh, Base parameters = null)
+    public RevitTopography([SchemaMainParam] Mesh displayMesh, List<Parameter> parameters = null)
     {
       this.displayMesh = displayMesh;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 }

--- a/Objects/Objects/BuiltElements/View.cs
+++ b/Objects/Objects/BuiltElements/View.cs
@@ -44,7 +44,7 @@ namespace Objects.BuiltElements
 //  {
 //    public bool createView { get; set; }
 
-//    public List<Parameter> parameters { get; set; }
+//    public Base parameters { get; set; }
 
 //    public string elementId { get; set; }
 
@@ -57,7 +57,7 @@ namespace Objects.BuiltElements
 //      [SchemaParamInfo("Level name. NOTE: updating level name is not supported")] string name,
 //      [SchemaParamInfo("Level elevation. NOTE: updating level elevation is not supported, a new one will be created unless another level at the new elevation already exists.")] double elevation,
 //      [SchemaParamInfo("If true, it creates an associated view in Revit. NOTE: only used when creating a level for the first time")] bool createView,
-//      List<Parameter> parameters = null)
+//      Base parameters = null)
 //    {
 //      this.name = name;
 //      this.elevation = elevation;

--- a/Objects/Objects/BuiltElements/View.cs
+++ b/Objects/Objects/BuiltElements/View.cs
@@ -57,12 +57,12 @@ namespace Objects.BuiltElements
 //      [SchemaParamInfo("Level name. NOTE: updating level name is not supported")] string name,
 //      [SchemaParamInfo("Level elevation. NOTE: updating level elevation is not supported, a new one will be created unless another level at the new elevation already exists.")] double elevation,
 //      [SchemaParamInfo("If true, it creates an associated view in Revit. NOTE: only used when creating a level for the first time")] bool createView,
-//      Base parameters = null)
+//      List<Parameter> parameters = null)
 //    {
 //      this.name = name;
 //      this.elevation = elevation;
 //      this.createView = createView;
-//      this.parameters = parameters;
+//      this.parameters = parameters.ToBase();
 //      this.referenceOnly = false;
 //    }
 

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -1,4 +1,5 @@
 ﻿using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -72,7 +73,7 @@ namespace Objects.BuiltElements.Revit
     public RevitWall(string family, string type,
       [SchemaMainParam] ICurve baseLine, Level level, Level topLevel, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -84,7 +85,7 @@ namespace Objects.BuiltElements.Revit
       this.level = level;
       this.topLevel = topLevel;
       this.elements = elements;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
 
     /// <summary>
@@ -106,7 +107,7 @@ namespace Objects.BuiltElements.Revit
     public RevitWall(string family, string type,
       [SchemaMainParam] ICurve baseLine, Level level, double height, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -118,7 +119,7 @@ namespace Objects.BuiltElements.Revit
       this.structural = structural;
       this.level = level;
       this.elements = elements;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 
@@ -139,7 +140,7 @@ namespace Objects.BuiltElements.Revit
       [SchemaParamInfo("Surface or single face Brep to use")][SchemaMainParam] Brep surface,
       Level level, LocationLine locationLine = LocationLine.Interior,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      Base parameters = null)
+      List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -147,7 +148,7 @@ namespace Objects.BuiltElements.Revit
       this.locationLine = locationLine;
       this.level = level;
       this.elements = elements;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -48,7 +48,7 @@ namespace Objects.BuiltElements.Revit
     public bool structural { get; set; }
     public Level level { get; set; }
     public Level topLevel { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitWall() { }
@@ -72,7 +72,7 @@ namespace Objects.BuiltElements.Revit
     public RevitWall(string family, string type,
       [SchemaMainParam] ICurve baseLine, Level level, Level topLevel, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -106,7 +106,7 @@ namespace Objects.BuiltElements.Revit
     public RevitWall(string family, string type,
       [SchemaMainParam] ICurve baseLine, Level level, double height, double baseOffset = 0, double topOffset = 0, bool flipped = false, bool structural = false,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -129,7 +129,7 @@ namespace Objects.BuiltElements.Revit
     public Surface surface { get; set; }
     public Level level { get; set; }
     public LocationLine locationLine { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitFaceWall() { }
@@ -139,7 +139,7 @@ namespace Objects.BuiltElements.Revit
       [SchemaParamInfo("Surface or single face Brep to use")][SchemaMainParam] Brep surface,
       Level level, LocationLine locationLine = LocationLine.Interior,
       [SchemaParamInfo("Set in here any nested elements that this level might have.")] List<Base> elements = null,
-      List<Parameter> parameters = null)
+      Base parameters = null)
     {
       this.family = family;
       this.type = type;
@@ -163,7 +163,7 @@ namespace Objects.BuiltElements.Revit
   //   public bool flipped { get; set; }
   //
   //   [SchemaOptional]
-  //   public List<Parameter> parameters { get; set; }
+  //   public Base parameters { get; set; }
   //
   //   [SchemaIgnore]
   //   public string elementId { get; set; }
@@ -174,7 +174,7 @@ namespace Objects.BuiltElements.Revit
   // public class RevitWallByPoint : Base
   // {
   //   [SchemaOptional]
-  //   public List<Parameter> parameters { get; set; }
+  //   public Base parameters { get; set; }
   //
   //   [SchemaIgnore]
   //   public string elementId { get; set; }

--- a/Objects/Objects/BuiltElements/Wire.cs
+++ b/Objects/Objects/BuiltElements/Wire.cs
@@ -29,13 +29,13 @@ namespace Objects.BuiltElements.Revit
     public List<double> constructionPoints { get; set; } // used in constructor for revit native wires
     public string system { get; set; }
     public Level level { get; set; }
-    public List<Parameter> parameters { get; set; }
+    public Base parameters { get; set; }
     public string elementId { get; set; }
 
     public RevitWire() { }
 
     [SchemaInfo("RevitWire", "Creates a Revit wire from points and level", "Revit", "MEP")]
-    public RevitWire(List<double> constructionPoints, string family, string type, Level level, string wiringType = "Arc", List<Parameter> parameters = null)
+    public RevitWire(List<double> constructionPoints, string family, string type, Level level, string wiringType = "Arc", Base parameters = null)
     {
       this.constructionPoints = constructionPoints;
       this.family = family;

--- a/Objects/Objects/BuiltElements/Wire.cs
+++ b/Objects/Objects/BuiltElements/Wire.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Objects.Geometry;
+using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 
@@ -35,14 +36,14 @@ namespace Objects.BuiltElements.Revit
     public RevitWire() { }
 
     [SchemaInfo("RevitWire", "Creates a Revit wire from points and level", "Revit", "MEP")]
-    public RevitWire(List<double> constructionPoints, string family, string type, Level level, string wiringType = "Arc", Base parameters = null)
+    public RevitWire(List<double> constructionPoints, string family, string type, Level level, string wiringType = "Arc", List<Parameter> parameters = null)
     {
       this.constructionPoints = constructionPoints;
       this.family = family;
       this.type = type;
       this.level = level;
       this.wiringType = wiringType;
-      this.parameters = parameters;
+      this.parameters = parameters.ToBase();
     }
   }
 }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -26,6 +26,8 @@ namespace Objects.Geometry
       }
       set
       {
+        if (value == null)
+          return;
         start = new Point(value[0], value[1], value[2]);
         end = new Point(value[3], value[4], value[5]);
       }

--- a/Objects/Objects/Utils/Parameters.cs
+++ b/Objects/Objects/Utils/Parameters.cs
@@ -22,7 +22,7 @@ namespace Objects.Utils
       foreach(Parameter p in parameters)
       {
         //if an applicationId is defined (BuiltInName) use that as key, otherwise use the display name
-          var key = string.IsNullOrEmpty(p.applicationId) ? p.name : p.applicationId;
+          var key = string.IsNullOrEmpty(p.applicationInternalName) ? p.name : p.applicationInternalName;
           if(string.IsNullOrEmpty(key) || @base[key]!=null)
               continue;
 

--- a/Objects/Objects/Utils/Parameters.cs
+++ b/Objects/Objects/Utils/Parameters.cs
@@ -1,0 +1,37 @@
+﻿using Objects.BuiltElements.Revit;
+using Speckle.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Objects.Utils
+{
+  public static class Parameters
+  {
+    /// <summary>
+    /// Turns a List of Parameters into a Base so that it can be used with the Speckle parameters prop
+    /// </summary>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    public static Base ToBase (this List<Parameter> parameters)
+    {
+      if (parameters == null)
+        return null; 
+      var @base = new Base();
+
+      foreach(Parameter p in parameters)
+      {
+        //if an applicationId is defined (BuiltInName) use that as key, otherwise use the display name
+          var key = string.IsNullOrEmpty(p.applicationId) ? p.name : p.applicationId;
+          if(string.IsNullOrEmpty(key) || @base[key]!=null)
+              continue;
+
+          @base[key] = p;
+
+      }
+
+
+      return @base;
+    }
+  }
+}


### PR DESCRIPTION
## Description

- Fixes #593 
Revit parameters in Speckle are now stored in a `Base` object instead of a` List<Parameter>` to improve access and searchability

## Type of change

**Breaking change** this will break scripts creating or reading parameters of Revit elements

## How has this been tested?

- Manual Tests in Revit and Schema Builder
- Revit xUnit Tests

## Docs

- Will be updated ASAP

