### PR TITLE
GH: Fix confusing behaviour in ExpandSpeckleObject

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
@@ -132,8 +132,8 @@ namespace ConnectorGrasshopper.Objects
 
       if (tokenCount == 0 || !OutputMismatch()) return;
       RecordUndoEvent("Creating Outputs");
+      
       // Check for single param rename, if so, just rename it and go on.
-      var singleRename = HasSingleRename();
       if (HasSingleRename())
       {
         var diffParams = Params.Output.Where(param => !outputList.Contains(param.NickName));

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
@@ -119,13 +119,38 @@ namespace ConnectorGrasshopper.Objects
       outputList.Count != Params.Output.Count
       || outputList.Where((t, i) => Params.Output[i].NickName != t).Any();
 
+    private bool HasSingleRename()
+    {
+      var equalLength = outputList.Count == Params.Output.Count;
+      if (!equalLength) return false;
+      var diffParams = Params.Output.Where(param => !outputList.Contains(param.NickName));
+      return diffParams.Count() == 1;
+    }
     private void AutoCreateOutputs()
     {
       var tokenCount = outputList?.Count ?? 0;
 
       if (tokenCount == 0 || !OutputMismatch()) return;
       RecordUndoEvent("Creating Outputs");
+      // Check for single param rename, if so, just rename it and go on.
+      var singleRename = HasSingleRename();
+      if (HasSingleRename())
+      {
+        var diffParams = Params.Output.Where(param => !outputList.Contains(param.NickName));
+        var diffOut = outputList
+          .Where(name => 
+            !Params.Output.Select(p => p.NickName)
+              .Contains(name));
+      
+        var newName = diffOut.First();
+        var renameParam = diffParams.First();
+      
+        renameParam.NickName = newName;
+        renameParam.Name = newName;
+        renameParam.Description = $"Data from property: {newName}";
 
+        return;
+      }
       // Check what params must be deleted, and do so when safe.
       var remove = Params.Output.Select((p, i) =>
       {


### PR DESCRIPTION
## Description

- Fixes #629 

`ExpandSpeckleObject` node now detects if there has been a single parameter rename. If so, we'll skip the entire process of generating outputs and just rename the corresponding parameter.

I also skipped sorting to prevent the outputs from reorganising while a user is renaming. They would be re-sorted on the next solution regardless.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

Same tests as in the original issue:

- Rename a single input
- Change object to expand to a completely different one (no shared inputs) should preserve empty connections.

## Docs

- No updates needed

