### PR TITLE
Dynamo/fixes

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
+++ b/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
@@ -76,10 +76,10 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="MaterialDesignColors">
-      <Version>1.2.7</Version>
+      <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="MaterialDesignThemes">
-      <Version>2.6.0</Version>
+      <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/ReceiveUi.xaml
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/ReceiveUi.xaml
@@ -56,7 +56,7 @@
     <md:Badged
       Margin="87,22,10,0"
       Badge="{Binding ExpiredCount}"
-      BadgeColorZoneMode="Accent"
+      BadgeColorZoneMode="SecondaryMid"
       ToolTip="Has new data to send" />
     <ToggleButton
       Grid.Row="1"

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/SendUi.xaml
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/SendUi.xaml
@@ -64,7 +64,7 @@
     <md:Badged
       Margin="87,22,10,0"
       Badge="{Binding ExpiredCount}"
-      BadgeColorZoneMode="Accent"
+      BadgeColorZoneMode="SecondaryMid"
       ToolTip="Has new data to send" />
     <ToggleButton
       Grid.Row="1"

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -117,7 +117,7 @@ namespace Speckle.ConnectorDynamo.Functions
         }
         catch (Exception ex)
         {
-          throw new SpeckleException("Could not convert " + value.GetType() + " to Speckle", ex);
+          throw new SpeckleException("Could not convert " + value.GetType() + " to Speckle:" + ex.Message, ex);
         }
       }
 

--- a/DesktopUI/DesktopUI/DesktopUI.csproj
+++ b/DesktopUI/DesktopUI/DesktopUI.csproj
@@ -225,10 +225,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MaterialDesignColors">
-      <Version>2.0.0</Version>
+      <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="MaterialDesignThemes">
-      <Version>4.0.0</Version>
+      <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.1.31</Version>

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Units.cs
@@ -66,10 +66,16 @@ namespace Objects.Converter.Dynamo
           return Speckle.Core.Kits.Units.Centimeters;
         case DisplayUnitType.DUT_METERS:
           return Speckle.Core.Kits.Units.Meters;
+        case DisplayUnitType.DUT_METERS_CENTIMETERS:
+          return Speckle.Core.Kits.Units.Meters;
         case DisplayUnitType.DUT_DECIMAL_INCHES:
           return Speckle.Core.Kits.Units.Inches;
         case DisplayUnitType.DUT_DECIMAL_FEET:
           return Speckle.Core.Kits.Units.Feet;
+        case DisplayUnitType.DUT_FEET_FRACTIONAL_INCHES:
+          return Speckle.Core.Kits.Units.Feet;
+        case DisplayUnitType.DUT_FRACTIONAL_INCHES:
+          return Speckle.Core.Kits.Units.Inches;
         default:
           throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{type}\" is unsupported.");
       }
@@ -99,10 +105,16 @@ namespace Objects.Converter.Dynamo
         return Speckle.Core.Kits.Units.Centimeters;
       else if (typeId == UnitTypeId.Meters)
         return Speckle.Core.Kits.Units.Meters;
+      else if (typeId == UnitTypeId.MetersCentimeters)
+        return Speckle.Core.Kits.Units.Meters;
       else if (typeId == UnitTypeId.Inches)
         return Speckle.Core.Kits.Units.Inches;
       else if (typeId == UnitTypeId.Feet)
         return Speckle.Core.Kits.Units.Feet;
+      else if (typeId == UnitTypeId.FeetFractionalInches)
+        return Speckle.Core.Kits.Units.Feet;
+      else if (typeId == UnitTypeId.FractionalInches)
+        return Speckle.Core.Kits.Units.Inches;
 
       throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{typeId}\" is unsupported.");
     }


### PR DESCRIPTION
## Description

Fixes an issue potentially linked to Revit<>Dynamo material design version mismatch.
I've aligned the nuget package versions and also added support for fractial inches that was missing!

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests in Revit 2021, soz don't have other versions on thismachine!

## Docs

- No updates needed

