### PR TITLE
fix(gh): Incorrect condition on GenericAccessParam menu was hidding options

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
@@ -48,7 +48,7 @@ namespace ConnectorGrasshopper.Extras
 
     public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
     {
-      if (Kind != GH_ParamKind.input || Kind != GH_ParamKind.floating)
+      if (Kind != GH_ParamKind.input)
       {
         // Append graft,flatten,etc... options to outputs.
         base.AppendAdditionalMenuItems(menu);


### PR DESCRIPTION
Fixes #1067

Wrong condition was skipping the CSO options. Will release GH 2.4.1 after this.