### PR TITLE
Alignments: modifies class and adds ToNative conversions

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -7,18 +7,25 @@ using Speckle.Core.Models;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.Civil.ApplicationServices;
 using CivilDB = Autodesk.Civil.DatabaseServices;
+using Civil = Autodesk.Civil;
+using Autodesk.AutoCAD.Geometry;
 using Acad = Autodesk.AutoCAD.Geometry;
 
 using Alignment = Objects.BuiltElements.Alignment;
+using Arc = Objects.Geometry.Arc;
 using Interval = Objects.Primitive.Interval;
 using Polycurve = Objects.Geometry.Polycurve;
 using Curve = Objects.Geometry.Curve;
 using Featureline = Objects.BuiltElements.Featureline;
+using Line = Objects.Geometry.Line;
 using Point = Objects.Geometry.Point;
 using Brep = Objects.Geometry.Brep;
 using Mesh = Objects.Geometry.Mesh;
 using Pipe = Objects.BuiltElements.Pipe;
+using Plane = Objects.Geometry.Plane;
 using Polyline = Objects.Geometry.Polyline;
+using Spiral = Objects.Geometry.Spiral;
+using SpiralType = Objects.Geometry.SpiralType;
 using Station = Objects.BuiltElements.Station;
 using Structure = Objects.BuiltElements.Structure;
 
@@ -39,15 +46,107 @@ namespace Objects.Converter.AutocadCivil
     }
 
     // alignments
+    public SpiralType SpiralTypeToSpeckle(Civil.SpiralType type)
+    {
+      switch (type)
+      {
+        case Civil.SpiralType.Clothoid:
+          return SpiralType.Clothoid;
+        case Civil.SpiralType.Bloss:
+          return SpiralType.Bloss;
+        case Civil.SpiralType.BiQuadratic:
+          return SpiralType.Biquadratic;
+        case Civil.SpiralType.CubicParabola:
+          return SpiralType.CubicParabola;
+        case Civil.SpiralType.Sinusoidal:
+          return SpiralType.Sinusoid;
+        default:
+          return SpiralType.Unknown;
+      }
+    }
+
+    public Civil.SpiralType SpiralTypeToNative(SpiralType type)
+    {
+      switch (type)
+      {
+        case SpiralType.Clothoid:
+          return Civil.SpiralType.Clothoid;
+        case SpiralType.Bloss:
+          return Civil.SpiralType.Bloss;
+        case SpiralType.Biquadratic:
+          return Civil.SpiralType.BiQuadratic;
+        case SpiralType.CubicParabola:
+          return Civil.SpiralType.CubicParabola;
+        case SpiralType.Sinusoid:
+          return Civil.SpiralType.Sinusoidal;
+        default:
+          return Civil.SpiralType.Clothoid;
+      }
+    }
     public Alignment AlignmentToSpeckle(CivilDB.Alignment alignment)
     {
       var _alignment = new Alignment();
 
-      _alignment.baseCurve = CurveToSpeckle(alignment.BaseCurve, ModelUnits);
+      // get the alignment subentity curves
+      List<ICurve> curves = new List<ICurve>();
+      var stations = new List<double>();
+      for (int i = 0; i < alignment.Entities.Count; i++)
+      {
+        var entity = alignment.Entities.GetEntityByOrder(i);
+
+        var polycurve = new Polycurve(units: ModelUnits, applicationId: entity.EntityId.ToString());
+        var segments = new List<ICurve>();
+        double length = 0;
+        for (int j = 0; j < entity.SubEntityCount; j++)
+        {
+          CivilDB.AlignmentSubEntity subEntity = entity[j];
+          ICurve segment = null;
+          switch (subEntity.SubEntityType)
+          {
+            case CivilDB.AlignmentSubEntityType.Arc:
+              var arc = subEntity as CivilDB.AlignmentSubEntityArc;
+              segment = AlignmentArcToSpeckle(arc);
+              break;
+            case CivilDB.AlignmentSubEntityType.Line:
+              var line = subEntity as CivilDB.AlignmentSubEntityLine;
+              segment = AlignmentLineToSpeckle(line);
+              break;
+            case CivilDB.AlignmentSubEntityType.Spiral:
+              var spiral = subEntity as CivilDB.AlignmentSubEntitySpiral;
+              segment = AlignmentSpiralToSpeckle(spiral, alignment);
+              break;
+          }
+          if (segment != null)
+          {
+            length += subEntity.Length;
+            segments.Add(segment);
+          }
+
+        }
+        if (segments.Count == 1)
+        {
+          curves.Add(segments[0]);
+        }
+        else
+        {
+          polycurve.segments = segments;
+          polycurve.length = length;
+
+          // add additional props like entity type
+          polycurve["alignmentType"] = entity.EntityType.ToString();
+          curves.Add(polycurve);
+        }
+      }
+
+      // get display poly
+      var poly = alignment.Spline.ToPolyline(false, true);
+      _alignment.displayValue = CurveToSpeckle(poly) as Polyline;
+
+      _alignment.curves = curves;
       if (alignment.DisplayName != null)
         _alignment.name = alignment.DisplayName;
       if (alignment.StartingStation != null)
-        _alignment.startStation  = alignment.StartingStation;
+        _alignment.startStation = alignment.StartingStation;
       if (alignment.EndingStation != null)
         _alignment.endStation = alignment.EndingStation;
 
@@ -65,9 +164,217 @@ namespace Objects.Converter.AutocadCivil
 
       _alignment.units = ModelUnits;
 
+      // add civil3d props if they exist
+      if (alignment.SiteName != null)
+        _alignment["site"] = alignment.SiteName;
+      if (alignment.StyleName != null)
+        _alignment["style"] = alignment.StyleName;
+
+      return _alignment;
+    }
+    public CivilDB.Alignment AlignmentToNative(Alignment alignment)
+    {
+      var name = alignment.name ?? string.Empty;
+      var layer = Doc.Database.LayerZero;
+
+      BlockTableRecord modelSpaceRecord = Doc.Database.GetModelSpace();
+      var civilDoc = CivilApplication.ActiveDocument;
+      if (civilDoc == null)
+        return null;
+
+      #region properties
+      var site = ObjectId.Null;
+      var style = civilDoc.Styles.AlignmentStyles.First();
+      var label = civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles.First();
+
+      // get site
+      if (alignment["site"] != null)
+      {
+        var _site = alignment["site"] as string;
+        if (_site != string.Empty)
+        {
+          foreach (ObjectId docSite in civilDoc.GetSiteIds())
+          {
+            var siteEntity = Trans.GetObject(docSite, OpenMode.ForRead) as CivilDB.Site;
+            if (siteEntity.Name.Equals(_site))
+            {
+              site = docSite;
+              break;
+            }
+          }
+        }
+      }
+
+      // get style
+      if (alignment["style"] != null)
+      {
+        var _style = alignment["style"] as string;
+        foreach (var docStyle in civilDoc.Styles.AlignmentStyles)
+        {
+          var styleEntity = Trans.GetObject(docStyle, OpenMode.ForRead) as CivilDB.Styles.AlignmentStyle;
+          if (styleEntity.Name.Equals(_style))
+          {
+            style = docStyle;
+            break;
+          }
+        }
+      }
+
+      // get labelset
+      if (alignment["label"] != null)
+      {
+        var _label = alignment["label"] as string;
+        foreach (var docLabelSet in civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles)
+        {
+          var labelEntity = Trans.GetObject(docLabelSet, OpenMode.ForRead) as CivilDB.Styles.AlignmentLabelSetStyle;
+          if (labelEntity.Name.Equals(_label))
+          {
+            label = docLabelSet;
+            break;
+          }
+        }
+      }
+      #endregion
+
+      // create alignment entity curves
+      var id = CivilDB.Alignment.Create(civilDoc, name, site, layer, style, label);
+      if (id == ObjectId.Null)
+        return null;
+      var _alignment = Trans.GetObject(id, OpenMode.ForWrite) as CivilDB.Alignment;
+      var entities = _alignment.Entities;
+      foreach (var curve in alignment.curves)
+      {
+        CivilDB.AlignmentEntity entity = null;
+        switch (curve)
+        {
+          case Line o:
+            entities.AddFixedLine(PointToNative(o.start), PointToNative(o.end));
+            break;
+
+          case Arc o:
+            entities.AddFixedCurve(entities.LastEntity, PointToNative(o.startPoint), PointToNative(o.midPoint), PointToNative(o.endPoint));
+            break;
+
+          case Spiral o:
+            var origin = PointToNative(o.plane.origin);
+            var start = PointToNative(o.startPoint);
+            var end = PointToNative(o.endPoint);
+            bool clockwise = (o.turns > 0) ? false : true;
+            entities.AddFixedSpiral(entities.LastEntity, start, end, origin.DistanceTo(start), origin.DistanceTo(end), o.length, clockwise, SpiralTypeToNative(o.spiralType));
+            break;
+
+          case Polycurve o:
+            // recursive stuff, move this to separate method
+            break;
+
+          default:
+            continue;
+            break;
+        }
+      }
+
       return _alignment;
     }
 
+    #region helper methods
+    private Line AlignmentLineToSpeckle(CivilDB.AlignmentSubEntityLine line)
+    {
+      var _line = LineToSpeckle(new LineSegment2d(line.StartPoint, line.EndPoint));
+      return _line;
+    }
+    private Arc AlignmentArcToSpeckle(CivilDB.AlignmentSubEntityArc arc)
+    {
+      // calculate midpoint of chord as between start and end point
+      Point2d chordMid = new Point2d((arc.StartPoint.X + arc.EndPoint.X) / 2, (arc.StartPoint.Y + arc.EndPoint.Y) / 2);
+
+      // calculate sagitta as radius minus distance between arc center and chord midpoint
+      var sagitta = arc.Radius - arc.CenterPoint.GetDistanceTo(chordMid);
+
+      // get unit vector from arc center to chord mid
+      var midVector = arc.CenterPoint.GetVectorTo(chordMid);
+      var unitMidVector = midVector.DivideBy(midVector.Length);
+
+      // get midpoint of arc by moving chord mid point the length of the sagitta along mid vector
+      var midPoint = chordMid.Add(unitMidVector.MultiplyBy(sagitta));
+
+      // find arc plane (normal is in clockwise dir)
+      var center3 = new Point3d(arc.CenterPoint.X, arc.CenterPoint.Y, 0);
+      Acad.Plane plane = (arc.Clockwise) ? new Acad.Plane(center3, Vector3d.ZAxis.MultiplyBy(-1)) : new Acad.Plane(center3, Vector3d.ZAxis);
+
+      // calculate start and end angles
+      var startVector = new Vector3d(arc.StartPoint.X - center3.X, arc.StartPoint.Y - center3.Y, 0);
+      var endVector = new Vector3d(arc.EndPoint.X - center3.X, arc.EndPoint.Y - center3.Y, 0);
+      var startAngle = startVector.AngleOnPlane(plane);
+      var endAngle = endVector.AngleOnPlane(plane);
+
+      // calculate total angle. 
+      // TODO: This needs to be improved with more research into autocad .AngleOnPlane() return values (negative angles, etc).
+      var totalAngle = (arc.Clockwise) ? System.Math.Abs(endAngle - startAngle) : System.Math.Abs(endAngle - startAngle);
+
+      // create arc
+      var _arc = new Arc(PlaneToSpeckle(plane), arc.Radius, startAngle, endAngle, totalAngle, ModelUnits);
+      _arc.startPoint = PointToSpeckle(arc.StartPoint);
+      _arc.endPoint = PointToSpeckle(arc.EndPoint);
+      _arc.midPoint = PointToSpeckle(midPoint);
+      _arc.domain = IntervalToSpeckle(new Acad.Interval(0, 1, tolerance));
+      _arc.length = arc.Length;
+
+      return _arc;
+    }
+    
+    private Spiral AlignmentSpiralToSpeckle(CivilDB.AlignmentSubEntitySpiral spiral, CivilDB.Alignment alignment)
+    {
+      var _spiral = new Spiral();
+      _spiral.startPoint = PointToSpeckle(spiral.StartPoint);
+      _spiral.endPoint = PointToSpeckle(spiral.EndPoint);
+      _spiral.length = spiral.Length;
+      _spiral.pitch = 0;
+      _spiral.spiralType = SpiralTypeToSpeckle(spiral.SpiralDefinition);
+
+      // get plane
+      var vX = new Vector3d(System.Math.Cos(spiral.StartDirection) + spiral.StartPoint.X, System.Math.Sin(spiral.StartDirection) + spiral.StartPoint.Y, 0);
+      var vY = vX.RotateBy(System.Math.PI / 2, Vector3d.ZAxis);
+      var plane = new Acad.Plane(new Point3d(spiral.RadialPoint.X, spiral.RadialPoint.Y, 0), vX, vY);
+      _spiral.plane = PlaneToSpeckle(plane);
+
+      // get turns
+      int turnDirection = (spiral.Direction == CivilDB.SpiralDirectionType.DirectionLeft) ? 1 : -1;
+      _spiral.turns = turnDirection * spiral.Delta / (System.Math.PI * 2);
+
+      // create polyline display, default tessellation length is 1
+      var tessellation = 1;
+      int spiralSegmentCount = System.Convert.ToInt32(System.Math.Ceiling(spiral.Length / tessellation));
+      spiralSegmentCount = (spiralSegmentCount < 10) ? 10 : spiralSegmentCount;
+      double spiralSegmentLength = spiral.Length / spiralSegmentCount;
+      List<Point2d> points = new List<Point2d>();
+      points.Add(spiral.StartPoint);
+      for (int i = 1; i < spiralSegmentCount; i++)
+      {
+        double x = 0;
+        double y = 0;
+        double z = 0;
+
+        alignment.PointLocation(spiral.StartStation + (i * spiralSegmentLength), 0, tolerance, ref x, ref y, ref z);
+        points.Add(new Point2d(x, y));
+      }
+      points.Add(spiral.EndPoint);
+      double length = 0;
+      for (int j = 1; j < points.Count; j++)
+      {
+        length += points[j].GetDistanceTo(points[j - 1]);
+      }
+      var poly = new Polyline();
+      poly.value = PointsToFlatList(points);
+      poly.units = ModelUnits;
+      poly.closed = (spiral.StartPoint != spiral.EndPoint) ? false : true;
+      poly.length = length;
+      _spiral.displayValue = poly;
+
+      return _spiral;
+    }
+                        
+    #endregion
+     
     // profiles
     public Base ProfileToSpeckle(CivilDB.Profile profile)
     {
@@ -249,8 +556,8 @@ namespace Objects.Converter.AutocadCivil
       switch (pipe.SubEntityType)
       {
         case CivilDB.PipeSubEntityType.Straight:
-          var line = new Line(pipe.StartPoint, pipe.EndPoint);
-          curve = CurveToSpeckle(line);
+          var line = new Acad.LineSegment3d(pipe.StartPoint, pipe.EndPoint);
+          curve = LineToSpeckle(line);
           break;
         default:
           curve = CurveToSpeckle(pipe.Spline);

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -312,6 +312,8 @@ namespace Objects.Converter.AutocadCivil
       return new AcadDB.Ellipse(PointToNative(ellipse.plane.origin), normal, majorAxis, radiusRatio, 0, 2 * Math.PI);
     }
 
+    // Spiral
+
     // Polyline
     public Polyline PolylineToSpeckle(AcadDB.Polyline polyline) // AcadDB.Polylines can have linear or arc segments. This will convert to linear
     {

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -372,9 +372,14 @@ public static string AutocadAppName = Applications.Autocad2022;
           Report.Log($"Created Text {o.id}");
           break;
 
-        // TODO: add Civil3D directive to convert to alignment instead of curve
         case Alignment o:
           string fallback = " as Polyline";
+          if (o.curves is null) // TODO: remove after a few releases, this is for backwards compatibility
+          {
+            acadObj = CurveToNativeDB(o.baseCurve);
+            Report.Log($"Created Alignment {o.id} as Curve");
+            break;
+          }
 #if (CIVIL2020 || CIVIL2021)
           acadObj = AlignmentToNative(o);
           if (acadObj != null)

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -375,14 +375,13 @@ public static string AutocadAppName = Applications.Autocad2022;
         // TODO: add Civil3D directive to convert to alignment instead of curve
         case Alignment o:
           string fallback = " as Polyline";
-#if (CIVIL2020 || Civil2021)
+#if (CIVIL2020 || CIVIL2021)
           acadObj = AlignmentToNative(o);
+          if (acadObj != null)
+            fallback = string.Empty;
+#endif
           if (acadObj == null)
             acadObj = PolylineToNativeDB(o.displayValue);
-          else
-            fallback = string.Empty();
-#endif
-          acadObj = PolylineToNativeDB(o.displayValue);
           Report.Log($"Created Alignment {o.id}{fallback}");
           break;
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -374,8 +374,16 @@ public static string AutocadAppName = Applications.Autocad2022;
 
         // TODO: add Civil3D directive to convert to alignment instead of curve
         case Alignment o:
-          acadObj = CurveToNativeDB(o.baseCurve);
-          Report.Log($"Created Alignment {o.id} as Curve");
+          string fallback = " as Polyline";
+#if (CIVIL2020 || Civil2021)
+          acadObj = AlignmentToNative(o);
+          if (acadObj == null)
+            acadObj = PolylineToNativeDB(o.displayValue);
+          else
+            fallback = string.Empty();
+#endif
+          acadObj = PolylineToNativeDB(o.displayValue);
+          Report.Log($"Created Alignment {o.id}{fallback}");
           break;
 
         case ModelCurve o:

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -638,9 +638,41 @@ namespace Objects.Converter.Dynamo
     // TODO: send this as a spiral class
     public Base HelixToSpeckle(Helix helix, string units = null)
     {
+      var u = units ?? ModelUnits;
+
+      /* untested code to send as spiral
+      using (DS.Plane basePlane = DS.Plane.ByOriginNormal(helix.AxisPoint, helix.Normal))
+      {
+        var spiral = new Spiral();
+
+        spiral.startPoint = PointToSpeckle(helix.StartPoint, u);
+        spiral.endPoint = PointToSpeckle(helix.EndPoint, u);
+        spiral.plane = PlaneToSpeckle(basePlane, u);
+        spiral.pitchAxis = VectorToSpeckle(helix.AxisDirection, u);
+        spiral.pitch = helix.Pitch;
+        spiral.turns = helix.Angle / (2 * Math.PI);
+
+        // display value
+        DS.Curve[] curves = helix.ApproximateWithArcAndLineSegments();
+        List<double> polylineCoordinates =
+          curves.SelectMany(c => PointListToFlatArray(new DS.Point[2] { c.StartPoint, c.EndPoint })).ToList();
+        polylineCoordinates.AddRange(PointToArray(curves.Last().EndPoint));
+        curves.ForEach(c => c.Dispose());
+        Polyline displayValue = new Polyline(polylineCoordinates, u);
+        spiral.displayValue = displayValue;
+
+        CopyProperties(spiral, helix);
+
+        spiral.length = helix.Length;
+        spiral.bbox = BoxToSpeckle(helix.BoundingBox.ToCuboid(), u);
+
+        return spiral;
+      }
+      */
+
       using (NurbsCurve nurbsCurve = helix.ToNurbsCurve())
       {
-        var curve = CurveToSpeckle(nurbsCurve, units ?? ModelUnits);
+        var curve = CurveToSpeckle(nurbsCurve, u);
         CopyProperties(curve, helix);
         return curve;
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -322,8 +322,8 @@ namespace Objects.Converter.Revit
 
         // non revit built elems
         case BE.Alignment o:
-          Report.Log($"Created Alignment {o.applicationId}");
-          return ModelCurveToNative(o.baseCurve);
+          Report.Log($"Created Alignment {o.applicationId} as Curves");
+          return AlignmentToNative(o);
 
         case BE.Structure o:
           Report.Log($"Created Structure {o.applicationId}");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -322,6 +322,11 @@ namespace Objects.Converter.Revit
 
         // non revit built elems
         case BE.Alignment o:
+          if (o.curves is null) // TODO: remove after a few releases, this is for backwards compatibility
+          {
+            Report.Log($"Created Alignment {o.applicationId}");
+            return ModelCurveToNative(o.baseCurve);
+          }
           Report.Log($"Created Alignment {o.applicationId} as Curves");
           return AlignmentToNative(o);
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -332,6 +332,18 @@ namespace Objects.Converter.Revit
       }
     }
 
+    public CurveArray CurveToNative(List<ICurve> crvs)
+    {
+      CurveArray crvsArray = new CurveArray();
+      foreach (var crv in crvs)
+      {
+        var crvEnumerator = CurveToNative(crv).GetEnumerator();
+        while (crvEnumerator.MoveNext() && crvEnumerator.Current != null)
+          crvsArray.Append(crvEnumerator.Current as DB.Curve);
+      }
+      return crvsArray;
+    }
+
     /// <summary>
     /// Recursively creates an ordered list of curves from a polycurve/polyline.
     /// Please note that a polyline is broken down into lines.

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -10,6 +10,7 @@ using Speckle.Core.Kits;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Alignment = Objects.BuiltElements.Alignment; 
 using Column = Objects.BuiltElements.Column;
 using Beam = Objects.BuiltElements.Beam;
 using Wall = Objects.BuiltElements.Wall;
@@ -267,5 +268,26 @@ namespace Objects.Converter.RhinoGh
         outCurves = (brpCurves.Count() == 1) ? new List<ICurve>() { (ICurve)ConvertToSpeckle(brpCurves[0]) } : RH.Curve.JoinCurves(brpCurves, tol).Select(o => (ICurve)ConvertToSpeckle(o)).ToList();
       return outCurves;
     }
+
+    #region CIVIL
+
+    // alignment
+    public RH.Curve AlignmentToNative(Alignment alignment)
+    {
+      var curves = new List<RH.Curve>();
+      foreach (var entity in alignment.curves)
+      {
+        var converted = CurveToNative(entity);
+        if (converted != null)
+          curves.Add(converted);
+      }
+      if (curves.Count == 0) return null;
+
+      // try to join entity curves
+      var joined = RH.Curve.JoinCurves(curves);
+      return joined.First();
+    }
+
+    #endregion
   }
 }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -560,8 +560,8 @@ namespace Objects.Converter.RhinoGh
           break;
 
         case Alignment o:
-          rhinoObj = CurveToNative(o.baseCurve);
-          Report.Log($"Created Alignment {o.id}");
+          rhinoObj = AlignmentToNative(o);
+          Report.Log($"Created Alignment {o.id} as Curve");
           break;
 
         case ModelCurve o:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -560,6 +560,12 @@ namespace Objects.Converter.RhinoGh
           break;
 
         case Alignment o:
+          if (o.curves is null) // TODO: remove after a few releases, this is for backwards compatibility
+          {
+            rhinoObj = CurveToNative(o.baseCurve);
+            Report.Log($"Created Alignment {o.id}");
+            break;
+          }
           rhinoObj = AlignmentToNative(o);
           Report.Log($"Created Alignment {o.id} as Curve");
           break;

--- a/Objects/Objects/BuiltElements/Alignment.cs
+++ b/Objects/Objects/BuiltElements/Alignment.cs
@@ -9,7 +9,7 @@ namespace Objects.BuiltElements
 {
   public class Alignment : Base
   {
-    public ICurve baseCurve { get; set; }
+    public List<ICurve> curves { get; set; }
 
     public string name { get; set; }
 
@@ -26,6 +26,8 @@ namespace Objects.BuiltElements
     /// Station equation direction for the corresponding station equation should be true for increasing or false for decreasing
     /// </summary>
     public List<bool> stationEquationDirections { get; set; }
+
+    public Polyline displayValue { get; set; }
 
     public string units { get; set; }
 

--- a/Objects/Objects/BuiltElements/Alignment.cs
+++ b/Objects/Objects/BuiltElements/Alignment.cs
@@ -1,6 +1,7 @@
 ﻿using Objects.Geometry;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -9,6 +10,9 @@ namespace Objects.BuiltElements
 {
   public class Alignment : Base
   {
+    [JsonIgnore, Obsolete("Use curves property")]
+    public ICurve baseCurve { get; set; }
+
     public List<ICurve> curves { get; set; }
 
     public string name { get; set; }


### PR DESCRIPTION
## Description

- Deprecates `baseCurve` prop and replaces with `curves` prop
- Adds `AlignmentToNative` conversions to Acad/C3D/rhino/revit
- Improves `AlignmentToSpeckle` conversion in C3D to include spiral segments

**Blocker** Arup's Bentley connectors aren't merged, waiting to improve OpenRoads Alignment conversions and test C3D <-> OpenRoads conversions until they are merged

- Fixes #788

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sent and received Alignments between C3D and other applications. **Note** `AlignmentToNative` conversion in C3D segments deviate slightly from original despite having correct endpoints per segment. Need to be improved in the future. 

## Docs

- Will be updated ASAP

