### PR TITLE
Gh/Dyn: `null` value alignment

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -239,16 +239,14 @@ namespace Speckle.ConnectorDynamo.SendNode
       {
         if (_transports == null)
           throw new SpeckleException("The stream provided is invalid");
-        if (_data == null)
-          throw new SpeckleException("The data provided is invalid");
-
+        
         long totalCount = 0;
         Base @base = null;
         var converter = new BatchConverter();
         try
         {
           @base = converter.ConvertRecursivelyToSpeckle(_data);
-          totalCount = @base.GetTotalChildrenCount();
+          totalCount = @base?.GetTotalChildrenCount() ?? 0;
         }
         catch (Exception e)
         {

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -45,6 +45,8 @@ namespace Speckle.ConnectorDynamo.Functions
         throw new SpeckleException("Invalid input");
 
       var converted = RecurseTreeToSpeckle(@object);
+
+      if (converted is null) return null;
       var @base = new Base();
 
       //case 1: lists and basic types => add them to a wrapper Base object in a `data` prop
@@ -122,7 +124,7 @@ namespace Speckle.ConnectorDynamo.Functions
       }
 
 
-      if (value is Base || value.GetType().IsSimpleType())
+      if (value is Base || value is null || value.GetType().IsSimpleType())
       {
         return value;
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -193,8 +193,11 @@ namespace ConnectorGrasshopper.Extras
         // TODO: Handle dicts!!
         var value = keyval.Value;
         if (value == null)
+        {
           // TODO: Handle null values in properties here. For now, we just ignore that prop in the object
+          copy[keyval.Key] = null;
           return;
+        }
         if (value is IList list)
         {
           var converted = new List<object>();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -291,8 +291,8 @@ namespace ConnectorGrasshopper.Extras
     /// <returns>An <see cref="IGH_Goo"/> instance holding the converted object. </returns>
     public static object TryConvertItemToSpeckle(object value, ISpeckleConverter converter, bool recursive = false,  Action OnConversionProgress = null)
     {
-      if (value is null) throw new Exception("Null values are not allowed, please clean your data tree.");
-      
+      //if (value is null) throw new Exception("Null values are not allowed, please clean your data tree.");
+      if (value is null) return value;
       if (value is IGH_Goo)
       {
         value = value.GetType().GetProperty("Value").GetValue(value);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -291,7 +291,6 @@ namespace ConnectorGrasshopper.Extras
     /// <returns>An <see cref="IGH_Goo"/> instance holding the converted object. </returns>
     public static object TryConvertItemToSpeckle(object value, ISpeckleConverter converter, bool recursive = false,  Action OnConversionProgress = null)
     {
-      //if (value is null) throw new Exception("Null values are not allowed, please clean your data tree.");
       if (value is null) return value;
       if (value is IGH_Goo)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
@@ -85,13 +85,6 @@ namespace ConnectorGrasshopper.Objects
                 }
               }
 
-              if (values.Any(p => p == null))
-              {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-                  $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree.");
-                hasErrors = true;
-              }
-
               inputData[key] = values;
               break;
             case GH_ParamAccess.tree:

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectAsync.cs
@@ -272,13 +272,6 @@ namespace ConnectorGrasshopper.Objects
               }
             }
 
-            // if (values.Any(p => p == null))
-            // {
-            //   RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,
-            //     $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree."));
-            //   hasErrors = true;
-            // }
-
             inputData[key] = values;
             break;
           case GH_ParamAccess.tree:

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectAsync.cs
@@ -272,12 +272,12 @@ namespace ConnectorGrasshopper.Objects
               }
             }
 
-            if (values.Any(p => p == null))
-            {
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,
-                $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree."));
-              hasErrors = true;
-            }
+            // if (values.Any(p => p == null))
+            // {
+            //   RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,
+            //     $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree."));
+            //   hasErrors = true;
+            // }
 
             inputData[key] = values;
             break;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectAsync.cs
@@ -278,12 +278,12 @@ namespace ConnectorGrasshopper.Objects
               }
             }
 
-            if (values.Any(p => p == null))
-            {
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,
-                $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree."));
-              hasErrors = true;
-            }
+            // if (values.Any(p => p == null))
+            // {
+            //   RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,
+            //     $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree."));
+            //   hasErrors = true;
+            // }
 
             inputData[key] = values;
             break;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectAsync.cs
@@ -278,13 +278,6 @@ namespace ConnectorGrasshopper.Objects
               }
             }
 
-            // if (values.Any(p => p == null))
-            // {
-            //   RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning,
-            //     $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree."));
-            //   hasErrors = true;
-            // }
-
             inputData[key] = values;
             break;
           case GH_ParamAccess.tree:

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
@@ -215,9 +215,9 @@ namespace ConnectorGrasshopper.Objects
         var b = (ghGoo as GH_SpeckleBase).Value;
         b?.GetMemberNames().ToList().ForEach(prop =>
         {
-          if (!fullProps.Contains(prop) && b[prop] != null)
+          if (!fullProps.Contains(prop))
             fullProps.Add(prop);
-          else if (fullProps.Contains(prop) && b[prop] == null)
+          else if (fullProps.Contains(prop))
             fullProps.Remove(prop);
         });
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
@@ -104,13 +104,6 @@ namespace ConnectorGrasshopper.Objects
                 }
               }
 
-              // if (values.Any(p => p == null))
-              // {
-              //   AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-              //     $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree.");
-              //   hasErrors = true;
-              // }
-
               inputData[key] = values;
               break;
             case GH_ParamAccess.tree:

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
@@ -104,12 +104,12 @@ namespace ConnectorGrasshopper.Objects
                 }
               }
 
-              if (values.Any(p => p == null))
-              {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-                  $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree.");
-                hasErrors = true;
-              }
+              // if (values.Any(p => p == null))
+              // {
+              //   AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
+              //     $"List access parameter {param.NickName} cannot contain null values. Please clean your data tree.");
+              //   hasErrors = true;
+              // }
 
               inputData[key] = values;
               break;


### PR DESCRIPTION
## Description

- Fixes #491 🥳  

Null values are now allowed everywhere in GH and Dyn.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests (please write what did you do?)

Tested sending nulls along with other objects to/from Grasshopper/Dynamo in all directions. Null values got properly serialised and deserialised on each program.

Also ensured that receiving in DUI connectors like Rhino/Revit did not break anything.

## Docs

- No updates needed as there is no reference of this anywhere in the docs.

