### PR TITLE
Make streams private on their creation in Dynamo and Gh connectors

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStream.cs
+++ b/ConnectorDynamo/ConnectorDynamo/CreateStreamNode/CreateStream.cs
@@ -141,7 +141,7 @@ namespace Speckle.ConnectorDynamo.CreateStreamNode
       var client = new Client(SelectedAccount);
       try
       {
-        var res = client.StreamCreate(new StreamCreateInput()).Result;
+        var res = client.StreamCreate(new StreamCreateInput { isPublic = false }).Result;
 
         Stream = new StreamWrapper(res, SelectedAccount.userInfo.id, SelectedAccount.serverInfo.url);
         CreateEnabled = false;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
@@ -105,7 +105,7 @@ namespace ConnectorGrasshopper.Streams
         var client = new Client(account);
         try
         {
-          var streamId = await client.StreamCreate(new StreamCreateInput());
+          var streamId = await client.StreamCreate(new StreamCreateInput { isPublic = false });
           stream = new StreamWrapper(
             streamId,
             account.userInfo.id,


### PR DESCRIPTION
## Description

- Default to making streams private when they are created with the Dynamo and Gh connectors (since all other connectors, through DUI/DUI2, currently default to making streams private on creation)

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests (created new streams with Dynamo and Gh connectors)

## Docs

- No updates needed

