### PR TITLE
fix(gh): Empty optional arguments no longer block sender

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -187,10 +187,14 @@ namespace ConnectorGrasshopper.Extras
       if (subclass) 
         return @base;
       var copy = @base.ShallowCopy();
-      copy.GetMembers().ToList().ForEach(keyval =>
+      var keyValuePairs = copy.GetMembers().ToList();
+      keyValuePairs.ForEach(keyval =>
       {
         // TODO: Handle dicts!!
-        if (keyval.Value is IList list)
+        var value = keyval.Value;
+        if (value == null)
+          return;
+        if (value is IList list)
         {
           var converted = new List<object>();
           foreach (var item in list)
@@ -200,17 +204,18 @@ namespace ConnectorGrasshopper.Extras
           }
 
           copy[keyval.Key] = converted;
-        } else if (typeof(IDictionary).IsAssignableFrom(keyval.Value.GetType()))
+        } 
+        else if (typeof(IDictionary).IsAssignableFrom(value.GetType()))
         {
           var converted = new Dictionary<string, object>();
-          foreach(DictionaryEntry kvp in keyval.Value as IDictionary)
+          foreach(DictionaryEntry kvp in value as IDictionary)
           {
             converted[kvp.Key.ToString()] = TryConvertItemToSpeckle(kvp.Value, converter, true);
           }
           copy[keyval.Key] = converted;
         }
         else
-          copy[keyval.Key] = TryConvertItemToSpeckle(keyval.Value, converter, true);
+          copy[keyval.Key] = TryConvertItemToSpeckle(value, converter, true);
       });
       return copy;
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -193,6 +193,7 @@ namespace ConnectorGrasshopper.Extras
         // TODO: Handle dicts!!
         var value = keyval.Value;
         if (value == null)
+          // TODO: Handle null values in properties here. For now, we just ignore that prop in the object
           return;
         if (value is IList list)
         {


### PR DESCRIPTION
Fixes #580

This fixes an error when optional arguments existed but had no data (or were null) were making the sender get stuck and throw a 'Null Exception'. Right now, it will ignore any non-set properties (just like the 'Expand Speckle Object'  works, but I'm aware this may not sit well with some users.

We've had other petitions to keep the null items when being sent to the server, so I'm not sure if we should tackle this now, or in a separate issue.

Bonus: Better error handling when sender performs conversions.