### PR TITLE
GH: Reduce calls to `Tracker.TrackPageView`

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.AccountDetails.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Accounts/Accounts.AccountDetails.cs
@@ -48,7 +48,10 @@ namespace ConnectorGrasshopper.Streams
     {
       string userId = null;
       if (!DA.GetData(0, ref userId)) return;
-    
+      
+      if(DA.Iteration == 0) // Only report on first iteration of the component.
+        Tracker.TrackPageview(Tracker.ACCOUNT_DETAILS);
+
       if (string.IsNullOrEmpty(userId))
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "No account provided. Trying with default account.");
@@ -76,7 +79,6 @@ namespace ConnectorGrasshopper.Streams
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.ACCOUNT_DETAILS);
       base.BeforeSolveInstance();
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
@@ -45,7 +45,6 @@ namespace ConnectorGrasshopper.Conversion
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.CONVERT_TONATIVE);
       base.BeforeSolveInstance();
     }
 
@@ -77,10 +76,10 @@ namespace ConnectorGrasshopper.Conversion
       try
       {
         if (CancellationToken.IsCancellationRequested)
-        {
           return;
-        }
-
+        
+        Tracker.TrackPageview(Tracker.CONVERT_TONATIVE);
+        
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)
         {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToNativeAsync.cs
@@ -78,8 +78,6 @@ namespace ConnectorGrasshopper.Conversion
         if (CancellationToken.IsCancellationRequested)
           return;
         
-        Tracker.TrackPageview(Tracker.CONVERT_TONATIVE);
-        
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)
         {
@@ -135,6 +133,9 @@ namespace ConnectorGrasshopper.Conversion
       {
         return;
       }
+      
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview(Tracker.CONVERT_TONATIVE);
 
       GH_Structure<IGH_Goo> _objects;
       DA.GetDataTree(0, out _objects);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToSpeckleAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToSpeckleAsync.cs
@@ -76,7 +76,6 @@ namespace ConnectorGrasshopper.Conversion
       try
       {
         if (CancellationToken.IsCancellationRequested)return;
-        Tracker.TrackPageview(Tracker.CONVERT_TOSPECKLE);
 
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)
@@ -134,6 +133,9 @@ namespace ConnectorGrasshopper.Conversion
     {
       if (CancellationToken.IsCancellationRequested)return;
       DA.DisableGapLogic();
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview(Tracker.CONVERT_TOSPECKLE);
+      
       GH_Structure<IGH_Goo> _objects;
       DA.GetDataTree(0, out _objects);
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToSpeckleAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Convert.ToSpeckleAsync.cs
@@ -45,7 +45,6 @@ namespace ConnectorGrasshopper.Conversion
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.CONVERT_TOSPECKLE);
       base.BeforeSolveInstance();
     }
 
@@ -77,6 +76,7 @@ namespace ConnectorGrasshopper.Conversion
       try
       {
         if (CancellationToken.IsCancellationRequested)return;
+        Tracker.TrackPageview(Tracker.CONVERT_TOSPECKLE);
 
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.DeserializeObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.DeserializeObject.cs
@@ -36,7 +36,6 @@ namespace ConnectorGrasshopper.Conversion
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.DESERIALIZE);
       base.BeforeSolveInstance();
     }
   }
@@ -57,7 +56,8 @@ namespace ConnectorGrasshopper.Conversion
       try
       {
         if (CancellationToken.IsCancellationRequested)return;
-
+        
+        Tracker.TrackPageview(Tracker.DESERIALIZE);
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)
         {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.DeserializeObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.DeserializeObject.cs
@@ -57,7 +57,6 @@ namespace ConnectorGrasshopper.Conversion
       {
         if (CancellationToken.IsCancellationRequested)return;
         
-        Tracker.TrackPageview(Tracker.DESERIALIZE);
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)
         {
@@ -100,7 +99,9 @@ namespace ConnectorGrasshopper.Conversion
     public override void GetData(IGH_DataAccess DA, GH_ComponentParamServer Params)
     {
       if (CancellationToken.IsCancellationRequested)return;
-
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview(Tracker.DESERIALIZE);
+      
       GH_Structure<GH_String> _objects;
       DA.GetDataTree(0, out _objects);
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.SerialiseObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.SerialiseObject.cs
@@ -58,8 +58,6 @@ namespace ConnectorGrasshopper.Conversion
       {
         if (CancellationToken.IsCancellationRequested)return;
         
-        Tracker.TrackPageview(Tracker.SERIALIZE);
-        
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)
         {
@@ -110,7 +108,8 @@ namespace ConnectorGrasshopper.Conversion
     public override void GetData(IGH_DataAccess DA, GH_ComponentParamServer Params)
     {
       if (CancellationToken.IsCancellationRequested)return;
-
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview(Tracker.SERIALIZE);
       GH_Structure<GH_SpeckleBase> _objects;
       DA.GetDataTree(0, out _objects);
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.SerialiseObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Serialisation.SerialiseObject.cs
@@ -37,7 +37,6 @@ namespace ConnectorGrasshopper.Conversion
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.SERIALIZE);
       base.BeforeSolveInstance();
     }
   }
@@ -58,7 +57,9 @@ namespace ConnectorGrasshopper.Conversion
       try
       {
         if (CancellationToken.IsCancellationRequested)return;
-
+        
+        Tracker.TrackPageview(Tracker.SERIALIZE);
+        
         int branchIndex = 0, completed = 0;
         foreach (var list in Objects.Branches)
         {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectByKeyValueTaskComponent.cs
@@ -40,6 +40,8 @@ namespace ConnectorGrasshopper.Objects
       {
         var keys = new List<string>();
         var valueTree = new GH_Structure<IGH_Goo>();
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview("objects", "create", "keyValue");
 
         DA.GetDataList(0, keys);
         DA.GetDataTree(1, out valueTree);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
@@ -50,6 +50,9 @@ namespace ConnectorGrasshopper.Objects
           AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "You cannot set all parameters as optional");
           return;
         }
+        
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview("objects", "create", "variableinput");
 
         Params.Input.ForEach(ighParam =>
         {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
@@ -46,6 +46,9 @@ namespace ConnectorGrasshopper.Objects
         GH_SpeckleBase ghSpeckleBase = null;
         DA.GetData(0, ref ghSpeckleBase);
         var @base = ghSpeckleBase?.Value;
+        
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview("objects", "expand");
 
         var task = Task.Run(() => DoWork(@base));
         TaskList.Add(task);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectByKeyValueTaskComponent.cs
@@ -48,6 +48,9 @@ namespace ConnectorGrasshopper.Objects
         DA.GetData(0, ref @base);
         DA.GetDataList(1, keys);
         DA.GetDataTree(2, out valueTree);
+        
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview("objects", "extend", "keyValue");
 
         TaskList.Add(Task.Run(() => DoWork(@base.Value.ShallowCopy(), keys, valueTree)));
         return;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
@@ -61,6 +61,9 @@ namespace ConnectorGrasshopper.Objects
           inputData = null;
           return;
         }
+        
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview("objects", "extend", "variableinput");
 
         inputData = new Dictionary<string, object>();
         for (int i = 1; i < Params.Input.Count; i++)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
@@ -43,6 +43,8 @@ namespace ConnectorGrasshopper.Objects
         var key = "";
         DA.GetData(0, ref speckleObj);
         DA.GetData(1, ref key);
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview("objects", "valueByKey");
 
         var @base = speckleObj?.Value;
         var task = Task.Run(() => DoWork(@base,key, CancelToken));

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -509,6 +509,8 @@ namespace ConnectorGrasshopper.Ops
           }
         };
 
+        var sw = new StreamWrapper("");
+
         ErrorAction = (transportName, exception) =>
         {
           // TODO: This message condition should be removed once the `link sharing` issue is resolved server-side.

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -456,7 +456,6 @@ namespace ConnectorGrasshopper.Ops
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview("receive", AutoReceive ? "auto" : "manual");
       base.BeforeSolveInstance();
     }
   }
@@ -498,6 +497,8 @@ namespace ConnectorGrasshopper.Ops
       var receiveComponent = ((ReceiveComponent)Parent);
       try
       {
+        Tracker.TrackPageview("receive", receiveComponent.AutoReceive ? "auto" : "manual");
+
         InternalProgressAction = dict =>
         {
           //NOTE: progress set to indeterminate until the TotalChildrenCount is correct

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponentSync.cs
@@ -18,6 +18,7 @@ using Speckle.Core.Api;
 using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 using Speckle.Core.Transports;
 
 namespace ConnectorGrasshopper.Ops
@@ -255,6 +256,8 @@ namespace ConnectorGrasshopper.Ops
 
       if (InPreSolve)
       {
+        Tracker.TrackPageview("receive", "sync");
+
         var task = Task.Run(async () =>
         {
           var acc = await StreamWrapper?.GetAccount();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
@@ -103,7 +103,6 @@ namespace ConnectorGrasshopper.Ops
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.RECEIVE_LOCAL);
       base.BeforeSolveInstance();
     }
   }
@@ -119,6 +118,7 @@ namespace ConnectorGrasshopper.Ops
     {
       try
       {
+        Tracker.TrackPageview(Tracker.RECEIVE_LOCAL);
         Parent.Message = "Receiving...";
         var Converter = (Parent as ReceiveLocalComponent).Converter;
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
@@ -118,6 +118,8 @@ namespace ConnectorGrasshopper.Ops
     {
       try
       {
+        var acc = Speckle.Core.Credentials.AccountManager.GetDefaultAccount();
+        
         Tracker.TrackPageview(Tracker.RECEIVE_LOCAL);
         Parent.Message = "Receiving...";
         var Converter = (Parent as ReceiveLocalComponent).Converter;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -297,7 +297,6 @@ namespace ConnectorGrasshopper.Ops
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview("send", AutoSend ? "auto" : "manual");
       base.BeforeSolveInstance();
     }
     
@@ -369,7 +368,8 @@ namespace ConnectorGrasshopper.Ops
     {
       try
       {
-        if (((SendComponent)Parent).JustPastedIn)
+        var sendComponent = (SendComponent)Parent;
+        if (sendComponent.JustPastedIn)
         {
           Done();
           return;
@@ -377,18 +377,20 @@ namespace ConnectorGrasshopper.Ops
 
         if (CancellationToken.IsCancellationRequested)
         {
-          ((SendComponent)Parent).CurrentComponentState = "expired";
+          sendComponent.CurrentComponentState = "expired";
           return;
         }
+        
+        Tracker.TrackPageview("send", sendComponent.AutoSend ? "auto" : "manual");
 
         //the active document may have changed
-        ((SendComponent)Parent).Converter.SetContextDocument(RhinoDoc.ActiveDoc);
+        sendComponent.Converter.SetContextDocument(RhinoDoc.ActiveDoc);
 
         // Note: this method actually converts the objects to speckle too
         try
         {
           int convertedCount = 0;
-          var converted = Utilities.DataTreeToNestedLists(DataInput, ((SendComponent)Parent).Converter, CancellationToken, () =>
+          var converted = Utilities.DataTreeToNestedLists(DataInput, sendComponent.Converter, CancellationToken, () =>
           {
             ReportProgress("Conversion",Math.Round(convertedCount++ / (double) DataInput.DataCount, 2));
           });
@@ -413,7 +415,7 @@ namespace ConnectorGrasshopper.Ops
         
         if (CancellationToken.IsCancellationRequested)
         {
-          ((SendComponent)Parent).CurrentComponentState = "expired";
+          sendComponent.CurrentComponentState = "expired";
           return;
         }
 
@@ -524,7 +526,7 @@ namespace ConnectorGrasshopper.Ops
 
         if (CancellationToken.IsCancellationRequested)
         {
-          ((SendComponent)Parent).CurrentComponentState = "expired";
+          sendComponent.CurrentComponentState = "expired";
           return;
         }
 
@@ -534,7 +536,7 @@ namespace ConnectorGrasshopper.Ops
         {
           if (CancellationToken.IsCancellationRequested)
           {
-            ((SendComponent)Parent).CurrentComponentState = "expired";
+            sendComponent.CurrentComponentState = "expired";
             return;
           }
 
@@ -543,7 +545,7 @@ namespace ConnectorGrasshopper.Ops
             ObjectToSend,
             CancellationToken,
             Transports,
-            useDefaultCache: ((SendComponent)Parent).UseDefaultCache,
+            useDefaultCache: sendComponent.UseDefaultCache,
             onProgressAction: InternalProgressAction,
             onErrorAction: ErrorAction, disposeTransports: true);
 
@@ -555,13 +557,13 @@ namespace ConnectorGrasshopper.Ops
             message = $"Pushed {TotalObjectCount} elements from Grasshopper.";
           }
 
-          var prevCommits = ((SendComponent)Parent).OutputWrappers;
+          var prevCommits = sendComponent.OutputWrappers;
 
           foreach (var transport in Transports)
           {
             if (CancellationToken.IsCancellationRequested)
             {
-              ((SendComponent)Parent).CurrentComponentState = "expired";
+              sendComponent.CurrentComponentState = "expired";
               return;
             }
 
@@ -605,7 +607,7 @@ namespace ConnectorGrasshopper.Ops
 
           if (CancellationToken.IsCancellationRequested)
           {
-            ((SendComponent)Parent).CurrentComponentState = "expired";
+            sendComponent.CurrentComponentState = "expired";
             Done();
           }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponentSync.cs
@@ -15,6 +15,7 @@ using Rhino.Geometry;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
 
@@ -225,6 +226,7 @@ namespace ConnectorGrasshopper.Ops
         DA.GetData(2, ref messageInput);
         var transportsInput = new List<IGH_Goo> { transportInput };
         //var transportsInput = Params.Input[1].VolatileData.AllData(true).Select(x => x).ToList();
+        Tracker.TrackPageview("send", "sync");
 
         var task = Task.Run(async () =>
         {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendLocalComponent.cs
@@ -101,7 +101,6 @@ namespace ConnectorGrasshopper.Ops
     }
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.SEND_LOCAL);
       base.BeforeSolveInstance();
     }
   }
@@ -118,9 +117,11 @@ namespace ConnectorGrasshopper.Ops
 
     public override void DoWork(Action<string, double> ReportProgress, Action Done)
     {
-      Parent.Message = "Sending...";
       try
       {
+        Parent.Message = "Sending...";
+        Tracker.TrackPageview(Tracker.SEND_LOCAL);
+
         var converter = (Parent as SendLocalComponent)?.Converter;
         converter?.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
         var converted = Utilities.DataTreeToNestedLists(data, converter);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -349,6 +349,10 @@ namespace ConnectorGrasshopper
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No schema has been selected.");
         return;
       }
+      
+      // 
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview("objects", "create", "variableinput");
 
       var units = Units.GetUnitsFromString(Rhino.RhinoDoc.ActiveDoc.GetUnitSystemName(true, false, false, false));
 
@@ -615,7 +619,6 @@ namespace ConnectorGrasshopper
     protected override void BeforeSolveInstance()
     {
       Converter?.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
-      Tracker.TrackPageview("objects", "create", "variableinput");
       base.BeforeSolveInstance();
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -350,7 +350,7 @@ namespace ConnectorGrasshopper
         return;
       }
       
-      // 
+      
       if(DA.Iteration == 0)
         Tracker.TrackPageview("objects", "create", "variableinput");
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -326,8 +326,9 @@ namespace ConnectorGrasshopper
         return;
       }
 
-      Tracker.TrackPageview("objects", "create", "variableinput");
-
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview("objects", "create", "schema");
+      
       var units = Units.GetUnitsFromString(Rhino.RhinoDoc.ActiveDoc.GetUnitSystemName(true, false, false, false));
 
       List<object> cParamsValues = new List<object>();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -326,6 +326,8 @@ namespace ConnectorGrasshopper
         return;
       }
 
+      Tracker.TrackPageview("objects", "create", "variableinput");
+
       var units = Units.GetUnitsFromString(Rhino.RhinoDoc.ActiveDoc.GetUnitSystemName(true, false, false, false));
 
       List<object> cParamsValues = new List<object>();
@@ -595,7 +597,6 @@ namespace ConnectorGrasshopper
     protected override void BeforeSolveInstance()
     {
       Converter?.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
-      Tracker.TrackPageview("objects", "create", "variableinput");
       base.BeforeSolveInstance();
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
@@ -68,6 +68,8 @@ namespace ConnectorGrasshopper.Streams
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Cannot create multiple streams at the same time. This is an explicit guard against possibly unintended behaviour. If you want to create another stream, please use a new component.");
         return;
       }
+      
+      Tracker.TrackPageview(Tracker.STREAM_CREATE);
 
       string userId = null;
       Account account = null;
@@ -130,7 +132,6 @@ namespace ConnectorGrasshopper.Streams
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.STREAM_CREATE);
       base.BeforeSolveInstance();
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
@@ -68,7 +68,10 @@ namespace ConnectorGrasshopper.Streams
           Message = null;
           return;
         }
+        
+        Tracker.TrackPageview(Tracker.STREAM_DETAILS);
         Message = "Fetching";
+        
         if (ghStreamTree.DataCount == 0)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Input S failed to collect data.");

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
@@ -69,7 +69,9 @@ namespace ConnectorGrasshopper.Streams
           return;
         }
         
-        Tracker.TrackPageview(Tracker.STREAM_DETAILS);
+        if(DA.Iteration == 0) 
+          Tracker.TrackPageview(Tracker.STREAM_DETAILS);
+        
         Message = "Fetching";
         
         if (ghStreamTree.DataCount == 0)
@@ -187,7 +189,6 @@ namespace ConnectorGrasshopper.Streams
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.STREAM_DETAILS);
       base.BeforeSolveInstance();
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
@@ -82,6 +82,9 @@ namespace ConnectorGrasshopper.Streams
         Message = "Fetching";
         // Validation
         string errorMessage = null;
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview(Tracker.STREAM_GET);
+
         if (!ValidateInput(account, idWrapper.StreamId, ref errorMessage))
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Error, errorMessage);
@@ -153,7 +156,6 @@ namespace ConnectorGrasshopper.Streams
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.STREAM_GET);
       base.BeforeSolveInstance();
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
@@ -54,6 +54,8 @@ namespace ConnectorGrasshopper.Streams
         Message = "Fetching";
         string userId = null;
         var limit = 10;
+        if(DA.Iteration == 0)
+          Tracker.TrackPageview(Tracker.STREAM_LIST);
 
         DA.GetData(0, ref userId);
         DA.GetData(1, ref limit); // Has default value so will never be empty.
@@ -115,7 +117,6 @@ namespace ConnectorGrasshopper.Streams
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.STREAM_LIST);
       base.BeforeSolveInstance();
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
@@ -49,12 +49,15 @@ namespace ConnectorGrasshopper.Streams
       string name = null;
       string description = null;
       bool isPublic = false;
-
+      
+      if (DA.Iteration == 0)
+        Tracker.TrackPageview(Tracker.STREAM_UPDATE);
+      
       if (!DA.GetData(0, ref ghSpeckleStream)) return;
       DA.GetData(1, ref name);
       DA.GetData(2, ref description);
       DA.GetData(3, ref isPublic);
-
+      
       var streamWrapper = ghSpeckleStream.Value;
       if (error != null)
       {
@@ -116,7 +119,6 @@ namespace ConnectorGrasshopper.Streams
     }
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview(Tracker.STREAM_UPDATE);
       base.BeforeSolveInstance();
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Transports/SendReceiveTransport.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Transports/SendReceiveTransport.cs
@@ -40,6 +40,8 @@ namespace ConnectorGrasshopper.Transports
         return;
       }
 
+      Tracker.TrackPageview("transports", "send_to_transport");
+
       List<ITransport> transports = new List<ITransport>();
       DA.GetDataList(0, transports);
 
@@ -66,7 +68,6 @@ namespace ConnectorGrasshopper.Transports
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview("transports", "send_to_transport");
       base.BeforeSolveInstance();
     }
 
@@ -100,6 +101,8 @@ namespace ConnectorGrasshopper.Transports
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "This component does not work with multiple iterations. Please ensure you've inputed only one transport and a flat list of object ids.");
         return;
       }
+      
+      Tracker.TrackPageview("transports", "receive_from_transport");
 
       List<string> ids = new List<string>();
       DA.GetDataList(1, ids);
@@ -131,7 +134,6 @@ namespace ConnectorGrasshopper.Transports
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview("transports", "receive_from_transport");
       base.BeforeSolveInstance();
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Transports/Transports.Disk.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Transports/Transports.Disk.cs
@@ -34,6 +34,9 @@ namespace ConnectorGrasshopper.Transports
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Cannot create multiple transports at the same time. This is an explicit guard against possibly unintended behaviour. If you want to create another transport, please use a new component.");
         return;
       }
+      
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview("transports", "disk");
 
       string basePath = null;
       DA.GetData(0, ref basePath);
@@ -45,7 +48,6 @@ namespace ConnectorGrasshopper.Transports
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview("transports", "disk");
       base.BeforeSolveInstance();
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Transports/Transports.Memory.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Transports/Transports.Memory.cs
@@ -35,6 +35,10 @@ namespace ConnectorGrasshopper.Transports
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Cannot create multiple transports at the same time. This is an explicit guard against possibly unintended behaviour. If you want to create another transport, please use a new component.");
         return;
       }
+      
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview("transports", "memory");
+
       string name = null;
       DA.GetData(0, ref name);
 
@@ -46,7 +50,6 @@ namespace ConnectorGrasshopper.Transports
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview("transports", "memory");
       base.BeforeSolveInstance();
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Transports/Transports.Sqlite.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Transports/Transports.Sqlite.cs
@@ -35,6 +35,9 @@ namespace ConnectorGrasshopper.Transports
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Cannot create multiple transports at the same time. This is an explicit guard against possibly unintended behaviour. If you want to create another transport, please use a new component.");
         return;
       }
+      
+      if(DA.Iteration == 0)
+        Tracker.TrackPageview("transports", "sqlite");
 
       string basePath = null, applicationName = null, scope = null;
 
@@ -49,7 +52,6 @@ namespace ConnectorGrasshopper.Transports
 
     protected override void BeforeSolveInstance()
     {
-      Tracker.TrackPageview("transports", "sqlite");
       base.BeforeSolveInstance();
     }
 


### PR DESCRIPTION
## Description

- Fixes #743

Moved tracking from "BeforeSolveInstance" to the actual function that does the work (depending on the component, that may be `SolveInstance` or the `DoWork` in the worker.

Tracker will only log when the node performs some operation, as opposed to the previous behaviour, that allowed for pages to be tracked when `F5` was pressed, even if the node had no inputs connected.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Manual Tests (please write what did you do?)

Set breakpoints on tracker lines and ensured they were:
- Never called twice in the same operation
- Never get called if the node does not perform an operation (invalid inputs, etc).

## Docs

- No updates needed

