### PR TITLE
fix(acad): finally adding mesh to native conversion

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using System.Collections;
 
+
 using Speckle.Newtonsoft.Json;
 using Speckle.Core.Models;
 using Speckle.Core.Kits;
@@ -36,8 +37,14 @@ namespace Speckle.ConnectorAutocadCivil.UI
     /// </summary>
     public List<Exception> Exceptions { get; set; } = new List<Exception>();
 
+    // AutoCAD API should only be called on the main thread.
+    // Not doing so results in botched conversions for any that require adding objects to Document model space before modifying (eg adding vertices and faces for meshes)
+    // There's no easy way to access main thread from document object, therefore we are creating a control during Connector Bindings constructor (since it's called on main thread) that allows for invoking worker threads on the main thread
+    public System.Windows.Forms.Control Control; 
     public ConnectorBindingsAutocad() : base()
     {
+      Control = new System.Windows.Forms.Control();
+      Control.CreateControl();
     }
 
     public void SetExecutorAndInit()
@@ -214,6 +221,20 @@ namespace Speckle.ConnectorAutocadCivil.UI
         RaiseNotification($"Encountered error: {Exceptions.Last().Message}");
       }
 
+      // invoke conversions on the main thread via control
+      if (Control.InvokeRequired)
+        Control.Invoke(new ConversionDelegate(ConvertCommit), new object[] { commitObject, converter, state, stream, id });
+      else
+        ConvertCommit(commitObject, converter, state, stream, id);
+
+      return state;
+    }
+
+    // main thread operations
+
+    delegate void ConversionDelegate(Base commitObject, ISpeckleConverter converter, StreamState state, Stream stream, string id);
+    private void ConvertCommit(Base commitObject, ISpeckleConverter converter, StreamState state, Stream stream, string id)
+    {
       using (DocumentLock l = Doc.LockDocument())
       {
         using (AcadDb.Transaction tr = Doc.Database.TransactionManager.StartTransaction())
@@ -340,10 +361,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
           tr.Commit();
         }
       }
-
-      return state;
     }
-
     // Recurses through the commit object and flattens it. Returns list of Base objects with their bake layers
     private List<Tuple<Base, string>> FlattenCommitObject(object obj, ISpeckleConverter converter, string layer, StreamState state, ref int count, bool foundConvertibleMember = false)
     {

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -204,8 +204,6 @@ namespace Speckle.ConnectorAutocadCivil.UI
         id = res.id;
       }
 
-      //var commit = state.Commit;
-
       var commitObject = await Operations.Receive(
         referencedObject,
         state.CancellationTokenSource.Token,
@@ -229,8 +227,6 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
       return state;
     }
-
-    // main thread operations
 
     delegate void ConversionDelegate(Base commitObject, ISpeckleConverter converter, StreamState state, Stream stream, string id);
     private void ConvertCommit(Base commitObject, ISpeckleConverter converter, StreamState state, Stream stream, string id)

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -8,6 +8,23 @@ using Speckle.Core.Models;
 
 namespace Objects.Converter.AutocadCivil
 {
+  public static class Utils
+  {
+    public static BlockTableRecord GetModelSpace(this Database db)
+    {
+      return (BlockTableRecord)SymbolUtilityServices.GetBlockModelSpaceId(db).GetObject(OpenMode.ForWrite);
+    }
+    public static ObjectId Append(this BlockTableRecord owner, Entity entity)
+    {
+      if (!entity.IsNewObject)
+        return entity.Id;
+      var tr = owner.Database.TransactionManager.TopTransaction;
+      var id = owner.AppendEntity(entity);
+      tr.AddNewlyCreatedDBObject(entity, true);
+      return id;
+    }
+  }
+
   public partial class ConverterAutocadCivil
   {
     public static string invalidChars = @"<>/\:;""?*|=,‘";
@@ -74,14 +91,6 @@ namespace Objects.Converter.AutocadCivil
       // remove all other invalid chars
       return Regex.Replace(cleanDelimiter, $"[{invalidChars}]", string.Empty);
     }
-
-    /*
-    public static bool Append(this DBObject obj, ObjectId toAppend)
-    {
-      // get model space
-
-    }
-    */
 
     public DisplayStyle GetStyle(DBObject obj)
     {

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -75,6 +75,14 @@ namespace Objects.Converter.AutocadCivil
       return Regex.Replace(cleanDelimiter, $"[{invalidChars}]", string.Empty);
     }
 
+    /*
+    public static bool Append(this DBObject obj, ObjectId toAppend)
+    {
+      // get model space
+
+    }
+    */
+
     public DisplayStyle GetStyle(DBObject obj)
     {
       var style = new DisplayStyle();

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -180,7 +180,6 @@ public static string AutocadAppName = Applications.Autocad2022;
 
         case Mesh o:
           return MeshToNativeDB(o);
-        */
 
         case BlockInstance o:
           return BlockInstanceToNativeDB(o, out BlockReference refernce);

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -170,15 +170,15 @@ public static string AutocadAppName = Applications.Autocad2022;
         /*
         case Surface o: 
           return SurfaceToNative(o);
+        */
 
         case Brep o:
           if (o.displayMesh != null)
             return MeshToNativeDB(o.displayMesh);
           else
             return null;
-        */
 
-        case Mesh o: // unstable, do not use for now
+        case Mesh o:
           return MeshToNativeDB(o);
 
         case BlockInstance o:
@@ -371,7 +371,7 @@ public static string AutocadAppName = Applications.Autocad2022;
         case Polyline _:
         case Polycurve _:
         case Curve _:
-        //case Brep _:
+        case Brep _:
         case Mesh _:
 
         case BlockDefinition _:


### PR DESCRIPTION
## Description

Enables mesh to native conversion due to **running all AutoCAD API calls on the main thread**. Previously this was causing errors with large meshes because it was necessary to add the mesh to modelspace before adding vertices, faces, etc.

Now all calls to API (all conversions) run on the main thread.

Also includes a minor hatch boundary bug found during testing.

- Fixes #680 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sent and received test files between autocad and rhino

## Docs

- Will be updated ASAP

