### PR TITLE
Rhino/GH Converter should to use ContextDocument first, then fallback to ActiveDoc

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -459,7 +459,7 @@ namespace Objects.Converter.RhinoGh
     public ICurve CurveToSpeckle(RH.Curve curve, string units = null)
     {
       var u = units ?? ModelUnits;
-      var tolerance = RhinoDoc.ActiveDoc.ModelAbsoluteTolerance;
+      var tolerance = Doc.ModelAbsoluteTolerance;
       Rhino.Geometry.Plane pln = Rhino.Geometry.Plane.Unset;
       curve.TryGetPlane(out pln, tolerance);
       
@@ -754,7 +754,7 @@ namespace Objects.Converter.RhinoGh
     /// <returns></returns>
     public Brep BrepToSpeckle(RH.Brep brep, string units = null)
     {
-      var tol = RhinoDoc.ActiveDoc.ModelAbsoluteTolerance;
+      var tol = Doc.ModelAbsoluteTolerance;
       //tol = 0;
       var u = units ?? ModelUnits;
       brep.Repair(tol); //should maybe use ModelAbsoluteTolerance ?
@@ -892,7 +892,7 @@ namespace Objects.Converter.RhinoGh
     /// <exception cref="Exception">Throws exception if the provenance is not Rhino</exception>
     public RH.Brep BrepToNative(Brep brep)
     {
-      var tol = RhinoDoc.ActiveDoc.ModelAbsoluteTolerance;
+      var tol = Doc.ModelAbsoluteTolerance;
       try
       {
         // TODO: Provenance exception is meaningless now, must change for provenance build checks.

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -62,7 +62,7 @@ namespace Objects.Converter.RhinoGh
 
     public HashSet<Exception> ConversionErrors { get; private set; } = new HashSet<Exception>();
 
-    public RhinoDoc Doc { get; private set; }
+    public RhinoDoc Doc { get; private set; } = Rhino.RhinoDoc.ActiveDoc ?? null;
 
     public List<ApplicationPlaceholderObject> ContextObjects { get; set; } = new List<ApplicationPlaceholderObject>();
 


### PR DESCRIPTION
## Description

- Fixes #745

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual conversions providing a custom RhinoDoc using Converter.SetContextDocument(customDoc);
- [x] Point, Mesh, Polyline, Surface, Brep, Circle, Rectangle (Rhino -> Speckle -> Rhino)

Manual conversions **without** providing a custom RhinoDoc (should fallback to RhinoApp.ActiveDoc);
- [x] Point, Mesh, Polyline, Surface, Brep, Circle, Rectangle (Rhino -> Speckle -> Rhino)

## Docs

- No updates needed

