### PR TITLE
Added target prop back into revit views

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
@@ -44,26 +44,23 @@ namespace Objects.Converter.Revit
         var forward = rv3d.GetSavedOrientation().ForwardDirection; // this is unit vector
         var up = rv3d.GetSavedOrientation().UpDirection; // this is unit vector
 
-        /* not accurate, will result in distorted camera axes if sent to rhino NOTE!! TRY USING THIS FOR ISO ONLY
         // get target
         var target = PointToSpeckle(CalculateTarget(rv3d, forward));
-        */
 
         speckleView = new View3D
         {
           origin = PointToSpeckle(rv3d.Origin),
           forwardDirection = VectorToSpeckle(forward, Speckle.Core.Kits.Units.None),
           upDirection = VectorToSpeckle(up, Speckle.Core.Kits.Units.None),
-          //target = target,
+          target = target,
           isOrthogonal = !rv3d.IsPerspective,
-          boundingBox = BoxToSpeckle(rv3d.CropBox)
+          boundingBox = BoxToSpeckle(rv3d.CropBox),
+          name = revitView.Name
         };
 
         // set props
         AttachViewParams(speckleView, rv3d);
       }
-
-      speckleView.name = revitView.Name;
 
       GetAllRevitParamsAndIds(speckleView, revitView);
       return speckleView;


### PR DESCRIPTION
## Description
Adds the target prop back into Revit views. Testing on sample files seem to be *more or less* comparable to views sent without target, when received in Rhino.

Helps resolve part of [https://github.com/specklesystems/speckle-server/issues/328](https://github.com/specklesystems/speckle-server/issues/328), as views are now registered in the viewer, but their id instead of the name is being used for display. See:

[https://speckle.xyz/streams/5dfbeb49c9/commits/dc5c07302f](https://speckle.xyz/streams/5dfbeb49c9/commits/dc5c07302f)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests : views sent back and forth from revit arch sample file 

## Docs

- No updates needed


