### PR TITLE
AcadCivil: block names with invalid chars causes app to crash when receiving

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -431,7 +431,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
     private bool GetOrMakeLayer(string layerName, AcadDb.Transaction tr, out string cleanName)
     {
-      cleanName = Utils.RemoveInvalidLayerChars(layerName);
+      cleanName = Utils.RemoveInvalidChars(layerName);
       try
       {
         AcadDb.LayerTable lyrTbl = tr.GetObject(Doc.Database.LayerTableId, AcadDb.OpenMode.ForRead) as AcadDb.LayerTable;

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -28,7 +28,7 @@ public static string AutocadAppName = Applications.Autocad2022;
     public static string AutocadAppName = Applications.Civil2022;
     public static string AppName = "Civil 3D";
 #endif
-    public static string invalidChars = @"<>/\:;""?*|=‘";
+    public static string invalidChars = @"<>/\:;""?*|=,‘";
 
     #region extension methods
 
@@ -223,11 +223,11 @@ public static string AutocadAppName = Applications.Autocad2022;
     }
 
     /// <summary>
-    /// Removes invalid characters for Autocad names
+    /// Removes invalid characters for Autocad layer and block names
     /// </summary>
     /// <param name="str"></param>
     /// <returns></returns>
-    public static string RemoveInvalidLayerChars(string str)
+    public static string RemoveInvalidChars(string str)
     {
       // using this to handle rhino nested layer syntax
       // replace "::" layer delimiter with "$" (acad standard)

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -10,6 +10,8 @@ namespace Objects.Converter.AutocadCivil
 {
   public partial class ConverterAutocadCivil
   {
+    public static string invalidChars = @"<>/\:;""?*|=,‘";
+
     #region units
     private string _modelUnits;
     public string ModelUnits
@@ -58,6 +60,21 @@ namespace Objects.Converter.AutocadCivil
     }
     #endregion
 
+    /// <summary>
+    /// Removes invalid characters for Autocad layer and block names
+    /// </summary>
+    /// <param name="str"></param>
+    /// <returns></returns>
+    public static string RemoveInvalidChars(string str)
+    {
+      // using this to handle rhino nested layer syntax
+      // replace "::" layer delimiter with "$" (acad standard)
+      string cleanDelimiter = str.Replace("::", "$");
+
+      // remove all other invalid chars
+      return Regex.Replace(cleanDelimiter, $"[{invalidChars}]", string.Empty);
+    }
+
     public DisplayStyle GetStyle(DBObject obj)
     {
       var style = new DisplayStyle();
@@ -90,7 +107,7 @@ namespace Objects.Converter.AutocadCivil
 
         // get linetype
         style.linetype = entity.Linetype;
-        if (entity.Linetype == "BYLAYER")
+        if (entity.Linetype.ToUpper() == "BYLAYER")
         {
           using(Transaction tr = Doc.Database.TransactionManager.StartTransaction())
           {

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.DBObjects.cs
@@ -1250,7 +1250,7 @@ namespace Objects.Converter.AutocadCivil
     public ObjectId BlockDefinitionToNativeDB(BlockDefinition definition)
     {
       // get modified definition name with commit info
-      var blockName = $"{Doc.UserData["commit"]} - {definition.name}";
+      var blockName = $"{Doc.UserData["commit"]} - {RemoveInvalidChars(definition.name)}";
 
       ObjectId blockId = ObjectId.Null;
       using (Transaction tr = Doc.TransactionManager.StartTransaction())


### PR DESCRIPTION
## Description
 
Fixed crash issue when trying to receive block definitions with invalid chars. Also includes minor improvement for determining line styles while sending.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests

## Docs

- No updates needed


