### PR TITLE
Added json-ignore to computed properties in Objects

### DIFF
--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -3,9 +3,8 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
-using System.Text;
 using Speckle.Core.Logging;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
@@ -65,7 +64,9 @@ namespace Objects.Geometry
 
     #region Convenience Methods
     
+    [JsonIgnore]
     public int VerticesCount => vertices.Count / 3;
+    [JsonIgnore]
     public int TextureCoordinatesCount => textureCoordinates.Count / 2;
 
     /// <summary>

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 using Objects.Geometry;
 using Speckle.Core.Logging;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.Other
 {
@@ -30,7 +31,7 @@ namespace Objects.Other
   /// </summary>
   public class BlockInstance : Base
   {
-    [Obsolete("Use GetInsertionPoint method")]
+    [JsonIgnore, Obsolete("Use GetInsertionPoint method")]
     public Point insertionPoint { get => GetInsertionPoint(); set { } }
 
     /// <summary>


### PR DESCRIPTION
## Description

- Fixes issue with Mesh and Block conveniance properties from being serialised.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Tests not required

## Docs

- No updates needed
