### PR TITLE
GH (fix): Handle "no kit found" scenario gracefully

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitTaskCapableComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitTaskCapableComponentBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -144,6 +144,11 @@ namespace ConnectorGrasshopper.Objects
     public override void ComputeData()
     {
       //Ensure converter document is up to date
+      if (Kit == null)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
       if (Converter == null)
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "No converter was provided. Conversions are disabled.");

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitTaskCapableComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitTaskCapableComponentBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,22 +43,24 @@ namespace ConnectorGrasshopper.Objects
       SetConverter();
     }
 
-    public virtual void SetConverter()
+    public virtual bool SetConverter()
     {
       if (SelectedKitName == "None")
       {
         Kit = null;
         Converter = null;
         Message = "No Conversion";
-        return;
+        return true;
       }
       try
       {
         SetConverterFromKit(SelectedKitName);
+        return true;
       }
       catch
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No default kit found on this machine.");
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return false;
       }
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -243,7 +243,7 @@ namespace ConnectorGrasshopper.Ops
       ExpireSolution(true);
     }
 
-    private bool foundKit = false;
+    private bool foundKit;
     private void SetDefaultKitAndConverter()
     {
       try

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -132,7 +132,7 @@ namespace ConnectorGrasshopper.Ops
       writer.SetBoolean("AutoReceive", AutoReceive);
       writer.SetString("CurrentComponentState", CurrentComponentState);
       
-      writer.SetString("KitName", Kit.Name);
+      writer.SetString("KitName", Kit?.Name);
       var streamUrl = StreamWrapper != null ? StreamWrapper.ToString() : "";
       writer.SetString("StreamWrapper", streamUrl);
       writer.SetString("LastInfoMessage", LastInfoMessage);
@@ -190,7 +190,7 @@ namespace ConnectorGrasshopper.Ops
     protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
     {
       Menu_AppendSeparator(menu);
-      Menu_AppendItem(menu, "Select the converter you want to use:");
+      Menu_AppendItem(menu, "Select the converter you want to use:",null,null,false,false);
       var kits = KitManager.GetKitsWithConvertersForApp(Applications.Rhino);
 
       foreach (var kit in kits)
@@ -243,6 +243,7 @@ namespace ConnectorGrasshopper.Ops
       ExpireSolution(true);
     }
 
+    private bool foundKit = false;
     private void SetDefaultKitAndConverter()
     {
       try
@@ -250,16 +251,24 @@ namespace ConnectorGrasshopper.Ops
         Kit = KitManager.GetDefaultKit();
         Converter = Kit.LoadConverter(Applications.Rhino);
         Converter.SetContextDocument(RhinoDoc.ActiveDoc);
+        foundKit = true;
       }
       catch
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No default kit found on this machine.");
+        foundKit = false;
       }
     }
 
     protected override void SolveInstance(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
+
+      if (!foundKit)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
       // We need to call this always in here to be able to react and set events :/
       ParseInput(DA);
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponentSync.cs
@@ -206,17 +206,20 @@ namespace ConnectorGrasshopper.Ops
       return base.Read(reader);
     }
 
+    private bool foundKit;
     private void SetDefaultKitAndConverter()
     {
-      Kit = KitManager.GetDefaultKit();
       try
       {
+        Kit = KitManager.GetDefaultKit();
         Converter = Kit.LoadConverter(Applications.Rhino);
         Converter.SetContextDocument(RhinoDoc.ActiveDoc);
+        foundKit = true;
       }
       catch
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No default kit found on this machine.");
+        foundKit = false;
       }
     }
 
@@ -245,6 +248,12 @@ namespace ConnectorGrasshopper.Ops
     /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
     protected override void SolveInstance(IGH_DataAccess DA)
     {
+      if (!foundKit)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
+      
       if (RunCount == 1)
       {
         CreateCancelationToken();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
@@ -77,18 +77,31 @@ namespace ConnectorGrasshopper.Ops
       ExpireSolution(true);
     }
 
+    public bool foundKit;
     private void SetDefaultKitAndConverter()
     {
-      Kit = KitManager.GetDefaultKit();
       try
-      {
+      { 
+        Kit = KitManager.GetDefaultKit();
         Converter = Kit.LoadConverter(Applications.Rhino);
         Converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+        foundKit = true;
       }
       catch
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No default kit found on this machine.");
+        foundKit = false;
       }
+    }
+
+    protected override void SolveInstance(IGH_DataAccess DA)
+    {
+      if (!foundKit)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
+      base.SolveInstance(DA);
     }
 
     protected override void BeforeSolveInstance()

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -226,7 +226,7 @@ namespace ConnectorGrasshopper.Ops
       }
     }
 
-    private bool foundKit = false;
+    private bool foundKit;
     private void SetDefaultKitAndConverter()
     {
       try

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -74,7 +74,7 @@ namespace ConnectorGrasshopper.Ops
       writer.SetBoolean("AutoSend", AutoSend);
       writer.SetString("CurrentComponentState", CurrentComponentState);
       writer.SetString("BaseId", BaseId);
-      writer.SetString("KitName", Kit.Name);
+      writer.SetString("KitName", Kit?.Name);
 
       var owSer = string.Join("\n", OutputWrappers.Select(ow => $"{ow.ServerUrl}\t{ow.StreamId}\t{ow.CommitId}"));
       writer.SetString("OutputWrappers", owSer);
@@ -151,6 +151,7 @@ namespace ConnectorGrasshopper.Ops
       Menu_AppendSeparator(menu);
       var menuItem = Menu_AppendItem(menu, "Select the converter you want to use:");
       menuItem.Enabled = false;
+      menuItem.Image = Properties.Resources.speckle_logo;
       var kits = KitManager.GetKitsWithConvertersForApp(Applications.Rhino);
 
       foreach (var kit in kits)
@@ -199,35 +200,57 @@ namespace ConnectorGrasshopper.Ops
 
     public void SetConverterFromKit(string kitName)
     {
-      if (Kit == null) return;
+      if (Kit == null)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
       if (kitName == Kit.Name)
       {
         return;
       }
 
-      Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
-      Converter = Kit.LoadConverter(Applications.Rhino);
-
-      Message = $"Using the {Kit.Name} Converter";
-      ExpireSolution(true);
-    }
-
-    private void SetDefaultKitAndConverter()
-    {
-      Kit = KitManager.GetDefaultKit();
       try
       {
+        Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
+        Converter = Kit.LoadConverter(Applications.Rhino);
+
+        Message = $"Using the {Kit.Name} Converter";
+        foundKit = true;
+        ExpireSolution(true);
+      }
+      catch (Exception e)
+      {
+        Console.WriteLine(e);
+        foundKit = false;
+      }
+    }
+
+    private bool foundKit = false;
+    private void SetDefaultKitAndConverter()
+    {
+      try
+      {
+        Kit = KitManager.GetDefaultKit();
         Converter = Kit.LoadConverter(Applications.Rhino);
         Converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+        foundKit = true;
       }
       catch
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No default kit found on this machine.");
+        foundKit = false;
       }
     }
 
     protected override void SolveInstance(IGH_DataAccess DA)
     {
+      // Fast exit if no default kit was found!
+      if (!foundKit)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
+      
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.
       if (JustPastedIn)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponentSync.cs
@@ -162,17 +162,20 @@ namespace ConnectorGrasshopper.Ops
       base.AddedToDocument(document);
     }
 
+    private bool foundKit;
     private void SetDefaultKitAndConverter()
     {
-      Kit = KitManager.GetDefaultKit();
       try
       {
+        Kit = KitManager.GetDefaultKit();
         Converter = Kit.LoadConverter(Applications.Rhino);
         Converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+        foundKit = true;
       }
       catch
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No default kit found on this machine.");
+        foundKit = false;
       }
     }
 
@@ -187,7 +190,13 @@ namespace ConnectorGrasshopper.Ops
     protected override void SolveInstance(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
-
+      
+      if (!foundKit)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
+      
       if (RunCount == 1)
       {
         CreateCancelationToken();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendLocalComponent.cs
@@ -73,20 +73,32 @@ namespace ConnectorGrasshopper.Ops
       ExpireSolution(true);
     }
 
+    public bool foundKit;
     private void SetDefaultKitAndConverter()
     {
-      Kit = KitManager.GetDefaultKit();
       try
       {
+        Kit = KitManager.GetDefaultKit();
         Converter = Kit.LoadConverter(Applications.Rhino);
         Converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+        foundKit = true;
       }
       catch
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No default kit found on this machine.");
+        foundKit = false;
       }
     }
-
+    
+    protected override void SolveInstance(IGH_DataAccess DA)
+    {
+      if (!foundKit)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No kit found on this machine.");
+        return;
+      }
+      base.SolveInstance(DA);
+    }
     protected override void BeforeSolveInstance()
     {
       Tracker.TrackPageview(Tracker.SEND_LOCAL);


### PR DESCRIPTION
Fixes #690

As reported in the forum thread linked in #686, when no kit was found (due to corrupted install, missing dll or any other reason), the `Send` and `Receive` nodes will display an unhelpful message, and also **cannot be deleted from the canvas**

## Solution

There was an error being thrown in the `Read` method of the `Send/Receive` nodes that was preventing proper deletion.
They also now prevent further execution and report a clearer error message.

- [x] Send node
- [x] Receive node
- [x] Local send node
- [x] Local receive node
- [x] Sync send node
- [x] Sync receive node
- [x] Object management nodes