### PR TITLE
fix: converts to string on deserialization if needed

### DIFF
--- a/Core/Core/Serialisation/ValueConverter.cs
+++ b/Core/Core/Serialisation/ValueConverter.cs
@@ -27,6 +27,13 @@ namespace Speckle.Core.Serialisation
       bool isList = value is List<object>;
       List<object> valueList = value as List<object>;
 
+      //strings
+      if (type == typeof(string))
+      {
+        convertedValue = Convert.ToString(value);
+        return true;
+      }
+
       #region Enum
       if (type.IsEnum)
       {
@@ -68,7 +75,7 @@ namespace Speckle.Core.Serialisation
           if (valueType == typeof(double)) { convertedValue = (Single)(double)value; return true; }
           if (valueType == typeof(long)) { convertedValue = (Single)(long)value; return true; }
           else return false;
-        #endregion
+          #endregion
       }
 
       // Handle List<?>


### PR DESCRIPTION
## Description

- Fixes a casting error that was thrown when other types were sent instead of strings (eg numbers), this is a safe cast and I think won't hurt?



