### PR TITLE
fix(dui2): added progress dialog window to sending and receiving from saved streams

### DIFF
--- a/DesktopUI2/DesktopUI2/DummyBindings.cs
+++ b/DesktopUI2/DesktopUI2/DummyBindings.cs
@@ -19,7 +19,6 @@ namespace DesktopUI2
   {
     Random rnd = new Random();
 
-
     public override string GetActiveViewName()
     {
       return "An Active View Name";
@@ -77,9 +76,8 @@ namespace DesktopUI2
       var nums = rnd.Next(1000);
       var strs = new List<string>();
       for (int i = 0; i < nums; i++)
-      {
         strs.Add($"Object-{i}");
-      }
+
       return strs;
     }
 
@@ -228,20 +226,13 @@ namespace DesktopUI2
 
       #endregion
 
-
       foreach (var stream in testStreams)
-      {
         collection.Add(new StreamState(AccountManager.GetDefaultAccount(), stream));
-      }
 
       collection[0].SelectedObjectIds.Add("random_obj");
 
       return collection;
     }
-
-
-
-
 
     public override void SelectClientObjects(string args)
     {
@@ -259,9 +250,7 @@ namespace DesktopUI2
       for (int i = 1; i < 100; i += 10)
       {
         if (progress.CancellationTokenSource.IsCancellationRequested)
-        {
           return state;
-        }
 
         await Task.Delay(TimeSpan.FromMilliseconds(rnd.Next(200, 1000)));
         pd["A1"] = i;

--- a/DesktopUI2/DesktopUI2/ViewModels/ProgressViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/ProgressViewModel.cs
@@ -19,8 +19,8 @@ namespace DesktopUI2.ViewModels
 
     public ProgressReport Report { get; set; } = new ProgressReport();
 
-
     private ConcurrentDictionary<string, int> _progressDict;
+
     public ConcurrentDictionary<string, int> ProgressDict
     {
       get => _progressDict;
@@ -83,15 +83,10 @@ namespace DesktopUI2.ViewModels
       }
     }
 
-
-
     public void Update(ConcurrentDictionary<string, int> pd)
     {
-      //Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-      //{
       ProgressDict = pd;
       Value = pd.Values.Last();
-      //}, Avalonia.Threading.DispatcherPriority.MaxValue);
     }
 
     public void GetHelpCommand()

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamEditViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamEditViewModel.cs
@@ -128,7 +128,6 @@ namespace DesktopUI2.ViewModels
 
     private StreamState _streamState { get; }
 
-
     public string _previewImageUrl = "";
     public string PreviewImageUrl
     {
@@ -140,18 +139,12 @@ namespace DesktopUI2.ViewModels
       }
     }
 
-
-
-
     private Avalonia.Media.Imaging.Bitmap _previewImage = null;
     public Avalonia.Media.Imaging.Bitmap PreviewImage
     {
       get => _previewImage;
       set => this.RaiseAndSetIfChanged(ref _previewImage, value);
     }
-
-
-
 
     public StreamEditViewModel()
     {
@@ -164,7 +157,6 @@ namespace DesktopUI2.ViewModels
       Client = streamState.Client;
       _streamState = streamState; //cached, should not be accessed
 
-
       //use dependency injection to get bindings
       Bindings = Locator.Current.GetService<ConnectorBindings>();
 
@@ -175,7 +167,6 @@ namespace DesktopUI2.ViewModels
 
       GetBranchesAndRestoreState(streamState.Client, streamState);
     }
-
 
     private async void GetBranchesAndRestoreState(Client client, StreamState streamState)
     {
@@ -209,8 +200,6 @@ namespace DesktopUI2.ViewModels
       if (!IsReceiver)
         _streamState.Filter = SelectedFilter.Filter;
       return _streamState;
-
-
     }
 
     private async void GetCommits()
@@ -228,12 +217,6 @@ namespace DesktopUI2.ViewModels
         Commits = new List<Commit>();
         SelectedCommit = null;
       }
-      //else
-      //{
-      //  Commits = new List<Commit>() { new Commit { id = "latest", message = "This branch has no commits." } };
-      //}
-
-
     }
 
     public void DownloadImage(string url)
@@ -283,7 +266,6 @@ namespace DesktopUI2.ViewModels
       Progress.IsProgressing = true;
       var dialog = Dialogs.SendReceiveDialog("Sending...", this);
 
-
       _ = dialog.ShowDialog(MainWindow.Instance).ContinueWith(x =>
       {
         if (x.Result.GetResult == "cancel")
@@ -302,13 +284,12 @@ namespace DesktopUI2.ViewModels
       Progress.IsProgressing = true;
       var dialog = Dialogs.SendReceiveDialog("Receiving...", this);
 
-
       _ = dialog.ShowDialog(MainWindow.Instance).ContinueWith(x =>
       {
         if (x.Result.GetResult == "cancel")
           Progress.CancellationTokenSource.Cancel();
-      }
-        );
+      });
+
       await Task.Run(() => Bindings.ReceiveStream(GetStreamState(), Progress));
       dialog.GetWindow().Close();
       Progress.IsProgressing = false;


### PR DESCRIPTION
## Description

Adds a dialog window with progress bar and cancel button (same as used for quick send and quick receive) to sending and receiving from saved streams.

- Fixes #991

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
## How has this been tested?

- Manual Tests: cancelled a few sends and receives

## Docs

- No updates needed


