### PR TITLE
Semver: Remove `-beta` ending from build version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,8 +184,8 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Build << parameters.slnname >>
           command: |
             $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.0" } else { $env:CIRCLE_TAG }
-            $semver = if($tag.Contains('/')) {$tag.replace("-beta","").Split("/")[1] } else { $tag }
-            $version = "$($semver).$($env:CIRCLE_BUILD_NUM)"
+            $semver = if($tag.Contains('/')) {$tag.Split("/")[1] } else { $tag }
+            $version = "$($semver.replace("-beta","")).$($env:CIRCLE_BUILD_NUM)"
             msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:AssemblyVersionNumber=$version /p:AssemblyInformationalVersion=$semver /p:Version=$version
             $channel = "latest"
             if($env:CIRCLE_TAG -like "*-beta") { $channel = "beta" }    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,8 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.0" } else { $env:CIRCLE_TAG }
             $semver = if($tag.Contains('/')) {$tag.Split("/")[1] } else { $tag }
-            $version = "$($semver.replace("-beta","")).$($env:CIRCLE_BUILD_NUM)"
+            $ver = $semver.replace("-beta","")
+            $version = "$($ver).$($env:CIRCLE_BUILD_NUM)"
             msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:AssemblyVersionNumber=$version /p:AssemblyInformationalVersion=$semver /p:Version=$version
             $channel = "latest"
             if($env:CIRCLE_TAG -like "*-beta") { $channel = "beta" }    


### PR DESCRIPTION
Removes the trailing `-beta` at the end of the build version to comply with Semver format