### PR TITLE
Objects: correct block insertion point method

### DIFF
--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -61,10 +61,10 @@ namespace Objects.Other
       if (transform.Length != 16)
         throw new SpeckleException($"{nameof(BlockInstance)}.{nameof(transform)} is malformed: expected length to be 4x4 = 16");
 
-      for (int i = 0; i < 4; i++)
-        for (int j = 0; j < 16; j+= 4)
-          insertion[i] = insertion[i] * (transform[j] + transform[j + 1] + transform[j + 2] + transform[j + 3]);
-      
+      for (int i = 0; i < 16; i += 4)
+        insertion[i / 4] = insertion[0] * transform[i] + insertion[1] * transform[i + 1] +
+                         insertion[2] * transform[i + 2] + insertion[3] * transform[i + 3];
+
       return new Point(
         insertion[0] / insertion[3], 
         insertion[1] / insertion[3], 


### PR DESCRIPTION
## Description
Previous convenience method was not multiplying transform and base pt correctly

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: autocad, revit tested

## Docs

- No updates needed

