### PR TITLE
fix(objects): deprecates insertion point from block instance class

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -146,7 +146,6 @@ namespace Objects.Converter.AutocadCivil
 
       var instance = new BlockInstance()
       {
-        insertionPoint = PointToSpeckle(reference.Position),
         transform = reference.BlockTransform.ToArray(),
         blockDefinition = definition,
         units = ModelUnits
@@ -169,7 +168,7 @@ namespace Objects.Converter.AutocadCivil
         return result;
 
       // insertion pt
-      Point3d insertionPoint = PointToNative(instance.insertionPoint);
+      Point3d insertionPoint = PointToNative(instance.GetInsertionPoint());
 
       // transform
       double[] transform = instance.transform;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -162,7 +162,6 @@ namespace Objects.Converter.RhinoGh
 
       var _instance = new BlockInstance()
       {
-        insertionPoint = PointToSpeckle(instance.InsertionPoint),
         transform = transformArray,
         blockDefinition = def,
         units = ModelUnits

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -31,7 +31,7 @@ namespace Objects.Other
   public class BlockInstance : Base
   {
     [Obsolete("Use GetInsertionPoint method")]
-    public Point insertionPoint { get; set; }
+    public Point insertionPoint { get => GetInsertionPoint(); set { } }
 
     /// <summary>
     /// The 4x4 transform matrix.
@@ -50,12 +50,12 @@ namespace Objects.Other
     public BlockInstance() { }
 
     /// <summary>
-    /// Retrieves Instance insertion point by applying <paramref name="transform"/> to <paramref name="blockDefinition"/> base point
+    /// Retrieves Instance insertion point by applying <see cref="transform"/> to <see cref="BlockDefinition.basePoint"/>
     /// </summary>
     /// <returns>Insertion point as a <see cref="Point"/></returns>
     public Point GetInsertionPoint()
     {
-      blockDefinition.basePoint.Deconstruct(out double x, out double y, out double z, out string units);
+      var (x, y, z, u) = blockDefinition.basePoint;
       var insertion = new double[] { x, y, z, 1 };
 
       if (transform.Length != 16)
@@ -69,7 +69,7 @@ namespace Objects.Other
         insertion[0] / insertion[3], 
         insertion[1] / insertion[3], 
         insertion[2] / insertion[3], 
-        units);
+        u);
     }
   }
 }


### PR DESCRIPTION
## Description
Deprecates the `insertionPoint` class prop by:
- adding an obsolete flag on the prop
- adding a `GetInsertionPoint()` convenience method
- using the convenience method as the obsolete prop getter
- removing prop assignment in Acad and Rhino converters
- removing prop in Acad ToNative conversion

part of #746 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: blocks to and from autocad

## Docs

- No updates needed


