### PR TITLE
acad: displaystyle refactor

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil2.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil2.cs
@@ -311,28 +311,11 @@ namespace Speckle.ConnectorAutocadCivil.UI
                 var res = convertedEntity.Append(cleanName);
                 if (res.IsValid)
                 {
-                  // handle display
+                  // handle display - fallback to rendermaterial if no displaystyle exists
                   Base display = obj[@"displayStyle"] as Base;
-                  if (display != null)
-                  {
-                    var color = display["color"] as int?;
-                    var lineType = display["linetype"] as string;
-                    var lineWidth = display["lineweight"] as double?;
-
-                    if (color != null)
-                    {
-                      var systemColor = System.Drawing.Color.FromArgb((int)color);
-                      convertedEntity.Color = Color.FromRgb(systemColor.R, systemColor.G, systemColor.B);
-                      convertedEntity.Transparency = new Transparency(systemColor.A);
-                    }
-
-                    if (lineWidth != null)
-                      convertedEntity.LineWeight = Utils.GetLineWeight((double)lineWidth);
-
-                    if (lineType != null)
-                      if (lineTypeDictionary.ContainsKey(lineType))
-                        convertedEntity.LinetypeId = lineTypeDictionary[lineType];
-                  }
+                  if (display == null) display = obj[@"renderMaterial"] as Base;
+                  if (display != null) Utils.SetStyle(display, convertedEntity, lineTypeDictionary);
+                    
                   tr.TransactionManager.QueueForGraphicsFlush();
                 }
                 else

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -220,7 +220,7 @@ public static string AutocadAppName = VersionedHostApplications.Autocad2022;
 #endif
           }
 
-          DisplayStyle style = GetStyle(obj);
+          DisplayStyle style = DisplayStyleToSpeckle(obj as Entity);
           if (style != null)
             @base["displayStyle"] = style;
 


### PR DESCRIPTION
-added displaystyle conversions ToSpeckle and ToNative
-applies displaystyle with rendermaterial as fallback to block definitions

## Description

Part of release testing

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- No updates needed

