### PR TITLE
fix(autocad): add block attributes as a dictionary

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -26,7 +26,7 @@ namespace Objects.Converter.AutocadCivil
 
   public partial class ConverterAutocadCivil
   {
-    public static string invalidChars = @"<>/\:;""?*|=,‘";
+    public static string invalidAutocadChars = @"<>/\:;""?*|=,‘";
 
     #region units
     private string _modelUnits;
@@ -86,14 +86,14 @@ namespace Objects.Converter.AutocadCivil
     /// </summary>
     /// <param name="str"></param>
     /// <returns></returns>
-    public static string RemoveInvalidChars(string str)
+    public static string RemoveInvalidAutocadChars(string str)
     {
       // using this to handle rhino nested layer syntax
       // replace "::" layer delimiter with "$" (acad standard)
       string cleanDelimiter = str.Replace("::", "$");
 
       // remove all other invalid chars
-      return Regex.Replace(cleanDelimiter, $"[{invalidChars}]", string.Empty);
+      return Regex.Replace(cleanDelimiter, $"[{invalidAutocadChars}]", string.Empty);
     }
 
     public DisplayStyle GetStyle(DBObject obj)

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -168,9 +168,11 @@ namespace Objects.Converter.AutocadCivil
     // Blocks
     public BlockInstance BlockReferenceToSpeckle(BlockReference reference)
     {
+      /*
       // skip if dynamic block
       if (reference.IsDynamicBlock)
         return null;
+      */
 
       // get record
       BlockDefinition definition = null;
@@ -193,10 +195,9 @@ namespace Objects.Converter.AutocadCivil
         blockDefinition = definition,
         units = ModelUnits
       };
-      
+
       // add attributes
-      foreach (var attribute in attributes)
-        instance[attribute.Key] = attribute.Value;
+      instance["attributes"] = attributes;
 
       return instance;
     }
@@ -223,6 +224,12 @@ namespace Objects.Converter.AutocadCivil
       BlockTableRecord modelSpaceRecord = Doc.Database.GetModelSpace();
       BlockReference br = new BlockReference(insertionPoint, definitionId);
       br.BlockTransform = convertedTransform;
+      // add attributes if there are any
+      var attributes = instance["attributes"] as Dictionary<string, string>;
+      if (attributes != null)
+      {
+        // TODO: figure out how to add attributes
+      }
       ObjectId id = ObjectId.Null;
       if (AppendToModelSpace)
         id = modelSpaceRecord.Append(br);
@@ -270,7 +277,7 @@ namespace Objects.Converter.AutocadCivil
     public ObjectId BlockDefinitionToNativeDB(BlockDefinition definition)
     {
       // get modified definition name with commit info
-      var blockName = $"{Doc.UserData["commit"]} - {RemoveInvalidChars(definition.name)}";
+      var blockName = $"{Doc.UserData["commit"]} - {RemoveInvalidAutocadChars(definition.name)}";
 
       ObjectId blockId = ObjectId.Null;
 


### PR DESCRIPTION
## Description
This was a blocker for Bilal's acad to revit workflow - the files he's using has dynamic blocks.
- Fixes #893

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- No updates needed

