### PR TITLE
fix(acad/rhino): better hatch handling

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil2.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil2.cs
@@ -493,8 +493,6 @@ namespace Speckle.ConnectorAutocadCivil.UI
     {
       var kit = KitManager.GetDefaultKit();
       var converter = kit.LoadConverter(Utils.AutocadAppName);
-      converter.SetContextDocument(Doc);
-
       var streamId = state.StreamId;
       var client = state.Client;
 
@@ -531,6 +529,9 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
       using (Transaction tr = Doc.Database.TransactionManager.StartTransaction())
       {
+        // set the context doc for conversion - this is set inside the transaction loop because the converter retrieves this transaction for all db editing when the context doc is set!
+        converter.SetContextDocument(Doc);
+
         foreach (var autocadObjectHandle in state.SelectedObjectIds)
         {
           if (progress.CancellationTokenSource.Token.IsCancellationRequested)

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -372,77 +372,88 @@ namespace SpeckleRhino
     // conversion and bake
     private void BakeObject(Base obj, string layerPath, StreamState state, ISpeckleConverter converter)
     {
-      var converted = converter.ConvertToNative(obj);
-      var convertedRH = converted as Rhino.Geometry.GeometryBase;
-
-      if (convertedRH != null)
+      var converted = converter.ConvertToNative(obj); // this may be an array, eg hatches
+      if (converted == null)
       {
-        if (convertedRH.IsValidWithLog(out string log))
+        state.Errors.Add(new Exception($"Failed to convert object {obj.id} of type {obj.speckle_type}."));
+        return;
+      }
+
+      var convertedList = new List<object>();
+      if (converted.GetType().IsArray)
+        foreach (object o in (Array)converted)
+          convertedList.Add(o);
+      else
+        convertedList.Add(converted);
+
+      foreach (var convertedItem in convertedList)
+      {
+        var convertedRH = convertedItem as Rhino.Geometry.GeometryBase;
+        if (convertedRH != null)
         {
-          Layer bakeLayer = Doc.GetLayer(layerPath, true);
-          if (bakeLayer != null)
+          if (convertedRH.IsValidWithLog(out string log))
           {
-            var attributes = new ObjectAttributes { LayerIndex = bakeLayer.Index };
-
-            // handle display
-            Base display = obj[@"displayStyle"] as Base;
-            if (display != null)
+            Layer bakeLayer = Doc.GetLayer(layerPath, true);
+            if (bakeLayer != null)
             {
-              var color = display["color"] as int?;
-              var lineStyle = display["linetype"] as string;
-              var lineWidth = display["lineweight"] as double?;
+              var attributes = new ObjectAttributes { LayerIndex = bakeLayer.Index };
 
-              if (color != null)
+              // handle display
+              Base display = obj[@"displayStyle"] as Base;
+              if (display != null)
               {
-                attributes.ColorSource = ObjectColorSource.ColorFromObject;
-                attributes.ObjectColor = System.Drawing.Color.FromArgb((int)color);
-              }
-              if (lineWidth != null)
-                attributes.PlotWeight = (double)lineWidth;
-              if (lineStyle != null)
-              {
-                var ls = Doc.Linetypes.FindName(lineStyle);
-                if (ls != null)
-                {
-                  attributes.LinetypeSource = ObjectLinetypeSource.LinetypeFromObject;
-                  attributes.LinetypeIndex = ls.Index;
-                }
-              }
-            }
-            /* Not implemented since revit displaymesh objs do not have render materials attached
-            else
-            {
-              Base render = obj[@"renderMaterial"] as Base;
-              if (render != null)
-              {
-                var color = render["diffuse"] as int?;
+                var color = display["color"] as int?;
+                var lineStyle = display["linetype"] as string;
+                var lineWidth = display["lineweight"] as double?;
 
                 if (color != null)
                 {
                   attributes.ColorSource = ObjectColorSource.ColorFromObject;
                   attributes.ObjectColor = System.Drawing.Color.FromArgb((int)color);
                 }
+                if (lineWidth != null)
+                  attributes.PlotWeight = (double)lineWidth;
+                if (lineStyle != null)
+                {
+                  var ls = Doc.Linetypes.FindName(lineStyle);
+                  if (ls != null)
+                  {
+                    attributes.LinetypeSource = ObjectLinetypeSource.LinetypeFromObject;
+                    attributes.LinetypeIndex = ls.Index;
+                  }
+                }
               }
+              /* Not implemented since revit displaymesh objs do not have render materials attached
+              else
+              {
+                Base render = obj[@"renderMaterial"] as Base;
+                if (render != null)
+                {
+                  var color = render["diffuse"] as int?;
+
+                  if (color != null)
+                  {
+                    attributes.ColorSource = ObjectColorSource.ColorFromObject;
+                    attributes.ObjectColor = System.Drawing.Color.FromArgb((int)color);
+                  }
+                }
+              }
+              */
+
+              // handle schema
+              string schema = obj["SpeckleSchema"] as string;
+              if (schema != null)
+                attributes.SetUserString("SpeckleSchema", schema);
+
+              if (Doc.Objects.Add(convertedRH, attributes) == Guid.Empty)
+                state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}."));
             }
-            */
-
-            // handle schema
-            string schema = obj["SpeckleSchema"] as string;
-            if (schema != null)
-              attributes.SetUserString("SpeckleSchema", schema);
-
-            if (Doc.Objects.Add(convertedRH, attributes) == Guid.Empty)
-              state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}."));
+            else
+              state.Errors.Add(new Exception($"Could not create layer {layerPath} to bake objects into."));
           }
           else
-            state.Errors.Add(new Exception($"Could not create layer {layerPath} to bake objects into."));
+            state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}: {log.Replace("\n", "").Replace("\r", "")}"));
         }
-        else
-          state.Errors.Add(new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}: {log.Replace("\n", "").Replace("\r", "")}"));
-      }
-      else if (converted == null)
-      {
-        state.Errors.Add(new Exception($"Failed to convert object {obj.id} of type {obj.speckle_type}."));
       }
     }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -695,6 +695,21 @@ namespace Objects.Converter.AutocadCivil
           return NurbsToSpeckle(curve as NurbCurve3d);
       }
     }
+    public ICurve CurveToSpeckle(Curve2d curve, string units = null)
+    {
+      var u = units ?? ModelUnits;
+
+      // note: some curve2ds may not have endpoints!
+      switch (curve)
+      {
+        case LineSegment2d line:
+          return LineToSpeckle(line);
+        case CircularArc2d arc:
+          return ArcToSpeckle(arc);
+        default:
+          return NurbsToSpeckle(curve as NurbCurve2d);
+      }
+    }
     public Curve NurbsToSpeckle(NurbCurve2d curve)
     {
       var _curve = new Curve();

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -32,10 +32,11 @@ namespace Objects.Converter.AutocadCivil
       for (int i = 0; i < hatch.NumberOfLoops; i++)
       {
         var loop = hatch.GetLoopAt(i);
+        loop.LoopType == HatchLoopTypes.
         if (loop.IsPolyline)
         {
           var poly = GetPolylineFromBulgeVertexCollection(loop.Polyline);
-          var converted = (poly.IsOnlyLines) ? PolylineToSpeckle(poly) : PolycurveToSpeckle(poly);
+          var converted = poly.IsOnlyLines ? PolylineToSpeckle(poly) : PolycurveToSpeckle(poly);
           curves.Add(converted);
         }
         else
@@ -47,6 +48,7 @@ namespace Objects.Converter.AutocadCivil
         }
       }
       _hatch.curves = curves;
+      _hatch["style"] = hatch.HatchStyle.ToString();
 
       return _hatch;
     }
@@ -98,6 +100,9 @@ namespace Objects.Converter.AutocadCivil
       _hatch.PatternScale = hatch.scale;
       _hatch.AppendLoop(HatchLoopTypes.Default, curveIds);
       _hatch.EvaluateHatch(true);
+      var style = hatch["style"] as string;
+      if (style != null)
+        _hatch.HatchStyle = Enum.TryParse(style, out HatchStyle hatchStyle) ? hatchStyle : HatchStyle.Normal;
 
       // delete created hatch curves
       foreach (DBObject curve in curves)
@@ -115,6 +120,7 @@ namespace Objects.Converter.AutocadCivil
         polyline.AddVertexAt(i, bulgeVertex.Vertex, bulgeVertex.Bulge, 1.0, 1.0);
         totalBulge += bulgeVertex.Bulge;
       }
+      polyline.Closed = bulges[0].Vertex.IsEqualTo(bulges[bulges.Count - 1].Vertex) ? true : false;
       return polyline;
     }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using BlockDefinition = Objects.Other.BlockDefinition;
 using BlockInstance = Objects.Other.BlockInstance;
 using Hatch = Objects.Other.Hatch;
+using HatchLoop = Objects.Other.HatchLoop;
 using Polyline = Objects.Geometry.Polyline;
 using Text = Objects.Other.Text;
 using RH = Rhino.DocObjects;
@@ -22,9 +23,11 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
-    public Rhino.Geometry.Hatch HatchToNative(Hatch hatch)
+    public Rhino.Geometry.Hatch[] HatchToNative(Hatch hatch)
     {
-      var curves = hatch.curves.Select(o => CurveToNative(o));
+
+      var curves = new List<Rhino.Geometry.Curve>();
+      curves = (hatch.loops != null) ? hatch.loops.Select(o => CurveToNative(o.Curve)).ToList() : hatch.curves.Select(o => CurveToNative(o)).ToList();
       var pattern = Doc.HatchPatterns.FindName(hatch.pattern);
       int index;
       if (pattern == null)
@@ -36,15 +39,21 @@ namespace Objects.Converter.RhinoGh
       else
         index = pattern.Index;
       var hatches = Rhino.Geometry.Hatch.Create(curves, index, hatch.rotation, hatch.scale, 0.001);
-      return hatches.FirstOrDefault();
+
+      return hatches;
     }
     public Hatch HatchToSpeckle(Rhino.Geometry.Hatch hatch)
     {
       var _hatch = new Hatch();
 
-      var curves = hatch.Get3dCurves(true).ToList();
-      curves.AddRange(hatch.Get3dCurves(false));
-      _hatch.curves = curves.Select(o => CurveToSpeckle(o)).ToList();
+      // retrieve hatch loops
+      var loops = new List<HatchLoop>();
+      foreach (var outer in hatch.Get3dCurves(true).ToList())
+        loops.Add(new HatchLoop(CurveToSpeckle(outer), Other.HatchLoopType.Outer));
+      foreach (var inner in hatch.Get3dCurves(false).ToList())
+        loops.Add(new HatchLoop(CurveToSpeckle(inner), Other.HatchLoopType.Inner));
+
+      _hatch.loops = loops;
       _hatch.scale = hatch.PatternScale;
       _hatch.pattern = Doc.HatchPatterns.ElementAt(hatch.PatternIndex).Name;
       _hatch.rotation = hatch.PatternRotation;
@@ -107,22 +116,27 @@ namespace Objects.Converter.RhinoGh
       {
         if (CanConvertToNative(geo))
         {
-          GeometryBase converted = null;
+          List<GeometryBase> converted = new List<GeometryBase>();
           switch (geo)
           {
             case BlockInstance o:
               var instance = BlockInstanceToNative(o);
               if (instance != null)
               {
-                converted = instance.DuplicateGeometry();
+                converted.Add(instance.DuplicateGeometry());
                 Doc.Objects.Delete(instance);
               }
               break;
             default:
-              converted = (GeometryBase)ConvertToNative(geo);
+              var convertedObj = ConvertToNative(geo);
+              if (convertedObj.GetType().IsArray)
+                foreach (object o in (Array)convertedObj)
+                  converted.Add((GeometryBase)o);
+              else
+                converted.Add((GeometryBase)convertedObj);
               break;
           }
-          if (converted == null)
+          if (converted.Count == 0)
             continue;
           var layerName = (geo["Layer"] != null) ? $"{commitInfo}{Layer.PathSeparator}{geo["Layer"] as string}" : $"{commitInfo}";
           int index = 1;
@@ -132,7 +146,7 @@ namespace Objects.Converter.RhinoGh
           {
             LayerIndex = index
           };
-          geometry.Add(converted);
+          geometry.AddRange(converted);
           attributes.Add(attribute);
         }
       }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -36,7 +36,7 @@ namespace Objects.Converter.RhinoGh
       else
         index = pattern.Index;
       var hatches = Rhino.Geometry.Hatch.Create(curves, index, hatch.rotation, hatch.scale, 0.001);
-      return hatches.First();
+      return hatches.FirstOrDefault();
     }
     public Hatch HatchToSpeckle(Rhino.Geometry.Hatch hatch)
     {

--- a/Objects/Objects/Other/Hatch.cs
+++ b/Objects/Objects/Other/Hatch.cs
@@ -9,13 +9,10 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.Other
 {
-  /// <summary>
-  /// Hatch class for Rhino and AutoCAD
-  /// </summary>
   public class Hatch : Base
   {
     [Obsolete ("Use Loops instead")]
-    public List<ICurve> curves { get => loops.Select(o => o.Curve).ToList(); set { } }
+    public List<ICurve> curves { get; set; }
     public List<HatchLoop> loops { get; set; }
     public string pattern { get; set; }
     public double scale { get; set; } = 1;

--- a/Objects/Objects/Other/Hatch.cs
+++ b/Objects/Objects/Other/Hatch.cs
@@ -1,9 +1,11 @@
 ﻿using Speckle.Core.Models;
 using Speckle.Core.Kits;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.Other
 {
@@ -12,11 +14,42 @@ namespace Objects.Other
   /// </summary>
   public class Hatch : Base
   {
-    public List<ICurve> curves { get; set; }
+    [Obsolete ("Use Loops instead")]
+    public List<ICurve> curves { get => loops.Select(o => o.Curve).ToList(); set { } }
+    public List<HatchLoop> loops { get; set; }
     public string pattern { get; set; }
     public double scale { get; set; } = 1;
     public double rotation { get; set; } = 0; // relative angle
 
     public Hatch() { }
+  }
+
+  /// <summary>
+  /// Represents a Hatch Loop from a <see cref="Hatch"/>'s curve.
+  /// </summary>
+  public class HatchLoop : Base
+  {
+    public ICurve Curve { get; set; }
+    public HatchLoopType Type { get; set; }
+
+    public HatchLoop()
+    {
+    }
+
+    public HatchLoop(ICurve curve, HatchLoopType type)
+    {
+      Curve = curve;
+      Type = type;
+    }
+  }
+
+  /// <summary>
+  /// Represents the type of a loop in a <see cref="Hatch"/>'s curves.
+  /// </summary>
+  public enum HatchLoopType
+  {
+    Unknown,
+    Outer,
+    Inner
   }
 }


### PR DESCRIPTION
## Description

- Adds `HatchLoop` class and 'HatchLoopType` enum to Objects. Makes `Hatch.curves` obsolete: shouldn't be a breaking change, but code in rhino and autocad converters should be updated after a few releases to no longer handle old hatches that only have the curves prop and no loops prop.
- Rhino now returns `Hatch[ ]` in `HatchToNative( )` conversion to handle autocad hatchs with multiple external curves

Part of #746

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests : sent and received standard test file between acad and rhino, sent and received some blocks with hatches in acad and rhino

## Docs

- No updates needed

