### PR TITLE
fix(revit): pass adaptive component test

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
@@ -15,7 +15,7 @@ namespace Objects.Converter.Revit
     {
       var docObj = GetExistingElementByApplicationId(speckleAc.applicationId);
 
-      string familyName = speckleAc["family"] as string != null ? speckleAc["family"] as string : "";
+      string familyName = speckleAc["type"] as string != null ? speckleAc["type"] as string : "";
       DB.FamilySymbol familySymbol = GetElementType<DB.FamilySymbol>(speckleAc);
       if (familySymbol.FamilyName != familyName)
       {
@@ -73,7 +73,7 @@ namespace Objects.Converter.Revit
     private AdaptiveComponent AdaptiveComponentToSpeckle(DB.FamilyInstance revitAc)
     {
       var speckleAc = new AdaptiveComponent();
-      speckleAc.family = Doc.GetElement(revitAc.GetTypeId()).Name;
+      speckleAc.type = Doc.GetElement(revitAc.GetTypeId()).Name;
       speckleAc.basePoints = GetAdaptivePoints(revitAc);
       speckleAc.flipped = AdaptiveComponentInstanceUtils.IsInstanceFlipped(revitAc);
       speckleAc.displayMesh = GetElementMesh(revitAc);


### PR DESCRIPTION
tests look for `type` not `family` so need to set that instead
in order to pass

## Description

- continues to fix the adaptive component issue that came up in testing

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- unit and manual tests

## Docs

- No updates needed


