### PR TITLE
ETABS 2d results

### DIFF
--- a/ConnectorETABS/ConnectorETABS/Util/ConnectorETABSUtils.cs
+++ b/ConnectorETABS/ConnectorETABS/Util/ConnectorETABSUtils.cs
@@ -600,7 +600,7 @@ namespace Speckle.ConnectorETABS.Util
             //BraceResults,
             //PierResults,
             //SpandrelResults,
-            //AnalysisResults
+            AnalysisResults
         }
 
         /// <summary>

--- a/Objects/Converters/ConverterETABS/ConverterETABSShared/ConverterETABSShared.projitems
+++ b/Objects/Converters/ConverterETABS/ConverterETABSShared/ConverterETABSShared.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\Properties\ConvertSectionProfile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\Geometry\ConvertStories.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\Geometry\ConvertWall.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\Results\ConvertResultSet2D.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Partial Classes\Analysis\" />

--- a/Objects/Converters/ConverterETABS/ConverterETABSShared/ConverterETABSUtils.cs
+++ b/Objects/Converters/ConverterETABS/ConverterETABSShared/ConverterETABSUtils.cs
@@ -262,7 +262,7 @@ namespace Objects.Converter.ETABS
             //BraceResults,
             //PierResults,
             //SpandrelResults
-            //AnalysisResults
+            AnalysisResults
         }
     }
 }

--- a/Objects/Converters/ConverterETABS/ConverterETABSShared/Partial Classes/Geometry/ConvertArea.cs
+++ b/Objects/Converters/ConverterETABS/ConverterETABSShared/Partial Classes/Geometry/ConvertArea.cs
@@ -82,15 +82,28 @@ namespace Objects.Converter.ETABS
                 coordinates.Add(node.basePoint.z);
             }
 
-            PolygonMesher polygonMesher = new PolygonMesher();
+                #region Get orientation angle
+                double angle = 0;
+                bool advanced = true;
+
+                Model.AreaObj.GetLocalAxes(name, ref angle, ref advanced);
+
+                speckleStructArea.orientationAngle = angle;
+
+                #endregion
+
+                PolygonMesher polygonMesher = new PolygonMesher();
             polygonMesher.Init(coordinates);
             var faces = polygonMesher.Faces();
             var vertices = polygonMesher.Coordinates;
             speckleStructArea.displayMesh = new Geometry.Mesh(vertices, faces);
+
+
             
 
                 SpeckleModel.elements.Add(speckleStructArea);
             }
+
 
 
             return speckleStructArea;

--- a/Objects/Converters/ConverterETABS/ConverterETABSShared/Partial Classes/Results/ConvertResultSet2D.cs
+++ b/Objects/Converters/ConverterETABS/ConverterETABSShared/Partial Classes/Results/ConvertResultSet2D.cs
@@ -1,0 +1,79 @@
+﻿using Objects.Structural.Results;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Objects.Converter.ETABS
+{
+    public partial class ConverterETABS
+    {
+        public ResultSet2D AreaResultSet2dToSpeckle(List<string> areaNames)
+        {
+            List<Result2D> results = new List<Result2D>();
+
+            foreach (var areaName in areaNames)
+            {
+                #region Return force results
+                int numberOfForceResults = 0;
+                string[] obj, elm, pointElm, loadCase, stepType;
+                double[] stepNum, f11, f22, f12, fMax, fMin, fAngle, fVonMises, m11, m22, m12, mMax, mMin, mAngle, v13, v23, vMax, vAngle;
+                obj = elm = pointElm = loadCase = stepType = new string[] { };
+                stepNum = f11 = f22 = f12 = fMax = fMin = fAngle = fVonMises = m11 = m22 = m12 = mMax = mMin = mAngle = v13 = v23 = vMax = vAngle = new double[] { };
+
+                Model.Results.AreaForceShell(areaName, ETABSv1.eItemTypeElm.ObjectElm, ref numberOfForceResults, ref obj, ref elm, ref pointElm, ref loadCase, ref stepType, ref stepNum, ref f11, ref f22, ref f12, ref fMax, ref fMin, ref fAngle, ref fVonMises, ref m11, ref m22, ref m12, ref mMax, ref mMin, ref mAngle, ref v13, ref v23, ref vMax, ref vAngle);
+                #endregion
+
+                #region Return stress results
+                int numberOfStressResults = 0;
+                string[] stressObj, stressElm, stressPointElm, stressLoadCase, stressStepType;
+                double[] stressStepNum, S11Top, S22Top, S12Top, SMaxTop, SMinTop, SAngleTop, sVonMisesTop, S11Bot, S22Bot, S12Bot, SMaxBot, SMinBot, SAngleBot, sVonMisesBot, S13Avg, S23Avg, SMaxAvg, SAngleAvg;
+                stressObj = stressElm = stressPointElm = stressLoadCase = stressStepType = new string[] { };
+                stressStepNum = S11Top = S22Top = S12Top = SMaxTop = SMinTop = SAngleTop = sVonMisesTop = S11Bot = S22Bot = S12Bot = SMaxBot = SMinBot = SAngleBot = sVonMisesBot = S13Avg = S23Avg = SMaxAvg = SAngleAvg = new double[] { };
+
+                Model.Results.AreaStressShell(areaName, ETABSv1.eItemTypeElm.ObjectElm, ref numberOfStressResults, ref stressObj, ref stressElm, ref stressPointElm, ref stressLoadCase, ref stressStepType, ref stressStepNum, ref S11Top, ref S22Top, ref S12Top, ref SMaxTop, ref SMinTop, ref SAngleTop, ref sVonMisesTop, ref S11Bot, ref S22Bot, ref S12Bot, ref SMaxBot, ref SMinBot, ref SAngleBot, ref sVonMisesBot, ref S13Avg, ref S23Avg, ref SMaxAvg, ref SAngleAvg);
+                #endregion
+
+                for (int i = 0; i < numberOfForceResults; i++)
+                {
+                    results.Add(new Result2D
+                    {
+                        element = new Structural.Geometry.Element2D() { name = elm[i] }, //AreaToSpeckle(areaName),
+                        permutation = loadCase[i],
+                        position = new List<double>(),
+                        dispX = 0, // pulling this data would require large amount of data parsing, implementation TBD
+                        dispY = 0, // pulling this data would require large amount of data parsing, implementation TBD
+                        dispZ = 0, // pulling this data would require large amount of data parsing, implementation TBD
+                        forceXX = (float)f11[i],
+                        forceYY = (float)f22[i],
+                        forceXY = (float)f12[i],
+                        momentXX = (float)m11[i],
+                        momentYY = (float)m22[i],
+                        momentXY = (float)m12[i],
+                        shearX = (float)v13[i],
+                        shearY = (float)v23[i],
+                        stressTopXX = (float)S11Top[i],
+                        stressTopYY = (float)S22Top[i],
+                        stressTopZZ = 0, // shell elements are 2D elements
+                        stressTopXY = (float)S12Top[i],
+                        stressTopYZ = (float)S23Avg[i], // ETABS reports avg out-of-plane shear
+                        stressTopZX = (float)S12Top[i],
+                        stressMidXX = 0, // ETABS does not report
+                        stressMidYY = 0, // ETABS does not report
+                        stressMidZZ = 0, // ETABS does not report
+                        stressMidXY = 0, // ETABS does not report
+                        stressMidYZ = 0, // ETABS does not report
+                        stressMidZX = 0, // ETABS does not report
+                        stressBotXX = (float)S11Bot[i],
+                        stressBotYY = (float)S22Bot[i],
+                        stressBotZZ = 0, // shell elements are 2D elements
+                        stressBotXY = (float)S12Bot[i],
+                        stressBotYZ = (float)S23Avg[i], // ETABS reports avg out-of-plane shear
+                        stressBotZX = (float)S12Bot[i],
+                    });                         
+                }
+            }
+
+            return new ResultSet2D { results2D = results };
+        }
+    }
+}

--- a/Objects/Converters/ConverterETABS/ConverterETABSShared/Partial Classes/Results/ConvertResults.cs
+++ b/Objects/Converters/ConverterETABS/ConverterETABSShared/Partial Classes/Results/ConvertResults.cs
@@ -40,11 +40,22 @@ namespace Objects.Converter.ETABS
             
             Model.SpandrelLabel.GetNameList(ref numberOfSpandrelNames, ref spandrelNames, ref isMultiStory);
             List<string> convertedSpandrelNames = spandrelNames.ToList();
-            
+
 
             #endregion
 
-            ResultSetAll results = new ResultSetAll(AllResultSet1dToSpeckle(convertedFrameNames, convertedPierNames, convertedSpandrelNames), new ResultSet2D(), new ResultSet3D(), new ResultGlobal(), AllResultSetNodesToSpeckle());
+            #region Retrieve area names
+
+            int numberOfAreaNames = 0;
+            var areaNames = new string[] { };
+
+            Model.AreaObj.GetNameList(ref numberOfAreaNames, ref areaNames);
+
+            List<string> convertedAreaNames = areaNames.ToList();
+
+            #endregion
+
+            ResultSetAll results = new ResultSetAll(AllResultSet1dToSpeckle(convertedFrameNames, convertedPierNames, convertedSpandrelNames), AreaResultSet2dToSpeckle(convertedAreaNames), new ResultSet3D(), new ResultGlobal(), AllResultSetNodesToSpeckle());
 
             return results;
         }


### PR DESCRIPTION
## Description

- Adds 2d results
- Adds local axis orientation to ConvertAreaToSpeckle

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests - pushed results from ETABS to speckle

## Docs

- No updates needed


