### PR TITLE
refactor(rhino): moved displaystyle assignment to converter

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BlockDefinition = Objects.Other.BlockDefinition;
 using BlockInstance = Objects.Other.BlockInstance;
+using DisplayStyle = Objects.Other.DisplayStyle;
 using Hatch = Objects.Other.Hatch;
 using HatchLoop = Objects.Other.HatchLoop;
 using Polyline = Objects.Geometry.Polyline;
@@ -23,6 +24,20 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
+    public ObjectAttributes DisplayStyleToNative(DisplayStyle display)
+    {
+      var attributes = new ObjectAttributes();
+
+      attributes.ColorSource = ObjectColorSource.ColorFromObject;
+      attributes.ObjectColor = System.Drawing.Color.FromArgb(display.color);
+      attributes.PlotWeight = display.lineweight;
+      attributes.LinetypeSource = ObjectLinetypeSource.LinetypeFromObject;
+      var lineStyle = Doc.Linetypes.FindName(display.linetype);
+      attributes.LinetypeIndex = (lineStyle != null) ? lineStyle.Index : 0;
+
+      return attributes;
+    }
+
     public Rhino.Geometry.Hatch[] HatchToNative(Hatch hatch)
     {
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -567,6 +567,7 @@ namespace Objects.Converter.RhinoGh
             Report.Log($"Created Brep {o.id}");
           }
           break;
+
         case Surface o:
           rhinoObj = SurfaceToNative(o);
           Report.Log($"Created Surface {o.id}");
@@ -615,6 +616,10 @@ namespace Objects.Converter.RhinoGh
         case Text o:
           rhinoObj = TextToNative(o);
           Report.Log($"Created Text {o.id}");
+          break;
+
+        case DisplayStyle o:
+          rhinoObj = DisplayStyleToNative(o);
           break;
 
         default:
@@ -706,6 +711,7 @@ case RH.SubD _:
 
         //TODO: This types are not supported in GH!
         case Pointcloud _:
+        case DisplayStyle _:
         case ModelCurve _:
         case DirectShape _:
         case View3D _:


### PR DESCRIPTION
## Description

On receiving, moves the display style property assignment from the connector to the converter.
Adds a `DisplayStyleToNative` method to the converter

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: sent and received from rhino

## Docs

- No updates needed

