### PR TITLE
bug(rhino): adds elements to receiving

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -66,9 +66,7 @@ namespace Speckle.ConnectorRevit.UI
         try
         {
           if (revitElement == null)
-          {
             continue;
-          }
 
           if (!converter.CanConvertToSpeckle(revitElement))
           {
@@ -77,9 +75,7 @@ namespace Speckle.ConnectorRevit.UI
           }
 
           if (progress.CancellationTokenSource.Token.IsCancellationRequested)
-          {
             return;
-          }
 
           var conversionResult = converter.ConvertToSpeckle(revitElement);
 
@@ -97,9 +93,8 @@ namespace Speckle.ConnectorRevit.UI
           {
             var category = $"@{revitElement.Category.Name}";
             if (commitObject[category] == null)
-            {
               commitObject[category] = new List<Base>();
-            }
+
              ((List<Base>)commitObject[category]).Add(conversionResult);
           }
 

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino2.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino2.cs
@@ -265,6 +265,8 @@ namespace SpeckleRhino
             props.Add("displayValue");
           if (@base.GetMembers().ContainsKey("displayMesh")) // add display mesh to member list if it exists. this will be deprecated soon
             props.Add("displayMesh");
+          if (@base.GetMembers().ContainsKey("elements")) // this is for builtelements like roofs, walls, and floors.
+            props.Add("elements");
           int totalMembers = props.Count;
 
           foreach (var prop in props)
@@ -294,6 +296,14 @@ namespace SpeckleRhino
       {
         count = 0;
         foreach (var listObj in list)
+          objects.AddRange(FlattenCommitObject(listObj, converter, layer, state, ref count));
+        return objects;
+      }
+
+      if (obj is IReadOnlyList<object> readOnlyList)
+      {
+        count = 0;
+        foreach (var listObj in readOnlyList)
           objects.AddRange(FlattenCommitObject(listObj, converter, layer, state, ref count));
         return objects;
       }


### PR DESCRIPTION
## Description

Previously, the Rhino connector was not converting child elements in certain BuiltElements classes from revit (like walls). Adds a case in FlattenCommitObject() to add `elements` to props to flatten as well as handling `IReadOnly` lists.

- Fixes #1018 
- Fixes #995 : not correctly receiving all nested element displayvalues was the source of this issue, 995 no longer needed because of this

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: received revit walls with elements in rhino

## Docs

- No updates needed
