### PR TITLE
GH: Adds `extract parameter` option to speckle related output nodes.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
@@ -131,7 +131,7 @@ namespace ConnectorGrasshopper.Extras
           {
             ghDocument.AddObject(ghParam, false);
             ghParam.AddSource(this);
-            ExpireSolution(true);
+            ghParam.ExpireSolution(true);
           }
         }
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
@@ -2,9 +2,12 @@
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
+using GH_IO;
 using GH_IO.Serialization;
+using Grasshopper;
 using Grasshopper.GUI.Canvas;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Attributes;
 using Grasshopper.Kernel.Parameters;
 
 
@@ -45,10 +48,12 @@ namespace ConnectorGrasshopper.Extras
 
     public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
     {
-      if (Kind != GH_ParamKind.input)
+      if (Kind != GH_ParamKind.input || Kind != GH_ParamKind.floating)
       {
         // Append graft,flatten,etc... options to outputs.
         base.AppendAdditionalMenuItems(menu);
+        if(Kind == GH_ParamKind.output)
+          Menu_AppendExtractParameter(menu);
         return;
       }
 
@@ -87,16 +92,51 @@ namespace ConnectorGrasshopper.Extras
       base.AppendAdditionalMenuItems(menu);
     }
 
-    protected override void ValuesChanged()
-    {
-      base.ValuesChanged();
-    }
 
-    protected override void OnVolatileDataCollected()
-    {
-      base.OnVolatileDataCollected();
-    }
+    protected new void Menu_AppendExtractParameter(ToolStripDropDown menu) => Menu_AppendItem(menu, "Extract parameter", Menu_ExtractParameterClicked, Recipients.Count == 0);
 
+    private void Menu_ExtractParameterClicked(object sender, EventArgs e)
+    {
+      var ghArchive = new GH_Archive();
+      if (!ghArchive.AppendObject(this, "Parameter"))
+      {
+        Tracing.Assert(new Guid("{96ACE3FC-F716-4b2e-B226-9E2D1F9DA229}"), "Parameter serialization failed.");
+      }
+      else
+      {
+        var ghDocumentObject = Instances.ComponentServer.EmitObject(this.ComponentGuid);
+        if (ghDocumentObject == null)
+          return;
+        var ghParam = (IGH_Param) ghDocumentObject;
+        ghParam.CreateAttributes();
+        if (!ghArchive.ExtractObject(ghParam, "Parameter"))
+        {
+          Tracing.Assert(new Guid("{2EA6E057-E390-4fc5-B9AB-1B74A8A17625}"), "Parameter deserialization failed.");
+        }
+        else
+        {
+          ghParam.NewInstanceGuid();
+          ghParam.Attributes.Selected = false;
+          ghParam.Attributes.Pivot = new PointF(this.Attributes.Pivot.X + 120f, this.Attributes.Pivot.Y);
+          ghParam.Attributes.ExpireLayout();
+          ghParam.MutableNickName = true;
+          if (ghParam.Attributes is GH_FloatingParamAttributes)
+            ((GH_Attributes<IGH_Param>) ghParam.Attributes).PerformLayout();
+          var ghDocument = OnPingDocument();
+          if (ghDocument == null)
+          {
+            Tracing.Assert(new Guid("{D74F80C4-CA72-4dbd-8597-450D27098F55}"), "Document could not be located.");
+          }
+          else
+          {
+            ghDocument.AddObject(ghParam, false);
+            ghParam.AddSource(this);
+            ExpireSolution(true);
+          }
+        }
+      }
+    }
+    
     private void HandleParamStateChange()
     {
       OnObjectChanged(GH_ObjectEventType.DataMapping);


### PR DESCRIPTION
## Description

- Adds new feature to extract a parameter from an output node (this is possible by default in Grasshopper inputs, but not outputs for some reason).
- This allows the user to extract the param name and data without having to modify the output names (which come from the expanded/received object)

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- Will be updated ASAP

