### PR TITLE
C3D: add alignments and stations to Objects Kit

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -9,31 +9,30 @@ using Autodesk.Civil.ApplicationServices;
 using CivilDB = Autodesk.Civil.DatabaseServices;
 using Acad = Autodesk.AutoCAD.Geometry;
 
+using Alignment = Objects.BuiltElements.Alignment;
 using Interval = Objects.Primitive.Interval;
 using Polycurve = Objects.Geometry.Polycurve;
 using Curve = Objects.Geometry.Curve;
 using Point = Objects.Geometry.Point;
 using Brep = Objects.Geometry.Brep;
 using Mesh = Objects.Geometry.Mesh;
+using Polyline = Objects.Geometry.Polyline;
+using Station = Objects.BuiltElements.Station;
 
 namespace Objects.Converter.AutocadCivil
 {
   public partial class ConverterAutocadCivil
   {
-    /*
     // stations
-    public Point StationToSpeckle(CivilDB.Station station)
+    public Station StationToSpeckle(CivilDB.Station station)
     {
-      var point = PointToSpeckle(station.Location);
-      if (station.DisplayName != null)
-        point["name"] = station.DisplayName;
-      if (station.Description != null)
-        point["description"] = station.Description;
-      point["type"] = station.StationType.ToString();
-      point["number"] = station.RawStation;
-      return point;
+      var _station = new Station();
+      _station.location = PointToSpeckle(station.Location);
+      _station.type = station.StationType.ToString();
+      _station.number = station.RawStation;
+
+      return _station;
     }
-    */
 
     public CivilDB.FeatureLine FeatureLineToNative(Polycurve polycurve)
     {
@@ -41,20 +40,32 @@ namespace Objects.Converter.AutocadCivil
     }
 
     // alignments
-    public Base AlignmentToSpeckle(CivilDB.Alignment alignment)
+    public Alignment AlignmentToSpeckle(CivilDB.Alignment alignment)
     {
-      var curve = CurveToSpeckle(alignment.BaseCurve, ModelUnits) as Base;
+      var _alignment = new Alignment();
 
+      _alignment.baseCurve = CurveToSpeckle(alignment.BaseCurve, ModelUnits);
       if (alignment.DisplayName != null)
-        curve["name"] = alignment.DisplayName;
-      if (alignment.Description != null)
-        curve["description"] = alignment.Description;
+        _alignment.name = alignment.DisplayName;
       if (alignment.StartingStation != null)
-        curve["startStation"] = alignment.StartingStation;
+        _alignment.startStation  = alignment.StartingStation;
       if (alignment.EndingStation != null)
-        curve["endStation"] = alignment.EndingStation;
+        _alignment.endStation = alignment.EndingStation;
 
-      return curve;
+      // handle station equations
+      var equations = new List<double[]>();
+      var directions = new List<bool>();
+      foreach (var stationEquation in alignment.StationEquations)
+      {
+        var equation = new double[] { stationEquation.RawStationBack, stationEquation.StationBack, stationEquation.StationAhead };
+        equations.Add(equation);
+        bool equationIncreasing = (stationEquation.EquationType.Equals(CivilDB.StationEquationType.Increasing)) ? true : false;
+        directions.Add(equationIncreasing);
+      }
+      _alignment.stationEquations = equations;
+      _alignment.stationEquationDirections = directions;
+
+      return _alignment;
     }
 
     // profiles

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -65,6 +65,8 @@ namespace Objects.Converter.AutocadCivil
       _alignment.stationEquations = equations;
       _alignment.stationEquationDirections = directions;
 
+      _alignment.units = ModelUnits;
+
       return _alignment;
     }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -552,7 +552,10 @@ namespace Objects.Converter.AutocadCivil
           return LineToSpeckle(line, u);
 
         case AcadDB.Polyline polyline:
-          return PolylineToSpeckle(polyline);
+          if (polyline.IsOnlyLines)
+            return PolylineToSpeckle(polyline);
+          else 
+            return PolycurveToSpeckle(polyline);
 
         case AcadDB.Polyline2d polyline2d:
           return PolycurveToSpeckle(polyline2d);

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -67,6 +67,11 @@ namespace Objects.Converter.AutocadCivil
       var u = units ?? ModelUnits;
       return new Point(point.X, point.Y, point.Z, u);
     }
+    public Point PointToSpeckle(Point2d point, string units = null)
+    {
+      var u = units ?? ModelUnits;
+      return new Point(point.X, point.Y, 0, u);
+    }
     public Point3d PointToNative(Point point)
     {
       var _point = new Point3d(ScaleToNative(point.x, point.units),

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using Objects.Other;
+using Alignment = Objects.BuiltElements.Alignment;
 using Arc = Objects.Geometry.Arc;
 using BlockInstance = Objects.Other.BlockInstance;
 using BlockDefinition = Objects.Other.BlockDefinition;
@@ -180,6 +181,10 @@ public static string AutocadAppName = Applications.Autocad2022;
 
         case BlockDefinition o:
           return BlockDefinitionToNativeDB(o);
+
+        // TODO: add Civil3D directive to convert to alignment instead of curve
+        case Alignment o:
+          return CurveToNativeDB(o.baseCurve);
 
         default:
           throw new NotSupportedException();
@@ -362,6 +367,8 @@ public static string AutocadAppName = Applications.Autocad2022;
 
         case BlockDefinition _:
         case BlockInstance _:
+
+        case Alignment _:
           return true;
 
         default:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGh.cs
@@ -10,6 +10,7 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Alignment = Objects.BuiltElements.Alignment;
 using Arc = Objects.Geometry.Arc;
 using Box = Objects.Geometry.Box;
 using Brep = Objects.Geometry.Brep;
@@ -325,6 +326,9 @@ namespace Objects.Converter.RhinoGh
         case Surface o:
           return SurfaceToNative(o);
 
+        case Alignment o:
+          return CurveToNative(o.baseCurve);
+
         case ModelCurve o:
           return CurveToNative(o.baseCurve);
 
@@ -427,6 +431,7 @@ namespace Objects.Converter.RhinoGh
         case View3D _:
         case BlockDefinition _:
         case BlockInstance _:
+        case Alignment _:
           return true;
         
         default:

--- a/Objects/Objects/BuiltElements/Alignment.cs
+++ b/Objects/Objects/BuiltElements/Alignment.cs
@@ -1,0 +1,33 @@
+﻿using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Objects.BuiltElements
+{
+  public class Alignment : Base
+  {
+    public ICurve baseCurve { get; set; }
+
+    public string name { get; set; }
+
+    public double startStation { get; set; }
+
+    public double endStation { get; set; }
+
+    /// <summary>
+    /// Station equation arrays should contain doubles indicating raw station back, station back, and station ahead
+    /// </summary>
+    public List<double[]> stationEquations { get; set; }
+
+    /// <summary>
+    /// Station equation direction for the corresponding station equation should be true for increasing or false for decreasing
+    /// </summary>
+    public List<bool> stationEquationDirections { get; set; }
+
+    public Alignment() { }
+
+  }
+}

--- a/Objects/Objects/BuiltElements/Station.cs
+++ b/Objects/Objects/BuiltElements/Station.cs
@@ -1,0 +1,19 @@
+﻿using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace Objects.BuiltElements
+{
+  public class Station : Base
+  {
+    public double number { get; set; }
+    public string type { get; set; }
+    public Point location { get; set; }
+
+    public Station() { }
+  }
+}


### PR DESCRIPTION
## Description

Adds Station and Alignment BuiltElements base classes to the Objects kit. Also updates Alignment conversions in the C3D connector. Includes a bug fix where CurveToSpeckle method was not differentiating between line-only polylines and polylines with arc segments.

- Fixes #599 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: tested sending alignments from C3D and receiving them in grasshopper, dynamo, rhino, autocad. Receiving in Revit currently not supported

## Docs

- No updates needed

