### PR TITLE
bonus(gh): Added settings to hide unwanted tabs

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
@@ -94,6 +94,10 @@ namespace ConnectorGrasshopper
       CreateSchemaConversionMenu();
       speckleMenu.DropDown.Items.Add(new ToolStripSeparator());
       CreateMeshingSettingsMenu();
+      speckleMenu.DropDown.Items.Add(new ToolStripSeparator());
+      CreateTabsMenu();
+      speckleMenu.DropDown.Items.Add(new ToolStripSeparator());
+
       // Help items
       var helpHeader = speckleMenu.DropDown.Items.Add("Looking for help?");
       helpHeader.Enabled = false;
@@ -133,6 +137,23 @@ namespace ConnectorGrasshopper
       }
 
       MenuHasBeenAdded = true;
+    }
+
+    private void CreateTabsMenu()
+    {
+      var tabsMenu = speckleMenu.DropDown.Items.Add("Tabs") as ToolStripMenuItem;
+      new List<string>{"BIM", "Revit", "Structural", "ETABS", "GSA"}.ForEach(s =>
+      {
+        var category = $"Speckle 2 {s}";
+        var mi = tabsMenu.DropDown.Items.Add(category) as ToolStripMenuItem;
+        mi.CheckOnClick = true;
+        mi.Checked = SpeckleGHSettings.GetTabVisibility(category);
+        mi.Click += (sender, args) =>
+        {
+          var tmi = sender as ToolStripMenuItem;
+          SpeckleGHSettings.SetTabVisibility(category, tmi.Checked);
+        };
+      });
     }
 
     private void CreateMeshingSettingsMenu()

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
@@ -142,6 +142,8 @@ namespace ConnectorGrasshopper
     private void CreateTabsMenu()
     {
       var tabsMenu = speckleMenu.DropDown.Items.Add("Tabs") as ToolStripMenuItem;
+      var warn = tabsMenu.DropDown.Items.Add("Changes require restarting Rhino to take effect.");
+      warn.Enabled = false;
       new List<string>{"BIM", "Revit", "Structural", "ETABS", "GSA"}.ForEach(s =>
       {
         var category = $"Speckle 2 {s}";

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -22,7 +22,9 @@ namespace ConnectorGrasshopper
 {
   public abstract class CreateSchemaObjectBase : SelectKitComponentBase, IGH_VariableParameterComponent
   {
-    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    public override GH_Exposure Exposure => SpeckleGHSettings.GetTabVisibility(Category)
+      ? GH_Exposure.tertiary
+      : GH_Exposure.hidden;
 
     protected ConstructorInfo SelectedConstructor;
     private bool readFailed;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SpeckleGHSettings.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SpeckleGHSettings.cs
@@ -8,10 +8,6 @@ namespace ConnectorGrasshopper
     private const string MESH_SETTINGS = "Speckle2:kit.meshing.settings";
     private const string USE_SCHEMA_TAG_STRATEGY = "Speckle2:conversion.schema.tag";
 
-    // For future disabling of structural tabs
-    private const string SHOW_STRUCTURAL_TABS = "Speckle2:tabs.structural.show";
-    private const string SHOW_BUILT_ELEMENT_TABS = "Speckle2:tabs.builtelements.show";
-
     /// <summary>
     /// Gets or sets the default selected kit name to be used in this Grasshopper instance.
     /// </summary>
@@ -49,6 +45,18 @@ namespace ConnectorGrasshopper
         Grasshopper.Instances.Settings.SetValue(USE_SCHEMA_TAG_STRATEGY, value);
         Grasshopper.Instances.Settings.WritePersistentSettings();
       }
+    }
+
+    public static bool GetTabVisibility(string name)
+    {
+      var tabVisibility = Grasshopper.Instances.Settings.GetValue($"Speckle2:tabs.{name}", true);
+      return tabVisibility;
+    }
+
+    public static void SetTabVisibility(string name, bool value)
+    {
+      Grasshopper.Instances.Settings.SetValue($"Speckle2:tabs.{name}", value);
+      Grasshopper.Instances.Settings.WritePersistentSettings();
     }
   }
 


### PR DESCRIPTION
Out of pure boredom this Sunday, I implemented a switch to disable specific Speckle BIM and Structural tabs when the user does not have the need for them.

Changing this settings requires a full GH restart to take effect.

![Screenshot 2021-12-13 at 08 31 03](https://user-images.githubusercontent.com/2316535/145770371-761b1d82-93e2-4db6-8fb3-7b831795395e.png)

