### PR TITLE
fix(rvt): Missing units in directshape solidToMesh conversion

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -141,6 +141,7 @@ namespace Objects.Converter.Revit
     {
       var mesh = new Mesh();
       (mesh.faces, mesh.vertices) = GetFaceVertexArrFromSolids(new List<Solid> { solid });
+      mesh.units = ModelUnits;
       return mesh;
     }
 


### PR DESCRIPTION
Fixes issue when receiving DirectShapes made of Solids from Revit into any other application.