### PR TITLE
fix(objects): Fixed arc conversion by passing units to Points.FromList

### DIFF
--- a/Objects/Objects/Geometry/Point.cs
+++ b/Objects/Objects/Geometry/Point.cs
@@ -53,6 +53,6 @@ namespace Objects.Geometry
 
     public List<double> ToList() => new List<double>() { x, y, z };
 
-    public static Point FromList(List<double> list, string units) => new Point(list[0], list[1], list[2]);
+    public static Point FromList(List<double> list, string units) => new Point(list[0], list[1], list[2], units);
   }
 }


### PR DESCRIPTION
## Description

Thx @clairekuang for being my extra pair of 👀  on this one!

- Fixes small issue reported in the forum: https://speckle.community/t/trimmed-surfaces-become-invalid-breps-upon-grasshopper-send-recieve/1804/16

## Type of change

- Bug fix (non-breaking change which fixes an issue)

`Point.FromList` was not properly propagating the units, resulting in scaling issues when it was being used.
Only place it is currently used is in the `Arc.FromList` conversion, and it only affected `Breps` as far as I am aware.

## How has this been tested?

- Manual Tests (please write what did you do?)
   
## Docs

- No updates needed

