### PR TITLE
feat(acad/c3d): US Survey unit support

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -542,8 +542,10 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
       var commitObj = new Base();
 
+      /* Deprecated until we decide whether or not commit objs need units. If so, should add UnitsToSpeckle conversion method to connector
       var units = Units.GetUnitsFromString(Doc.Database.Insunits.ToString());
       commitObj["units"] = units;
+      */
 
       var conversionProgressDict = new ConcurrentDictionary<string, int>();
       conversionProgressDict["Conversion"] = 0;

--- a/Core/Core/Kits/Units.cs
+++ b/Core/Core/Kits/Units.cs
@@ -9,11 +9,15 @@ namespace Speckle.Core.Kits
     public const string Centimeters = "cm";
     public const string Meters = "m";
     public const string Kilometers = "km";
-    public const string Inches = "in";
+    public const string Inches = "in"; // smelly ones
     public const string Feet = "ft"; // smelly ones
     public const string Yards = "yd"; // smelly ones
-    public const string Miles = "mi";
+    public const string Miles = "mi"; // smelly ones
     public const string None = "none";
+    // public const string USInches = "us_in"; the smelliest ones, can add later if people scream "USA #1"
+    // public const string USFeet = "us_ft"; the smelliest ones, can add later if people scream "USA #1"
+    // public const string USYards = "us_yd"; the smelliest ones, can add later if people scream "USA #1"
+    // public const string USMiles = "us_mi"; the smelliest ones, can add later if people scream "USA #1"
 
     public static double GetConversionFactor(string from, string to)
     {

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -50,6 +50,7 @@ namespace Objects.Converter.AutocadCivil
       return value * f;
     }
 
+    // Note: Difference between International Foot and US Foot is ~ 0.0000006 as described in: https://www.pobonline.com/articles/98788-us-survey-feet-versus-international-feet
     private string UnitToSpeckle(UnitsValue units)
     {
       switch (units)
@@ -63,12 +64,16 @@ namespace Objects.Converter.AutocadCivil
         case UnitsValue.Kilometers:
           return Units.Kilometers;
         case UnitsValue.Inches:
+        case UnitsValue.USSurveyInch:
           return Units.Inches;
         case UnitsValue.Feet:
+        case UnitsValue.USSurveyFeet:
           return Units.Feet;
         case UnitsValue.Yards:
+        case UnitsValue.USSurveyYard:
           return Units.Yards;
         case UnitsValue.Miles:
+        case UnitsValue.USSurveyMile:
           return Units.Miles;
         default:
           throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{units}\" is unsupported.");


### PR DESCRIPTION
## Description
Adds support for US Survey units: inches, feet, yards, miles
Approximates them to International inches, feet, yards, miles. 
For more info on the difference: https://www.pobonline.com/articles/98788-us-survey-feet-versus-international-feet
lol
- Fixes #827 

Also removes units from the commit obj in the acad/c3d connector - this seems to align with other connectors. Can reinstate if consensus is reached on whether commit objs should have units.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests

## Docs

- No updates needed

