### PR TITLE
Rhino: Render material

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino2.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino2.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -27,6 +28,8 @@ using DesktopUI2.ViewModels;
 using DesktopUI2.Models.Filters;
 using DesktopUI2.Models.Settings;
 using System.Threading;
+using Rhino.Geometry;
+using Rhino.Render;
 using Speckle.Core.Logging;
 
 namespace SpeckleRhino
@@ -292,18 +295,10 @@ namespace SpeckleRhino
         }
       }
 
-      if (obj is List<object> list)
+      if (obj is IReadOnlyList<object> list)
       {
         count = 0;
         foreach (var listObj in list)
-          objects.AddRange(FlattenCommitObject(listObj, converter, layer, state, ref count));
-        return objects;
-      }
-
-      if (obj is IReadOnlyList<object> readOnlyList)
-      {
-        count = 0;
-        foreach (var listObj in readOnlyList)
           objects.AddRange(FlattenCommitObject(listObj, converter, layer, state, ref count));
         return objects;
       }
@@ -339,77 +334,76 @@ namespace SpeckleRhino
 
       foreach (var convertedItem in convertedList)
       {
-        var convertedRH = convertedItem as Rhino.Geometry.GeometryBase;
-        if (convertedRH != null)
+        if (!(convertedItem is GeometryBase convertedRH)) continue;
+        
+        if (!convertedRH.IsValidWithLog(out string log))
         {
-          if (convertedRH.IsValidWithLog(out string log))
+          var exception =
+            new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}: {log.Replace("\n", "").Replace("\r", "")}");
+          converter.Report.LogConversionError(exception);
+          continue;
+        }
+
+        Layer bakeLayer = Doc.GetLayer(layerPath, true);
+        if (bakeLayer == null)
+        {
+          var exception = new Exception($"Could not create layer {layerPath} to bake objects into.");
+          converter.Report.LogConversionError(exception);
+          continue;
+        }
+
+        var attributes = new ObjectAttributes();
+
+        // handle display style
+        if (obj[@"displayStyle"] is Base display)
+        {
+          if (converter.ConvertToNative(display) is ObjectAttributes displayAttribute)
+            attributes = displayAttribute;
+        }
+        else if (obj[@"renderMaterial"] is Base renderMaterial)
+        {
+          if (renderMaterial["diffuse"] is int color)
           {
-            Layer bakeLayer = Doc.GetLayer(layerPath, true);
-            if (bakeLayer != null)
-            {
-              var attributes = new ObjectAttributes();
-
-              // handle display
-              Base display = obj[@"displayStyle"] as Base;
-              if (display != null)
-              {
-                var displayAttribute = converter.ConvertToNative(display) as ObjectAttributes;
-                if (displayAttribute != null)
-                  attributes = displayAttribute;
-              }
-
-              /* Not implemented since revit displaymesh objs do not have render materials attached
-              else
-              {
-                Base render = obj[@"renderMaterial"] as Base;
-                if (render != null)
-                {
-                  var color = render["diffuse"] as int?;
-
-                  if (color != null)
-                  {
-                    attributes.ColorSource = ObjectColorSource.ColorFromObject;
-                    attributes.ObjectColor = System.Drawing.Color.FromArgb((int)color);
-                  }
-                }
-              }
-              */
-
-              // assign layer
-              attributes.LayerIndex = bakeLayer.Index;
-
-              // TODO: deprecate after awhile, schemas included in user strings. This would be a breaking change.
-              string schema = obj["SpeckleSchema"] as string;
-              if (schema != null)
-                attributes.SetUserString("SpeckleSchema", schema);
-
-              // handle user strings
-              var userStrings = obj[UserStrings] as Dictionary<string, string>;
-              if (userStrings != null)
-                foreach (var key in userStrings.Keys)
-                  attributes.SetUserString(key, userStrings[key]);
-
-              // handle user dictionaries
-              var dict = obj[UserDictionary] as Dictionary<string, object>;
-              if (dict != null)
-                ParseDictionaryToArchivable(attributes.UserDictionary, dict);
-
-              if (Doc.Objects.Add(convertedRH, attributes) == Guid.Empty)
-              {
-                var exception = new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}.");
-                converter.Report.LogConversionError(exception);
-              }
-            }
-            else
-            {
-              var exception = new Exception($"Could not create layer {layerPath} to bake objects into.");
-              converter.Report.LogConversionError(exception);
-            }
+            attributes.ColorSource = ObjectColorSource.ColorFromObject;
+            attributes.ObjectColor = Color.FromArgb(color);
           }
-          else
+        }
+        
+        // assign layer
+        attributes.LayerIndex = bakeLayer.Index;
+
+        // TODO: deprecate after awhile, schemas included in user strings. This would be a breaking change.
+        if (obj["SpeckleSchema"] is string schema)
+          attributes.SetUserString("SpeckleSchema", schema);
+
+        // handle user strings
+        if (obj[UserStrings] is Dictionary<string, string> userStrings)
+        {
+          foreach (var key in userStrings.Keys)
+            attributes.SetUserString(key, userStrings[key]);
+        }
+
+        // handle user dictionaries
+        if (obj[UserDictionary] is Dictionary<string, object> dict)
+          ParseDictionaryToArchivable(attributes.UserDictionary, dict);
+
+        Guid id = Doc.Objects.Add(convertedRH, attributes);
+
+        if (id == Guid.Empty)
+        {
+          var exception = new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}.");
+          converter.Report.LogConversionError(exception);
+          continue;
+        }
+        
+        if (obj[@"renderMaterial"] is Base render)
+        {
+          var convertedMaterial = converter.ConvertToNative(render); //Maybe wrap in try catch in case no conversion exists?
+          if (convertedMaterial is RenderMaterial rm)
           {
-            var exception = new Exception($"Failed to bake object {obj.id} of type {obj.speckle_type}: {log.Replace("\n", "").Replace("\r", "")}");
-            converter.Report.LogConversionError(exception);
+            var rhinoObject = Doc.Objects.FindId(id);
+            rhinoObject.RenderMaterial = rm;
+            rhinoObject.CommitChanges();
           }
         }
       }   

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino2.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino2.cs
@@ -378,10 +378,8 @@ namespace SpeckleRhino
 
         // handle user strings
         if (obj[UserStrings] is Dictionary<string, string> userStrings)
-        {
           foreach (var key in userStrings.Keys)
             attributes.SetUserString(key, userStrings[key]);
-        }
 
         // handle user dictionaries
         if (obj[UserDictionary] is Dictionary<string, object> dict)
@@ -396,6 +394,7 @@ namespace SpeckleRhino
           continue;
         }
         
+        // handle render material
         if (obj[@"renderMaterial"] is Base render)
         {
           var convertedMaterial = converter.ConvertToNative(render); //Maybe wrap in try catch in case no conversion exists?

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -9,6 +9,7 @@ using Speckle.Core.Models;
 using Speckle.Core.Kits;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using BlockDefinition = Objects.Other.BlockDefinition;
 using BlockInstance = Objects.Other.BlockInstance;
@@ -18,6 +19,7 @@ using HatchLoop = Objects.Other.HatchLoop;
 using Polyline = Objects.Geometry.Polyline;
 using Text = Objects.Other.Text;
 using RH = Rhino.DocObjects;
+using RenderMaterial = Objects.Other.RenderMaterial;
 using Rhino;
 
 namespace Objects.Converter.RhinoGh
@@ -38,6 +40,32 @@ namespace Objects.Converter.RhinoGh
       return attributes;
     }
 
+    public Rhino.Render.RenderMaterial RenderMaterialToNative(RenderMaterial speckleMaterial)
+    {
+      var commitInfo = GetCommitInfo();
+      var name = $"{commitInfo} - {speckleMaterial.name}";
+      
+      var existing = Doc.RenderMaterials.FirstOrDefault(x => x.Name == name);
+      if (existing != null)
+      {
+        return existing;
+      }
+      
+      var rhinoMaterial = new Material
+      {
+        Name = name,
+        DiffuseColor = Color.FromArgb(speckleMaterial.diffuse),
+        EmissionColor = Color.FromArgb(speckleMaterial.emissive),
+        Transparency = 1 - speckleMaterial.opacity,
+        Reflectivity = speckleMaterial.metalness,
+      };
+      
+      var renderMaterial = Rhino.Render.RenderMaterial.CreateBasicMaterial(rhinoMaterial, Doc);
+      Doc.RenderMaterials.Add(renderMaterial);
+
+      return renderMaterial;
+    }
+    
     public Rhino.Geometry.Hatch[] HatchToNative(Hatch hatch)
     {
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -15,52 +15,6 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
-    private RenderMaterial GetMaterial(RhinoObject o)
-    {
-      var material = o.GetMaterial(true);
-      var renderMaterial = new RenderMaterial();
-
-      // If it's a default material use the display color.
-      if (!material.HasId)
-      {
-        renderMaterial.diffuse = o.Attributes.DrawColor(Doc).ToArgb();
-        return renderMaterial;
-      }
-
-      // Otherwise, extract what properties we can. 
-      renderMaterial.name = material.Name;
-      renderMaterial.diffuse = material.DiffuseColor.ToArgb();
-      renderMaterial.emissive = material.EmissionColor.ToArgb();
-      renderMaterial.opacity = 1 - material.Transparency;
-      renderMaterial.metalness = material.Reflectivity;
-      
-      if (material.Name != null && material.Name.ToLower().Contains("glass") && renderMaterial.opacity == 0)
-      {
-        renderMaterial.opacity = 0.3;
-      }
-
-      return renderMaterial;
-    }
-
-    private DisplayStyle GetStyle(RhinoObject o)
-    {
-      var att = o.Attributes;
-      var style = new DisplayStyle();
-
-      // color
-      style.color = att.DrawColor(Doc).ToArgb();
-
-      // linetype
-      var lineType = Doc.Linetypes[att.LinetypeIndex];
-      if (lineType.HasName)
-        style.linetype = lineType.Name;
-
-      // lineweight
-      style.lineweight = att.PlotWeight;
-
-      return style;
-    }
-
     private string GetSchema(RhinoObject obj, out string[] args)
     {
       args = null;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -621,6 +621,10 @@ namespace Objects.Converter.RhinoGh
         case DisplayStyle o:
           rhinoObj = DisplayStyleToNative(o);
           break;
+        
+        case RenderMaterial o:
+          rhinoObj = RenderMaterialToNative(o);
+          break;
 
         default:
           Report.Log($"Skipped not supported type: {@object.GetType()} {@object.id}");

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -109,8 +109,8 @@ namespace Objects.Converter.RhinoGh
       Base schema = null;
       if (@object is RhinoObject ro)
       {
-        material = GetMaterial(ro);
-        style = GetStyle(ro);
+        material = RenderMaterialToSpeckle(ro.GetMaterial(true));
+        style = DisplayStyleToSpeckle(ro.Attributes);
 
         if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
            schema = ConvertToSpeckleBE(ro) ?? ConvertToSpeckleStr(ro);
@@ -722,6 +722,7 @@ case RH.SubD _:
         case BlockDefinition _:
         case BlockInstance _:
         case Alignment _:
+        case RenderMaterial _:
         case Text _:
           return true;
 


### PR DESCRIPTION
## Description

- Added Render material conversion ToNative.
- If incoming geometry has no `displayStyle` property, we will try and use the `renderMaterial`'s diffuse colour.
- Fixes #1030 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Receiving the [PBR test stream](https://latest.speckle.dev/streams/2158263a8f) 

## Docs

- The rhino docs don't currently mention render materials at all.
