### PR TITLE
Civil3D: added pipe and structure conversions

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -228,24 +228,26 @@ namespace Objects.Converter.AutocadCivil
     }
 
     // structures
-    public Mesh StructureToSpeckle(CivilDB.Structure structure)
+    public Structure StructureToSpeckle(CivilDB.Structure structure)
     {
+      // get ids pipes that are connected to this structure
+      var pipeIds = new List<string>();
+      for (int i = 0; i < structure.ConnectedPipesCount; i++)
+        pipeIds.Add(structure.get_ConnectedPipe(i).ToString());
+
       var _structure = new Structure();
 
-      _structure.baseCurve = CurveToSpeckle(structure.BaseCurve, ModelUnits) as Curve;
       _structure.location = PointToSpeckle(structure.Location, ModelUnits);
+      _structure.pipeIds = pipeIds;
       _structure.displayMesh = SolidToSpeckle(structure.Solid3dBody);
       _structure.units = ModelUnits;
 
       // assign additional structure props
-      try{
       _structure["name"] = (structure.DisplayName != null) ? structure.DisplayName : "";
-      _structure["description"] = structure.Description;
-      _structure["connectedPipes"] = structure.ConnectedPipesCount;
-      _structure["station"] = structure.Station;
-      _structure["network"] = structure.NetworkName;
-      }
-      catch{}
+      _structure["description"] = (structure.Description != null) ? structure.Description : "";
+      try{ _structure["grate"] = structure.Grate; } catch{ }
+      try{ _structure["station"] = structure.Station; } catch{ }
+      try{ _structure["network"] = structure.NetworkName; } catch{ }
 
       return _structure;
     }
@@ -261,18 +263,17 @@ namespace Objects.Converter.AutocadCivil
       _pipe.units = ModelUnits;
 
       // assign additional structure props
-      try{
       _pipe["name"] = (pipe.DisplayName != null) ? pipe.DisplayName : "";
       _pipe["description"] = (pipe.DisplayName != null) ? pipe.Description : "";
-      _pipe["flowDirection"] = pipe.FlowDirection.ToString();
-      _pipe["flowRate"] = pipe.FlowRate;
-      _pipe["network"] = pipe.NetworkName;
-      _pipe["startOffset"] = pipe.StartOffset;
-      _pipe["endOffset"] = pipe.EndOffset;
-      _pipe["startStation"] = pipe.StartStation;
-      _pipe["endStation"] = pipe.EndStation;
-      }
-      catch{}
+      try{ _pipe["shape"] = pipe.CrossSectionalShape.ToString(); } catch{ }
+      try{ _pipe["flowDirection"] = pipe.FlowDirection.ToString(); } catch{ }
+      try{ _pipe["flowRate"] = pipe.FlowRate; } catch{ }
+      try{ _pipe["network"] = pipe.NetworkName; } catch{ }
+      try{ _pipe["startOffset"] = pipe.StartOffset; } catch{ }
+      try{ _pipe["endOffset"] = pipe.EndOffset; } catch{ }
+      try{ _pipe["startStation"] = pipe.StartStation; } catch{ }
+      try{ _pipe["endStation"] = pipe.EndStation; } catch{ }
+
       return _pipe;
     }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -255,8 +255,21 @@ namespace Objects.Converter.AutocadCivil
     // pipes
     public Pipe PipeToSpeckle(CivilDB.Pipe pipe)
     {
+      // get the pipe curve
+      ICurve curve = null;
+      switch (pipe.SubEntityType)
+      {
+        case CivilDB.PipeSubEntityType.Straight:
+          var line = new Line(pipe.StartPoint, pipe.EndPoint);
+          curve = CurveToSpeckle(line);
+          break;
+        default:
+          curve = CurveToSpeckle(pipe.Spline);
+          break;
+      }
+
       var _pipe = new Pipe();
-      _pipe.baseCurve = CurveToSpeckle(pipe.BaseCurve, ModelUnits) as Curve;
+      _pipe.baseCurve = curve;
       _pipe.diameter = pipe.InnerDiameterOrWidth;
       _pipe.length = pipe.Length3DToInsideEdge;
       _pipe.displayMesh = SolidToSpeckle(pipe.Solid3dBody);
@@ -266,6 +279,7 @@ namespace Objects.Converter.AutocadCivil
       _pipe["name"] = (pipe.DisplayName != null) ? pipe.DisplayName : "";
       _pipe["description"] = (pipe.DisplayName != null) ? pipe.Description : "";
       try{ _pipe["shape"] = pipe.CrossSectionalShape.ToString(); } catch{ }
+      try{ _pipe["slope"] = pipe.Slope; } catch{ }
       try{ _pipe["flowDirection"] = pipe.FlowDirection.ToString(); } catch{ }
       try{ _pipe["flowRate"] = pipe.FlowRate; } catch{ }
       try{ _pipe["network"] = pipe.NetworkName; } catch{ }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -13,8 +13,19 @@ namespace Objects.Converter.Revit
   {
     public List<ApplicationPlaceholderObject> PipeToNative(BuiltElements.Pipe specklePipe)
     {
+      // check if this is a line based pipe, return null if not
+      DB.Line baseLine = null;
+      switch (specklePipe.baseCurve)
+      {
+        case Line line:
+          baseLine = LineToNative(line);
+          break;
+        default:
+          ConversionErrors.Add(new Exception($"Pipe baseCurve is not a line"));
+          return null;
+      }
+
       // geometry
-      var baseLine = LineToNative(specklePipe.baseLine);
       var speckleRevitPipe = specklePipe as RevitPipe;
       var level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromCurve(baseLine));
 
@@ -76,7 +87,7 @@ namespace Objects.Converter.Revit
       // speckle pipe
       var specklePipe = new RevitPipe
       {
-        baseLine = baseLine,
+        baseCurve = baseLine,
         family = revitPipe.PipeType.FamilyName,
         type = revitPipe.PipeType.Name,
         systemName = revitPipe.MEPSystem.Name,

--- a/Objects/Objects/BuiltElements/Pipe.cs
+++ b/Objects/Objects/BuiltElements/Pipe.cs
@@ -8,7 +8,7 @@ namespace Objects.BuiltElements
 {
   public class Pipe : Base, IDisplayMesh
   {
-    public Line baseLine { get; set; }
+    public ICurve baseCurve { get; set; }
     public double length { get; set; }
     public double diameter { get; set; }
 
@@ -17,9 +17,9 @@ namespace Objects.BuiltElements
     public Pipe() { }
 
     [SchemaInfo("Pipe", "Creates a Speckle pipe", "BIM", "MEP")]
-    public Pipe(Line baseLine, double length, double diameter, double flowrate = 0, double relativeRoughness = 0)
+    public Pipe(ICurve baseCurve, double length, double diameter, double flowrate = 0, double relativeRoughness = 0)
     {
-      this.baseLine = baseLine;
+      this.baseCurve = baseCurve;
       this.length = length;
       this.diameter = diameter;
     }
@@ -42,11 +42,11 @@ namespace Objects.BuiltElements.Revit
     public RevitPipe() { }
 
     [SchemaInfo("RevitPipe", "Creates a Revit pipe", "Revit", "MEP")]
-    public RevitPipe(string family, string type, Line baseLine, double diameter, Level level,  string systemName = "", string systemType = "", List<Parameter> parameters = null)
+    public RevitPipe(string family, string type, ICurve baseCurve, double diameter, Level level,  string systemName = "", string systemType = "", List<Parameter> parameters = null)
     {
       this.family = family;
       this.type = type;
-      this.baseLine = baseLine;
+      this.baseCurve = baseCurve;
       this.diameter = diameter;
       this.systemName = systemName;
       this.systemType = systemType;

--- a/Objects/Objects/BuiltElements/Structure.cs
+++ b/Objects/Objects/BuiltElements/Structure.cs
@@ -1,0 +1,21 @@
+﻿using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace Objects.BuiltElements
+{
+  public class Structure : Base, IDisplayMesh
+  {
+    public ICurve baseCurve { get; set; }
+    public Point location { get; set; }
+    public List<Pipe> pipes { get; set; }
+
+    [DetachProperty] public Mesh displayMesh { get; set; }
+
+    public Structure() { }
+  }
+}

--- a/Objects/Objects/BuiltElements/Structure.cs
+++ b/Objects/Objects/BuiltElements/Structure.cs
@@ -10,11 +10,11 @@ namespace Objects.BuiltElements
 {
   public class Structure : Base, IDisplayMesh
   {
-    public ICurve baseCurve { get; set; }
     public Point location { get; set; }
-    public List<Pipe> pipes { get; set; }
+    public List<string> pipeIds { get; set; }
 
-    [DetachProperty] public Mesh displayMesh { get; set; }
+    [DetachProperty]
+    public Mesh displayMesh { get; set; }
 
     public Structure() { }
   }


### PR DESCRIPTION
## Description

Modified pipe base class (originally line based) to accommodate Civil3D pipes (line or curve based).
Added structure base class.
Changed pipe and structure conversions in Civil3D to return pipe and structure base classes.
Modified pipe conversions in Revit to only convert line based pipes
- Fixes #640 

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Manual Tests: sent pipes and structures out of civil, received pipes in Revit

## Docs

- No updates needed
