### PR TITLE
bug(rhino): handle block transforms with sketchup conventions

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -256,10 +256,6 @@ namespace SpeckleRhino
 
       // give converter a way to access the base commit layer name
       RhinoDoc.ActiveDoc.Notes += "%%%" + commitLayerName;
-
-      var existingLayer = Doc.Layers.FindName(commitLayerName);
-      if (existingLayer != null)
-        Doc.Layers.Purge(existingLayer.Id, false);
       
       // flatten the commit object to retrieve children objs
       int count = 0;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -110,10 +110,13 @@ namespace Objects.Converter.RhinoGh
           GeometryBase converted = null;
           switch (geo)
           {
-            case BlockInstance _:
-              var instance = (InstanceObject)ConvertToNative(geo);
-              converted = instance.Geometry;
-              Doc.Objects.Delete(instance);
+            case BlockInstance o:
+              var instance = BlockInstanceToNative(o);
+              if (instance != null)
+              {
+                converted = instance.DuplicateGeometry();
+                Doc.Objects.Delete(instance);
+              }
               break;
             default:
               converted = (GeometryBase)ConvertToNative(geo);
@@ -140,6 +143,7 @@ namespace Objects.Converter.RhinoGh
         return null;
 
       var blockDefinition = Doc.InstanceDefinitions[definitionIndex];
+
       return blockDefinition;
     }
 
@@ -173,19 +177,25 @@ namespace Objects.Converter.RhinoGh
       InstanceDefinition definition = BlockDefinitionToNative(instance.blockDefinition);
 
       // get the transform
-      if (instance.transform.Length != 16)
-        return null;
-      Transform transform = new Transform();
-      int count = 0;
-      for (int i = 0; i < 4; i++)
+      // rhino doesn't seem to handle transform matrices where the translation vector last value is a divisor instead of 1, so make sure last value is set to 1
+      Transform transform = Transform.Identity;
+      double[] t = instance.transform;
+      if (t.Length == 16)
       {
-        for (int j = 0; j < 4; j++)
+        int count = 0;
+        for (int i = 0; i < 4; i++)
         {
-          if (j == 3 && i != 3) // scale the delta values for translation transformations
-            transform[i, j] = ScaleToNative(instance.transform[count], instance.units);
-          else
-            transform[i, j] = instance.transform[count];
-          count++;
+          for (int j = 0; j < 4; j++)
+          {
+            if (j == 3) // scale the delta values for translation transformations and set last value (divisor) to 1
+              if (t[15] != 0)
+                transform[i, j] = (i != 3) ? ScaleToNative(t[count] / t[15], instance.units) : 1;
+              else
+                transform[i, j] = (i != 3) ? ScaleToNative(t[count], instance.units) : 1;
+            else
+              transform[i, j] = t[count];
+            count++;
+          }
         }
       }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -199,7 +199,7 @@ namespace Objects.Converter.RhinoGh
     private static Layer MakeLayer(RhinoDoc doc, string name, out int index, Layer parentLayer = null)
     {
       index = -1;
-      Layer newLayer = new Layer() { Color = System.Drawing.Color.AliceBlue, Name = name };
+      Layer newLayer = new Layer() { Color = System.Drawing.Color.White, Name = name };
       if (parentLayer != null)
         newLayer.ParentLayerId = parentLayer.Id;
       int newIndex = doc.Layers.Add(newLayer);

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -36,8 +36,7 @@ namespace Objects.Other
     /// </summary>
     /// <remarks>
     /// the 3x3 sub-matrix determines scaling
-    /// the 4th column's first three values define translation
-    /// the 4th row is an identity row
+    /// the 4th column defines translation, where the last value could be a divisor
     /// </remarks>
     public double[] transform { get; set; }
 

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -32,8 +32,13 @@ namespace Objects.Other
     public Point insertionPoint { get; set; }
 
     /// <summary>
-    /// The 4x4 transform matrix. Row-dominant, should have 16 values.
+    /// The 4x4 transform matrix.
     /// </summary>
+    /// <remarks>
+    /// the 3x3 sub-matrix determines scaling
+    /// the 4th column's first three values define translation
+    /// the 4th row is an identity row
+    /// </remarks>
     public double[] transform { get; set; }
 
     public string units { get; set; }


### PR DESCRIPTION
## Description
-No longer deletes commit layer before receiving commit.
-Discovered that sketchup sends block instance transforms where the translation vector is not necessarily [x,y,z,1]: the last value can be a non-1 divisor value. Rhino is now handling division in ToNative conversions.
-Discovered that sketchup sends block instance transforms where the last row is not necessarily the identity row: it's sometimes [0,0,0,0] instead of [0,0,0,1]. This usually indicates vector transform (not a point transform), **need to figure out why sketchup is sending these**. For now, rhino is changing the last row from [x,y,z,0] to [x,y,z,1] which seems to fix it for now.

**NOTE**
When testing, Sketchup > Rhino and Sketchup > Acad work well.
Sketchup > Acad > Rhino works well.
Sketchup > Rhino > Acad has a few blocks with nested block defs that are not translated correctly. Needs further debugging in acad.

- Fixes #758 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- No updates needed


