### PR TITLE
Improve support for non `IList<object>` props.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -78,12 +79,12 @@ namespace ConnectorGrasshopper.Objects
         case null:
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Key not found in object");
           break;
-        case IList<object> list:
-          {
-            var ghGoos = list.Select(GH_Convert.ToGoo).ToList();
-            DA.SetDataList(0, ghGoos);
-            break;
-          }
+        case IEnumerable list:
+        {
+          var ghGoos = list.Cast<object>().Select(GH_Convert.ToGoo).ToList();
+          DA.SetDataList(0, ghGoos);
+          break;
+        }
         default:
           Params.Output[0].Access = GH_ParamAccess.item;
           DA.SetData(0, GH_Convert.ToGoo(value));
@@ -109,12 +110,12 @@ namespace ConnectorGrasshopper.Objects
           case null:
             AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Key not found in object: " + key);
             break;
-          case List<object> list:
-            {
-              value = list.Select(
-                item => Converter != null ? Utilities.TryConvertItemToNative(item, Converter) : item).ToList();
-              break;
-            }
+          case IList list:
+          {
+            value = list.Cast<object>().Select(
+              item => Converter != null ? Utilities.TryConvertItemToNative(item, Converter) : item).ToList();
+            break;
+          }
           default:
             value = Converter != null ? Utilities.TryConvertItemToNative(obj, Converter) : obj;
             break;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -485,11 +485,11 @@ namespace ConnectorGrasshopper
     {
       if (!values.Any()) return null;
 
-      var list = (IList)Activator.CreateInstance(t);
-      var listElementType = list.GetType().GetGenericArguments().Single();
-      foreach (var value in values)
+      var listElementType = t.GetElementType();
+      var list = (IList)Array.CreateInstance(listElementType, values.Count);
+      for (int i=0; i< values.Count; i++)
       {
-        list.Add(ConvertType(listElementType, value, param.Name));
+        list[i] = (ConvertType(listElementType, values[i], param.Name));
       }
 
       return list;


### PR DESCRIPTION
## Description

- Fixes #980
- Fixes #979

Nodes were assuming that all props that are lists will be `IList<object>`, It seems that wasn't generic enough so now we're using IEnumerable, so people can shove in whatever they want, as long as it can be enumerated.

Also, many thanks to the forum user who reported it and suggested a fix! 🙌🏼 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Added support for `double[]` and other types of arrays by changing our implementation to use `IEnumerable` instead of `IList<object>``

Should be backwards compatible all the way.

## How has this been tested?


- Manual Tests (please write what did you do?)

Made sure that old classes that used lists still work.
Made sure that arrays also work now.

## Docs

- No updates needed

