### PR TITLE
GH: Receive handles case where referencedObject is convertible

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -378,7 +378,7 @@ namespace ConnectorGrasshopper.Extras
       if (Converter != null && Converter.CanConvertToNative(@base))
       {
         var converted = Converter.ConvertToNative(@base);
-        data.Append(TryConvertItemToNative(converted, Converter));
+        data.Append(TryConvertItemToNative(GH_Convert.ToGoo(converted), Converter));
       }
       // Simple pass the SpeckleBase
       else

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -730,7 +730,7 @@ namespace ConnectorGrasshopper.Ops
       converter?.SetContextDocument(RhinoDoc.ActiveDoc);
       parent.PrevReceivedData = new Dictionary<string, GH_Structure<IGH_Goo>>();
 
-      if (!parent.ExpandOutput || converter != null && converter.CanConvertToNative(ReceivedObject))
+      if (!parent.ExpandOutput || (converter != null && converter.CanConvertToNative(ReceivedObject)))
       {
         var tree = Utilities.ConvertToTree(converter, ReceivedObject, Parent.AddRuntimeMessage);
         var receiveComponent = (VariableInputReceiveComponent)this.Parent;
@@ -758,7 +758,7 @@ namespace ConnectorGrasshopper.Ops
     private List<string> GetOutputList(Base b)
     {
       var receiveComponent = (VariableInputReceiveComponent)Parent;
-      if (!receiveComponent.ExpandOutput || receiveComponent.Converter.CanConvertToNative(b))
+      if (!receiveComponent.ExpandOutput || (receiveComponent.Converter != null && receiveComponent.Converter.CanConvertToNative(b)))
         return new List<string> { "Data" };
 
       // Get the full list of output parameters

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -730,7 +730,7 @@ namespace ConnectorGrasshopper.Ops
       converter?.SetContextDocument(RhinoDoc.ActiveDoc);
       parent.PrevReceivedData = new Dictionary<string, GH_Structure<IGH_Goo>>();
 
-      if (!parent.ExpandOutput)
+      if (!parent.ExpandOutput || converter != null && converter.CanConvertToNative(ReceivedObject))
       {
         var tree = Utilities.ConvertToTree(converter, ReceivedObject, Parent.AddRuntimeMessage);
         var receiveComponent = (VariableInputReceiveComponent)this.Parent;
@@ -757,8 +757,10 @@ namespace ConnectorGrasshopper.Ops
 
     private List<string> GetOutputList(Base b)
     {
-      if (!((VariableInputReceiveComponent)Parent).ExpandOutput)
+      var receiveComponent = (VariableInputReceiveComponent)Parent;
+      if (!receiveComponent.ExpandOutput || receiveComponent.Converter.CanConvertToNative(b))
         return new List<string> { "Data" };
+
       // Get the full list of output parameters
       var fullProps = new List<string>();
       b?.GetMemberNames().ToList().ForEach(prop =>


### PR DESCRIPTION
Fixes #1045 

Added handling of case where a commit referenced object that was convertible `toNative` (such as a point, line, mesh...) was never converted.

It will now default to convert it regardless of the `expandOutput` setting.

If user wishes to not convert it and expand it instead, they should use the `doNotConvert` flag along side the `expandOutput` flag.