### PR TITLE
fix(rhino): dui2 issues and rhino bim extrusions

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -476,64 +476,65 @@ namespace SpeckleRhino
       foreach (var applicationId in state.SelectedObjectIds)
       {
         if (state.CancellationTokenSource.Token.IsCancellationRequested)
-        {
           return null;
-        }
 
         Base converted = null;
         string containerName = string.Empty;
 
-        try
+        // applicationId can either be doc obj guid or name of view
+        RhinoObject obj = null;
+        int viewIndex = -1;
+        try 
         {
-          RhinoObject obj = Doc.Objects.FindId(new Guid(applicationId)); // try get geom object
-          if (obj != null)
-          {
-            if (!converter.CanConvertToSpeckle(obj))
-            {
-              state.Errors.Add(new Exception($"Objects of type ${obj.Geometry.ObjectType} are not supported"));
-              continue;
-            }
-            converted = converter.ConvertToSpeckle(obj);
-            if (converted == null)
-            {
-              state.Errors.Add(new Exception($"Failed to convert object ${applicationId} of type ${obj.Geometry.ObjectType}."));
-              continue;
-            }
-
-            foreach (var key in obj.Attributes.GetUserStrings().AllKeys)
-              converted[key] = obj.Attributes.GetUserString(key);
-
-            if (obj is InstanceObject)
-              containerName = "Blocks";
-            else
-            {
-              var layerPath = Doc.Layers[obj.Attributes.LayerIndex].FullPath;
-              string cleanLayerPath = RemoveInvalidDynamicPropChars(layerPath);
-              containerName = cleanLayerPath;
-              if (!cleanLayerPath.Equals(layerPath))
-                renamedlayers = true;
-            }
-          }
+          obj = Doc.Objects.FindId(new Guid(applicationId)); // try get geom object
         }
-        catch
+        catch 
         {
-          int viewIndex = Doc.NamedViews.FindByName(applicationId); // try get view
-          ViewInfo view = (viewIndex >= 0) ? Doc.NamedViews[viewIndex] : null;
-          if (view != null)
+          viewIndex = Doc.NamedViews.FindByName(applicationId); // try get view
+        }
+        if (obj != null)
+        {
+          if (!converter.CanConvertToSpeckle(obj))
           {
-            converted = converter.ConvertToSpeckle(view);
-          }
-          else
-          {
-            state.Errors.Add(new Exception($"Failed to find doc object ${applicationId}."));
+            state.Errors.Add(new Exception($"Objects of type ${obj.Geometry.ObjectType} are not supported"));
             continue;
           }
+          converted = converter.ConvertToSpeckle(obj);
+          if (converted == null)
+          {
+            state.Errors.Add(new Exception($"Failed to convert object ${applicationId} of type ${obj.Geometry.ObjectType}."));
+            continue;
+          }
+
+          foreach (var key in obj.Attributes.GetUserStrings().AllKeys)
+            converted[key] = obj.Attributes.GetUserString(key);
+
+          if (obj is InstanceObject)
+            containerName = "Blocks";
+          else
+          {
+            var layerPath = Doc.Layers[obj.Attributes.LayerIndex].FullPath;
+            string cleanLayerPath = RemoveInvalidDynamicPropChars(layerPath);
+            containerName = cleanLayerPath;
+            if (!cleanLayerPath.Equals(layerPath))
+              renamedlayers = true;
+          }
+        }
+        else if (viewIndex != -1)
+        {
+          ViewInfo view = Doc.NamedViews[viewIndex];
+          converted = converter.ConvertToSpeckle(view);
           if (converted == null)
           {
             state.Errors.Add(new Exception($"Failed to convert object ${applicationId} of type ${view.GetType()}."));
             continue;
           }
           containerName = "Named Views";
+        }
+        else
+        {
+          state.Errors.Add(new Exception($"Failed to find doc object ${applicationId}."));
+          continue;
         }
 
         if (commitObj[$"@{containerName}"] == null)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -951,29 +951,7 @@ namespace Objects.Converter.RhinoGh
       }
     }
 
-    // Extrusions
-    // TODO: Research into how to properly create and recreate extrusions. Current way we compromise by transforming them into breps.
-    public Brep BrepToSpeckle(Rhino.Geometry.Extrusion extrusion, string units = null)
-    {
-      return BrepToSpeckle(extrusion.ToBrep(), units ?? ModelUnits);
-
-      //var myExtrusion = new SpeckleExtrusion( SpeckleCore.Converter.Serialise( extrusion.Profile3d( 0, 0 ) ), extrusion.PathStart.DistanceTo( extrusion.PathEnd ), extrusion.IsCappedAtBottom );
-
-      //myExtrusion.PathStart = extrusion.PathStart.ToSpeckle();
-      //myExtrusion.PathEnd = extrusion.PathEnd.ToSpeckle();
-      //myExtrusion.PathTangent = extrusion.PathTangent.ToSpeckle();
-
-      //var Profiles = new List<SpeckleObject>();
-      //for ( int i = 0; i < extrusion.ProfileCount; i++ )
-      //  Profiles.Add( SpeckleCore.Converter.Serialise( extrusion.Profile3d( i, 0 ) ) );
-
-      //myExtrusion.Profiles = Profiles;
-      //myExtrusion.Properties = extrusion.UserDictionary.ToSpeckle( root: extrusion );
-      //myExtrusion.GenerateHash();
-      //return myExtrusion;
-    }
-
-    // TODO: See above. We're no longer creating new extrusions. This is here just for backwards compatibility.
+    // TODO: We're no longer creating new extrusions - they are converted as brep. This is here just for backwards compatibility.
     public RH.Extrusion ExtrusionToNative(Extrusion extrusion)
     {
       RH.Curve outerProfile = CurveToNative((Curve)extrusion.profile);


### PR DESCRIPTION
## Description

As part of 2.2.4 beta release testing for Rhino:

- adds DUI2 button to rhino speckle toolbar
- fixes DUI2 crashing rhino when sending named views via filter
- refactored connector sending for old and new UI bindings for better error handling
- added extrusion rhino BIM handling to main converter logic

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: sent and received standard and rhino bim test files

## Docs

- No updates needed

