### PR TITLE
Jm/revit spaces conversion

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -568,7 +568,7 @@ public class SpaceSchemaComponent: CreateSchemaObjectBase {
 // This is generated code:
 public class Space1SchemaComponent: CreateSchemaObjectBase {
      
-    public Space1SchemaComponent(): base("Space with upper limit and offset parameters", "Space with upper limit and offset parameters", "Creates a Speckle space with the specified upper limit and offsets", "Speckle 2 BIM", "MEP") { }
+    public Space1SchemaComponent(): base("Space with top level and offset parameters", "Space with top level and offset parameters", "Creates a Speckle space with the specified top level and offsets", "Speckle 2 BIM", "MEP") { }
     
     public override Guid ComponentGuid => new Guid("8f7b0323-3533-e7cd-ae43-0bdeb34f3570");
     

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -573,7 +573,20 @@ public class SpaceSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("c6907933-2792-eb6d-7c64-fb54835e9b44");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Space.ctor(System.String,System.String,Objects.Geometry.Point,Objects.BuiltElements.Level,Objects.BuiltElements.Level)","Objects.BuiltElements.Space");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Space.ctor(System.String,System.String,Objects.Geometry.Point,Objects.BuiltElements.Level)","Objects.BuiltElements.Space");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class SpaceSeparationLineSchemaComponent: CreateSchemaObjectBase {
+     
+    public SpaceSeparationLineSchemaComponent(): base("SpaceSeparationLine", "SpaceSeparationLine", "Creates a Revit space separation line", "Speckle 2 Revit", "Curves") { }
+    
+    public override Guid ComponentGuid => new Guid("0bba13ce-5758-8513-42fd-9e0b3702a654");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.SpaceSeparationLine.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.SpaceSeparationLine");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -462,19 +462,6 @@ public class RevitShaftSchemaComponent: CreateSchemaObjectBase {
 }
 
 // This is generated code:
-public class RevitSpaceSchemaComponent: CreateSchemaObjectBase {
-     
-    public RevitSpaceSchemaComponent(): base("RevitSpace", "RevitSpace", "Creates a Revit space", "Speckle 2 Revit", "MEP") { }
-    
-    public override Guid ComponentGuid => new Guid("378a7eb4-4c87-07fc-4bbf-97ffd07107b0");
-    
-    public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitSpace.ctor(Objects.Geometry.Mesh,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitSpace");
-        base.AddedToDocument(document);
-    }
-}
-
-// This is generated code:
 public class RevitTopographySchemaComponent: CreateSchemaObjectBase {
      
     public RevitTopographySchemaComponent(): base("RevitTopography", "RevitTopography", "Creates a Revit topography", "Speckle 2 Revit", "Architecture") { }
@@ -574,6 +561,19 @@ public class SpaceSchemaComponent: CreateSchemaObjectBase {
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Space.ctor(System.String,System.String,Objects.Geometry.Point,Objects.BuiltElements.Level)","Objects.BuiltElements.Space");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class Space1SchemaComponent: CreateSchemaObjectBase {
+     
+    public Space1SchemaComponent(): base("Space with upper limit and offset parameters", "Space with upper limit and offset parameters", "Creates a Speckle space with the specified upper limit and offsets", "Speckle 2 BIM", "MEP") { }
+    
+    public override Guid ComponentGuid => new Guid("8f7b0323-3533-e7cd-ae43-0bdeb34f3570");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Space.ctor(System.String,System.String,Objects.Geometry.Point,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double)","Objects.BuiltElements.Space");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -462,6 +462,19 @@ public class RevitShaftSchemaComponent: CreateSchemaObjectBase {
 }
 
 // This is generated code:
+public class RevitSpaceSchemaComponent: CreateSchemaObjectBase {
+     
+    public RevitSpaceSchemaComponent(): base("RevitSpace", "RevitSpace", "Creates a Revit space", "Speckle 2 Revit", "MEP") { }
+    
+    public override Guid ComponentGuid => new Guid("378a7eb4-4c87-07fc-4bbf-97ffd07107b0");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitSpace.ctor(Objects.Geometry.Mesh,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitSpace");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
 public class RevitTopographySchemaComponent: CreateSchemaObjectBase {
      
     public RevitTopographySchemaComponent(): base("RevitTopography", "RevitTopography", "Creates a Revit topography", "Speckle 2 Revit", "Architecture") { }
@@ -548,6 +561,19 @@ public class RoomBoundaryLineSchemaComponent: CreateSchemaObjectBase {
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.RoomBoundaryLine.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.RoomBoundaryLine");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class SpaceSchemaComponent: CreateSchemaObjectBase {
+     
+    public SpaceSchemaComponent(): base("Space", "Space", "Creates a Speckle space", "Speckle 2 BIM", "MEP") { }
+    
+    public override Guid ComponentGuid => new Guid("c6907933-2792-eb6d-7c64-fb54835e9b44");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Space.ctor(System.String,System.String,Objects.Geometry.Point,Objects.BuiltElements.Level,Objects.BuiltElements.Level)","Objects.BuiltElements.Space");
         base.AddedToDocument(document);
     }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -99,7 +99,8 @@ namespace Objects.Converter.Revit
           if ((BuiltInCategory)o.Category.Id.IntegerValue == BuiltInCategory.OST_RoomSeparationLines)
           {
             returnObject = RoomBoundaryLineToSpeckle(o);
-          } else if ((BuiltInCategory)o.Category.Id.IntegerValue == BuiltInCategory.OST_MEPSpaceSeparationLines)
+          } 
+          else if ((BuiltInCategory)o.Category.Id.IntegerValue == BuiltInCategory.OST_MEPSpaceSeparationLines)
           {
             returnObject = SpaceSeparationLineToSpeckle(o);
           }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -99,6 +99,9 @@ namespace Objects.Converter.Revit
           if ((BuiltInCategory)o.Category.Id.IntegerValue == BuiltInCategory.OST_RoomSeparationLines)
           {
             returnObject = RoomBoundaryLineToSpeckle(o);
+          } else if ((BuiltInCategory)o.Category.Id.IntegerValue == BuiltInCategory.OST_MEPSpaceSeparationLines)
+          {
+            returnObject = SpaceSeparationLineToSpeckle(o);
           }
           else
           {
@@ -126,6 +129,9 @@ namespace Objects.Converter.Revit
           break;
         case DB.Mechanical.Duct o:
           returnObject = DuctToSpeckle(o);
+          break;
+        case DB.Mechanical.Space o:
+          returnObject = SpaceToSpeckle(o);
           break;
         case DB.Plumbing.Pipe o:
           returnObject = PipeToSpeckle(o);
@@ -303,6 +309,9 @@ namespace Objects.Converter.Revit
         case BERC.RoomBoundaryLine o:
           return RoomBoundaryLineToNative(o);
 
+        case BERC.SpaceSeparationLine o:
+          return SpaceSeparationLineToNative(o);
+
         case BE.Roof o:
           return RoofToNative(o);
 
@@ -343,6 +352,9 @@ namespace Objects.Converter.Revit
         case BE.GridLine o:
           return GridLineToNative(o);
 
+        case BE.Space o:
+            return SpaceToNative(o);
+
         // other
         case Other.BlockInstance o:
           return BlockInstanceToNative(o);
@@ -375,6 +387,7 @@ namespace Objects.Converter.Revit
         DB.Architecture.TopographySurface _ => true,
         DB.Wall _ => true,
         DB.Mechanical.Duct _ => true,
+        DB.Mechanical.Space _ => true,
         DB.Plumbing.Pipe _ => true,
         DB.Electrical.Wire _ => true,
         DB.CurtainGridLine _ => true, //these should be handled by curtain walls
@@ -455,6 +468,7 @@ namespace Objects.Converter.Revit
         BE.View3D _ => true,
         BE.Room _ => true,
         BE.GridLine _ => true,
+        BE.Space _ => true,
         Other.BlockInstance _ => true,
         _ => false
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -455,6 +455,7 @@ namespace Objects.Converter.Revit
         BERC.ModelCurve _ => true,
         BE.Opening _ => true,
         BERC.RoomBoundaryLine _ => true,
+        BERC.SpaceSeparationLine _ => true,
         BE.Roof _ => true,
         BE.Topography _ => true,
         BER.RevitFaceWall _ => true,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertPipe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertRevitElement.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertArea.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertSpace.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertProfileWall.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertWire.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\FreeformElement.cs" />

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
@@ -15,11 +15,11 @@ namespace Objects.Converter.Revit
     {
       var revitRoom = GetExistingElementByApplicationId(speckleRoom.applicationId) as DB.Room;
       var level = LevelToNative(speckleRoom.level);
-
+      var center = PointToNative(speckleRoom.center);
 
       if (revitRoom == null)
       {
-        revitRoom = Doc.Create.NewRoom(level, new UV(speckleRoom.center.x, speckleRoom.center.y));
+        revitRoom = Doc.Create.NewRoom(level, new UV(center.X, center.Y));
       }
 
      

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
@@ -15,11 +15,11 @@ namespace Objects.Converter.Revit
     {
       var revitRoom = GetExistingElementByApplicationId(speckleRoom.applicationId) as DB.Room;
       var level = LevelToNative(speckleRoom.level);
-      var center = PointToNative(speckleRoom.center);
+      var basePoint = PointToNative(speckleRoom.basePoint);
 
       if (revitRoom == null)
       {
-        revitRoom = Doc.Create.NewRoom(level, new UV(center.X, center.Y));
+        revitRoom = Doc.Create.NewRoom(level, new UV(basePoint.X, basePoint.Y));
       }
 
      
@@ -50,7 +50,7 @@ namespace Objects.Converter.Revit
 
       speckleRoom.name = revitRoom.get_Parameter(BuiltInParameter.ROOM_NAME).AsString();
       speckleRoom.number = revitRoom.Number;
-      speckleRoom.center = (Point)LocationToSpeckle(revitRoom);
+      speckleRoom.basePoint = (Point)LocationToSpeckle(revitRoom);
       speckleRoom.level = ConvertAndCacheLevel(revitRoom, BuiltInParameter.ROOM_LEVEL_ID);
       speckleRoom.outline = profiles[0];
       speckleRoom.area = GetParamValue<double>(revitRoom, BuiltInParameter.ROOM_AREA);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
@@ -54,6 +54,7 @@ namespace Objects.Converter.Revit
       speckleRoom.level = ConvertAndCacheLevel(revitRoom, BuiltInParameter.ROOM_LEVEL_ID);
       speckleRoom.outline = profiles[0];
       speckleRoom.area = GetParamValue<double>(revitRoom, BuiltInParameter.ROOM_AREA);
+      speckleRoom.volume = GetParamValue<double>(revitRoom, BuiltInParameter.ROOM_VOLUME);
       if (profiles.Count > 1)
       {
         speckleRoom.voids = profiles.Skip(1).ToList();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -1,0 +1,79 @@
+﻿using Autodesk.Revit.DB;
+using Objects.BuiltElements;
+using Objects.Geometry;
+using Speckle.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using DB = Autodesk.Revit.DB.Mechanical;
+using Point = Objects.Geometry.Point;
+
+namespace Objects.Converter.Revit
+{
+    public partial class ConverterRevit
+    {
+        public List<ApplicationPlaceholderObject> SpaceToNative(Space speckleSpace)
+        {
+            var revitSpace = GetExistingElementByApplicationId(speckleSpace.applicationId) as DB.Space;
+            var level = LevelToNative(speckleSpace.level);
+
+
+            //TODO: support updating rooms
+            if (revitSpace != null)
+            {
+                Doc.Delete(revitSpace.Id);
+            }
+
+            revitSpace = Doc.Create.NewSpace(level, new UV(speckleSpace.basePoint.x, speckleSpace.basePoint.y));
+
+            revitSpace.Name = speckleSpace.name;
+            revitSpace.Number = speckleSpace.number;
+
+            SetInstanceParameters(revitSpace, speckleSpace);
+
+            var placeholders = new List<ApplicationPlaceholderObject>()
+              {
+                new ApplicationPlaceholderObject
+                {
+                applicationId = speckleSpace.applicationId,
+                ApplicationGeneratedId = revitSpace.UniqueId,
+                NativeObject = revitSpace
+                }
+              };
+
+            return placeholders;
+
+        }
+
+        public BuiltElements.Space SpaceToSpeckle(DB.Space revitSpace)
+        {
+            var profiles = GetProfiles(revitSpace);
+
+            var speckleSpace = new Space();
+
+            speckleSpace.name = revitSpace.Name;
+            speckleSpace.number = revitSpace.Number;
+            speckleSpace.basePoint = (Point)LocationToSpeckle(revitSpace);
+            speckleSpace.level = ConvertAndCacheLevel(revitSpace.LevelId);
+            speckleSpace.baseOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_LOWER_OFFSET);
+            speckleSpace.upperLimit = ConvertAndCacheLevel(revitSpace.UpperLimit.Id);
+            speckleSpace.limitOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_UPPER_OFFSET);
+            speckleSpace.boundary = profiles[0];
+            speckleSpace.area = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_AREA);
+            speckleSpace.volume = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_VOLUME);
+
+            //speckleSpace.baseOffset = revitSpace.BaseOffset;
+            //speckleSpace.limitOffset = revitSpace.LimitOffset;
+            //speckleSpace.area = revitSpace.Area;
+            //speckleSpace.volume = revitSpace.Volume;
+
+            GetAllRevitParamsAndIds(speckleSpace, revitSpace);
+            speckleSpace.displayMesh = GetElementDisplayMesh(revitSpace);
+
+            return speckleSpace;
+        }
+
+
+
+
+    }
+}

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -12,51 +12,68 @@ namespace Objects.Converter.Revit
 {
     public partial class ConverterRevit
     {
-        
         public List<ApplicationPlaceholderObject> SpaceToNative(Space speckleSpace)
         {
-            // create new space or update existing space
             var revitSpace = GetExistingElementByApplicationId(speckleSpace.applicationId) as DB.Space;
             var level = LevelToNative(speckleSpace.level);
-            
-            if (speckleSpace.separationLines.Any())
-            {
-                foreach (var separationLine in speckleSpace.separationLines)
-                {
-                    // create new space separation lines, update existing space separation lines 
-                    SpaceSeparationLineToNative(separationLine);
-                }
-            } 
-            else
-            {                
-                var boundaries = revitSpace.GetBoundarySegments(new SpatialElementBoundaryOptions());
-                foreach (var loop in boundaries)
-                {
-                    foreach (var segment in loop)
-                    {
-                        var curve = Doc.GetElement(segment.ElementId) as ModelCurve;
-                        if (curve == null)
-                        {
-                            continue;
-                        }
+            var basePoint = PointToNative(speckleSpace.basePoint);
+            var upperLimit = LevelToNative(speckleSpace.upperLimit);
 
-                        // remove unused space separation lines
-                        if (curve.CurveElementType == CurveElementType.SpaceSeparation)
-                        {                            
-                            Doc.Delete(curve.Id);
-                        }
+            // create new space if none existing, include zone information if available
+            if (revitSpace == null)
+            {                
+                revitSpace = Doc.Create.NewSpace(level, new UV(basePoint.X, basePoint.Y));
+                if (speckleSpace.zoneId != null)
+                {
+                    var speckleZone = Doc.GetElement(speckleSpace.zoneId) as DB.Zone;
+                    if (speckleZone != null) // else space is added to default zone
+                    {
+                        var spaceSet = new DB.SpaceSet();
+                        spaceSet.Insert(revitSpace);
+                        speckleZone.AddSpaces(spaceSet);
                     }
                 }
             }
-            
-            if (revitSpace == null)
-            {
-                revitSpace = Doc.Create.NewSpace(level, new UV(speckleSpace.basePoint.x, speckleSpace.basePoint.y));
+            else
+            {                
+                // unplaced space, so just delete and recreate from scratch (but make sure to copy host zone info)
+                // ideally we just place/move the existing space instead, but this seems like a real pain to do with the revit api? should update in future!
+                if (revitSpace.Area == 0 && revitSpace.Location == null) 
+                {
+                    var zone = revitSpace.Zone;
+                    Doc.Delete(revitSpace.Id);
+                    revitSpace = Doc.Create.NewSpace(level, new UV(basePoint.X, basePoint.Y));
+                    if (zone != null)
+                    {
+                        var spaceSet = new DB.SpaceSet();
+                        spaceSet.Insert(revitSpace);
+                        zone.AddSpaces(spaceSet);
+                    }
+                }
             }
 
             revitSpace.Name = speckleSpace.name;
             revitSpace.Number = speckleSpace.number;
-            revitSpace.SpaceType = !string.IsNullOrEmpty(speckleSpace.spaceType) ? (DB.SpaceType) Enum.Parse(typeof(DB.SpaceType), speckleSpace.spaceType) : DB.SpaceType.NoSpaceType; 
+
+            // if user does not specify an UpperLimit level, assume use of default UpperLimit (current level) and default offset values (base offset of 0, limit offset is distance to next level above)
+            if(upperLimit != null)
+            {
+                revitSpace.get_Parameter(BuiltInParameter.ROOM_UPPER_LEVEL).Set(upperLimit.Id); // not sure why, don't actually seem to be able to set the UpperLimit property when UpperLimit is the same as Level - it stays null after assignment!
+                revitSpace.LimitOffset = ScaleToNative(speckleSpace.limitOffset, speckleSpace.units);
+                revitSpace.BaseOffset = ScaleToNative(speckleSpace.baseOffset, speckleSpace.units);
+            }  
+
+            if (!string.IsNullOrEmpty(speckleSpace.spaceType))
+            {
+                try
+                {
+                    revitSpace.SpaceType = (DB.SpaceType)Enum.Parse(typeof(DB.SpaceType), speckleSpace.spaceType);
+                }
+                catch
+                {
+                    revitSpace.SpaceType = DB.SpaceType.NoSpaceType;
+                }
+            }
 
             SetInstanceParameters(revitSpace, speckleSpace);
 
@@ -78,41 +95,18 @@ namespace Objects.Converter.Revit
             var profiles = GetProfiles(revitSpace);
 
             var speckleSpace = new Space();
-
             speckleSpace.name = revitSpace.Name;
             speckleSpace.number = revitSpace.Number;
             speckleSpace.basePoint = (Point)LocationToSpeckle(revitSpace);
             speckleSpace.level = ConvertAndCacheLevel(revitSpace.LevelId);
-            speckleSpace.baseOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_LOWER_OFFSET);
-            speckleSpace.upperLimit = ConvertAndCacheLevel(revitSpace.UpperLimit.Id);
+            speckleSpace.upperLimit = ConvertAndCacheLevel(revitSpace.get_Parameter(BuiltInParameter.ROOM_UPPER_LEVEL).AsElementId());
+            speckleSpace.baseOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_LOWER_OFFSET); 
             speckleSpace.limitOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_UPPER_OFFSET);
             speckleSpace.boundary = profiles[0];
             speckleSpace.area = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_AREA);
             speckleSpace.volume = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_VOLUME);
             speckleSpace.spaceType = revitSpace.SpaceType.ToString();
-
-            var spaceSeparationLines = new List<BuiltElements.Revit.Curve.SpaceSeparationLine>();
-            var boundaries = revitSpace.GetBoundarySegments(new SpatialElementBoundaryOptions());
-            foreach (var loop in boundaries)
-            {
-                foreach (var segment in loop)
-                {
-                    var curve = Doc.GetElement(segment.ElementId) as ModelCurve;
-                    if (curve == null)
-                    {
-                        continue;
-                    }
-
-                    // what about room separation lines?
-                    if (curve.CurveElementType == CurveElementType.SpaceSeparation)
-                    {
-                        var spaceSeparationLine = SpaceSeparationLineToSpeckle(curve);
-                        spaceSeparationLines.Add(spaceSeparationLine);
-                    }
-                }
-            }
-
-            speckleSpace.separationLines = spaceSeparationLines;
+            speckleSpace.zoneId = revitSpace.Zone.Id.ToString();
 
             GetAllRevitParamsAndIds(speckleSpace, revitSpace);
             speckleSpace.displayMesh = GetElementDisplayMesh(revitSpace);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -4,6 +4,7 @@ using Objects.Geometry;
 using Speckle.Core.Models;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 using DB = Autodesk.Revit.DB.Mechanical;
 using Point = Objects.Geometry.Point;
 
@@ -11,22 +12,51 @@ namespace Objects.Converter.Revit
 {
     public partial class ConverterRevit
     {
+        
         public List<ApplicationPlaceholderObject> SpaceToNative(Space speckleSpace)
         {
+            // create new space or update existing space
             var revitSpace = GetExistingElementByApplicationId(speckleSpace.applicationId) as DB.Space;
             var level = LevelToNative(speckleSpace.level);
-
-
-            //TODO: support updating rooms
-            if (revitSpace != null)
+            
+            if (speckleSpace.separationLines.Any())
             {
-                Doc.Delete(revitSpace.Id);
-            }
+                foreach (var separationLine in speckleSpace.separationLines)
+                {
+                    // create new space separation lines, update existing space separation lines 
+                    SpaceSeparationLineToNative(separationLine);
+                }
+            } 
+            else
+            {                
+                var boundaries = revitSpace.GetBoundarySegments(new SpatialElementBoundaryOptions());
+                foreach (var loop in boundaries)
+                {
+                    foreach (var segment in loop)
+                    {
+                        var curve = Doc.GetElement(segment.ElementId) as ModelCurve;
+                        if (curve == null)
+                        {
+                            continue;
+                        }
 
-            revitSpace = Doc.Create.NewSpace(level, new UV(speckleSpace.basePoint.x, speckleSpace.basePoint.y));
+                        // remove unused space separation lines
+                        if (curve.CurveElementType == CurveElementType.SpaceSeparation)
+                        {                            
+                            Doc.Delete(curve.Id);
+                        }
+                    }
+                }
+            }
+            
+            if (revitSpace == null)
+            {
+                revitSpace = Doc.Create.NewSpace(level, new UV(speckleSpace.basePoint.x, speckleSpace.basePoint.y));
+            }
 
             revitSpace.Name = speckleSpace.name;
             revitSpace.Number = speckleSpace.number;
+            revitSpace.SpaceType = !string.IsNullOrEmpty(speckleSpace.spaceType) ? (DB.SpaceType) Enum.Parse(typeof(DB.SpaceType), speckleSpace.spaceType) : DB.SpaceType.NoSpaceType; 
 
             SetInstanceParameters(revitSpace, speckleSpace);
 
@@ -41,7 +71,6 @@ namespace Objects.Converter.Revit
               };
 
             return placeholders;
-
         }
 
         public BuiltElements.Space SpaceToSpeckle(DB.Space revitSpace)
@@ -60,20 +89,35 @@ namespace Objects.Converter.Revit
             speckleSpace.boundary = profiles[0];
             speckleSpace.area = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_AREA);
             speckleSpace.volume = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_VOLUME);
+            speckleSpace.spaceType = revitSpace.SpaceType.ToString();
 
-            //speckleSpace.baseOffset = revitSpace.BaseOffset;
-            //speckleSpace.limitOffset = revitSpace.LimitOffset;
-            //speckleSpace.area = revitSpace.Area;
-            //speckleSpace.volume = revitSpace.Volume;
+            var spaceSeparationLines = new List<BuiltElements.Revit.Curve.SpaceSeparationLine>();
+            var boundaries = revitSpace.GetBoundarySegments(new SpatialElementBoundaryOptions());
+            foreach (var loop in boundaries)
+            {
+                foreach (var segment in loop)
+                {
+                    var curve = Doc.GetElement(segment.ElementId) as ModelCurve;
+                    if (curve == null)
+                    {
+                        continue;
+                    }
+
+                    // what about room separation lines?
+                    if (curve.CurveElementType == CurveElementType.SpaceSeparation)
+                    {
+                        var spaceSeparationLine = SpaceSeparationLineToSpeckle(curve);
+                        spaceSeparationLines.Add(spaceSeparationLine);
+                    }
+                }
+            }
+
+            speckleSpace.separationLines = spaceSeparationLines;
 
             GetAllRevitParamsAndIds(speckleSpace, revitSpace);
             speckleSpace.displayMesh = GetElementDisplayMesh(revitSpace);
 
             return speckleSpace;
         }
-
-
-
-
     }
 }

--- a/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
+++ b/Objects/Objects/BuiltElements/Revit/ModelCurves.cs
@@ -62,4 +62,20 @@ namespace Objects.BuiltElements.Revit.Curve
       this.parameters = parameters.ToBase();
     }
   }
+
+  public class SpaceSeparationLine : Base
+  {
+    public ICurve baseCurve { get; set; }
+    public Base parameters { get; set; }
+    public string elementId { get; set; }
+    public string units { get; set; }
+    public SpaceSeparationLine() { }
+
+    [SchemaInfo("SpaceSeparationLine", "Creates a Revit space separation line", "Revit", "Curves")]
+    public SpaceSeparationLine([SchemaMainParam] ICurve baseCurve, List<Parameter> parameters = null)
+    {
+      this.baseCurve = baseCurve;
+      this.parameters = parameters.ToBase();
+    }
+  }
 }

--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -15,7 +15,7 @@ namespace Objects.BuiltElements
     public double area { get; set; }
     public double volume { get; set; }
     public Level level { get; set; }
-    public Point center { get; set; }
+    public Point basePoint { get; set; }
     public List<ICurve> voids { get; set; } = new List<ICurve>();
     public ICurve outline { get; set; }
 
@@ -31,12 +31,12 @@ namespace Objects.BuiltElements
     /// </summary>
     /// <remarks>Assign units when using this constructor due to <paramref name="height"/> param</remarks>
     [SchemaInfo("Room", "Creates a Speckle room", "BIM", "Architecture")]
-    public Room(string name, string number, Level level, [SchemaMainParam] Point center)
+    public Room(string name, string number, Level level, [SchemaMainParam] Point basePoint)
     {
       this.name = name;
       this.number = number;
       this.level = level;
-      this.center = center;
+      this.basePoint = basePoint;
     }
   }
 }

--- a/Objects/Objects/BuiltElements/Space.cs
+++ b/Objects/Objects/BuiltElements/Space.cs
@@ -26,7 +26,7 @@ namespace Objects.BuiltElements
         public Mesh displayMesh { get; set; }
         public Space() { }
 
-        [SchemaInfo("Space", "Creates a Speckle space", "BIM", "Mechanical")]
+        [SchemaInfo("Space", "Creates a Speckle space", "BIM", "MEP")]
         public Space(string name, string number, [SchemaMainParam] Point basePoint, Level level, Level upperLimit)
         {
             this.name = name;
@@ -47,7 +47,7 @@ namespace Objects.BuiltElements.Revit
 
         public RevitSpace() { }
 
-        [SchemaInfo("RevitSpace", "Creates a Revit space", "Revit", "Mechanical")]
+        [SchemaInfo("RevitSpace", "Creates a Revit space", "Revit", "MEP")]
         public RevitSpace([SchemaMainParam] Mesh displayMesh, List<Parameter> parameters = null)
         {
             this.displayMesh = displayMesh;

--- a/Objects/Objects/BuiltElements/Space.cs
+++ b/Objects/Objects/BuiltElements/Space.cs
@@ -4,6 +4,7 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Objects.BuiltElements.Revit.Curve;
 
 namespace Objects.BuiltElements
 {
@@ -18,22 +19,22 @@ namespace Objects.BuiltElements
         public Level level { get; set; }
         public double baseOffset { get; set; } = 0;
         public Level upperLimit { get; set; }
-        public double upperOffset { get; set; } = 0;
+        public double limitOffset { get; set; } = 0;
         public ICurve boundary { get; set; }
-        public List<ICurve> separationLines { get; set; } 
+        public List<SpaceSeparationLine> separationLines { get; set; } 
+        //missing Phase? Associated Room? Zone?
 
         [DetachProperty]
         public Mesh displayMesh { get; set; }
         public Space() { }
 
         [SchemaInfo("Space", "Creates a Speckle space", "BIM", "MEP")]
-        public Space(string name, string number, [SchemaMainParam] Point basePoint, Level level, Level upperLimit)
+        public Space(string name, string number, [SchemaMainParam] Point basePoint, Level level)
         {
             this.name = name;
             this.number = number;
             this.basePoint = basePoint;
             this.level = level;
-            this.upperLimit = upperLimit;
         }
     }
 }
@@ -44,7 +45,6 @@ namespace Objects.BuiltElements.Revit
     {
         public string elementId { get; set; }
         public List<Parameter> parameters { get; set; }
-
         public RevitSpace() { }
 
         [SchemaInfo("RevitSpace", "Creates a Revit space", "Revit", "MEP")]

--- a/Objects/Objects/BuiltElements/Space.cs
+++ b/Objects/Objects/BuiltElements/Space.cs
@@ -1,0 +1,57 @@
+﻿using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Objects.BuiltElements
+{
+    public class Space : Base, IHasArea, IHasVolume, IDisplayMesh
+    {
+        public string name { get; set; }
+        public string number { get; set; }
+        public double area { get; set; }
+        public double volume { get; set; }
+        public bool isUnbounded { get; set; }
+        public Point basePoint { get; set; }
+        public Level level { get; set; }
+        public double baseOffset { get; set; } = 0;
+        public Level upperLimit { get; set; }
+        public double upperOffset { get; set; } = 0;
+        public ICurve boundary { get; set; }
+        public List<ICurve> separationLines { get; set; } 
+
+        [DetachProperty]
+        public Mesh displayMesh { get; set; }
+        public Space() { }
+
+        [SchemaInfo("Space", "Creates a Speckle space", "BIM", "Mechanical")]
+        public Space(string name, string number, [SchemaMainParam] Point basePoint, Level level, Level upperLimit)
+        {
+            this.name = name;
+            this.number = number;
+            this.basePoint = basePoint;
+            this.level = level;
+            this.upperLimit = upperLimit;
+        }
+    }
+}
+
+namespace Objects.BuiltElements.Revit
+{
+    public class RevitSpace : Space
+    {
+        public string elementId { get; set; }
+        public List<Parameter> parameters { get; set; }
+
+        public RevitSpace() { }
+
+        [SchemaInfo("RevitSpace", "Creates a Revit space", "Revit", "Mechanical")]
+        public RevitSpace([SchemaMainParam] Mesh displayMesh, List<Parameter> parameters = null)
+        {
+            this.displayMesh = displayMesh;
+            this.parameters = parameters;
+        }
+    }
+}

--- a/Objects/Objects/BuiltElements/Space.cs
+++ b/Objects/Objects/BuiltElements/Space.cs
@@ -17,11 +17,12 @@ namespace Objects.BuiltElements
         public Point basePoint { get; set; }
         public Level level { get; set; }
         public double baseOffset { get; set; } = 0;
-        public Level upperLimit { get; set; }
-        public double limitOffset { get; set; } = 0; 
-        public ICurve boundary { get; set; }
+        public Level topLevel { get; set; } // corresponds to UpperLimit property in Revit api
+        public double topOffset { get; set; } = 0; // corresponds to LimitOffset property in Revit api
+        public List<ICurve> voids { get; set; } = new List<ICurve>();
+        public ICurve outline { get; set; }
         public string spaceType { get; set; }
-        public string zoneId { get; set; } 
+        public string zoneName { get; set; } 
 
         // additional properties to add: also inclue space separation lines here? Phase? Associated Room? Zone object instead of id?
 
@@ -39,15 +40,15 @@ namespace Objects.BuiltElements
             this.level = level;
         }
 
-        [SchemaInfo("Space with upper limit and offset parameters", "Creates a Speckle space with the specified upper limit and offsets", "BIM", "MEP")]
-        public Space(string name, string number, [SchemaMainParam] Point basePoint, Level level, Level upperLimit, double limitOffset, double baseOffset)
+        [SchemaInfo("Space with top level and offset parameters", "Creates a Speckle space with the specified top level and offsets", "BIM", "MEP")]
+        public Space(string name, string number, [SchemaMainParam] Point basePoint, Level level, Level topLevel, double topOffset, double baseOffset)
         {
             this.name = name;
             this.number = number;
             this.basePoint = basePoint;
             this.level = level;
-            this.upperLimit = upperLimit;
-            this.limitOffset = limitOffset;
+            this.topLevel = topLevel;
+            this.topOffset = topOffset;
             this.baseOffset = baseOffset;
         }
     }

--- a/Objects/Objects/BuiltElements/Space.cs
+++ b/Objects/Objects/BuiltElements/Space.cs
@@ -21,11 +21,15 @@ namespace Objects.BuiltElements
         public Level upperLimit { get; set; }
         public double limitOffset { get; set; } = 0;
         public ICurve boundary { get; set; }
+        public string spaceType { get; set; }
+
+        [DetachProperty]
         public List<SpaceSeparationLine> separationLines { get; set; } 
         //missing Phase? Associated Room? Zone?
 
         [DetachProperty]
         public Mesh displayMesh { get; set; }
+        public string units { get; set; }
         public Space() { }
 
         [SchemaInfo("Space", "Creates a Speckle space", "BIM", "MEP")]
@@ -36,22 +40,15 @@ namespace Objects.BuiltElements
             this.basePoint = basePoint;
             this.level = level;
         }
-    }
-}
 
-namespace Objects.BuiltElements.Revit
-{
-    public class RevitSpace : Space
-    {
-        public string elementId { get; set; }
-        public List<Parameter> parameters { get; set; }
-        public RevitSpace() { }
-
-        [SchemaInfo("RevitSpace", "Creates a Revit space", "Revit", "MEP")]
-        public RevitSpace([SchemaMainParam] Mesh displayMesh, List<Parameter> parameters = null)
+        [SchemaInfo("Space with space separation lines", "Creates a Speckle space with separation lines", "BIM", "MEP")]
+        public Space(string name, string number, Point basePoint, [SchemaMainParam] List<SpaceSeparationLine> separationLines, Level level)
         {
-            this.displayMesh = displayMesh;
-            this.parameters = parameters;
+            this.name = name;
+            this.number = number;
+            this.basePoint = basePoint;
+            this.separationLines = separationLines;
+            this.level = level;
         }
     }
 }

--- a/Objects/Objects/BuiltElements/Space.cs
+++ b/Objects/Objects/BuiltElements/Space.cs
@@ -14,18 +14,16 @@ namespace Objects.BuiltElements
         public string number { get; set; }
         public double area { get; set; }
         public double volume { get; set; }
-        public bool isUnbounded { get; set; }
         public Point basePoint { get; set; }
         public Level level { get; set; }
         public double baseOffset { get; set; } = 0;
         public Level upperLimit { get; set; }
-        public double limitOffset { get; set; } = 0;
+        public double limitOffset { get; set; } = 0; 
         public ICurve boundary { get; set; }
         public string spaceType { get; set; }
+        public string zoneId { get; set; } 
 
-        [DetachProperty]
-        public List<SpaceSeparationLine> separationLines { get; set; } 
-        //missing Phase? Associated Room? Zone?
+        // additional properties to add: also inclue space separation lines here? Phase? Associated Room? Zone object instead of id?
 
         [DetachProperty]
         public Mesh displayMesh { get; set; }
@@ -41,14 +39,16 @@ namespace Objects.BuiltElements
             this.level = level;
         }
 
-        [SchemaInfo("Space with space separation lines", "Creates a Speckle space with separation lines", "BIM", "MEP")]
-        public Space(string name, string number, Point basePoint, [SchemaMainParam] List<SpaceSeparationLine> separationLines, Level level)
+        [SchemaInfo("Space with upper limit and offset parameters", "Creates a Speckle space with the specified upper limit and offsets", "BIM", "MEP")]
+        public Space(string name, string number, [SchemaMainParam] Point basePoint, Level level, Level upperLimit, double limitOffset, double baseOffset)
         {
             this.name = name;
             this.number = number;
             this.basePoint = basePoint;
-            this.separationLines = separationLines;
             this.level = level;
+            this.upperLimit = upperLimit;
+            this.limitOffset = limitOffset;
+            this.baseOffset = baseOffset;
         }
     }
 }


### PR DESCRIPTION
## Description

- Addresses to-do item for Spaces in https://github.com/specklesystems/speckle-sharp/issues/394 (the ToSpeckle and ToNative methods for Space objects and SpaceSeparationLine objects added)
- Fixes ToNative method for Room item in https://github.com/specklesystems/speckle-sharp/issues/394 (use scaled center point instead of speckle center point for placement)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests, sent space separation lines, spaces and rooms to/from Rhino/GH and Revit

## Docs

- Will be updated ASAP

