### PR TITLE
Civil: alignments base class using flat station equation list

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -53,12 +53,11 @@ namespace Objects.Converter.AutocadCivil
         _alignment.endStation = alignment.EndingStation;
 
       // handle station equations
-      var equations = new List<double[]>();
+      var equations = new List<double>();
       var directions = new List<bool>();
       foreach (var stationEquation in alignment.StationEquations)
       {
-        var equation = new double[] { stationEquation.RawStationBack, stationEquation.StationBack, stationEquation.StationAhead };
-        equations.Add(equation);
+        equations.AddRange(new List<double> { stationEquation.RawStationBack, stationEquation.StationBack, stationEquation.StationAhead });
         bool equationIncreasing = (stationEquation.EquationType.Equals(CivilDB.StationEquationType.Increasing)) ? true : false;
         directions.Add(equationIncreasing);
       }

--- a/Objects/Objects/BuiltElements/Alignment.cs
+++ b/Objects/Objects/BuiltElements/Alignment.cs
@@ -18,9 +18,9 @@ namespace Objects.BuiltElements
     public double endStation { get; set; }
 
     /// <summary>
-    /// Station equation arrays should contain doubles indicating raw station back, station back, and station ahead
+    /// Station equation list contains doubles indicating raw station back, station back, and station ahead for each station equation
     /// </summary>
-    public List<double[]> stationEquations { get; set; }
+    public List<double> stationEquations { get; set; }
 
     /// <summary>
     /// Station equation direction for the corresponding station equation should be true for increasing or false for decreasing


### PR DESCRIPTION
## Description

Alignment base class was previously using a list of arrays for the station equation property. This was causing deserialization issues in core, so temporarily fixing by using a flattened list instead.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests

## Docs

- No updates needed

