### PR TITLE
fix(rh): Change Rhino7 converter to use netstandard2.0

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhino7/ConverterRhino7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhino7/ConverterRhino7.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>2.1.0</Version>
     <Title>Objects.Converter.RhinoGh7</Title>
     <Description></Description>


### PR DESCRIPTION
Should fix https://github.com/specklesystems/speckle-sharp-ci-tools/issues/17, as it expected a netstandard project