### PR TITLE
Check for duplicate seed when CreateSchemaObjectBase comp is added

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -182,6 +182,16 @@ namespace ConnectorGrasshopper
                 break;
               }
             }
+            var baseType = comp.GetType().BaseType;        
+            if (typeof(CreateSchemaObjectBase) == baseType)
+            {
+              var csob = (CreateSchemaObjectBase)comp;
+              if (csob.Seed == Seed)
+              {
+                Seed = GenerateSeed();
+                break;
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

- Fixes duplicate applicationId issue reported on community [forum](https://speckle.community/t/grasshopper-component-duplicates-application-id/2249)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (testing in GH script)

## Docs

- No updates needed

