### PR TITLE
GH: Adds right-click option to disable automatic expand in receive node

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -379,15 +379,6 @@ namespace ConnectorGrasshopper.Extras
         var converted = Converter.ConvertToNative(@base);
         data.Append(TryConvertItemToNative(converted, Converter));
       }
-      // We unpack automatically since we auto-wrapped it initially
-      // case 2: it's a wrapper Base
-      //       2a: if there's only one member unpack it
-      //       2b: otherwise return dictionary of unpacked members
-      else if (@base.IsWrapper())
-      {
-        var treeBuilder = new TreeBuilder(Converter) { ConvertToNative = Converter != null};
-        data = treeBuilder.Build(@base[@base.GetDynamicMembers().ElementAt(0)]);
-      }
       // Simple pass the SpeckleBase
       else
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -196,7 +196,7 @@ namespace ConnectorGrasshopper.Ops
       var noExpandMi = Menu_AppendItem(menu, "Expand commit object properties", (s, e) =>
       {
         ExpandOutput = !ExpandOutput;
-        RhinoApp.InvokeOnUiThread((Action)delegate { OnDisplayExpired(true); });
+        RhinoApp.InvokeOnUiThread((Action)delegate { ExpireSolution(true); });
       }, null, true, ExpandOutput);
       noExpandMi.ToolTipText = "Prevents expanding the commit object and outputs everything into the @data output.";
       

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -36,6 +36,7 @@ namespace ConnectorGrasshopper.Ops
     public VariableInputReceiveComponent() : base("Receive", "Receive", "Receive data from a Speckle server", ComponentCategories.PRIMARY_RIBBON,
       ComponentCategories.SEND_RECEIVE)
     {
+      ExpandOutput = true;
       BaseWorker = new VariableInputReceiveComponentWorker(this);
       Attributes = new VariableInputReceiveComponentAttributes(this);
     }
@@ -46,6 +47,8 @@ namespace ConnectorGrasshopper.Ops
     public bool AutoReceive { get; set; }
     
     public bool ReceiveOnOpen { get; set; }
+    
+    public bool ExpandOutput { get; set; }
 
     public override Guid ComponentGuid => new Guid("06A3E53B-2BFF-4EBD-BBCE-71B9CE36283E");
 
@@ -140,6 +143,7 @@ namespace ConnectorGrasshopper.Ops
       writer.SetString("LastCommitDate", LastCommitDate);
       writer.SetString("ReceivedCommitId", ReceivedCommitId);
       writer.SetBoolean("ReceiveOnOpen", ReceiveOnOpen);
+      writer.SetBoolean("ExpandOutput", ExpandOutput);
       return base.Write(writer);
     }
 
@@ -153,7 +157,7 @@ namespace ConnectorGrasshopper.Ops
       LastInfoMessage = reader.GetString("LastInfoMessage");
       LastCommitDate = reader.GetString("LastCommitDate");
       ReceivedCommitId = reader.GetString("ReceivedCommitId");
-      
+      ExpandOutput = reader.GetBoolean("ExpandOutput");
       var swString = reader.GetString("StreamWrapper");
       if (!string.IsNullOrEmpty(swString))
       {
@@ -185,7 +189,16 @@ namespace ConnectorGrasshopper.Ops
     public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
     {
       base.AppendAdditionalMenuItems(menu);
+    
+      Menu_AppendSeparator(menu);
 
+      var noExpandMi = Menu_AppendItem(menu, "Do not expand", (s, e) =>
+      {
+        ExpandOutput = !ExpandOutput;
+        RhinoApp.InvokeOnUiThread((Action)delegate { OnDisplayExpired(true); });
+      },null,false,);
+      noExpandMi.ToolTipText = "Prevents expanding the commit object and outputs everything into the @data output.";
+      
       Menu_AppendSeparator(menu);
 
       if (InputType == "Stream" || InputType == "Branch")

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -156,7 +156,9 @@ namespace ConnectorGrasshopper.Ops
       LastInfoMessage = reader.GetString("LastInfoMessage");
       LastCommitDate = reader.GetString("LastCommitDate");
       ReceivedCommitId = reader.GetString("ReceivedCommitId");
-      ExpandOutput = reader.GetBoolean("ExpandOutput");
+      var expand = true;
+      reader.TryGetBoolean("ExpandOutput", ref expand);
+      ExpandOutput = expand;
       var swString = reader.GetString("StreamWrapper");
       if (!string.IsNullOrEmpty(swString))
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -245,21 +245,6 @@ public class DuctSchemaComponent: CreateSchemaObjectBase {
     public DuctSchemaComponent(): base("Duct", "Duct", "Creates a Speckle duct", "Speckle 2 BIM", "MEP") { }
     
     public override Guid ComponentGuid => new Guid("51d40791-43ea-a8e7-ef13-e9bfdf9cd893");
-    public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
-    
-    public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Duct.ctor(Objects.Geometry.Line,System.Double,System.Double,System.Double,System.Double)","Objects.BuiltElements.Duct");
-        base.AddedToDocument(document);
-    }
-}
-
-// This is generated code:
-public class Duct1SchemaComponent: CreateSchemaObjectBase {
-     
-    public Duct1SchemaComponent(): base("Duct", "Duct", "Creates a Speckle duct", "Speckle 2 BIM", "MEP") { }
-    
-    public override Guid ComponentGuid => new Guid("7e3a3fba-7d4f-d549-96c0-41693b512db0");
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Duct.ctor(Objects.ICurve,System.Double,System.Double,System.Double,System.Double)","Objects.BuiltElements.Duct");
@@ -507,21 +492,6 @@ public class FreeformElementSchemaComponent: CreateSchemaObjectBase {
     public FreeformElementSchemaComponent(): base("Freeform element", "Freeform element", "Creates a Revit Freeform element using a list of Brep or Meshes.", "Speckle 2 Revit", "Families") { }
     
     public override Guid ComponentGuid => new Guid("b24dc861-1c3c-a509-bc8b-560e9f7d503e");
-    public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
-    
-    public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(Speckle.Core.Models.Base,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FreeformElement");
-        base.AddedToDocument(document);
-    }
-}
-
-// This is generated code:
-public class FreeformElement1SchemaComponent: CreateSchemaObjectBase {
-     
-    public FreeformElement1SchemaComponent(): base("Freeform element", "Freeform element", "Creates a Revit Freeform element using a list of Brep or Meshes.", "Speckle 2 Revit", "Families") { }
-    
-    public override Guid ComponentGuid => new Guid("d1bb3f50-6abc-9f34-acf3-297e82bbd8ac");
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FreeformElement");
@@ -1900,21 +1870,6 @@ public class RevitDuctSchemaComponent: CreateSchemaObjectBase {
     public RevitDuctSchemaComponent(): base("RevitDuct", "RevitDuct", "Creates a Revit duct", "Speckle 2 Revit", "MEP") { }
     
     public override Guid ComponentGuid => new Guid("d7781536-e8a9-8aef-1b27-571584f8c4a3");
-    public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
-    
-    public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.Geometry.Line,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
-        base.AddedToDocument(document);
-    }
-}
-
-// This is generated code:
-public class RevitDuct1SchemaComponent: CreateSchemaObjectBase {
-     
-    public RevitDuct1SchemaComponent(): base("RevitDuct", "RevitDuct", "Creates a Revit duct", "Speckle 2 Revit", "MEP") { }
-    
-    public override Guid ComponentGuid => new Guid("7bb86598-9cd2-8d29-a1dc-7500c4b4ed4b");
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
@@ -2139,21 +2094,6 @@ public class RibbedSlabSchemaComponent: CreateSchemaObjectBase {
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.ETABS.Properties.ETABSProperty2D+RibbedSlab.ctor(System.String,Objects.Structural.ETABS.Analysis.ShellType,Objects.Structural.Materials.Material,System.Double,System.Double,System.Double,System.Double,System.Double,System.Int32)","Objects.Structural.ETABS.Properties.ETABSProperty2D+RibbedSlab");
-        base.AddedToDocument(document);
-    }
-}
-
-// This is generated code:
-public class RoofSchemaComponent: CreateSchemaObjectBase {
-     
-    public RoofSchemaComponent(): base("Roof", "Roof", "Creates a Speckle roof", "Speckle 2 BIM", "Architecture") { }
-    
-    public override Guid ComponentGuid => new Guid("c10c6dcd-e6a8-be88-32f3-45c935d0bae9");
-    public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
-    
-    public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Roof.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.BuiltElements.Roof");
         base.AddedToDocument(document);
     }
 }


### PR DESCRIPTION
## Description

The new `Variable Output Receive` component was defaulting to always expanding the output.

This was not ideal when the commit object had too many keys to handle.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests (please write what did you do?)
- Tested both functionalities (expand and no-expand) with new nodes and existing ones.

## Docs

- Will be updated ASAP

