### PR TITLE
feat(revit): add flex duct and flex pipe conversions

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -245,9 +245,24 @@ public class DuctSchemaComponent: CreateSchemaObjectBase {
     public DuctSchemaComponent(): base("Duct", "Duct", "Creates a Speckle duct", "Speckle 2 BIM", "MEP") { }
     
     public override Guid ComponentGuid => new Guid("51d40791-43ea-a8e7-ef13-e9bfdf9cd893");
+    public override bool Obsolete => true;
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Duct.ctor(Objects.Geometry.Line,System.Double,System.Double,System.Double,System.Double)","Objects.BuiltElements.Duct");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class Duct1SchemaComponent: CreateSchemaObjectBase {
+     
+    public Duct1SchemaComponent(): base("Duct", "Duct", "Creates a Speckle duct", "Speckle 2 BIM", "MEP") { }
+    
+    public override Guid ComponentGuid => new Guid("7e3a3fba-7d4f-d549-96c0-41693b512db0");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Duct.ctor(Objects.ICurve,System.Double,System.Double,System.Double,System.Double)","Objects.BuiltElements.Duct");
         base.AddedToDocument(document);
     }
 }
@@ -1885,9 +1900,24 @@ public class RevitDuctSchemaComponent: CreateSchemaObjectBase {
     public RevitDuctSchemaComponent(): base("RevitDuct", "RevitDuct", "Creates a Revit duct", "Speckle 2 Revit", "MEP") { }
     
     public override Guid ComponentGuid => new Guid("d7781536-e8a9-8aef-1b27-571584f8c4a3");
+    public override bool Obsolete => true;
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.Geometry.Line,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class RevitDuct1SchemaComponent: CreateSchemaObjectBase {
+     
+    public RevitDuct1SchemaComponent(): base("RevitDuct", "RevitDuct", "Creates a Revit duct", "Speckle 2 Revit", "MEP") { }
+    
+    public override Guid ComponentGuid => new Guid("7bb86598-9cd2-8d29-a1dc-7500c4b4ed4b");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
         base.AddedToDocument(document);
     }
 }
@@ -1914,6 +1944,32 @@ public class RevitFaceWallSchemaComponent: CreateSchemaObjectBase {
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFaceWall.ctor(System.String,System.String,Objects.Geometry.Brep,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.LocationLine,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFaceWall");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class RevitFlexDuctSchemaComponent: CreateSchemaObjectBase {
+     
+    public RevitFlexDuctSchemaComponent(): base("RevitFlexDuct", "RevitFlexDuct", "Creates a Revit flex duct", "Speckle 2 Revit", "MEP") { }
+    
+    public override Guid ComponentGuid => new Guid("f350f9a2-06ca-6118-a4e6-88e721bb7f52");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFlexDuct.ctor(System.String,System.String,Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,Objects.Geometry.Vector,Objects.Geometry.Vector,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFlexDuct");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class RevitFlexPipeSchemaComponent: CreateSchemaObjectBase {
+     
+    public RevitFlexPipeSchemaComponent(): base("RevitFlexPipe", "RevitFlexPipe", "Creates a Revit flex pipe", "Speckle 2 Revit", "MEP") { }
+    
+    public override Guid ComponentGuid => new Guid("219bfacc-9c41-441a-210c-c2cfb877929b");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFlexPipe.ctor(System.String,System.String,Objects.ICurve,System.Double,Objects.BuiltElements.Level,Objects.Geometry.Vector,Objects.Geometry.Vector,System.String,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFlexPipe");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -104,12 +104,9 @@ namespace Speckle.ConnectorRevit.UI
         {
           progress.Report.LogConversionError(e);
         }
-
       }
 
-
       progress.Report.Merge(converter.Report);
-
 
       if (convertedCount == 0)
       {
@@ -118,9 +115,7 @@ namespace Speckle.ConnectorRevit.UI
       }
 
       if (progress.CancellationTokenSource.Token.IsCancellationRequested)
-      {
         return;
-      }
 
       var transports = new List<ITransport>() { new ServerTransport(client.Account, streamId) };
 
@@ -138,14 +133,10 @@ namespace Speckle.ConnectorRevit.UI
         );
 
       if (progress.Report.OperationErrorsCount != 0)
-      {
         return;
-      }
 
       if (progress.CancellationTokenSource.Token.IsCancellationRequested)
-      {
         return;
-      }
 
       var actualCommit = new CommitCreateInput()
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -10,7 +10,8 @@ namespace Objects.Converter.Revit
   {
     public static readonly List<BuiltInCategory> columnCategories = new List<BuiltInCategory> { BuiltInCategory.OST_Columns, BuiltInCategory.OST_StructuralColumns };
     public static readonly List<BuiltInCategory> beamCategories = new List<BuiltInCategory> { BuiltInCategory.OST_StructuralFraming };
-    public static readonly List<BuiltInCategory> ductCategories = new List<BuiltInCategory> { BuiltInCategory.OST_DuctCurves };
+    public static readonly List<BuiltInCategory> ductCategories = new List<BuiltInCategory> { BuiltInCategory.OST_DuctCurves, BuiltInCategory.OST_FlexDuctCurves };
+    public static readonly List<BuiltInCategory> pipeCategories = new List<BuiltInCategory> { BuiltInCategory.OST_PipeCurves, BuiltInCategory.OST_FlexPipeCurves };
     public static readonly List<BuiltInCategory> wallCategories = new List<BuiltInCategory> { BuiltInCategory.OST_Walls };
     public static readonly List<BuiltInCategory> floorCategories = new List<BuiltInCategory> { BuiltInCategory.OST_Floors };
     public static readonly List<BuiltInCategory> curtainWallSubElements = new List<BuiltInCategory> { BuiltInCategory.OST_CurtainWallMullions, BuiltInCategory.OST_CurtainWallPanels };
@@ -25,7 +26,6 @@ namespace Objects.Converter.Revit
       {
         return false;
       }
-
     }
 
     public static bool IsElementSupported(this Element e)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -173,10 +173,6 @@ namespace Objects.Converter.Revit
         }
       }
 
-
-
-
-
       if (paramBase.GetDynamicMembers().Any())
         speckleElement["parameters"] = paramBase;
       speckleElement["elementId"] = revitElement.Id.ToString();
@@ -563,42 +559,33 @@ namespace Objects.Converter.Revit
 
     private ElementFilter GetCategoryFilter(Base element)
     {
-      ElementFilter filter = null;
-      if (element is BuiltElements.Wall)
+      switch (element)
       {
-        filter = new ElementMulticategoryFilter(Categories.wallCategories);
+        case BuiltElements.Wall _:
+          return new ElementMulticategoryFilter(Categories.wallCategories);
+        case Column _:
+          return new ElementMulticategoryFilter(Categories.columnCategories);
+        case Beam _:
+        case Brace _:
+          return new ElementMulticategoryFilter(Categories.beamCategories);
+        case Duct _:
+          return new ElementMulticategoryFilter(Categories.ductCategories);
+        case Floor _:
+          return new ElementMulticategoryFilter(Categories.floorCategories);
+        case Pipe _:
+          return new ElementMulticategoryFilter(Categories.pipeCategories);
+        case Roof _:
+          return new ElementCategoryFilter(BuiltInCategory.OST_Roofs);
+        default:
+          ElementFilter filter = null;
+          if (element["category"] != null)
+          {
+            var cat = Doc.Settings.Categories.Cast<Category>().FirstOrDefault(x => x.Name == element["category"].ToString());
+            if (cat != null)
+              filter = new ElementMulticategoryFilter(new List<ElementId> { cat.Id });
+          }
+          return filter;
       }
-      else if (element is Column)
-      {
-        filter = new ElementMulticategoryFilter(Categories.columnCategories);
-      }
-      else if (element is Beam || element is Brace)
-      {
-        filter = new ElementMulticategoryFilter(Categories.beamCategories);
-      }
-      else if (element is Duct)
-      {
-        filter = new ElementMulticategoryFilter(Categories.ductCategories);
-      }
-      else if (element is Floor)
-      {
-        filter = new ElementMulticategoryFilter(Categories.floorCategories);
-      }
-      else if (element is Roof)
-      {
-        filter = new ElementCategoryFilter(BuiltInCategory.OST_Roofs);
-      }
-      else
-      {
-        //try get category from the parameters
-        if (element["category"] != null)
-        {
-          var cat = Doc.Settings.Categories.Cast<Category>().FirstOrDefault(x => x.Name == element["category"].ToString());
-          if (cat != null)
-            filter = new ElementMulticategoryFilter(new List<ElementId> { cat.Id });
-        }
-      }
-      return filter;
     }
 
     #endregion

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -158,6 +158,10 @@ namespace Objects.Converter.Revit
           returnObject = DuctToSpeckle(o);
           Report.Log($"Converted Duct {o.Id}");
           break;
+        case DB.Mechanical.FlexDuct o:
+          returnObject = DuctToSpeckle(o);
+          Report.Log($"Converted FlexDuct {o.Id}");
+          break;
         case DB.Mechanical.Space o:
           returnObject = SpaceToSpeckle(o);
           Report.Log($"Converted Space {o.Id}");
@@ -165,6 +169,10 @@ namespace Objects.Converter.Revit
         case DB.Plumbing.Pipe o:
           returnObject = PipeToSpeckle(o);
           Report.Log($"Converted Pipe {o.Id}");
+          break;
+        case DB.Plumbing.FlexPipe o:
+          returnObject = PipeToSpeckle(o);
+          Report.Log($"Converted FlexPipe {o.Id}");
           break;
         case DB.Electrical.Wire o:
           returnObject = WireToSpeckle(o);
@@ -290,7 +298,6 @@ namespace Objects.Converter.Revit
             return FreeformElementToNativeFamily(o);
           default:
             return null;
-
         }
       }
 
@@ -506,8 +513,10 @@ namespace Objects.Converter.Revit
         DB.Architecture.TopographySurface _ => true,
         DB.Wall _ => true,
         DB.Mechanical.Duct _ => true,
+        DB.Mechanical.FlexDuct _ => true,
         DB.Mechanical.Space _ => true,
         DB.Plumbing.Pipe _ => true,
+        DB.Plumbing.FlexPipe _ => true,
         DB.Electrical.Wire _ => true,
         DB.CurtainGridLine _ => true, //these should be handled by curtain walls
         DB.Architecture.BuildingPad _ => true,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -29,6 +29,16 @@ namespace Objects.Converter.Revit
   /// </summary>
   public partial class ConverterRevit
   {
+    // Convenience methods point:
+    public double[] PointToArray(Point pt)
+    {
+      return new double[] { pt.x, pt.y, pt.z };
+    }
+    public List<double> PointsToFlatList(IEnumerable<Point> points)
+    {
+      return points.SelectMany(PointToArray).ToList();
+    }
+
     public object GeometryToNative(Base geom)
     {
       switch (geom)
@@ -53,14 +63,6 @@ namespace Objects.Converter.Revit
       var intPt = ToInternalCoordinates(revitPoint, true);
       return intPt;
     }
-
-    //does not work
-    //public ReferencePoint PointToNativeReferencePoint(Point pt)
-    //{
-    //  var revitPoint = PointToNative(pt);
-    //  var referencePoint = Doc.FamilyCreate.NewReferencePoint(revitPoint);
-    //  return referencePoint;
-    //}
 
     public Point PointToSpeckle(XYZ pt, string units = null)
     {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -17,67 +17,70 @@ namespace Objects.Converter.Revit
     public List<ApplicationPlaceholderObject> PipeToNative(BuiltElements.Pipe specklePipe)
     {
       var speckleRevitPipe = specklePipe as RevitPipe;
+      var types = new FilteredElementCollector(Doc).WhereElementIsElementType()
+       .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
+      var systemFamily = speckleRevitPipe?.systemType ?? "";
+      var system = types.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
+                   types.FirstOrDefault(x => x.Name == systemFamily);
+      if (system == null)
+      {
+        system = types.FirstOrDefault();
+        Report.LogConversionError(new Exception($"Pipe type {systemFamily} not found; replaced with {system.Name}"));
+      }
 
       // check to see if pipe already exists in the doc
-      var isUpdate = false;
       var docObj = GetExistingElementByApplicationId(specklePipe.applicationId);
 
-      Level level = null;
-      Element element = null;
-      switch (specklePipe.baseCurve)
+      Element pipe = null;
+      if (specklePipe.baseCurve is Line line)
       {
-        case Line line:
-          var _line = LineToNative(line);
-          var linePipeType = GetElementType<DB.Plumbing.PipeType>(specklePipe);
-          level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromCurve(_line));
-          DB.Plumbing.Pipe linePipe = CreateLinearPipe(_line, speckleRevitPipe, level, linePipeType);
-          if (docObj != null)
-          {
-            var lineSystem = linePipe.MEPSystem.Id;
-            linePipe = (DB.Plumbing.Pipe)docObj;
-            linePipe.SetSystemType(lineSystem);
-            ((LocationCurve)linePipe.Location).Curve = _line;
-            isUpdate = true;
-          }
-          element = linePipe;
-          break;
-        case Arc arc:
-          var _arc = ArcToNative(arc);
-          var arcPipeType = GetElementType<DB.Plumbing.FlexPipeType>(specklePipe);
-          level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromCurve(_arc));
-          DB.Plumbing.FlexPipe arcPipe = CreateFlexPipe(_arc, speckleRevitPipe, level, arcPipeType);
-          if (docObj != null)
-          {
-            var arcSystem = arcPipe.MEPSystem.Id;
-            linePipe = (DB.Plumbing.Pipe)docObj;
-            linePipe.SetSystemType(arcSystem);
-            ((LocationCurve)linePipe.Location).Curve = _arc;
-            isUpdate = true;
-          }
-          element = arcPipe;
-          break;
-        case Polyline polyline:
-          //level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromPoint(revitCurve));
-          // this requires special handling to only extract vertices
-          break;
-        default:
-          Report.LogConversionError(new Exception($"Pipe baseCurve type of ${specklePipe.speckle_type} cannot be used to create pipes."));
-          return null;
+        var pipeType = GetElementType<DB.Plumbing.PipeType>(specklePipe);
+
+        DB.Line baseLine = LineToNative(line);
+        DB.Level level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromCurve(baseLine));
+        var linePipe = DB.Plumbing.Pipe.Create(Doc, system.Id, pipeType.Id, level.Id, baseLine.GetEndPoint(0), baseLine.GetEndPoint(1));
+        if (docObj != null)
+        {
+          var lineSystem = linePipe.MEPSystem.Id;
+          linePipe = (DB.Plumbing.Pipe)docObj;
+          linePipe.SetSystemType(lineSystem);
+          ((LocationCurve)linePipe.Location).Curve = baseLine;
+        }
+        pipe = linePipe;
+      }
+      else if (specklePipe.baseCurve is Polyline polyline)
+      {
+        var speckleRevitFlexPipe = specklePipe as RevitFlexPipe;
+        var pipeType = GetElementType<DB.Plumbing.FlexPipeType>(speckleRevitFlexPipe);
+
+        var points = polyline.GetPoints().Select(o => PointToNative(o)).ToList();
+        DB.Level level = LevelToNative(speckleRevitFlexPipe != null ? speckleRevitFlexPipe.level : LevelFromPoint(points.First()));
+        var startTangent = VectorToNative(speckleRevitFlexPipe.startTangent);
+        var endTangent = VectorToNative(speckleRevitFlexPipe.endTangent);
+        var flexPipe = DB.Plumbing.FlexPipe.Create(Doc, system.Id, pipeType.Id, level.Id, startTangent, endTangent, points);
+        
+        if (docObj != null)
+          Doc.Delete(docObj.Id); // deleting instead of updating for now!
+
+        pipe = flexPipe;
+      }
+      else
+      {
+        Report.LogConversionError(new Exception($"Pipe BaseCurve of type ${specklePipe.baseCurve.GetType()} cannot be used to create a Revit Pipe"));
       }
 
       if (speckleRevitPipe != null)
       {
-        TrySetParam(element, BuiltInParameter.RBS_START_LEVEL_PARAM, level);
-        SetInstanceParameters(element, speckleRevitPipe);
+        SetInstanceParameters(pipe, speckleRevitPipe);
       }
-      TrySetParam(element, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM, specklePipe.diameter, specklePipe.units);
+      TrySetParam(pipe, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM, specklePipe.diameter, specklePipe.units);
 
       var placeholders = new List<ApplicationPlaceholderObject>
       {
         new ApplicationPlaceholderObject
-          {applicationId = specklePipe.applicationId, ApplicationGeneratedId = element.UniqueId, NativeObject = element}
+          {applicationId = specklePipe.applicationId, ApplicationGeneratedId = pipe.UniqueId, NativeObject = pipe}
       };
-      Report.Log($"{(isUpdate ? "Updated" : "Created")} Pipe {element.Id}");
+
       return placeholders;
     }
 
@@ -106,8 +109,8 @@ namespace Objects.Converter.Revit
 
       GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
       {
-        "RBS_SYSTEM_CLASSIFICATION_PARAM",
         "RBS_PIPING_SYSTEM_TYPE_PARAM",
+        "RBS_SYSTEM_CLASSIFICATION_PARAM",
         "RBS_SYSTEM_NAME_PARAM",
         "RBS_PIPE_DIAMETER_PARAM",
         "CURVE_ELEM_LENGTH",
@@ -118,23 +121,24 @@ namespace Objects.Converter.Revit
     }
     public BuiltElements.Pipe PipeToSpeckle(DB.Plumbing.FlexPipe revitPipe)
     {
-      // geometry 
-      var baseGeometry = LocationToSpeckle(revitPipe);
-      if (!(baseGeometry is Curve baseCurve))
-      {
-        throw new Speckle.Core.Logging.SpeckleException("Could not register pipe base geometry as a Curve");
-      }
+      // create polyline from revitpipe points
+      var polyline = new Polyline();
+      polyline.value = PointsToFlatList(revitPipe.Points.Select(o => PointToSpeckle(o)));
+      polyline.units = ModelUnits;
+      polyline.closed = false;
 
       // speckle pipe
-      var specklePipe = new RevitPipe
+      var specklePipe = new RevitFlexPipe
       {
-        baseCurve = baseCurve,
+        baseCurve = polyline,
         family = revitPipe.FlexPipeType.FamilyName,
         type = revitPipe.FlexPipeType.Name,
         systemName = revitPipe.MEPSystem.Name,
         systemType = GetParamValue<string>(revitPipe, BuiltInParameter.RBS_SYSTEM_CLASSIFICATION_PARAM),
         diameter = GetParamValue<double>(revitPipe, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM),
         length = GetParamValue<double>(revitPipe, BuiltInParameter.CURVE_ELEM_LENGTH),
+        startTangent = VectorToSpeckle(revitPipe.StartTangent),
+        endTangent = VectorToSpeckle(revitPipe.EndTangent),
         level = ConvertAndCacheLevel(revitPipe, BuiltInParameter.RBS_START_LEVEL_PARAM),
         displayMesh = GetElementMesh(revitPipe)
       };
@@ -150,59 +154,6 @@ namespace Objects.Converter.Revit
       });
 
       return specklePipe;
-    }
-
-    private DB.Plumbing.Pipe CreateLinearPipe(DB.Line baseLine, RevitPipe speckleRevitPipe, Level level, DB.Plumbing.PipeType type)
-    {
-      DB.Plumbing.Pipe pipe = null;
-
-      // get MEP pipe system by name or by type
-      var types = new FilteredElementCollector(Doc).WhereElementIsElementType()
-        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
-      var systemFamily = speckleRevitPipe?.systemType ?? "";
-      var system = types.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
-                   types.FirstOrDefault(x => x.Name == systemFamily);
-      if (system == null)
-      {
-        system = types.FirstOrDefault();
-        Report.LogConversionError(new Exception($"Pipe type {systemFamily} not found; replaced with {system.Name}"));
-      }
-
-      // create the pipe
-      pipe = DB.Plumbing.Pipe.Create(Doc, system.Id, type.Id, level.Id, baseLine.GetEndPoint(0), baseLine.GetEndPoint(1));
-
-      return pipe;
-    }
-    private DB.Plumbing.FlexPipe CreateFlexPipe(DB.Curve baseCurve, RevitPipe speckleRevitPipe, Level level, DB.Plumbing.FlexPipeType type)
-    {
-      DB.Plumbing.FlexPipe pipe = null;
-
-      // get MEP pipe system by name or by type
-      var types = new FilteredElementCollector(Doc).WhereElementIsElementType()
-        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
-      var systemFamily = speckleRevitPipe?.systemType ?? "";
-      var system = types.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
-                   types.FirstOrDefault(x => x.Name == systemFamily);
-      if (system == null)
-      {
-        system = types.FirstOrDefault();
-        Report.LogConversionError(new Exception($"Pipe type {systemFamily} not found; replaced with {system.Name}"));
-      }
-
-      // create the pipe
-      switch (baseCurve)
-      {
-        case DB.Arc arc:
-          var st = new XYZ();
-          var et = new XYZ();
-          var arcPoints = new List<XYZ>() { baseCurve.GetEndPoint(0), baseCurve.GetEndPoint(1) };
-          pipe = DB.Plumbing.FlexPipe.Create(Doc, system.Id, type.Id, level.Id, st, et, arcPoints);
-          break;
-        default:
-          break;
-      }
-
-      return pipe;
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
 using DB = Autodesk.Revit.DB;
+using Arc = Objects.Geometry.Arc;
+using Curve = Objects.Geometry.Curve;
 using Line = Objects.Geometry.Line;
+using Polyline = Objects.Geometry.Polyline;
 using Objects.BuiltElements.Revit;
 using Speckle.Core.Models;
 
@@ -13,59 +16,61 @@ namespace Objects.Converter.Revit
   {
     public List<ApplicationPlaceholderObject> PipeToNative(BuiltElements.Pipe specklePipe)
     {
-      // check if this is a line based pipe, return null if not
-      DB.Line baseLine = null;
+      var speckleRevitPipe = specklePipe as RevitPipe;
+
+      // check to see if pipe already exists in the doc
+      var isUpdate = false;
+      var docObj = GetExistingElementByApplicationId(specklePipe.applicationId);
+
+      Level level = null;
+      Element element = null;
       switch (specklePipe.baseCurve)
       {
         case Line line:
-          baseLine = LineToNative(line);
+          var _line = LineToNative(line);
+          var linePipeType = GetElementType<DB.Plumbing.PipeType>(specklePipe);
+          level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromCurve(_line));
+          DB.Plumbing.Pipe linePipe = CreateLinearPipe(_line, speckleRevitPipe, level, linePipeType);
+          if (docObj != null)
+          {
+            var lineSystem = linePipe.MEPSystem.Id;
+            linePipe = (DB.Plumbing.Pipe)docObj;
+            linePipe.SetSystemType(lineSystem);
+            ((LocationCurve)linePipe.Location).Curve = _line;
+            isUpdate = true;
+          }
+          element = linePipe;
+          break;
+        case Arc arc:
+          var _arc = ArcToNative(arc);
+          var arcPipeType = GetElementType<DB.Plumbing.FlexPipeType>(specklePipe);
+          level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromCurve(_arc));
+          DB.Plumbing.FlexPipe arcPipe = CreateFlexPipe(_arc, speckleRevitPipe, level, arcPipeType);
+          if (docObj != null)
+          {
+            var arcSystem = arcPipe.MEPSystem.Id;
+            linePipe = (DB.Plumbing.Pipe)docObj;
+            linePipe.SetSystemType(arcSystem);
+            ((LocationCurve)linePipe.Location).Curve = _arc;
+            isUpdate = true;
+          }
+          element = arcPipe;
+          break;
+        case Polyline polyline:
+          //level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromPoint(revitCurve));
+          // this requires special handling to only extract vertices
           break;
         default:
-          Report.LogConversionError(new Exception($"Pipe baseCurve is not a line"));
+          Report.LogConversionError(new Exception($"Pipe baseCurve type of ${specklePipe.speckle_type} cannot be used to create pipes."));
           return null;
-      }
-
-      // geometry
-      var speckleRevitPipe = specklePipe as RevitPipe;
-      var level = LevelToNative(speckleRevitPipe != null ? speckleRevitPipe.level : LevelFromCurve(baseLine));
-
-      // get MEP pipe system by name or by type
-      var pipeType = GetElementType<DB.Plumbing.PipeType>(specklePipe);
-      var types = new FilteredElementCollector(Doc).WhereElementIsElementType()
-        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
-      var systemFamily = speckleRevitPipe?.systemType ?? "";
-      var system = types.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
-                   types.FirstOrDefault(x => x.Name == systemFamily);
-      if (system == null)
-      {
-        system = types.FirstOrDefault();
-        Report.LogConversionError(new Exception($"Pipe type {systemFamily} not found; replaced with {system.Name}"));
-      }
-
-      // create or update the pipe
-      DB.Plumbing.Pipe pipe;
-      var isUpdate = false;
-      var docObj = GetExistingElementByApplicationId(specklePipe.applicationId);
-      if (docObj == null)
-      {
-        pipe = DB.Plumbing.Pipe.Create(Doc, system.Id, pipeType.Id, level.Id,
-          baseLine.GetEndPoint(0),
-          baseLine.GetEndPoint(1));
-      }
-      else
-      {
-        pipe = (DB.Plumbing.Pipe)docObj;
-        pipe.SetSystemType(system.Id);
-        ((LocationCurve)pipe.Location).Curve = baseLine;
-        isUpdate = true;
       }
 
       if (speckleRevitPipe != null)
       {
-        TrySetParam(pipe, BuiltInParameter.RBS_START_LEVEL_PARAM, level);
-        SetInstanceParameters(pipe, speckleRevitPipe);
+        TrySetParam(element, BuiltInParameter.RBS_START_LEVEL_PARAM, level);
+        SetInstanceParameters(element, speckleRevitPipe);
       }
-      TrySetParam(pipe, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM, specklePipe.diameter, specklePipe.units);
+      TrySetParam(element, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM, specklePipe.diameter, specklePipe.units);
 
       var placeholders = new List<ApplicationPlaceholderObject>
       {
@@ -110,6 +115,96 @@ namespace Objects.Converter.Revit
       });
       //Report.Log($"Converted Pipe {revitPipe.Id}");
       return specklePipe;
+    }
+    public BuiltElements.Pipe PipeToSpeckle(DB.Plumbing.FlexPipe revitPipe)
+    {
+      // geometry 
+      var baseGeometry = LocationToSpeckle(revitPipe);
+      if (!(baseGeometry is Curve baseCurve))
+      {
+        throw new Speckle.Core.Logging.SpeckleException("Could not register pipe base geometry as a Curve");
+      }
+
+      // speckle pipe
+      var specklePipe = new RevitPipe
+      {
+        baseCurve = baseCurve,
+        family = revitPipe.FlexPipeType.FamilyName,
+        type = revitPipe.FlexPipeType.Name,
+        systemName = revitPipe.MEPSystem.Name,
+        systemType = GetParamValue<string>(revitPipe, BuiltInParameter.RBS_SYSTEM_CLASSIFICATION_PARAM),
+        diameter = GetParamValue<double>(revitPipe, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM),
+        length = GetParamValue<double>(revitPipe, BuiltInParameter.CURVE_ELEM_LENGTH),
+        level = ConvertAndCacheLevel(revitPipe, BuiltInParameter.RBS_START_LEVEL_PARAM),
+        displayMesh = GetElementMesh(revitPipe)
+      };
+
+      GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
+      {
+        "RBS_SYSTEM_CLASSIFICATION_PARAM",
+        "RBS_PIPING_SYSTEM_TYPE_PARAM",
+        "RBS_SYSTEM_NAME_PARAM",
+        "RBS_PIPE_DIAMETER_PARAM",
+        "CURVE_ELEM_LENGTH",
+        "RBS_START_LEVEL_PARAM",
+      });
+
+      return specklePipe;
+    }
+
+    private DB.Plumbing.Pipe CreateLinearPipe(DB.Line baseLine, RevitPipe speckleRevitPipe, Level level, DB.Plumbing.PipeType type)
+    {
+      DB.Plumbing.Pipe pipe = null;
+
+      // get MEP pipe system by name or by type
+      var types = new FilteredElementCollector(Doc).WhereElementIsElementType()
+        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
+      var systemFamily = speckleRevitPipe?.systemType ?? "";
+      var system = types.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
+                   types.FirstOrDefault(x => x.Name == systemFamily);
+      if (system == null)
+      {
+        system = types.FirstOrDefault();
+        Report.LogConversionError(new Exception($"Pipe type {systemFamily} not found; replaced with {system.Name}"));
+      }
+
+      // create the pipe
+      pipe = DB.Plumbing.Pipe.Create(Doc, system.Id, type.Id, level.Id, baseLine.GetEndPoint(0), baseLine.GetEndPoint(1));
+
+      return pipe;
+    }
+    private DB.Plumbing.FlexPipe CreateFlexPipe(DB.Curve baseCurve, RevitPipe speckleRevitPipe, Level level, DB.Plumbing.FlexPipeType type)
+    {
+      DB.Plumbing.FlexPipe pipe = null;
+
+      // get MEP pipe system by name or by type
+      var types = new FilteredElementCollector(Doc).WhereElementIsElementType()
+        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
+      var systemFamily = speckleRevitPipe?.systemType ?? "";
+      var system = types.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
+                   types.FirstOrDefault(x => x.Name == systemFamily);
+      if (system == null)
+      {
+        system = types.FirstOrDefault();
+        Report.LogConversionError(new Exception($"Pipe type {systemFamily} not found; replaced with {system.Name}"));
+      }
+
+      // create the pipe
+      switch (baseCurve)
+      {
+        case DB.Arc arc:
+          var st = new XYZ();
+          var et = new XYZ();
+          var arcPoints = new List<XYZ>() { baseCurve.GetEndPoint(0), baseCurve.GetEndPoint(1) };
+          pipe = DB.Plumbing.FlexPipe.Create(Doc, system.Id, type.Id, level.Id, st, et, arcPoints);
+          break;
+        case DB.PolyLine:
+          break;
+        default:
+          break;
+      }
+
+      return pipe;
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -75,9 +75,9 @@ namespace Objects.Converter.Revit
       var placeholders = new List<ApplicationPlaceholderObject>
       {
         new ApplicationPlaceholderObject
-          {applicationId = specklePipe.applicationId, ApplicationGeneratedId = pipe.UniqueId, NativeObject = pipe}
+          {applicationId = specklePipe.applicationId, ApplicationGeneratedId = element.UniqueId, NativeObject = element}
       };
-      Report.Log($"{(isUpdate ? "Updated" : "Created")} Pipe {pipe.Id}");
+      Report.Log($"{(isUpdate ? "Updated" : "Created")} Pipe {element.Id}");
       return placeholders;
     }
 
@@ -197,8 +197,6 @@ namespace Objects.Converter.Revit
           var et = new XYZ();
           var arcPoints = new List<XYZ>() { baseCurve.GetEndPoint(0), baseCurve.GetEndPoint(1) };
           pipe = DB.Plumbing.FlexPipe.Create(Doc, system.Id, type.Id, level.Id, st, et, arcPoints);
-          break;
-        case DB.PolyLine:
           break;
         default:
           break;

--- a/Objects/Objects/BuiltElements/Duct.cs
+++ b/Objects/Objects/BuiltElements/Duct.cs
@@ -3,12 +3,16 @@ using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System.Collections.Generic;
+using Speckle.Newtonsoft.Json;
+using System;
 
 namespace Objects.BuiltElements
 {
   public class Duct : Base, IDisplayMesh
   {
+    [JsonIgnore, Obsolete("Replaced with baseCurve property")]
     public Line baseLine { get; set; }
+    public ICurve baseCurve { get; set; }
     public double width { get; set; }
     public double height { get; set; }
     public double diameter { get; set; }

--- a/Objects/Objects/BuiltElements/Duct.cs
+++ b/Objects/Objects/BuiltElements/Duct.cs
@@ -36,9 +36,29 @@ namespace Objects.BuiltElements
     /// <param name="velocity"></param>
     /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
     [SchemaInfo("Duct", "Creates a Speckle duct", "BIM", "MEP")]
+    [SchemaDeprecated]
     public Duct([SchemaMainParam] Line baseLine, double width, double height, double diameter, double velocity = 0)
     {
-      this.baseLine = baseLine;
+      this.baseCurve = baseLine;
+      this.width = width;
+      this.height = height;
+      this.diameter = diameter;
+      this.velocity = velocity;
+    }
+
+    /// <summary>
+    /// SchemaBuilder constructor for a Speckle duct
+    /// </summary>
+    /// <param name="baseCurve"></param>
+    /// <param name="width"></param>
+    /// <param name="height"></param>
+    /// <param name="diameter"></param>
+    /// <param name="velocity"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
+    [SchemaInfo("Duct", "Creates a Speckle duct", "BIM", "MEP")]
+    public Duct([SchemaMainParam] ICurve baseCurve, double width, double height, double diameter, double velocity = 0)
+    {
+      this.baseCurve = baseCurve;
       this.width = width;
       this.height = height;
       this.diameter = diameter;
@@ -62,7 +82,7 @@ namespace Objects.BuiltElements.Revit
     public RevitDuct() { }
 
     /// <summary>
-    /// SchemaBuilder constructor for a Revit duct
+    /// SchemaBuilder constructor for a Revit duct (deprecated)
     /// </summary>
     /// <param name="family"></param>
     /// <param name="type"></param>
@@ -77,14 +97,87 @@ namespace Objects.BuiltElements.Revit
     /// <param name="parameters"></param>
     /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
     [SchemaInfo("RevitDuct", "Creates a Revit duct", "Revit", "MEP")]
+    [SchemaDeprecated]
     public RevitDuct(string family, string type, [SchemaMainParam] Line baseLine, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, List<Parameter> parameters = null)
     {
-      this.baseLine = baseLine;
+      this.baseCurve = baseLine;
       this.family = family;
       this.type = type;
       this.width = width;
       this.height = height;
       this.diameter = diameter;
+      this.velocity = velocity;
+      this.systemName = systemName;
+      this.systemType = systemType;
+      this.parameters = parameters.ToBase();
+      this.level = level;
+    }
+
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit duct
+    /// </summary>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="baseCurve"></param>
+    /// <param name="systemName"></param>
+    /// <param name="systemType"></param>
+    /// <param name="level"></param>
+    /// <param name="width"></param>
+    /// <param name="height"></param>
+    /// <param name="diameter"></param>
+    /// <param name="velocity"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
+    [SchemaInfo("RevitDuct", "Creates a Revit duct", "Revit", "MEP")]
+    public RevitDuct(string family, string type, [SchemaMainParam] ICurve baseCurve, string systemName, string systemType, Level level, double width, double height, double diameter, double velocity = 0, List<Parameter> parameters = null)
+    {
+      this.baseCurve = baseCurve;
+      this.family = family;
+      this.type = type;
+      this.width = width;
+      this.height = height;
+      this.diameter = diameter;
+      this.velocity = velocity;
+      this.systemName = systemName;
+      this.systemType = systemType;
+      this.parameters = parameters.ToBase();
+      this.level = level;
+    }
+  }
+
+  public class RevitFlexDuct : RevitDuct
+  {
+    public Vector startTangent { get; set; }
+    public Vector endTangent { get; set; }
+
+    public RevitFlexDuct() { }
+
+    /// <summary>
+    /// SchemaBuilder constructor for a Revit flex duct
+    /// </summary>
+    /// <param name="family"></param>
+    /// <param name="type"></param>
+    /// <param name="baseCurve"></param>
+    /// <param name="systemName"></param>
+    /// <param name="systemType"></param>
+    /// <param name="level"></param>
+    /// <param name="width"></param>
+    /// <param name="height"></param>
+    /// <param name="diameter"></param>
+    /// <param name="velocity"></param>
+    /// <param name="parameters"></param>
+    /// <remarks>Assign units when using this constructor due to <paramref name="width"/>, <paramref name="height"/>, and <paramref name="diameter"/> params</remarks>
+    [SchemaInfo("RevitFlexDuct", "Creates a Revit flex duct", "Revit", "MEP")]
+    public RevitFlexDuct(string family, string type, [SchemaMainParam] ICurve baseCurve, string systemName, string systemType, Level level, double width, double height, double diameter, Vector startTangent, Vector endTangent, double velocity = 0, List<Parameter> parameters = null)
+    {
+      this.baseCurve = baseCurve;
+      this.family = family;
+      this.type = type;
+      this.width = width;
+      this.height = height;
+      this.diameter = diameter;
+      this.startTangent = startTangent;
+      this.endTangent = endTangent;
       this.velocity = velocity;
       this.systemName = systemName;
       this.systemType = systemType;

--- a/Objects/Objects/BuiltElements/Pipe.cs
+++ b/Objects/Objects/BuiltElements/Pipe.cs
@@ -56,4 +56,27 @@ namespace Objects.BuiltElements.Revit
       this.parameters = parameters.ToBase();
     }
   }
+
+  public class RevitFlexPipe : RevitPipe
+  {
+    public Vector startTangent { get; set; }
+    public Vector endTangent { get; set; }
+
+    public RevitFlexPipe() { }
+
+    [SchemaInfo("RevitFlexPipe", "Creates a Revit flex pipe", "Revit", "MEP")]
+    public RevitFlexPipe(string family, string type, [SchemaMainParam] ICurve baseCurve, double diameter, Level level, Vector startTangent, Vector endTangent, string systemName = "", string systemType = "", List<Parameter> parameters = null)
+    {
+      this.family = family;
+      this.type = type;
+      this.baseCurve = baseCurve;
+      this.diameter = diameter;
+      this.startTangent = startTangent;
+      this.endTangent = endTangent;
+      this.systemName = systemName;
+      this.systemType = systemType;
+      this.level = level;
+      this.parameters = parameters.ToBase();
+    }
+  }
 }


### PR DESCRIPTION
## Description
Adds `FlexDuct` and `FlexPipe` conversions to Revit. Includes the following changes:
- Generally, FlexDuct and FlexPipe elements inherit from `MEPCurve` which contains a set of `XYZ` points and a start/end tangent. To support non-line based ducts and pipes, we are now capturing the point information as a generated `Polyline` in `ToSpeckle` conversions.
- `Objects`: change in `Duct` class property `Line baseLine` to `ICurve baseCurve`. The old property has been marked as deprecated and backwards compatibility with generated GH components preserved. This now aligns the Duct and Pipe classes to enable support for polyline base curves.
- Objects`: new `RevitFlexPipe` and `RevitFlexDuct` classes which inherit from `RevitPipe` and `RevitDuct`

- Fixes #920

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: tested with community-volunteered MEP revit model file
- *NOTE* found some bugs when testing the file, where the pipe system type is not sent correctly, and also some pipes and family instances were coming in a slightly different position (for pipes, top/bottom/horizontal param value differed from original)

## Docs

- Will be updated ASAP

