### PR TITLE
feat(core&revit): adds cabletray

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -165,6 +165,9 @@ namespace Objects.Converter.Revit
         case DB.Electrical.Wire o:
           returnObject = WireToSpeckle(o);
           break;
+        case DB.Electrical.CableTray o:
+          returnObject = CableTrayToSpeckle(o);
+          break;
         //these should be handled by curtain walls
         case DB.CurtainGridLine _:
           returnObject = null;
@@ -387,6 +390,9 @@ namespace Objects.Converter.Revit
         case BE.Wire o:
           return WireToNative(o);
 
+        case BE.CableTray o:
+          return CableTrayToNative(o);
+
         case BE.Revit.RevitRailing o:
           return RailingToNative(o);
 
@@ -455,6 +461,7 @@ namespace Objects.Converter.Revit
         DB.Plumbing.Pipe _ => true,
         DB.Plumbing.FlexPipe _ => true,
         DB.Electrical.Wire _ => true,
+        DB.Electrical.CableTray _ => true,
         DB.CurtainGridLine _ => true, //these should be handled by curtain walls
         DB.Architecture.BuildingPad _ => true,
         DB.Architecture.Stairs _ => true,
@@ -533,6 +540,7 @@ namespace Objects.Converter.Revit
         BE.Duct _ => true,
         BE.Pipe _ => true,
         BE.Wire _ => true,
+        BE.CableTray _ => true,
         BE.Revit.RevitRailing _ => true,
         BER.ParameterUpdater _ => true,
         BE.View3D _ => true,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertAnalyticalStick.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertAnalyticalNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertBeam.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertCableTray.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertRebar.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertBrace.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertBlock.cs" />

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
@@ -1,0 +1,91 @@
+﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Electrical;
+using Objects.BuiltElements.Revit;
+using Speckle.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DB = Autodesk.Revit.DB;
+using Line = Objects.Geometry.Line;
+
+namespace Objects.Converter.Revit
+{
+  public partial class ConverterRevit
+  {
+    public List<ApplicationPlaceholderObject> CableTrayToNative(BuiltElements.CableTray speckleCableTray)
+    {
+      var speckleRevitCableTray = speckleCableTray as RevitCableTray;
+      var cableTrayType = GetElementType<CableTrayType>(speckleCableTray);
+
+      Element cableTray = null;
+      if (speckleCableTray.baseCurve is Line)
+      {
+        DB.Line baseLine = LineToNative(speckleCableTray.baseCurve as Line);
+        XYZ startPoint = baseLine.GetEndPoint(0);
+        XYZ endPoint = baseLine.GetEndPoint(1);
+        DB.Level lineLevel = ConvertLevelToRevit(speckleRevitCableTray != null ? speckleRevitCableTray.level : LevelFromCurve(baseLine));
+        CableTray lineCableTray = CableTray.Create(Doc, cableTrayType.Id, startPoint, endPoint, lineLevel.Id);
+        cableTray = lineCableTray;
+      }
+      else
+      {
+        Report.LogConversionError(new Exception($"CableTray BaseCurve of type ${speckleCableTray.baseCurve.GetType()} cannot be used to create a Revit CableTray"));
+      }
+
+      var docObj = GetExistingElementByApplicationId(((Base)speckleCableTray).applicationId);
+
+      // deleting instead of updating for now!
+      if (docObj != null)
+      {
+        Doc.Delete(docObj.Id);
+      }
+
+      if (speckleRevitCableTray != null)
+      {
+        TrySetParam(cableTray, BuiltInParameter.RBS_CABLETRAY_HEIGHT_PARAM, speckleRevitCableTray.height, speckleRevitCableTray.units);
+        TrySetParam(cableTray, BuiltInParameter.RBS_CABLETRAY_WIDTH_PARAM, speckleRevitCableTray.width, speckleRevitCableTray.units);
+        TrySetParam(cableTray, BuiltInParameter.CURVE_ELEM_LENGTH, speckleRevitCableTray.length, speckleRevitCableTray.units);
+        SetInstanceParameters(cableTray, speckleRevitCableTray);
+      }
+
+      var placeholders = new List<ApplicationPlaceholderObject>
+      {
+        new ApplicationPlaceholderObject
+          {applicationId = speckleCableTray.applicationId, ApplicationGeneratedId = cableTray.UniqueId, NativeObject = cableTray}
+      };
+      Report.Log($"Created CableTray {cableTray.Id}");
+      return placeholders;
+    }
+
+    public BuiltElements.CableTray CableTrayToSpeckle(DB.Electrical.CableTray revitCableTray)
+    {
+      var baseGeometry = LocationToSpeckle(revitCableTray);
+      if (!(baseGeometry is Line baseLine))
+      {
+        throw new Speckle.Core.Logging.SpeckleException("Only line based CableTrays are currently supported.");
+      }
+      var cableTrayType = Doc.GetElement(revitCableTray.GetTypeId()) as CableTrayType;
+
+      // SPECKLE CABLETRAY
+      var speckleCableTray = new RevitCableTray
+      {
+        family = cableTrayType.FamilyName,
+        type = cableTrayType.Name,
+        baseCurve = baseLine,
+        height = GetParamValue<double>(revitCableTray, BuiltInParameter.RBS_CABLETRAY_HEIGHT_PARAM),
+        width = GetParamValue<double>(revitCableTray, BuiltInParameter.RBS_CABLETRAY_WIDTH_PARAM),
+        length = GetParamValue<double>(revitCableTray, BuiltInParameter.CURVE_ELEM_LENGTH),
+        level = ConvertAndCacheLevel(revitCableTray, BuiltInParameter.RBS_START_LEVEL_PARAM),
+        displayValue = GetElementMesh(revitCableTray)
+      };
+
+      GetAllRevitParamsAndIds(speckleCableTray, revitCableTray,
+        new List<string>
+        {
+          "RBS_CABLETRAY_HEIGHT_PARAM", "RBS_CABLETRAY_WIDTH_PARAM", "CURVE_ELEM_LENGTH", "RBS_START_LEVEL_PARAM"
+        });
+
+      return speckleCableTray;
+    }
+  }
+}

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -51,12 +51,8 @@ namespace Objects.Converter.Revit
       //is structural update
       TrySetParam(revitWall, BuiltInParameter.WALL_STRUCTURAL_SIGNIFICANT, structural);
 
-
       if (revitWall.WallType.Name != wallType.Name)
-      {
-
         revitWall.ChangeTypeId(wallType.Id);
-      }
 
       if (isUpdate)
       {

--- a/Objects/Objects/BuiltElements/CableTray.cs
+++ b/Objects/Objects/BuiltElements/CableTray.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Objects.Geometry;
+using Objects.Utils;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using Speckle.Newtonsoft.Json;
+
+namespace Objects.BuiltElements
+{
+  public class CableTray : Base, IDisplayValue<List<Mesh>>
+  {
+    public ICurve baseCurve { get; set; }
+    public double width { get; set; }
+    public double height { get; set; }
+    public double length { get; set; }
+    
+    [DetachProperty]
+    public List<Mesh> displayValue { get; set; }
+
+    public string units { get; set; }
+
+    public CableTray() { }
+
+  }
+}
+
+namespace Objects.BuiltElements.Revit
+{
+  public class RevitCableTray : CableTray
+  {
+    public string family { get; set; }
+    public string type { get; set; }
+    public Level level { get; set; }
+    public Base parameters { get; set; }
+    public string elementId { get; set; }
+
+    public RevitCableTray() { }
+
+  }
+}


### PR DESCRIPTION
## Description
Adds `CableTray` class to Core
Adds `CableTrayToSpeckle` and `CableTrayTonative` conversions to Revit
- Fixes #975 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: sent and received basic cable trays in revit

## Docs

- Will be updated ASAP

