### PR TITLE
Update ConverterRhinoGh.Other.cs

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -121,7 +121,7 @@ namespace Objects.Converter.RhinoGh
           }
           if (converted == null)
             continue;
-          var layerName = $"{commitInfo}{Layer.PathSeparator}{geo["Layer"] as string}";
+          var layerName = (geo["Layer"] != null) ? $"{commitInfo}{Layer.PathSeparator}{geo["Layer"] as string}" : $"{commitInfo}";
           int index = 1;
           if (layerName != null)
             GetLayer(Doc, layerName, out index, true);


### PR DESCRIPTION
## Description

- fixed issue where certain blocks were not able to be received in Rhino due to not having layer names

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?


- Manual Tests (sketchup to rhino)

## Docs

- No updates needed

