### PR TITLE
GH: 2.4.0 Release fixes

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
@@ -21,16 +21,21 @@ namespace ConnectorGrasshopper.Extras
       get
       {
         var tags = base.StateTags;
-        if (Kind != GH_ParamKind.input) return tags;
-        if (Optional)
-        {
-          tags.Add(new OptionalStateTag());
-        }
 
-        if (Detachable)
-          tags.Add(new DetachedStateTag());
-        if (Access == GH_ParamAccess.list)
-          tags.Add(new ListAccesStateTag());
+        if (Kind == GH_ParamKind.input)
+        {
+          if (Optional)
+            tags.Add(new OptionalStateTag());
+          if (Detachable)
+            tags.Add(new DetachedStateTag());
+          if (Access == GH_ParamAccess.list)
+            tags.Add(new ListAccesStateTag());
+        }
+        else if (Kind == GH_ParamKind.output)
+        {
+          if (Detachable)
+            tags.Add(new DetachedStateTag());
+        }
 
         return tags;
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -258,6 +258,7 @@ namespace ConnectorGrasshopper.Extras
           catch (Exception e)
           {
             converter.Report.ConversionErrors.Add(new Exception($"Could not convert {@base}", e));
+            return null;
           }
         }
         if (recursive)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -47,9 +47,10 @@ namespace ConnectorGrasshopper.Ops
 
     public override Guid ComponentGuid => new Guid("{3D07C1AC-2D05-42DF-A297-F861CCEEFBC7}");
     public override bool Obsolete => true;
+    
     public string CurrentComponentState { get; set; } = "needs_input";
 
-    public override GH_Exposure Exposure => GH_Exposure.primary;
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
 
     protected override Bitmap Icon => Resources.Receiver;
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -35,7 +35,7 @@ namespace ConnectorGrasshopper.Ops
     protected override Bitmap Icon => Properties.Resources.Sender;
     public override bool Obsolete => true;
 
-    public override GH_Exposure Exposure => GH_Exposure.primary;
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
     public override bool CanDisableConversion => false;
     public bool AutoSend { get; set; } = false;
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -781,7 +781,7 @@ namespace ConnectorGrasshopper.Ops
       var equalLength = outputList.Count == Parent?.Params.Output.Count;
       if (!equalLength) return false;
       
-      var diffParams = Parent?.Params.Output.Where(param => !outputList.Contains(param.NickName) && !outputList.Contains(param.NickName.Substring(1)));
+      var diffParams = Parent?.Params.Output.Where(param => !outputList.Contains(param.NickName) && !outputList.Contains("@" + param.NickName));
       return diffParams.Count() == 1;
     }
     private void AutoCreateOutputs(Base @base)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -778,9 +778,10 @@ namespace ConnectorGrasshopper.Ops
 
     private bool HasSingleRename()
     {
-      var equalLength = outputList.Count == Parent.Params.Output.Count;
+      var equalLength = outputList.Count == Parent?.Params.Output.Count;
       if (!equalLength) return false;
-      var diffParams = Parent.Params.Output.Where(param => !outputList.Contains(param.NickName));
+      
+      var diffParams = Parent?.Params.Output.Where(param => !outputList.Contains(param.NickName) && !outputList.Contains(param.NickName.Substring(1)));
       return diffParams.Count() == 1;
     }
     private void AutoCreateOutputs(Base @base)
@@ -791,7 +792,25 @@ namespace ConnectorGrasshopper.Ops
         return;
 
       Parent.RecordUndoEvent("Creating Outputs");
+      if (HasSingleRename())
+      { 
+        var diffParams = Parent.Params.Output.Where(param => !outputList.Contains(param.NickName));
+        var diffOut = outputList
+          .Where(name =>
+            !Parent.Params.Output.Select(p => p.NickName)
+              .Contains(name));
 
+        var newName = diffOut.First();
+        var renameParam = diffParams.First();
+        var isDetached = newName.StartsWith("@");
+        var cleanName = isDetached ? newName.Substring(1) : newName;
+        renameParam.NickName = cleanName;
+        renameParam.Name = cleanName;
+        renameParam.Description = $"Data from property: {cleanName}";
+        (renameParam as SendReceiveDataParam).Detachable = isDetached;
+        return;
+      }
+      
       // Check what params must be deleted, and do so when safe.
       var remove = Parent.Params.Output.Select((p, i) =>
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
@@ -244,7 +244,7 @@ namespace ConnectorGrasshopper.Ops
 
       return new SendReceiveDataParam
       {
-        Name = "Data" + uniqueName,
+        Name = uniqueName,
         NickName = uniqueName,
         MutableNickName = true,
         Optional = false

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
@@ -300,7 +300,7 @@ namespace ConnectorGrasshopper.Ops
       for (var i = 2; i < Params.Input.Count; i++)
       {
         DA.GetDataTree(i, out GH_Structure<IGH_Goo> input);
-        DataInputs.Add(Params.Input[i].NickName, input);
+        DataInputs.Add(Params.Input[i].Name, input);
       }
       DA.GetDataTree(0, out _TransportsInput);
       DA.GetDataTree(1, out _MessageInput);


### PR DESCRIPTION
## Description

Grasshopper part of https://github.com/specklesystems/admin/issues/246

- Adds single rename handling for Variable Input Receiver
- Hides old Send/Receive nodes
- Fixes bug where Variable Input Sender would not sync name and nickname (causing wrong prop names when sending)
- Fixes Expand Speckle Object so that it shows detached props with state tag instead.


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Manual Tests (please write what did you do?)

Tested manually each case to ensure all input/outputs were being updated properly. Also tested against the old send/receive nodes to ensure backwards compatibility with older commits.

## Docs

- Will be updated ASAP

