### PR TITLE
fix(civil3d): crash issues from community-contributed civil file

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -422,7 +422,7 @@ namespace Objects.Converter.AutocadCivil
       if (elevationPoints.Count > 0)
         _featureline[@"elevationPoints"] = elevationPoints;
 
-      try { _featureline["site"] = featureline.SiteId; } catch { }
+      try { _featureline["site"] = featureline.SiteId.ToString(); } catch { }
 
       return _featureline;
     }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -97,8 +97,6 @@ public static string AutocadAppName = Applications.Autocad2022;
           if (schema != null)
             return ObjectToSpeckleBuiltElement(o);
           */
-          DisplayStyle style = GetStyle(obj);
-
           switch (obj)
           {
             case DBPoint o:
@@ -166,6 +164,11 @@ public static string AutocadAppName = Applications.Autocad2022;
               Report.Log($"Converted SubD Mesh");
               break;
             case Solid3d o:
+              if (o.IsNull)
+              {
+                Report.Log($"Skipped null Solid");
+                return null;
+              }
               @base = SolidToSpeckle(o);
               Report.Log($"Converted Solid as Mesh");
               break;
@@ -216,6 +219,8 @@ public static string AutocadAppName = Applications.Autocad2022;
               break;
 #endif
           }
+
+          DisplayStyle style = GetStyle(obj);
           if (style != null)
             @base["displayStyle"] = style;
 


### PR DESCRIPTION
## Description

Discovered a few bugs that were resulting in crashes in Civil3d:

- Some civil3d docs have `Units.Undefined` returned from the Doc.Insunits property, needed to add a aec.interop class to retrieve valid units from the test file (used for civil files only).
- Featurelines with a site were attaching `ObjectId` to the base property rather than the string, this is fixed
- The file contained invisible null `Solids`, may have been a result from manual conversion of civil elements to 3d solids. Added a `Solid.IsNull` check to solid conversions.

- Fixes #996 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests:[https://speckle.xyz/streams/bff55266ce/commits/9a1bc290d1?c=%5B1911513.56621,562366.17512,753.00251,1911579.97933,562925.48915,-29.93577,0,1%5D]( https://speckle.xyz/streams/bff55266ce/commits/9a1bc290d1?c=%5B1911513.56621,562366.17512,753.00251,1911579.97933,562925.48915,-29.93577,0,1%5D)

## Docs

- No updates needed


