### PR TITLE
fix(revit): receiving blocks

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -18,13 +18,14 @@ namespace Objects.Converter.Revit
     // Creates a generic model instance in a project or family doc
     public Group BlockInstanceToNative(BlockInstance instance)
     {
-
-      string result = null;
-
       // Base point
-      var basePoint = PointToNative(instance.GetInsertionPoint());
+      var basePoint = PointToNative(Point.FromList(new [] {
+        instance.transform[ 3 ]/ instance.transform[ 15 ],
+        instance.transform[ 7 ] / instance.transform[ 15 ],
+        instance.transform[ 11 ] / instance.transform[ 15 ]
+      }, instance.units));
 
-      // Get or make family from block definition
+      // Get or make group from block definition
       GroupType block_def = new FilteredElementCollector(Doc)
         .OfClass(typeof(GroupType))
         .OfType<GroupType>()

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -1,74 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Numerics;
 using Autodesk.Revit.DB;
-using ConverterRevitShared.Revit;
 using Objects.Geometry;
 using Speckle.Core.Logging;
-using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
-using DirectShape = Objects.BuiltElements.Revit.DirectShape;
 using Mesh = Objects.Geometry.Mesh;
-using Parameter = Objects.BuiltElements.Revit.Parameter;
 using BlockInstance = Objects.Other.BlockInstance;
 using BlockDefinition = Objects.Other.BlockDefinition;
+using Point = Objects.Geometry.Point;
 
 namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
     // Creates a generic model instance in a project or family doc
-    public string BlockInstanceToNative(BlockInstance instance, Document familyDoc = null)
+    public Group BlockInstanceToNative(BlockInstance instance)
     {
 
       string result = null;
 
       // Base point
-      var basePoint = PointToNative(instance.insertionPoint);
+      var basePoint = PointToNative(instance.GetInsertionPoint());
 
       // Get or make family from block definition
-      FamilySymbol familySymbol = new FilteredElementCollector(Doc)
-        .OfClass(typeof(Family))
-        .OfType<Family>()
-        .FirstOrDefault(f => f.Name.Equals("SpeckleBlock_" + instance.blockDefinition.name))
-        ?.GetFamilySymbolIds()
-        .Select(id => Doc.GetElement(id))
-        .OfType<FamilySymbol>()
-        .First();
+      GroupType block_def = new FilteredElementCollector(Doc)
+        .OfClass(typeof(GroupType))
+        .OfType<GroupType>()
+        .FirstOrDefault(f => f.Name.Equals("SpeckleBlock_" + instance.blockDefinition.name)) ??
+        BlockDefinitionToNative(instance.blockDefinition);
 
-      if (familySymbol == null)
-      {
-        var familyPath = BlockDefinitionToNative(instance.blockDefinition);
-
-        if (familyDoc != null)
-        {
-          if (familyDoc.LoadFamily(familyPath, new FamilyLoadOption(), out var fam)) ;
-          familySymbol = familyDoc.GetElement(fam.GetFamilySymbolIds().First()) as DB.FamilySymbol;
-        }
-        else
-        {
-          if (Doc.LoadFamily(familyPath, new FamilyLoadOption(), out var fam))
-            familySymbol = Doc.GetElement(fam.GetFamilySymbolIds().First()) as DB.FamilySymbol;
-        }
-
-        familySymbol.Activate();
-        //File.Delete(familyPath);
-      }
-
-      // see if this is a nested family instance or to be inserted in project
-      FamilyInstance _instance = null;
-      if (familyDoc != null)
-      {
-        _instance = familyDoc.FamilyCreate.NewFamilyInstance(basePoint, familySymbol, DB.Structure.StructuralType.NonStructural);
-        familyDoc.Regenerate();
-      }
-      else
-      {
-        _instance = Doc.Create.NewFamilyInstance(basePoint, familySymbol, DB.Structure.StructuralType.NonStructural);
-        Doc.Regenerate();
-      }
+      Group _instance = Doc.Create.PlaceGroup(basePoint, block_def);
 
       // transform
       if (_instance != null)
@@ -88,60 +51,40 @@ namespace Objects.Converter.Revit
 
         }
         SetInstanceParameters(_instance, instance);
-        result = "success";
+
       }
-      //Report.Log($"Created Block {_instance.Id}");
-      return result;
+      Report.Log($"Created Block {_instance.Id}");
+      return _instance;
     }
 
-    // TODO: fix unit conversions since block geometry is being converted inside a new family document, which potentially has different unit settings from the main doc.
-    // This could be done by passing in an option Document argument for all conversions that defaults to the main doc (annoying)
-    // I suspect this also needs to be fixed for freeform elements
-    private string BlockDefinitionToNative(BlockDefinition definition)
+    private GroupType BlockDefinitionToNative(BlockDefinition definition)
     {
       // create a family to represent a block definition
       // TODO: rename block with stream commit info prefix taken from UI - need to figure out cleanest way of storing this in the doc for retrieval by converter
-      var templatePath = GetTemplatePath("Generic Model");
-      if (!File.Exists(templatePath))
-      {
-        throw new Exception($"Could not find template file - {templatePath}");
-      }
-
-      var famDoc = Doc.Application.NewFamilyDocument(templatePath);
 
       // convert definition geometry to native
-      var solids = new List<DB.Solid>();
-      var curves = new List<DB.Curve>();
-      var blocks = new List<BlockInstance>();
+      var ids = new List<ElementId>();
       foreach (var geometry in definition.geometry)
       {
         switch (geometry)
         {
           case Brep brep:
-            try
-            {
-              var solid = BrepToNative(geometry as Brep);
-              solids.Add(solid);
-            }
-            catch (Exception e)
-            {
-              Report.LogConversionError(new SpeckleException($"Could not convert block {definition.id} brep to native, falling back to mesh representation.", e));
-              var brepMeshSolids = MeshToNative(brep.displayMesh, DB.TessellatedShapeBuilderTarget.Solid, DB.TessellatedShapeBuilderFallback.Abort)
-                  .Select(m => m as DB.Solid);
-              solids.AddRange(brepMeshSolids);
-            }
+            var brepShape = DirectShapeToNative(brep).NativeObject as DB.DirectShape;
+            ids.Add(brepShape?.Id);
             break;
           case Mesh mesh:
-            var meshSolids = MeshToNative(mesh, DB.TessellatedShapeBuilderTarget.Solid, DB.TessellatedShapeBuilderFallback.Abort)
-                .Select(m => m as DB.Solid);
-            solids.AddRange(meshSolids);
+            var meshShape = DirectShapeToNative(mesh).NativeObject as DB.DirectShape;
+            ids.Add(meshShape.Id);
             break;
           case ICurve curve:
             try
             {
-              var modelCurves = CurveToNative(geometry as ICurve);
-              foreach (DB.Curve modelCurve in modelCurves)
-                curves.Add(modelCurve);
+              var modelCurves = CurveToNative(curve).Cast<DB.Curve>().ToList();
+              modelCurves.ForEach(o =>
+              {
+                var modelCurve = Doc.Create.NewModelCurve(o, NewSketchPlaneFromCurve(o, Doc));
+                ids.Add(modelCurve.Id);
+              });
             }
             catch (Exception e)
             {
@@ -149,33 +92,20 @@ namespace Objects.Converter.Revit
             }
             break;
           case BlockInstance instance:
-            blocks.Add(instance);
+            var grp = BlockInstanceToNative(instance);
+            ids.Add(grp.Id);
             break;
         }
       }
 
-      using (DB.Transaction t = new DB.Transaction(famDoc, "Create Block Geometry Elements"))
-      {
-        t.Start();
-
-        solids.ForEach(o => { DB.FreeFormElement.Create(famDoc, o); });
-        curves.ForEach(o => { famDoc.FamilyCreate.NewModelCurve(o, NewSketchPlaneFromCurve(o, famDoc)); });
-        blocks.ForEach(o => { BlockInstanceToNative(o, famDoc); });
-
-        t.Commit();
-      }
-
-      var famName = "SpeckleBlock_" + definition.name;
-      string familyPath = Path.Combine(Path.GetTempPath(), famName + ".rfa");
-      var so = new DB.SaveAsOptions();
-      so.OverwriteExistingFile = true;
-      famDoc.SaveAs(familyPath, so);
-      famDoc.Close();
-      Report.Log($"Created temp family {familyPath}");
-      return familyPath;
+      var group = Doc.Create.NewGroup(ids);
+      var groupType = group.GroupType;
+      Doc.Delete(group.Id);
+      groupType.Name = "SpeckleBlock_" + definition.name;
+      return groupType;
     }
 
-    private bool MatrixDecompose(double[] m, out double rotation)
+    private bool MatrixDecompose(double[ ] m, out double rotation)
     {
       var matrix = new Matrix4x4(
         (float)m[0], (float)m[1], (float)m[2], (float)m[3],

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -9,77 +9,103 @@ using DB = Autodesk.Revit.DB;
 using Mesh = Objects.Geometry.Mesh;
 using BlockInstance = Objects.Other.BlockInstance;
 using BlockDefinition = Objects.Other.BlockDefinition;
-using Point = Objects.Geometry.Point;
 
 namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
-    // Creates a generic model instance in a project or family doc
-    public Group BlockInstanceToNative(BlockInstance instance)
+    // Creates a new group definition for each scaling
+    public Group BlockInstanceToNative(BlockInstance instance, double[ ] scale = null)
     {
-      // Base point
-      var basePoint = PointToNative(Point.FromList(new [] {
-        instance.transform[ 3 ]/ instance.transform[ 15 ],
-        instance.transform[ 7 ] / instance.transform[ 15 ],
-        instance.transform[ 11 ] / instance.transform[ 15 ]
-      }, instance.units));
+      var totscale = new[ ] {1.0, 1.0, 1.0};
+      scale?.CopyTo(totscale, 0);
+      for ( var i = 0; i < 3; i++ )
+        totscale[ i ] *= instance.transform[ i * 5 ];
+
+      var blockDefName = "SpeckleBlock_" + instance.blockDefinition.name;
+      if ( totscale.All(s => Math.Abs(s - 1.0) > 0.0001) )
+        blockDefName += $"_{totscale[ 0 ]}x{totscale[ 1 ]}x{totscale[ 2 ]}";
+
+      var basePoint = PointToNative(instance.GetInsertionPoint());
 
       // Get or make group from block definition
       GroupType block_def = new FilteredElementCollector(Doc)
-        .OfClass(typeof(GroupType))
-        .OfType<GroupType>()
-        .FirstOrDefault(f => f.Name.Equals("SpeckleBlock_" + instance.blockDefinition.name)) ??
-        BlockDefinitionToNative(instance.blockDefinition);
+                              .OfClass(typeof(GroupType))
+                              .OfType<GroupType>()
+                              .FirstOrDefault(f => f.Name.Equals(blockDefName)) ??
+                            BlockDefinitionToNative(instance.blockDefinition, totscale);
 
       Group _instance = Doc.Create.PlaceGroup(basePoint, block_def);
 
       // transform
-      if (_instance != null)
+      if ( _instance != null )
       {
-        if (MatrixDecompose(instance.transform, out double rotation))
+        if ( MatrixDecompose(instance.transform, out double rotation) )
         {
           try
           {
             // some point based families don't have a rotation, so keep this in a try catch
-            if (rotation != (_instance.Location as LocationPoint).Rotation)
+            if ( rotation != ( _instance.Location as LocationPoint ).Rotation )
             {
-              var axis = DB.Line.CreateBound(new XYZ(basePoint.X, basePoint.Y, 0), new XYZ(basePoint.X, basePoint.Y, 1000));
-              (_instance.Location as LocationPoint).Rotate(axis, rotation - (_instance.Location as LocationPoint).Rotation);
+              var axis = DB.Line.CreateBound(new XYZ(basePoint.X, basePoint.Y, 0),
+                new XYZ(basePoint.X, basePoint.Y, 1000));
+              ( _instance.Location as LocationPoint ).Rotate(axis,
+                rotation - ( _instance.Location as LocationPoint ).Rotation);
             }
           }
-          catch { }
-
+          catch
+          {
+          }
         }
-        SetInstanceParameters(_instance, instance);
 
+        SetInstanceParameters(_instance, instance);
       }
+
       Report.Log($"Created Block {_instance.Id}");
       return _instance;
     }
 
-    private GroupType BlockDefinitionToNative(BlockDefinition definition)
+    private GroupType BlockDefinitionToNative(BlockDefinition definition, double[ ] scale)
     {
       // create a family to represent a block definition
       // TODO: rename block with stream commit info prefix taken from UI - need to figure out cleanest way of storing this in the doc for retrieval by converter
 
       // convert definition geometry to native
+      var isScaled = scale.All(s => Math.Abs(s - 1.0) > 0.0001);
       var ids = new List<ElementId>();
-      foreach (var geometry in definition.geometry)
+      foreach ( var geometry in definition.geometry )
       {
-        switch (geometry)
+        switch ( geometry )
         {
           case Brep brep:
             var brepShape = DirectShapeToNative(brep).NativeObject as DB.DirectShape;
             ids.Add(brepShape?.Id);
             break;
           case Mesh mesh:
+            if ( isScaled )
+            {
+              var verts = new List<double>();
+              for ( var i = 0; i < mesh.vertices.Count; i += 3 )
+              {
+                verts.AddRange(ScaleVertexValues(mesh.vertices[ i ], mesh.vertices[ i + 1 ], mesh.vertices[ i + 2 ],
+                  scale));
+              }
+
+              mesh = new Mesh(verts, mesh.faces, mesh.colors, units: mesh.units,
+                applicationId: mesh.applicationId ?? mesh.id);
+            }
+
             var meshShape = DirectShapeToNative(mesh).NativeObject as DB.DirectShape;
             ids.Add(meshShape.Id);
             break;
           case ICurve curve:
             try
             {
+              if ( isScaled )
+              {
+                // need to work out scaling for each curve type 🙃
+              }
+
               var modelCurves = CurveToNative(curve).Cast<DB.Curve>().ToList();
               modelCurves.ForEach(o =>
               {
@@ -87,13 +113,15 @@ namespace Objects.Converter.Revit
                 ids.Add(modelCurve.Id);
               });
             }
-            catch (Exception e)
+            catch ( Exception e )
             {
-              Report.LogConversionError(new SpeckleException($"Could not convert block {definition.id} curve to native.", e));
+              Report.LogConversionError(
+                new SpeckleException($"Could not convert block {definition.id} curve to native.", e));
             }
+
             break;
           case BlockInstance instance:
-            var grp = BlockInstanceToNative(instance);
+            var grp = BlockInstanceToNative(instance, scale);
             ids.Add(grp.Id);
             break;
         }
@@ -103,27 +131,32 @@ namespace Objects.Converter.Revit
       var groupType = group.GroupType;
       Doc.Delete(group.Id);
       groupType.Name = "SpeckleBlock_" + definition.name;
+      if ( isScaled )
+        groupType.Name += $"_{scale[ 0 ]}x{scale[ 1 ]}x{scale[ 2 ]}";
       return groupType;
+    }
+
+    private static IEnumerable<double> ScaleVertexValues(double x, double y, double z, IReadOnlyList<double> scale)
+    {
+      return new[ ] {x * scale[ 0 ], y * scale[ 1 ], z * scale[ 2 ]};
     }
 
     private bool MatrixDecompose(double[ ] m, out double rotation)
     {
       var matrix = new Matrix4x4(
-        (float)m[0], (float)m[1], (float)m[2], (float)m[3],
-        (float)m[4], (float)m[5], (float)m[6], (float)m[7],
-        (float)m[8], (float)m[9], (float)m[10], (float)m[11],
-        (float)m[12], (float)m[13], (float)m[14], (float)m[15]);
+        ( float ) m[ 0 ], ( float ) m[ 1 ], ( float ) m[ 2 ], ( float ) m[ 3 ],
+        ( float ) m[ 4 ], ( float ) m[ 5 ], ( float ) m[ 6 ], ( float ) m[ 7 ],
+        ( float ) m[ 8 ], ( float ) m[ 9 ], ( float ) m[ 10 ], ( float ) m[ 11 ],
+        ( float ) m[ 12 ], ( float ) m[ 13 ], ( float ) m[ 14 ], ( float ) m[ 15 ]);
 
-      if (Matrix4x4.Decompose(matrix, out Vector3 _scale, out Quaternion _rotation, out Vector3 _translation))
+      if ( Matrix4x4.Decompose(matrix, out Vector3 _scale, out Quaternion _rotation, out Vector3 _translation) )
       {
         rotation = Math.Acos(_rotation.W) * 2;
         return true;
       }
-      else
-      {
-        rotation = 0;
-        return false;
-      }
+
+      rotation = 0;
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Description

This will fix the mesh/brep block receiving issue in Revit to the best of our ability. Receiving block definitions now creates new Model Groups. New groups are placed for each instance of the block. If the block instance is scaled, the scaling is appended to the end of the definition name

#### issues
- curve blocks are not scaled! this is a bigger thing to tackle as curves all have diff defs and will require different procedures for scaling. maybe we'll want to extract this scaling logic separately into utility methods? not sure if it's useful for anything else tho 


Closes #608 

## Type of change

- Breaking change: blocks now come in as groups instead of families

## How has this been tested?

- Manual Tests with blocks from sketchup

## Docs

- Will be updated ASAP

