### PR TITLE
fix(rhino): invalid polycurve due to segment endpoint tolerance

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -354,7 +354,7 @@ namespace SpeckleRhino
 
       if (convertedRH != null)
       {
-        if (convertedRH.IsValid)
+        if (convertedRH.IsValidWithLog(out string log))
         {
           Layer bakeLayer = Doc.GetLayer(layerPath, true);
           if (bakeLayer != null)
@@ -415,7 +415,7 @@ namespace SpeckleRhino
             state.Errors.Add(new Exception($"Could not create layer {layerPath} to bake objects into."));
         }
         else
-          state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}: invalid object props"));
+          state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}: {log}"));
       }
       else if (converted == null)
       {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -268,23 +268,16 @@ namespace Objects.Converter.RhinoGh
       return arc;
     }
 
-    public ArcCurve ArcToNative(Arc a)
+    public ArcCurve ArcToNative(Arc arc)
     {
-      RH.Arc arc = new RH.Arc(PlaneToNative(a.plane), ScaleToNative((double)a.radius, a.units), (double)a.angleRadians);
-      arc.StartAngle = (double)a.startAngle;
-      arc.EndAngle = (double)a.endAngle;
-      if (!arc.IsValid) // try with different method if not valid
-      {
-        arc = new RH.Arc(PointToNative(a.startPoint).Location, PointToNative(a.midPoint).Location, PointToNative(a.endPoint).Location);
-      }
-      var myArc = new ArcCurve(arc);
+      // RH.Arc arc = new RH.Arc(PlaneToNative(a.plane), ScaleToNative((double)a.radius, a.units), (double)a.angleRadians); Not using this constructor due to angle tolerance rounding issues
+      var _arc = new RH.Arc(PointToNative(arc.startPoint).Location, PointToNative(arc.midPoint).Location, PointToNative(arc.endPoint).Location);
 
-      if (a.domain != null)
-      {
-        myArc.Domain = IntervalToNative(a.domain);
-      }
+      var arcCurve = new ArcCurve(_arc);
+      if (arc.domain != null)
+        arcCurve.Domain = IntervalToNative(arc.domain);
 
-      return myArc;
+      return arcCurve;
     }
 
     //Ellipse
@@ -435,12 +428,7 @@ namespace Objects.Converter.RhinoGh
       if (p.domain != null)
         myPolyc.Domain = IntervalToNative(p.domain);
 
-      // try removing tolerance based join issues
-      var simplifiedPoly = (PolyCurve)myPolyc.Simplify(CurveSimplifyOptions.AdjustG1, Doc.ModelAbsoluteTolerance, Doc.ModelAngleToleranceRadians);
-      if (!myPolyc.IsValid)
-        myPolyc = (PolyCurve)myPolyc.Simplify(CurveSimplifyOptions.AdjustG1, Doc.ModelAbsoluteTolerance, Doc.ModelAngleToleranceRadians);
-
-      return simplifiedPoly;
+      return myPolyc;
     }
 
     // Curve

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -420,7 +420,13 @@ namespace Objects.Converter.RhinoGh
         try
         {
           //let the converter pick the best type of curve
-          myPolyc.AppendSegment((RH.Curve)ConvertToNative((Base)segment));
+          var convertedSegment = (RH.Curve)ConvertToNative((Base)segment);
+          var result = myPolyc.AppendSegment(convertedSegment);
+          if (result != true)
+          {
+            var endpoint = myPolyc.PointAtEnd;
+            var convertedEnd = convertedSegment.PointAtEnd;
+          }
         }
         catch
         { }
@@ -429,7 +435,12 @@ namespace Objects.Converter.RhinoGh
       if (p.domain != null)
         myPolyc.Domain = IntervalToNative(p.domain);
 
-      return myPolyc;
+      // try removing tolerance based join issues
+      var simplifiedPoly = (PolyCurve)myPolyc.Simplify(CurveSimplifyOptions.AdjustG1, Doc.ModelAbsoluteTolerance, Doc.ModelAngleToleranceRadians);
+      if (!myPolyc.IsValid)
+        myPolyc = (PolyCurve)myPolyc.Simplify(CurveSimplifyOptions.AdjustG1, Doc.ModelAbsoluteTolerance, Doc.ModelAngleToleranceRadians);
+
+      return simplifiedPoly;
     }
 
     // Curve

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -413,13 +413,7 @@ namespace Objects.Converter.RhinoGh
         try
         {
           //let the converter pick the best type of curve
-          var convertedSegment = (RH.Curve)ConvertToNative((Base)segment);
-          var result = myPolyc.AppendSegment(convertedSegment);
-          if (result != true)
-          {
-            var endpoint = myPolyc.PointAtEnd;
-            var convertedEnd = convertedSegment.PointAtEnd;
-          }
+          var result = myPolyc.AppendSegment((RH.Curve)ConvertToNative((Base)segment));
         }
         catch
         { }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -413,7 +413,7 @@ namespace Objects.Converter.RhinoGh
         try
         {
           //let the converter pick the best type of curve
-          var result = myPolyc.AppendSegment((RH.Curve)ConvertToNative((Base)segment));
+          myPolyc.AppendSegment((RH.Curve)ConvertToNative((Base)segment));
         }
         catch
         { }


### PR DESCRIPTION
## Description

Fixes invalid polycurves when converting to native, due to very small segment endpoint mismatches from arc to native conversions. Figured out that **arcs should be constructed using midpoint, startpoint, and endpoint instead of angles** since model angle tolerance (used for angles) can be different from model space tolerance (used for points).

- Fixes #645 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests

## Docs

- No updates needed


