### PR TITLE
Claire/alignments rework

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil2.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil2.cs
@@ -701,7 +701,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
     //checks whether to refresh the stream list in case the user changes active view and selects a different document
     private void Application_WindowActivated(object sender, DocumentWindowActivatedEventArgs e)
     {
-      if (e.DocumentWindow.Document == null)
+      if (e.DocumentWindow.Document == null || UpdateSavedStreams == null)
         return;
 
       var streams = GetStreamsInFile();

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -325,6 +325,22 @@ namespace Objects.Converter.AutocadCivil
     // Spiral
 
     // Polyline
+    private Polyline PolylineToSpeckle(Point3dCollection points, bool closed)
+    {
+      double length = 0;
+      List<Point3d> vertices = new List<Point3d>();
+      foreach (Point3d point in points)
+      {
+        if (vertices.Count != 0) length += point.DistanceTo(vertices.Last());
+        vertices.Add(point);
+      }
+
+      var _polyline = new Polyline(PointsToFlatList(vertices), ModelUnits);
+      _polyline.closed = closed || vertices.First().IsEqualTo(vertices.Last()) ? true : false;
+      _polyline.length = length;
+
+      return _polyline;
+    }
     public Polyline PolylineToSpeckle(AcadDB.Polyline polyline) // AcadDB.Polylines can have linear or arc segments. This will convert to linear
     {
       List<Point3d> vertices = new List<Point3d>();

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -218,7 +218,16 @@ namespace Objects.Converter.AutocadCivil
     public Arc ArcToSpeckle(CircularArc2d arc)
     {
       var interval = arc.GetInterval();
-      var _arc = new Arc(PlaneToSpeckle(new AcadGeo.Plane(new Point3d(arc.Center.X, arc.Center.Y, 0), Vector3d.ZAxis)), arc.Radius, arc.StartAngle, arc.EndAngle, Math.Abs(arc.EndAngle - arc.StartAngle), ModelUnits);
+
+      // find arc plane (normal is in clockwise dir)
+      var center3 = new Point3d(arc.Center.X, arc.Center.Y, 0);
+      AcadGeo.Plane plane = (arc.IsClockWise) ? new AcadGeo.Plane(center3, Vector3d.ZAxis.MultiplyBy(-1)) : new AcadGeo.Plane(center3, Vector3d.ZAxis);
+
+      // calculate total angle. TODO: This needs to be validated across all possible arc orientations
+      var totalAngle = (arc.IsClockWise) ? System.Math.Abs(arc.EndAngle - arc.StartAngle) : System.Math.Abs(arc.EndAngle - arc.StartAngle);
+
+      // create arc
+      var _arc = new Arc(PlaneToSpeckle(plane), arc.Radius, arc.StartAngle, arc.EndAngle, totalAngle, ModelUnits);
       _arc.startPoint = PointToSpeckle(arc.StartPoint);
       _arc.endPoint = PointToSpeckle(arc.EndPoint);
       _arc.midPoint = PointToSpeckle(arc.EvaluatePoint((interval.UpperBound - interval.LowerBound) / 2));

--- a/Objects/Objects/BuiltElements/Featureline.cs
+++ b/Objects/Objects/BuiltElements/Featureline.cs
@@ -2,6 +2,7 @@
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
+using Speckle.Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Text;
 
@@ -9,7 +10,8 @@ namespace Objects.BuiltElements
 {
   public class Featureline : Base
   {
-    public ICurve baseCurve { get; set; } // this should probably be deprecated
+    [JsonIgnore, Obsolete("Use curve property")]
+    public ICurve baseCurve { get; set; }
 
     public ICurve curve { get; set; }
 

--- a/Objects/Objects/BuiltElements/Featureline.cs
+++ b/Objects/Objects/BuiltElements/Featureline.cs
@@ -9,7 +9,9 @@ namespace Objects.BuiltElements
 {
   public class Featureline : Base
   {
-    public ICurve baseCurve { get; set; }
+    public ICurve baseCurve { get; set; } // this should probably be deprecated
+
+    public ICurve curve { get; set; }
 
     public string name { get; set; }
 

--- a/Objects/Objects/BuiltElements/Profile.cs
+++ b/Objects/Objects/BuiltElements/Profile.cs
@@ -1,0 +1,29 @@
+﻿using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Objects.BuiltElements
+{
+  public class Profile : Base, IDisplayValue<Polyline>
+  {
+    public List<ICurve> curves { get; set; }
+
+    public string name { get; set; }
+
+    public double startStation { get; set; }
+
+    public double endStation { get; set; }
+
+    [DetachProperty]
+    public Polyline displayValue { get; set; }
+
+    public string units { get; set; }
+
+    public Profile() { }
+
+  }
+}


### PR DESCRIPTION
## Description

Cleans up alignment conversions (to speckle and to native).
Adds a `Profile` class to objects and adds ProfileToSpeckle conversions. Note; profiles are created relative to origin, couldn't figure out how to extract absolute point positions.
Improves corridor conversions so that they include alignments and profiles

- Fixes #889 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: on alignment and corridor test files

## Docs

- Will be updated ASAP

