### PR TITLE
fix(objects): Brep OnDeserialize properly sets it's circular references

### DIFF
--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -250,12 +250,61 @@ namespace Objects.Geometry
     internal void OnDeserialized(StreamingContext context)
     {
       Surfaces.ForEach(s => s.units = units);
-      Edges.ForEach(e => e.Brep = this);
-      Loops.ForEach(l => l.Brep = this);
-      Trims.ForEach(t => t.Brep = this);
-      Faces.ForEach(f => f.Brep = this);
+      
+      for (var i = 0; i < Edges.Count; i++)
+      {
+        var e = Edges[i];
+        lock (e)
+          if (e.Brep != null)
+          {
+            e = new BrepEdge(this, e.Curve3dIndex, e.TrimIndices, e.StartIndex, e.Curve3dIndex, e.ProxyCurveIsReversed,
+              e.Domain);
+            Edges[i] = e;
+          }
+          else
+            e.Brep = this;
+        
+      }
+      
+      for(var i = 0; i < Loops.Count; i++)
+      {
+        var l = Loops[i];
+        lock(l)
+          if (l.Brep != null)
+          {
+            l = new BrepLoop(this, l.FaceIndex, l.TrimIndices, l.Type);
+            Loops[i] = l;
+          }
+          else
+            l.Brep = this;
+      }
 
-      //TODO: all the data props to the real props
+      for (var i = 0; i < Trims.Count; i++)
+      {
+        var t = Trims[i];
+        lock(t)
+          if (t.Brep != null)
+          {
+            t = new BrepTrim(this, t.EdgeIndex, t.FaceIndex, t.LoopIndex, t.CurveIndex, t.IsoStatus, t.TrimType,
+              t.IsReversed, t.StartIndex, t.EndIndex);
+            Trims[i] = t;
+          }
+          else
+            t.Brep = this;
+      }
+
+      for (var i = 0; i < Faces.Count; i++)
+      {
+        var f = Faces[i];
+        lock(f)
+          if (f.Brep != null)
+          {
+            f = new BrepFace(this, f.SurfaceIndex, f.LoopIndices, f.OuterLoopIndex, f.OrientationReversed);
+            Faces[i] = f;
+          }
+          else
+            f.Brep = this;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

- Fixes #810 

The root of the issue was that in the new deserialiser, any objects with the same `speckle id` will become references to the same object in C#. This caused classes like `BrepLoop` or `BrepEdge` to deserialize with an incorrect Brep reference, as the exact values of these classes can coincide, but they should not be the same reference.

## Type of change

- Bug fix

## How has this been tested?

- Manual Tests: Tested receiving multiple objects of the same geometry in different postions. Can no longer reproduce the error after this fix.

## Docs

- No updates needed

