### PR TITLE
Fix confusing error in StreamWrapper.ValidateWithAccount()

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ViewNode/View.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ViewNode/View.cs
@@ -152,7 +152,7 @@ namespace Speckle.ConnectorDynamo.ViewNode
 
       if (inputMirror == null || inputMirror.GetData() == null) return null;
 
-      var data = inputMirror.GetData().Data.ToString();
+      var data = inputMirror.GetData().Data?.ToString();
 
       return data;
     }

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -273,6 +273,9 @@ namespace Speckle.Core.Credentials
 
     private async Task ValidateWithAccount(Account acc)
     {
+      if (ServerUrl != acc.serverInfo.url)
+        throw new SpeckleException($"Account is not from server ${ServerUrl}");
+      
       var client = new Client(acc);
       // First check if the stream exists
       try


### PR DESCRIPTION
## Description

- Fixes #850

This did not affect end users at all, but devs (such as myself) would find it very confusing to get "Could not get stream" errors only to finally have it working in the end.

This was due to the validation checking first for the default account, and then for any account from that server. That first check would be unnecessary if the `ServerUrl` is already different from the `Account.serverInfo.url`

### Solution
Added a quick check to ensure account and url are from the same server and throw and more appropriate error if it doesn't.

Discussed this with @izzylis and will open an issue in `specklepy` to keep the `StreamWrapper` behaviour aligned.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Tests not required
- Unit/Integration Tests (which?)
- Manual Tests (please write what did you do?)

## Docs

- No updates needed
- Have already been updated
- Will be updated ASAP

