### PR TITLE
fix(gh): Adds remark bubble to remind user to expand an object

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -367,7 +367,7 @@ namespace ConnectorGrasshopper.Extras
     /// <param name="Converter"></param>
     /// <param name="base"></param>
     /// <returns></returns>
-    public static GH_Structure<IGH_Goo> ConvertToTree(ISpeckleConverter Converter, Base @base)
+    public static GH_Structure<IGH_Goo> ConvertToTree(ISpeckleConverter Converter, Base @base, Action<GH_RuntimeMessageLevel,string> onError = null)
     {
       var data = new GH_Structure<IGH_Goo>();
 
@@ -388,12 +388,9 @@ namespace ConnectorGrasshopper.Extras
         data = treeBuilder.Build(@base[@base.GetDynamicMembers().ElementAt(0)]);
       }
       // Simple pass the SpeckleBase
-      // TODO: the base object has multiple members,
-      // therefore create a matching structure via the output ports, similar to 
-      // running the expando object
-      // then run the treebuilder for each port
       else
       {
+        onError(GH_RuntimeMessageLevel.Remark, "This object needs to be expanded.");
         data.Append(new GH_SpeckleBase(@base));
       }
       return data;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -706,7 +706,7 @@ namespace ConnectorGrasshopper.Ops
 
       converter?.SetContextDocument(RhinoDoc.ActiveDoc);
 
-      var tree = Utilities.ConvertToTree(converter, ReceivedObject);
+      var tree = Utilities.ConvertToTree(converter, ReceivedObject, Parent.AddRuntimeMessage);
       DA.SetDataTree(0, tree);
     }
   }


### PR DESCRIPTION
This happens only when the commit is not from GH/Dynamo, or when conversions are disabled.

Fixes #643 

![Screenshot 2021-11-24 at 16 10 38](https://user-images.githubusercontent.com/2316535/143264683-a0d802e1-8ed2-43bd-bd69-2659131b5bdb.png)
