### PR TITLE
`Block` and `Transform` reworks

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -16,6 +16,7 @@ using Text = Objects.Other.Text;
 using Speckle.Core.Models;
 using Speckle.Core.Kits;
 using Autodesk.AutoCAD.Windows.Data;
+using Objects.Other;
 
 namespace Objects.Converter.AutocadCivil
 {
@@ -191,7 +192,7 @@ namespace Objects.Converter.AutocadCivil
 
       var instance = new BlockInstance()
       {
-        transform = reference.BlockTransform.ToArray(),
+        transform = new Transform( reference.BlockTransform.ToArray(), ModelUnits ),
         blockDefinition = definition,
         units = ModelUnits
       };
@@ -215,7 +216,7 @@ namespace Objects.Converter.AutocadCivil
       Point3d insertionPoint = PointToNative(instance.GetInsertionPoint());
 
       // transform
-      double[] transform = instance.transform;
+      double[] transform = instance.transform.value;
       for (int i = 3; i < 12; i += 4)
         transform[i] = ScaleToNative(transform[i], instance.units);
       Matrix3d convertedTransform = new Matrix3d(transform);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -634,7 +634,7 @@ namespace Objects.Converter.Revit
     #region Project Base Point
     private class BetterBasePoint
     {
-      public Transform TotalTransform { get; set; } = Transform.Identity;
+      public DB.Transform TotalTransform { get; set; } = DB.Transform.Identity;
     }
 
     ////////////////////////////////////////////////
@@ -663,7 +663,7 @@ namespace Objects.Converter.Revit
 #else
             var point = bp.Position;
 #endif
-            _basePoint = new BetterBasePoint { TotalTransform = Transform.CreateTranslation(point).Inverse }; // rotation already accounted for
+            _basePoint = new BetterBasePoint { TotalTransform = DB.Transform.CreateTranslation(point).Inverse }; // rotation already accounted for
           }
         }
         return _basePoint;
@@ -743,14 +743,14 @@ namespace Objects.Converter.Revit
         //move curves to Z = 0, needed for shafts!
         curveA.MakeBound(0, 1);
         var z = curveA.GetEndPoint(0).Z;
-        var cA = curveA.CreateTransformed(Transform.CreateTranslation(new XYZ(0, 0, -z)));
+        var cA = curveA.CreateTransformed(DB.Transform.CreateTranslation(new XYZ(0, 0, -z)));
 
         foreach (var curveB in curveArrayB)
         {
           //move curves to Z = 0, needed for shafts!
           curveB.MakeBound(0, 1);
           z = curveB.GetEndPoint(0).Z;
-          var cB = curveB.CreateTransformed(Transform.CreateTranslation(new XYZ(0, 0, -z)));
+          var cB = curveB.CreateTransformed(DB.Transform.CreateTranslation(new XYZ(0, 0, -z)));
 
           var result = cA.Intersect(cB);
           if (result != SetComparisonResult.BothEmpty && result != SetComparisonResult.Disjoint)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -19,9 +19,9 @@ namespace Objects.Converter.Revit
     {
       // need to combine the two transforms, but i'm stupid and did it wrong so leaving like this for now
       if ( transform != null )
-        transform *= new Transform(instance.transform);
+        transform *= instance.transformMatrix;
       else
-        transform = new Transform(instance.transform);
+        transform = instance.transformMatrix;
       var applyTransform = transform.isScaled;
 
       // convert definition geometry to native
@@ -48,7 +48,7 @@ namespace Objects.Converter.Revit
             break;
           case Mesh mesh:
             if ( applyTransform )
-              mesh = mesh.Transform(transform);
+              mesh = mesh.TransformTo(transform);
             meshes.Add(mesh);
             break;
           case ICurve curve:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -52,7 +52,7 @@ namespace Objects.Converter.Revit
             {
               if ( curve is ITransformable tCurve )
               {
-                tCurve.TransformTo(transform, out tCurve);
+                tCurve.TransformTo( transform, out tCurve );
                 curve = ( ICurve ) tCurve;
               }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -14,176 +14,85 @@ using Mesh = Objects.Geometry.Mesh;
 using Parameter = Objects.BuiltElements.Revit.Parameter;
 using BlockInstance = Objects.Other.BlockInstance;
 using BlockDefinition = Objects.Other.BlockDefinition;
+using Transform = Objects.Other.Transform;
 
 namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
-    // Creates a generic model instance in a project or family doc
-    public string BlockInstanceToNative(BlockInstance instance, Document familyDoc = null)
+    public Group BlockInstanceToNative(BlockInstance instance, Transform transform = null)
     {
-
-      string result = null;
-
-      // Base point
-      var basePoint = PointToNative(instance.insertionPoint);
-
-      // Get or make family from block definition
-      FamilySymbol familySymbol = new FilteredElementCollector(Doc)
-        .OfClass(typeof(Family))
-        .OfType<Family>()
-        .FirstOrDefault(f => f.Name.Equals("SpeckleBlock_" + instance.blockDefinition.name))
-        ?.GetFamilySymbolIds()
-        .Select(id => Doc.GetElement(id))
-        .OfType<FamilySymbol>()
-        .First();
-
-      if (familySymbol == null)
-      {
-        var familyPath = BlockDefinitionToNative(instance.blockDefinition);
-
-        if (familyDoc != null)
-        {
-          if (familyDoc.LoadFamily(familyPath, new FamilyLoadOption(), out var fam)) ;
-          familySymbol = familyDoc.GetElement(fam.GetFamilySymbolIds().First()) as DB.FamilySymbol;
-        }
-        else
-        {
-          if (Doc.LoadFamily(familyPath, new FamilyLoadOption(), out var fam))
-            familySymbol = Doc.GetElement(fam.GetFamilySymbolIds().First()) as DB.FamilySymbol;
-        }
-
-        familySymbol.Activate();
-        //File.Delete(familyPath);
-      }
-
-      // see if this is a nested family instance or to be inserted in project
-      FamilyInstance _instance = null;
-      if (familyDoc != null)
-      {
-        _instance = familyDoc.FamilyCreate.NewFamilyInstance(basePoint, familySymbol, DB.Structure.StructuralType.NonStructural);
-        familyDoc.Regenerate();
-      }
-      else
-      {
-        _instance = Doc.Create.NewFamilyInstance(basePoint, familySymbol, DB.Structure.StructuralType.NonStructural);
-        Doc.Regenerate();
-      }
-
-      // transform
-      if (_instance != null)
-      {
-        if (MatrixDecompose(instance.transform, out double rotation))
-        {
-          try
-          {
-            // some point based families don't have a rotation, so keep this in a try catch
-            if (rotation != (_instance.Location as LocationPoint).Rotation)
-            {
-              var axis = DB.Line.CreateBound(new XYZ(basePoint.X, basePoint.Y, 0), new XYZ(basePoint.X, basePoint.Y, 1000));
-              (_instance.Location as LocationPoint).Rotate(axis, rotation - (_instance.Location as LocationPoint).Rotation);
-            }
-          }
-          catch { }
-
-        }
-        SetInstanceParameters(_instance, instance);
-        result = "success";
-      }
-      //Report.Log($"Created Block {_instance.Id}");
-      return result;
-    }
-
-    // TODO: fix unit conversions since block geometry is being converted inside a new family document, which potentially has different unit settings from the main doc.
-    // This could be done by passing in an option Document argument for all conversions that defaults to the main doc (annoying)
-    // I suspect this also needs to be fixed for freeform elements
-    private string BlockDefinitionToNative(BlockDefinition definition)
-    {
-      // create a family to represent a block definition
-      // TODO: rename block with stream commit info prefix taken from UI - need to figure out cleanest way of storing this in the doc for retrieval by converter
-      var templatePath = GetTemplatePath("Generic Model");
-      if (!File.Exists(templatePath))
-      {
-        throw new Exception($"Could not find template file - {templatePath}");
-      }
-
-      var famDoc = Doc.Application.NewFamilyDocument(templatePath);
+      // need to combine the two transforms, but i'm stupid and did it wrong so leaving like this for now
+      transform = new Transform(instance.transform);
+      var applyTransform = transform.isScaled;
 
       // convert definition geometry to native
-      var solids = new List<DB.Solid>();
+      var breps = new List<Brep>();
+      var meshes = new List<Mesh>();
       var curves = new List<DB.Curve>();
       var blocks = new List<BlockInstance>();
-      foreach (var geometry in definition.geometry)
+      foreach ( var geometry in instance.blockDefinition.geometry )
       {
-        switch (geometry)
+        switch ( geometry )
         {
           case Brep brep:
             try
             {
-              var solid = BrepToNative(geometry as Brep);
-              solids.Add(solid);
+              breps.Add(brep);
             }
-            catch (Exception e)
+            catch ( Exception e )
             {
-              Report.LogConversionError(new SpeckleException($"Could not convert block {definition.id} brep to native, falling back to mesh representation.", e));
-              var brepMeshSolids = MeshToNative(brep.displayMesh, DB.TessellatedShapeBuilderTarget.Solid, DB.TessellatedShapeBuilderFallback.Abort)
-                  .Select(m => m as DB.Solid);
-              solids.AddRange(brepMeshSolids);
+              Report.LogConversionError(new SpeckleException(
+                $"Could not convert block {instance.id} brep to native, falling back to mesh representation.", e));
+              meshes.Add(brep.displayMesh);
             }
+
             break;
           case Mesh mesh:
-            var meshSolids = MeshToNative(mesh, DB.TessellatedShapeBuilderTarget.Solid, DB.TessellatedShapeBuilderFallback.Abort)
-                .Select(m => m as DB.Solid);
-            solids.AddRange(meshSolids);
+            if ( applyTransform )
+              mesh = mesh.Transform(transform);
+            meshes.Add(mesh);
             break;
           case ICurve curve:
             try
             {
-              var modelCurves = CurveToNative(geometry as ICurve);
-              foreach (DB.Curve modelCurve in modelCurves)
-                curves.Add(modelCurve);
+              var modelCurves = CurveToNative(curve);
+              curves.AddRange(modelCurves.Cast<DB.Curve>());
             }
-            catch (Exception e)
+            catch ( Exception e )
             {
-              Report.LogConversionError(new SpeckleException($"Could not convert block {definition.id} curve to native.", e));
+              Report.LogConversionError(
+                new SpeckleException($"Could not convert block {instance.id} curve to native.", e));
             }
+
             break;
-          case BlockInstance instance:
-            blocks.Add(instance);
+          case BlockInstance blk:
+            blocks.Add(blk);
             break;
         }
       }
 
-      using (DB.Transaction t = new DB.Transaction(famDoc, "Create Block Geometry Elements"))
-      {
-        t.Start();
+      var ids = new List<ElementId>();
+      breps.ForEach(o => { ids.Add(( DirectShapeToNative(o).NativeObject as DB.DirectShape )?.Id); });
+      meshes.ForEach(o => { ids.Add(( DirectShapeToNative(o).NativeObject as DB.DirectShape )?.Id); });
+      curves.ForEach(o => { ids.Add(Doc.Create.NewModelCurve(o, NewSketchPlaneFromCurve(o, Doc)).Id); });
+      blocks.ForEach(o => { ids.Add(BlockInstanceToNative(o).Id); });
 
-        solids.ForEach(o => { DB.FreeFormElement.Create(famDoc, o); });
-        curves.ForEach(o => { famDoc.FamilyCreate.NewModelCurve(o, NewSketchPlaneFromCurve(o, famDoc)); });
-        blocks.ForEach(o => { BlockInstanceToNative(o, famDoc); });
-
-        t.Commit();
-      }
-
-      var famName = "SpeckleBlock_" + definition.name;
-      string familyPath = Path.Combine(Path.GetTempPath(), famName + ".rfa");
-      var so = new DB.SaveAsOptions();
-      so.OverwriteExistingFile = true;
-      famDoc.SaveAs(familyPath, so);
-      famDoc.Close();
-      Report.Log($"Created temp family {familyPath}");
-      return familyPath;
+      var group = Doc.Create.NewGroup(ids);
+      group.GroupType.Name = $"SpeckleBlock_{instance.blockDefinition.name}_{instance.applicationId ?? instance.id}";
+      return group;
     }
 
-    private bool MatrixDecompose(double[] m, out double rotation)
+
+    private bool MatrixDecompose(double[ ] m, out double rotation)
     {
       var matrix = new Matrix4x4(
-        (float)m[0], (float)m[1], (float)m[2], (float)m[3],
-        (float)m[4], (float)m[5], (float)m[6], (float)m[7],
-        (float)m[8], (float)m[9], (float)m[10], (float)m[11],
-        (float)m[12], (float)m[13], (float)m[14], (float)m[15]);
+        ( float ) m[ 0 ], ( float ) m[ 1 ], ( float ) m[ 2 ], ( float ) m[ 3 ],
+        ( float ) m[ 4 ], ( float ) m[ 5 ], ( float ) m[ 6 ], ( float ) m[ 7 ],
+        ( float ) m[ 8 ], ( float ) m[ 9 ], ( float ) m[ 10 ], ( float ) m[ 11 ],
+        ( float ) m[ 12 ], ( float ) m[ 13 ], ( float ) m[ 14 ], ( float ) m[ 15 ]);
 
-      if (Matrix4x4.Decompose(matrix, out Vector3 _scale, out Quaternion _rotation, out Vector3 _translation))
+      if ( Matrix4x4.Decompose(matrix, out Vector3 _scale, out Quaternion _rotation, out Vector3 _translation) )
       {
         rotation = Math.Acos(_rotation.W) * 2;
         return true;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -19,9 +19,9 @@ namespace Objects.Converter.Revit
     {
       // need to combine the two transforms, but i'm stupid and did it wrong so leaving like this for now
       if ( transform != null )
-        transform *= instance.transformMatrix;
+        transform *= instance.transform;
       else
-        transform = instance.transformMatrix;
+        transform = instance.transform;
 
       // convert definition geometry to native
       var breps = new List<Brep>();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -33,21 +33,15 @@ namespace Objects.Converter.Revit
         switch ( geometry )
         {
           case Brep brep:
-            try
-            {
-              if ( !brep.TransformTo(transform, out var tbrep) )
-                throw new SpeckleException(
-                  $"Brep transform for brep {brep.id} from block instance {instance.id} was not successful");
+            var success = brep.TransformTo(transform, out var tbrep);
+            if ( success )
               breps.Add(tbrep);
-            }
-            catch ( Exception e )
+            else
             {
               Report.LogConversionError(new SpeckleException(
-                $"Could not convert block {instance.id} brep to native, falling back to mesh representation.", e));
-              brep.displayMesh.TransformTo(transform, out var bmesh);
-              meshes.Add(bmesh);
+                $"Could not convert block {instance.id} brep to native, falling back to mesh representation."));
+              meshes.Add(tbrep.displayMesh);
             }
-
             break;
           case Mesh mesh:
             mesh.TransformTo(transform, out var tmesh);

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -176,7 +176,7 @@ namespace Objects.Converter.RhinoGh
 
       var _instance = new BlockInstance()
       {
-        transform = transformArray,
+        transform = new Other.Transform(transformArray, ModelUnits),
         blockDefinition = def,
         units = ModelUnits
       };
@@ -192,7 +192,7 @@ namespace Objects.Converter.RhinoGh
       // get the transform
       // rhino doesn't seem to handle transform matrices where the translation vector last value is a divisor instead of 1, so make sure last value is set to 1
       Transform transform = Transform.Identity;
-      double[] t = instance.transform;
+      double[] t = instance.transform.value;
       if (t.Length == 16)
       {
         int count = 0;

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -316,12 +316,18 @@ namespace Objects.Geometry
     public bool TransformTo(Transform transform, out Brep brep)
     {
       displayMesh.TransformTo(transform, out var mesh);
+      var surfaces = new List<Surface>(Surfaces.Count);
+      foreach ( var srf in Surfaces )
+      {
+        srf.TransformTo(transform, out var surface);
+        surfaces.Add(surface);
+      }
       brep = new Brep
       {
         provenance = provenance,
         units = units,
         displayMesh = mesh,
-        Surfaces = Surfaces,
+        Surfaces = surfaces,
         Curve3D = transform.ApplyToCurves(Curve3D, out bool success),
         Curve2D = Curve2D,
         Vertices = transform.ApplyToPoints(Vertices),

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -309,18 +309,18 @@ namespace Objects.Geometry
     }
 
     /// <summary>
-    /// Returns a new transformed Brep. Note that `displayMesh` is *NOT* transformed. If you fall back on
-    /// the `displayMesh`, make sure to call `TransformTo` on the mesh object.
+    /// Returns a new transformed Brep. Note that `displayMesh` is *NOT* transformed.
     /// </summary>
     /// <param name="transform"></param>
     /// <returns></returns>
     public bool TransformTo(Transform transform, out Brep brep)
     {
+      displayMesh.TransformTo(transform, out var mesh);
       brep = new Brep
       {
         provenance = provenance,
         units = units,
-        displayMesh = displayMesh,
+        displayMesh = mesh,
         Surfaces = Surfaces,
         Curve3D = transform.ApplyToCurves(Curve3D, out bool success),
         Curve2D = Curve2D,

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -5,12 +5,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
+using Objects.Other;
 using Objects.Primitive;
 
 
 namespace Objects.Geometry
 {
-  public class Brep : Base, IHasArea, IHasVolume, IHasBoundingBox, IDisplayMesh
+  public class Brep : Base, IHasArea, IHasVolume, IHasBoundingBox, IDisplayMesh, ITransformable<Brep>
   {
     public string provenance { get; set; }
     public Box bbox { get; set; }
@@ -305,6 +306,11 @@ namespace Objects.Geometry
           else
             f.Brep = this;
       }
+    }
+
+    public Brep TransformTo(Transform transform)
+    {
+      throw new System.NotImplementedException();
     }
   }
 

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -331,7 +331,7 @@ namespace Objects.Geometry
         Faces = Faces,
         IsClosed = IsClosed,
         Orientation = Orientation,
-        applicationId = applicationId
+        applicationId = applicationId ?? id
       };
     }
   }

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -314,15 +314,15 @@ namespace Objects.Geometry
     /// </summary>
     /// <param name="transform"></param>
     /// <returns></returns>
-    public Brep TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out Brep brep)
     {
-      return new Brep
+      brep = new Brep
       {
         provenance = provenance,
         units = units,
         displayMesh = displayMesh,
         Surfaces = Surfaces,
-        Curve3D = transform.ApplyToCurves(Curve3D),
+        Curve3D = transform.ApplyToCurves(Curve3D, out bool success),
         Curve2D = Curve2D,
         Vertices = transform.ApplyToPoints(Vertices),
         Edges = Edges,
@@ -333,6 +333,8 @@ namespace Objects.Geometry
         Orientation = Orientation,
         applicationId = applicationId ?? id
       };
+
+      return success;
     }
   }
 

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -264,7 +264,6 @@ namespace Objects.Geometry
           }
           else
             e.Brep = this;
-        
       }
       
       for(var i = 0; i < Loops.Count; i++)
@@ -322,25 +321,41 @@ namespace Objects.Geometry
         srf.TransformTo(transform, out var surface);
         surfaces.Add(surface);
       }
+
       brep = new Brep
       {
         provenance = provenance,
         units = units,
         displayMesh = mesh,
         Surfaces = surfaces,
-        Curve3D = transform.ApplyToCurves(Curve3D, out bool success),
-        Curve2D = Curve2D,
+        Curve3D = transform.ApplyToCurves(Curve3D, out bool success3D),
+        Curve2D = transform.ApplyToCurves(Curve2D, out bool success2D),
         Vertices = transform.ApplyToPoints(Vertices),
-        Edges = Edges,
-        Loops = Loops,
-        Trims = Trims,
-        Faces = Faces,
+        Edges = new List<BrepEdge>(Edges.Count),
+        Loops = new List<BrepLoop>(Loops.Count),
+        Trims = new List<BrepTrim>(Trims.Count),
+        Faces = new List<BrepFace>(Faces.Count),
         IsClosed = IsClosed,
         Orientation = Orientation,
         applicationId = applicationId ?? id
       };
 
-      return success;
+      foreach ( var e in Edges )
+        brep.Edges.Add(new BrepEdge(brep, e.Curve3dIndex, e.TrimIndices, e.StartIndex, e.Curve3dIndex,
+          e.ProxyCurveIsReversed,
+          e.Domain));
+
+      foreach ( var l in Loops )
+        brep.Loops.Add(new BrepLoop(brep, l.FaceIndex, l.TrimIndices, l.Type));
+
+      foreach ( var t in Trims )
+        brep.Trims.Add(new BrepTrim(brep, t.EdgeIndex, t.FaceIndex, t.LoopIndex, t.CurveIndex, t.IsoStatus, t.TrimType,
+          t.IsReversed, t.StartIndex, t.EndIndex));
+
+      foreach ( var f in Faces )
+        brep.Faces.Add(new BrepFace(brep, f.SurfaceIndex, f.LoopIndices, f.OuterLoopIndex, f.OrientationReversed));
+
+      return success2D && success3D;
     }
   }
 

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -308,9 +308,31 @@ namespace Objects.Geometry
       }
     }
 
+    /// <summary>
+    /// Returns a new transformed Brep. Note that `displayMesh` is *NOT* transformed. If you fall back on
+    /// the `displayMesh`, make sure to call `TransformTo` on the mesh object.
+    /// </summary>
+    /// <param name="transform"></param>
+    /// <returns></returns>
     public Brep TransformTo(Transform transform)
     {
-      throw new System.NotImplementedException();
+      return new Brep
+      {
+        provenance = provenance,
+        units = units,
+        displayMesh = displayMesh,
+        Surfaces = Surfaces,
+        Curve3D = transform.ApplyToCurves(Curve3D),
+        Curve2D = Curve2D,
+        Vertices = transform.ApplyToPoints(Vertices),
+        Edges = Edges,
+        Loops = Loops,
+        Trims = Trims,
+        Faces = Faces,
+        IsClosed = IsClosed,
+        Orientation = Orientation,
+        applicationId = applicationId
+      };
     }
   }
 

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -309,7 +309,7 @@ namespace Objects.Geometry
     }
 
     /// <summary>
-    /// Returns a new transformed Brep. Note that `displayMesh` is *NOT* transformed.
+    /// Returns a new transformed Brep.
     /// </summary>
     /// <param name="transform"></param>
     /// <returns></returns>

--- a/Objects/Objects/Geometry/ControlPoint.cs
+++ b/Objects/Objects/Geometry/ControlPoint.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
+using Objects.Other;
 using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
-  public class ControlPoint : Point, IHasBoundingBox
+  public class ControlPoint : Point, IHasBoundingBox, ITransformable<ControlPoint>
   {
     /// <summary>
     /// OBSOLETE - This is just here for backwards compatibility.
@@ -38,6 +39,13 @@ namespace Objects.Geometry
     }
 
     public double weight { get; set; }
+
+    public bool TransformTo(Transform transform, out ControlPoint ctrlPt)
+    {
+      var coords = transform.ApplyToPoint(new List<double> {x, y, z});
+      ctrlPt = new ControlPoint(coords[0], coords[1], coords[2], weight, units, applicationId);
+      return true;
+    }
 
     public override string ToString() => $"{{{x},{y},{z},{weight}}}";
     

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -125,9 +125,10 @@ namespace Objects.Geometry
       return curve;
     }
 
-    public ITransformable TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out ITransformable curve)
     {
-      return new Curve
+      var result = displayValue.TransformTo(transform, out ITransformable polyline);
+      curve = new Curve
       {
         degree = degree,
         periodic = periodic,
@@ -135,11 +136,13 @@ namespace Objects.Geometry
         points = transform.ApplyToPoints(points),
         weights = weights,
         knots = knots,
-        displayValue = ( Polyline ) displayValue.TransformTo(transform),
+        displayValue = ( Polyline ) polyline,
         closed = closed,
         units =  units,
         applicationId = applicationId
       };
+
+      return result;
     }
   }
 }

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Objects.Other;
 using Objects.Primitive;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
@@ -9,7 +10,7 @@ using Speckle.Core.Models;
 
 namespace Objects.Geometry
 {
-  public class Curve : Base, ICurve, IHasBoundingBox, IHasArea
+  public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable
   {
     public int degree { get; set; }
 
@@ -122,6 +123,23 @@ namespace Objects.Geometry
 
       curve.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
       return curve;
+    }
+
+    public ITransformable TransformTo(Transform transform)
+    {
+      return new Curve
+      {
+        degree = degree,
+        periodic = periodic,
+        rational = rational,
+        points = transform.ApplyToPoints(points),
+        weights = weights,
+        knots = knots,
+        displayValue = ( Polyline ) displayValue.TransformTo(transform),
+        closed = closed,
+        units =  units,
+        applicationId = applicationId
+      };
     }
   }
 }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -103,10 +103,13 @@ namespace Objects.Geometry
 
     public ITransformable TransformTo(Transform transform)
     {
-      var startPt = transform.ApplyToPoint(start);
-      var endPt = transform.ApplyToPoint(end);
-
-      return new Line(startPt, endPt, units, applicationId);
+      return new Line
+      {
+        start = transform.ApplyToPoint(start),
+        end = transform.ApplyToPoint(end),
+        applicationId = applicationId,
+        units = units
+      };
     }
   }
 }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -101,15 +101,16 @@ namespace Objects.Geometry
       return line;
     }
 
-    public ITransformable TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out ITransformable line)
     {
-      return new Line
+      line = new Line
       {
         start = transform.ApplyToPoint(start),
         end = transform.ApplyToPoint(end),
         applicationId = applicationId,
         units = units
       };
+      return true;
     }
   }
 }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Objects.Other;
 using Objects.Primitive;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
@@ -10,7 +11,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
-  public class Line : Base, ICurve, IHasBoundingBox
+  public class Line : Base, ICurve, IHasBoundingBox, ITransformable
   {
     /// <summary>
     /// OBSOLETE - This is just here for backwards compatibility.
@@ -98,6 +99,14 @@ namespace Objects.Geometry
       var line = new Line(startPt, endPt, units);
       line.domain = new Interval(list[8], list[9]);
       return line;
+    }
+
+    public ITransformable TransformTo(Transform transform)
+    {
+      var startPt = transform.ApplyToPoint(start);
+      var endPt = transform.ApplyToPoint(end);
+
+      return new Line(startPt, endPt, units, applicationId);
     }
   }
 }

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -175,7 +175,8 @@ namespace Objects.Geometry
       {
         vertices = transform.ApplyToPoints(vertices),
         textureCoordinates = textureCoordinates,
-        applicationId = applicationId,
+        applicationId = applicationId ?? id,
+        faces = faces,
         colors = colors,
         units = units
       };

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -171,10 +171,14 @@ namespace Objects.Geometry
 
     public Mesh TransformTo(Transform transform)
     {
-      // this should be more thorough, but just doing as simply as poss for testing rn
-      var _vertices = transform.ApplyToPoints(vertices);
-      var mesh = new Mesh(_vertices, faces, colors, textureCoordinates, units, applicationId ?? id);
-      return mesh;
+      return new Mesh
+      {
+        vertices = transform.ApplyToPoints(vertices),
+        textureCoordinates = textureCoordinates,
+        applicationId = applicationId,
+        colors = colors,
+        units = units
+      };
     }
   }
 }

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -169,7 +169,7 @@ namespace Objects.Geometry
     
     #endregion
 
-    public Mesh Transform(Transform transform)
+    public Mesh TransformTo(Transform transform)
     {
       // this should be more thorough, but just doing as simply as poss for testing rn
       var _vertices = transform.ApplyToPoints(vertices);

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -3,12 +3,13 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Objects.Other;
 using Speckle.Core.Logging;
 using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
-  public class Mesh : Base, IHasBoundingBox, IHasVolume, IHasArea
+  public class Mesh : Base, IHasBoundingBox, IHasVolume, IHasArea, ITransformable<Mesh>
   {
     [DetachProperty]
     [Chunkable(31250)]
@@ -167,5 +168,13 @@ namespace Objects.Geometry
     }
     
     #endregion
+
+    public Mesh Transform(Transform transform)
+    {
+      // this should be more thorough, but just doing as simply as poss for testing rn
+      var _vertices = transform.ApplyToPoints(vertices);
+      var mesh = new Mesh(_vertices, faces, colors, textureCoordinates, units, applicationId ?? id);
+      return mesh;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -169,9 +169,9 @@ namespace Objects.Geometry
     
     #endregion
 
-    public Mesh TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out Mesh mesh)
     {
-      return new Mesh
+      mesh = new Mesh
       {
         vertices = transform.ApplyToPoints(vertices),
         textureCoordinates = textureCoordinates,
@@ -180,6 +180,8 @@ namespace Objects.Geometry
         colors = colors,
         units = units
       };
+
+      return true;
     }
   }
 }

--- a/Objects/Objects/Geometry/Plane.cs
+++ b/Objects/Objects/Geometry/Plane.cs
@@ -60,9 +60,9 @@ namespace Objects.Geometry
       return plane;
     }
 
-    public Plane TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out Plane plane)
     {
-      return new Plane
+      plane = new Plane
       {
         origin = transform.ApplyToPoint(origin),
         normal = transform.ApplyToVector(normal),
@@ -71,6 +71,8 @@ namespace Objects.Geometry
         applicationId = applicationId,
         units = units
       };
+
+      return true;
     }
   }
 }

--- a/Objects/Objects/Geometry/Plane.cs
+++ b/Objects/Objects/Geometry/Plane.cs
@@ -3,10 +3,11 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Objects.Other;
 
 namespace Objects.Geometry
 {
-  public class Plane : Base
+  public class Plane : Base, ITransformable<Plane>
   {
     public Point origin { get; set; }
 
@@ -57,6 +58,19 @@ namespace Objects.Geometry
       plane.ydir = new Vector(list[9], list[10], list[11], units);
 
       return plane;
+    }
+
+    public Plane TransformTo(Transform transform)
+    {
+      return new Plane
+      {
+        origin = transform.ApplyToPoint(origin),
+        normal = transform.ApplyToVector(normal),
+        xdir = transform.ApplyToVector(xdir),
+        ydir = transform.ApplyToVector(ydir),
+        applicationId = applicationId,
+        units = units
+      };
     }
   }
 }

--- a/Objects/Objects/Geometry/Point.cs
+++ b/Objects/Objects/Geometry/Point.cs
@@ -3,10 +3,11 @@ using Speckle.Newtonsoft.Json;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
+using Objects.Other;
 
 namespace Objects.Geometry
 {
-  public class Point : Base, IHasBoundingBox
+  public class Point : Base, IHasBoundingBox, ITransformable<Point>
   {
     /// <summary>
     /// OBSOLETE - This is just here for backwards compatibility.
@@ -63,6 +64,11 @@ namespace Objects.Geometry
       x = this.x;
       y = this.y;
       z = this.z;
+    }
+
+    public Point TransformTo(Transform transform)
+    {
+      return transform.ApplyToPoint(this);
     }
   }
 }

--- a/Objects/Objects/Geometry/Point.cs
+++ b/Objects/Objects/Geometry/Point.cs
@@ -66,9 +66,10 @@ namespace Objects.Geometry
       z = this.z;
     }
 
-    public Point TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out Point point)
     {
-      return transform.ApplyToPoint(this);
+      point = transform.ApplyToPoint(this);
+      return true;
     }
   }
 }

--- a/Objects/Objects/Geometry/Pointcloud.cs
+++ b/Objects/Objects/Geometry/Pointcloud.cs
@@ -2,11 +2,12 @@
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
+using Objects.Other;
 using Speckle.Core.Logging;
 
 namespace Objects.Geometry
 {
-  public class Pointcloud : Base, IHasBoundingBox
+  public class Pointcloud : Base, IHasBoundingBox, ITransformable<Pointcloud>
   {
 
     [DetachProperty]
@@ -42,6 +43,17 @@ namespace Objects.Geometry
       }
       return pts;
     }
-    
+
+    public Pointcloud TransformTo(Transform transform)
+    {
+      return new Pointcloud
+      {
+        units = units,
+        points = transform.ApplyToPoints(points),
+        colors = colors,
+        sizes = sizes,
+        applicationId = applicationId
+      };
+    }
   }
 }

--- a/Objects/Objects/Geometry/Pointcloud.cs
+++ b/Objects/Objects/Geometry/Pointcloud.cs
@@ -44,9 +44,9 @@ namespace Objects.Geometry
       return pts;
     }
 
-    public Pointcloud TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out Pointcloud pointcloud)
     {
-      return new Pointcloud
+      pointcloud = new Pointcloud
       {
         units = units,
         points = transform.ApplyToPoints(points),
@@ -54,6 +54,8 @@ namespace Objects.Geometry
         sizes = sizes,
         applicationId = applicationId
       };
+      
+      return true;
     }
   }
 }

--- a/Objects/Objects/Geometry/Polycurve.cs
+++ b/Objects/Objects/Geometry/Polycurve.cs
@@ -87,15 +87,17 @@ namespace Objects.Geometry
       return polycurve;
     }
 
-    public ITransformable TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out ITransformable polycurve)
     {
-      return new Polycurve
+      polycurve = new Polycurve
       {
-        segments = transform.ApplyToCurves(segments),
+        segments = transform.ApplyToCurves(segments, out var success),
         applicationId = applicationId,
         closed = closed,
         units = units
       };
+
+      return success;
     }
   }
 }

--- a/Objects/Objects/Geometry/Polycurve.cs
+++ b/Objects/Objects/Geometry/Polycurve.cs
@@ -4,10 +4,11 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Objects.Other;
 
 namespace Objects.Geometry
 {
-  public class Polycurve : Base, ICurve, IHasArea, IHasBoundingBox
+  public class Polycurve : Base, ICurve, IHasArea, IHasBoundingBox, ITransformable
   {
     public List<ICurve> segments { get; set; } = new List<ICurve>();
     public Interval domain { get; set; }
@@ -84,6 +85,17 @@ namespace Objects.Geometry
       polycurve.segments = CurveArrayEncodingExtensions.FromArray(temp);
       polycurve.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
       return polycurve;
+    }
+
+    public ITransformable TransformTo(Transform transform)
+    {
+      return new Polycurve
+      {
+        segments = transform.ApplyToCurves(segments),
+        applicationId = applicationId,
+        closed = closed,
+        units = units
+      };
     }
   }
 }

--- a/Objects/Objects/Geometry/Polyline.cs
+++ b/Objects/Objects/Geometry/Polyline.cs
@@ -93,15 +93,17 @@ namespace Objects.Geometry
       throw new InvalidCastException();
     }
 
-    public ITransformable TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out ITransformable polyline)
     {
-      return new Polyline
+      polyline = new Polyline
       {
         value = transform.ApplyToPoints(value),
         closed = closed,
         applicationId = applicationId,
         units = units
       };
+
+      return true;
     }
 
     public TypeCode GetTypeCode()

--- a/Objects/Objects/Geometry/Polyline.cs
+++ b/Objects/Objects/Geometry/Polyline.cs
@@ -6,11 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Objects.Other;
 using Speckle.Core.Logging;
 
 namespace Objects.Geometry
 {
-  public class Polyline : Base, ICurve, IHasArea, IHasBoundingBox, IConvertible
+  public class Polyline : Base, ICurve, IHasArea, IHasBoundingBox, IConvertible, ITransformable
   {
     [DetachProperty]
     [Chunkable(31250)]
@@ -90,6 +91,13 @@ namespace Objects.Geometry
       if (conversionType == typeof(Polycurve))
         return (Polycurve)this;
       throw new InvalidCastException();
+    }
+
+    public ITransformable TransformTo(Transform transform)
+    {
+      var newValue = transform.ApplyToPoints(value);
+
+      return new Polyline(newValue, units, applicationId);
     }
 
     public TypeCode GetTypeCode()

--- a/Objects/Objects/Geometry/Polyline.cs
+++ b/Objects/Objects/Geometry/Polyline.cs
@@ -95,9 +95,13 @@ namespace Objects.Geometry
 
     public ITransformable TransformTo(Transform transform)
     {
-      var newValue = transform.ApplyToPoints(value);
-
-      return new Polyline(newValue, units, applicationId);
+      return new Polyline
+      {
+        value = transform.ApplyToPoints(value),
+        closed = closed,
+        applicationId = applicationId,
+        units = units
+      };
     }
 
     public TypeCode GetTypeCode()

--- a/Objects/Objects/Geometry/Surface.cs
+++ b/Objects/Objects/Geometry/Surface.cs
@@ -1,12 +1,13 @@
 ﻿using Objects.Primitive;
 using Speckle.Core.Models;
 using System.Collections.Generic;
+using Objects.Other;
 using Speckle.Core.Kits;
 
 namespace Objects.Geometry
 {
   //TODO: to finish
-  public class Surface : Base, IHasBoundingBox, IHasArea
+  public class Surface : Base, IHasBoundingBox, IHasArea, ITransformable<Surface>
   {
     public int degreeU { get; set; } //
     public int degreeV { get; set; } //
@@ -122,6 +123,37 @@ namespace Objects.Geometry
       var u = list[list.Count - 1];
       srf.units = Units.GetUnitFromEncoding(u);
       return srf;
+    }
+
+    public bool TransformTo(Transform transform, out Surface surface)
+    {
+      var ptMatrix = GetControlPoints();
+      foreach ( var ctrlPts in ptMatrix )
+      {
+        for ( int i = 0; i < ctrlPts.Count; i++ )
+        {
+          ctrlPts[ i ].TransformTo(transform, out var tPt);
+          ctrlPts[ i ] = tPt;
+        }
+      }
+      surface = new Surface()
+      {
+        degreeU = degreeU,
+        degreeV = degreeV,
+        countU = countU,
+        countV = countV,
+        rational = rational,
+        closedU = closedU,
+        closedV = closedV,
+        domainU = domainU,
+        domainV = domainV,
+        knotsU = knotsU,
+        knotsV = knotsV,
+        units = units
+      };
+      surface.SetControlPoints(ptMatrix);
+
+      return true;
     }
   }
 }

--- a/Objects/Objects/Geometry/Vector.cs
+++ b/Objects/Objects/Geometry/Vector.cs
@@ -75,9 +75,10 @@ namespace Objects.Geometry
       set;
     }
 
-    public Vector TransformTo(Transform transform)
+    public bool TransformTo(Transform transform, out Vector vector)
     {
-      return transform.ApplyToVector(this);
+      vector = transform.ApplyToVector(this);
+      return true;
     }
   }
 }

--- a/Objects/Objects/Geometry/Vector.cs
+++ b/Objects/Objects/Geometry/Vector.cs
@@ -3,11 +3,12 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Objects.Other;
 using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
-  public class Vector : Base, IHasBoundingBox
+  public class Vector : Base, IHasBoundingBox, ITransformable<Vector>
   {
     /// <summary>
     /// OBSOLETE - This is just here for backwards compatibility.
@@ -72,6 +73,11 @@ namespace Objects.Geometry
     {
       get;
       set;
+    }
+
+    public Vector TransformTo(Transform transform)
+    {
+      return transform.ApplyToVector(this);
     }
   }
 }

--- a/Objects/Objects/Interfaces.cs
+++ b/Objects/Objects/Interfaces.cs
@@ -34,7 +34,7 @@ namespace Objects
 
   public interface ITransformable<T> where T : ITransformable<T>
   {
-    T Transform(Transform transform);
+    T TransformTo(Transform transform);
   }
 
   #endregion

--- a/Objects/Objects/Interfaces.cs
+++ b/Objects/Objects/Interfaces.cs
@@ -38,7 +38,7 @@ namespace Objects
   /// <typeparam name="T"></typeparam>
   public interface ITransformable<T> where T : ITransformable<T>
   {
-    T TransformTo(Transform transform);
+    bool TransformTo(Transform transform, out T transformed);
   }
 
   /// <summary>
@@ -46,7 +46,7 @@ namespace Objects
   /// </summary>
   public interface ITransformable
   {
-    ITransformable TransformTo(Transform transform);
+    bool TransformTo(Transform transform, out ITransformable transformed);
   }
 
   #endregion

--- a/Objects/Objects/Interfaces.cs
+++ b/Objects/Objects/Interfaces.cs
@@ -32,6 +32,11 @@ namespace Objects
     Interval domain { get; set; }
   }
 
+  public interface ITransformable<T> where T : ITransformable<T>
+  {
+    T Transform(Transform transform);
+  }
+
   #endregion
 
   #region Built elements

--- a/Objects/Objects/Interfaces.cs
+++ b/Objects/Objects/Interfaces.cs
@@ -32,9 +32,21 @@ namespace Objects
     Interval domain { get; set; }
   }
 
+  /// <summary>
+  /// Interface for transformable objects.
+  /// </summary>
+  /// <typeparam name="T"></typeparam>
   public interface ITransformable<T> where T : ITransformable<T>
   {
     T TransformTo(Transform transform);
+  }
+
+  /// <summary>
+  /// Interface for transformable objects where the type may not be known on convert (eg ICurve implementations)
+  /// </summary>
+  public interface ITransformable
+  {
+    ITransformable TransformTo(Transform transform);
   }
 
   #endregion

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -41,7 +41,14 @@ namespace Objects.Other
     /// the 3x3 sub-matrix determines scaling
     /// the 4th column defines translation, where the last value could be a divisor
     /// </remarks>
-    public double[] transform { get; set; }
+    [JsonIgnore, Obsolete("Use Transform object in `transformMatrix` instead")]
+    public double[] transform
+    {
+      get => transformMatrix.value;
+      set => transformMatrix = new Transform(value);
+    }
+
+    public Transform transformMatrix { get; set; } = new Transform();
 
     public string units { get; set; }
 
@@ -56,21 +63,7 @@ namespace Objects.Other
     /// <returns>Insertion point as a <see cref="Point"/></returns>
     public Point GetInsertionPoint()
     {
-      var (x, y, z, u) = blockDefinition.basePoint;
-      var insertion = new double[] { x, y, z, 1 };
-
-      if (transform.Length != 16)
-        throw new SpeckleException($"{nameof(BlockInstance)}.{nameof(transform)} is malformed: expected length to be 4x4 = 16");
-
-      for (int i = 0; i < 16; i += 4)
-        insertion[i / 4] = insertion[0] * transform[i] + insertion[1] * transform[i + 1] +
-                         insertion[2] * transform[i + 2] + insertion[3] * transform[i + 3];
-
-      return new Point(
-        insertion[0] / insertion[3], 
-        insertion[1] / insertion[3], 
-        insertion[2] / insertion[3], 
-        u);
+      return blockDefinition.basePoint.TransformTo(transformMatrix);
     }
   }
 }

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -41,14 +41,8 @@ namespace Objects.Other
     /// the 3x3 sub-matrix determines scaling
     /// the 4th column defines translation, where the last value could be a divisor
     /// </remarks>
-    [JsonIgnore, Obsolete("Use Transform object in `transformMatrix` instead")]
-    public double[] transform
-    {
-      get => transformMatrix.value;
-      set => transformMatrix = new Transform(value);
-    }
 
-    public Transform transformMatrix { get; set; } = new Transform();
+    public Transform transform { get; set; } = new Transform();
 
     public string units { get; set; }
 
@@ -63,7 +57,7 @@ namespace Objects.Other
     /// <returns>Insertion point as a <see cref="Point"/></returns>
     public Point GetInsertionPoint()
     {
-      return blockDefinition.basePoint.TransformTo(transformMatrix);
+      return blockDefinition.basePoint.TransformTo(transform);
     }
   }
 }

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -57,7 +57,7 @@ namespace Objects.Other
     /// <returns>Insertion point as a <see cref="Point"/></returns>
     public Point GetInsertionPoint()
     {
-      return blockDefinition.basePoint.TransformTo(transform);
+      return transform.ApplyToPoint(blockDefinition.basePoint);
     }
   }
 }

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -95,13 +95,12 @@ namespace Objects.Other
     /// </summary>
     public List<double> ApplyToPoint(List<double> point)
     {
-      var newPoint = new List<double>(4) {point[ 0 ], point[ 1 ], point[ 2 ], 1};
+      var transformed = new List<double>();
       for ( var i = 0; i < 16; i += 4 )
-        newPoint[ i / 4 ] = newPoint[ 0 ] * value[ i ] + newPoint[ 1 ] * value[ i + 1 ] +
-                            newPoint[ 2 ] * value[ i + 2 ] + newPoint[ 3 ] * value[ i + 3 ];
+        transformed.Add(point[ 0 ] * value[ i ] + point[ 1 ] * value[ i + 1 ] + point[ 2 ] * value[ i + 2 ] + value[ i + 3 ]);
 
       return new List<double>(3)
-        {newPoint[ 0 ] / newPoint[ 3 ], newPoint[ 1 ] / newPoint[ 3 ], newPoint[ 2 ] / newPoint[ 3 ]};
+        {transformed[ 0 ] / transformed[ 3 ], transformed[ 1 ] / transformed[ 3 ], transformed[ 2 ] / transformed[ 3 ]};
     }
 
     /// <summary>

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -38,9 +38,10 @@ namespace Objects.Other
     {
     }
 
-    public Transform(double[ ] value)
+    public Transform(double[ ] value, string units = null)
     {
       this.value = value;
+      this.units = units;
     }
 
     /// <summary>

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -63,6 +63,9 @@ namespace Objects.Other
     /// </summary>
     public List<double> ApplyToPoints(List<double> points)
     {
+      if ( points.Count % 3 != 0 )
+        throw new SpeckleException(
+          $"Cannot apply transform as the points list is malformed: expected length to be multiple of 3");
       var transformed = new List<double>(points.Count);
       for ( var i = 0; i < points.Count; i += 3 )
         transformed.AddRange(ApplyToPoint(new List<double>(3) {points[ i ], points[ i + 1 ], points[ i + 2 ]}));
@@ -75,10 +78,6 @@ namespace Objects.Other
     /// </summary>
     public List<Point> ApplyToPoints(List<Point> points)
     {
-      if ( points.Count % 3 != 0 )
-        throw new SpeckleException(
-          $"Cannot apply transform as the points list is malformed: expected length to be multiple of 3");
-
       var transformed = new List<Point>(points.Count);
       for ( var i = 0; i < points.Count; i++ )
         transformed.Add(ApplyToPoint(points[ i ]));

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Numerics;
 using Objects.Geometry;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
@@ -56,9 +55,6 @@ namespace Objects.Other
       units = this.units;
     }
 
-
-    // TODO! Apply to vector
-
     /// <summary>
     /// Transform a flat list of doubles representing points
     /// </summary>
@@ -91,8 +87,7 @@ namespace Objects.Other
     {
       var (x, y, z, units) = point;
       var newCoords = ApplyToPoint(new List<double> {x, y, z});
-      var newPoint = Point.FromList(newCoords, units);
-      return newPoint;
+      return new Point(newCoords[0], newCoords[1], newCoords[2], point.units, point.applicationId);
     }
 
     /// <summary>
@@ -107,6 +102,30 @@ namespace Objects.Other
 
       return new List<double>(3)
         {newPoint[ 0 ] / newPoint[ 3 ], newPoint[ 1 ] / newPoint[ 3 ], newPoint[ 2 ] / newPoint[ 3 ]};
+    }
+
+    /// <summary>
+    /// Transform a single speckle Vector
+    /// </summary>
+    public Vector ApplyToVector(Vector vector)
+    {
+      var newCoords = ApplyToVector(new List<double> {vector.x, vector.y, vector.z});
+
+      return new Geometry.Vector(newCoords[0], newCoords[1], newCoords[2], vector.units, vector.applicationId);
+    }
+
+    /// <summary>
+    /// Transform a list of three doubles representing a vector
+    /// </summary>
+    public List<double> ApplyToVector(List<double> vector)
+    {
+      var newPoint = new List<double>(4) {vector[ 0 ], vector[ 1 ], vector[ 2 ]};
+      for ( var i = 0; i < 16; i += 4 )
+        newPoint[ i / 4 ] = newPoint[ 0 ] * value[ i ] + newPoint[ 1 ] * value[ i + 1 ] +
+                            newPoint[ 2 ] * value[ i + 2 ];
+
+      return new List<double>(3)
+        {newPoint[ 0 ], newPoint[ 1 ], newPoint[ 2 ]};
     }
 
     /// <summary>

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Objects.Geometry;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
@@ -125,6 +126,15 @@ namespace Objects.Other
 
       return new List<double>(3)
         {newPoint[ 0 ], newPoint[ 1 ], newPoint[ 2 ]};
+    }
+
+    /// <summary>
+    /// Transform a flat list of ICurves. Note that if any of the ICurves does not implement `ITransformable`,
+    /// it will not be returned.
+    /// </summary>
+    public List<ICurve> ApplyToCurves(List<ICurve> curves)
+    {
+      return ( List<ICurve> ) curves.Select(c => ( ICurve ) ( ( ITransformable ) c )?.TransformTo(this));
     }
 
     /// <summary>

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
+
+namespace Objects.Other
+{
+  /// <summary>
+  /// The 4x4 transform matrix.
+  /// </summary>
+  /// <remarks>
+  /// The 3x3 sub-matrix determines scaling.
+  /// The 4th column defines translation, where the last value could be a divisor.
+  /// </remarks>
+  public class Transform : Base
+  {
+    public double[ ] value { get; set; } = {1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0};
+
+    [JsonIgnore] public double[ ] translation => value.Subset(3, 7, 11, 15);
+
+    [JsonIgnore] public double[ ] scaling => value.Subset(0, 1, 2, 4, 5, 6, 8, 9, 10);
+
+    [JsonIgnore] public bool isIdentity => value == new[ ] {1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0};
+
+    [JsonIgnore] public bool isScaled => scaling != new[ ] {1.0, 0, 0, 0, 1.0, 0, 0, 0, 1.0};
+
+    public Transform()
+    {
+    }
+
+    public Transform(double[ ] value)
+    {
+      this.value = value;
+    }
+
+    // TODO! Apply to vector
+
+    /// <summary>
+    /// Transform a flat list of doubles representing points
+    /// </summary>
+    public List<double> ApplyToPoints(List<double> points)
+    {
+      var transformed = new List<double>(points.Count);
+      for ( var i = 0; i < points.Count; i += 3 )
+        transformed.AddRange(ApplyToPoint(new List<double>(3) {points[ i ], points[ i + 1 ], points[ i + 2 ]}));
+
+      return transformed;
+    }
+
+    /// <summary>
+    /// Transform a flat list of speckle Points
+    /// </summary>
+    public List<Point> ApplyToPoints(List<Point> points)
+    {
+      var transformed = new List<Point>(points.Count);
+      for ( var i = 0; i < points.Count; i++ )
+        transformed.Add(ApplyToPoint(points[ i ]));
+
+      return transformed;
+    }
+
+
+    /// <summary>
+    /// Transform a single speckle Point
+    /// </summary>
+    public Point ApplyToPoint(Point point)
+    {
+      var (x, y, z, units) = point;
+      var newCoords = ApplyToPoint(new List<double> {x, y, z});
+      var newPoint = Point.FromList(newCoords, units);
+      return newPoint;
+    }
+
+    /// <summary>
+    /// Transform a list of three doubles representing a point
+    /// </summary>
+    public List<double> ApplyToPoint(List<double> point)
+    {
+      var newPoint = new List<double>(4) {point[ 0 ], point[ 1 ], point[ 2 ], 1};
+      for ( var i = 0; i < 16; i += 4 )
+        newPoint[ i / 4 ] = newPoint[ 0 ] * value[ i ] + newPoint[ 1 ] * value[ i + 1 ] +
+                            newPoint[ 2 ] * value[ i + 2 ] + newPoint[ 3 ] * value[ i + 3 ];
+
+      return new List<double>(3)
+        {newPoint[ 0 ] / newPoint[ 3 ], newPoint[ 1 ] / newPoint[ 3 ], newPoint[ 2 ] / newPoint[ 3 ]};
+    }
+  }
+
+  static class ArrayUtils
+  {
+    // create a subset from a specific list of indices
+    public static T[ ] Subset<T>(this T[ ] array, params int[ ] indices)
+    {
+      var subset = new T[ indices.Length ];
+      for ( var i = 0; i < indices.Length; i++ )
+      {
+        subset[ i ] = array[ indices[ i ] ];
+      }
+
+      return subset;
+    }
+  }
+}


### PR DESCRIPTION
## Description

This is a rework of Blocks to open the door for support in applications that don't properly support them (eg Revit).

TLDR: `Transform` is now a speckle object rather than a list of doubles representing the transform matrix. It allows you to apply the transform to points and vectors. Speckle objects can now implement `ITransformable` which involves writing a `TransformTo()` method. Meshes and some `ICurves` have been implemented as `ITransformable` and the Revit connector now supports them. The Revit connector does not truly support the concept of blocks, so new Groups are created for each `BlockInstance` with the transform baked into the source geometry. Note that this is p slow and could use optimisation.

- Fixes #608 indirectly

![image](https://user-images.githubusercontent.com/7717434/144416513-09030a19-1ba4-4aae-a659-579b1e51f441.png)

---

A new class `Objects.Other.Transform` as well as the interfaces `ITransformable` and `ITransformable<T>` have been added. The `Transform` class holds the matrix at `Transform.value` and contains helper methods for transforming points and vectors. The `ITransformable` interfaces can be implemented for any object that is transformable. You'll need to write a `TransformTo` method that returns a *new* object with the transformed values. `ITransformable<T>` is preferred as the return type of the `TransformTo` will match the current type, but `ITransformable` should be used in cases like curves where you need to check if an object implements `ITransformable` without knowing the type argument `<T>`. 

The only change to existing/future connectors is that the flat list of doubles representing the transform is accessed from `BlockInstance.transform.value` rather than `BlockInstance.transform`. This is a **⚠ BREAKING CHANGE** as the type of `BlockInstance.transform` is no longer a `double [ ]` but a `Transform`.

AutoCAD & Rhino have been updated to use the new transform:

![image](https://user-images.githubusercontent.com/7717434/144475339-fe65fd4b-c3bf-4784-a864-2d7ecccc187a.png)

![image](https://user-images.githubusercontent.com/7717434/144475487-b55e2e56-522e-47c9-a7bd-6ac95cba03bb.png)


## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Manual Tests with the usual test streams

## Docs

- Will be updated ASAP

