### PR TITLE
GH: Split rhino converter into Grasshopper specific one.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper.sln
+++ b/ConnectorGrasshopper/ConnectorGrasshopper.sln
@@ -20,11 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorGrasshopperUtils", "ConnectorGrasshopperUtils\ConnectorGrasshopperUtils.csproj", "{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterRhino6", "..\Objects\Converters\ConverterRhinoGh\ConverterRhino6\ConverterRhino6.csproj", "{4902152D-64BC-4DF0-A588-61EC7BE93AF0}"
-EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ConverterRhinoGhShared", "..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.shproj", "{B74CB8C1-187B-46A6-B20B-92B8C129F3EE}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterRhino7", "..\Objects\Converters\ConverterRhinoGh\ConverterRhino7\ConverterRhino7.csproj", "{E6D4A1FA-D208-4170-88B7-6C4AF08BEB37}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper6", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper6\ConverterGrasshopper6.csproj", "{D79A3AAC-B7C4-46EA-90AC-5F63BE1E8775}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper7", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{D0783323-D28A-4A2B-9F4E-3534275D3909}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -57,14 +57,14 @@ Global
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4902152D-64BC-4DF0-A588-61EC7BE93AF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4902152D-64BC-4DF0-A588-61EC7BE93AF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4902152D-64BC-4DF0-A588-61EC7BE93AF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4902152D-64BC-4DF0-A588-61EC7BE93AF0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E6D4A1FA-D208-4170-88B7-6C4AF08BEB37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E6D4A1FA-D208-4170-88B7-6C4AF08BEB37}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E6D4A1FA-D208-4170-88B7-6C4AF08BEB37}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E6D4A1FA-D208-4170-88B7-6C4AF08BEB37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D79A3AAC-B7C4-46EA-90AC-5F63BE1E8775}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D79A3AAC-B7C4-46EA-90AC-5F63BE1E8775}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D79A3AAC-B7C4-46EA-90AC-5F63BE1E8775}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D79A3AAC-B7C4-46EA-90AC-5F63BE1E8775}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0783323-D28A-4A2B-9F4E-3534275D3909}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0783323-D28A-4A2B-9F4E-3534275D3909}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0783323-D28A-4A2B-9F4E-3534275D3909}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0783323-D28A-4A2B-9F4E-3534275D3909}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,9 +73,9 @@ Global
 		{B4D98D2C-E5DA-463E-BF6C-68E9B77C72F3} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
 		{8F16A9A1-DC5F-4800-821C-336E6CCF8F9C} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
 		{9103058A-0D20-49AA-B053-01548DD66D16} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
-		{4902152D-64BC-4DF0-A588-61EC7BE93AF0} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
 		{B74CB8C1-187B-46A6-B20B-92B8C129F3EE} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
-		{E6D4A1FA-D208-4170-88B7-6C4AF08BEB37} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
+		{D79A3AAC-B7C4-46EA-90AC-5F63BE1E8775} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
+		{D0783323-D28A-4A2B-9F4E-3534275D3909} = {CCD06981-ACB2-4B1C-9953-00976F1E535D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3196A316-D590-4D60-8363-3A2FB801A6DC}

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -12,20 +12,28 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Rhino.Geometry;
 using System.Threading;
+using Rhino;
 
 namespace ConnectorGrasshopper.Extras
 {
   public static class Utilities
   {
+    public static string GetVersionedAppName()
+    {
+      var version = VersionedHostApplications.Grasshopper6;
+      if (RhinoApp.Version.Major == 7)
+        version = VersionedHostApplications.Grasshopper7;
+      return version;
+    }
     public static ISpeckleConverter GetDefaultConverter()
     {
       var n = SpeckleGHSettings.SelectedKitName;
       try
       {
-        var defKit = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6).FirstOrDefault(kit => kit != null && kit.Name == n);
-        var converter = defKit.LoadConverter(VersionedHostApplications.Rhino6);
+        var defKit = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName()).FirstOrDefault(kit => kit != null && kit.Name == n);
+        var converter = defKit.LoadConverter(Extras.Utilities.GetVersionedAppName());
         converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
-        converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+        converter.SetContextDocument(RhinoDoc.ActiveDoc);
         return converter;
       }
       catch

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
@@ -10,6 +10,7 @@ using Grasshopper.GUI;
 using Grasshopper.GUI.Canvas;
 using Grasshopper.GUI.Canvas.Interaction;
 using Grasshopper.Kernel;
+using Rhino;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using KeyEventArgs = System.Windows.Forms.KeyEventArgs;
@@ -31,7 +32,11 @@ namespace ConnectorGrasshopper
 
     public override GH_LoadingInstruction PriorityLoad()
     {
-      Setup.Init(VersionedHostApplications.Grasshopper, HostApplications.Grasshopper.Name);
+      var version = VersionedHostApplications.Grasshopper6;
+      if (RhinoApp.Version.Major == 7)
+        version = VersionedHostApplications.Grasshopper7;
+      
+      Setup.Init(version, HostApplications.Grasshopper.Name);
       Grasshopper.Instances.DocumentServer.DocumentAdded += CanvasCreatedEvent;
       Grasshopper.Instances.ComponentServer.AddCategoryIcon(ComponentCategories.PRIMARY_RIBBON,
         Properties.Resources.speckle_logo);
@@ -88,7 +93,7 @@ namespace ConnectorGrasshopper
 
       try
       {
-        loadedKits = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6);
+        loadedKits = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName());
 
         var kitItems = new List<ToolStripItem>();
         loadedKits.ToList().ForEach(kit =>

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/SelectKitAsyncComponentBase.cs
@@ -75,7 +75,7 @@ namespace ConnectorGrasshopper.Objects
     {
       try
       {
-        var kits = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6);
+        var kits = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName());
 
         Menu_AppendSeparator(menu);
         Menu_AppendItem(menu, "Select the converter you want to use:", null, false);
@@ -109,7 +109,7 @@ namespace ConnectorGrasshopper.Objects
       if (kitName == Kit?.Name) return;
       Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
       SelectedKitName = Kit.Name;
-      Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+      Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
       Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
       SpeckleGHSettings.OnMeshSettingsChanged +=
         (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitComponentBase.cs
@@ -29,7 +29,7 @@ namespace ConnectorGrasshopper.Objects
     {
       try
       {
-        var kits = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6);
+        var kits = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName());
 
         Menu_AppendSeparator(menu);
         Menu_AppendItem(menu, "Select the converter you want to use:", null, false);
@@ -55,7 +55,7 @@ namespace ConnectorGrasshopper.Objects
       try
       {
         Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
-        Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+        Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
         Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
         SpeckleGHSettings.OnMeshSettingsChanged +=
           (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
@@ -95,8 +95,8 @@ namespace ConnectorGrasshopper.Objects
       base.AddedToDocument(document);
       try
       {
-        Kit = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6).FirstOrDefault(kit => kit.Name == SpeckleGHSettings.SelectedKitName);
-        Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+        Kit = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName()).FirstOrDefault(kit => kit.Name == SpeckleGHSettings.SelectedKitName);
+        Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
         Converter.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
         Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
         SpeckleGHSettings.OnMeshSettingsChanged +=

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitTaskCapableComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/SelectKitTaskCapableComponentBase.cs
@@ -80,7 +80,7 @@ namespace ConnectorGrasshopper.Objects
       //base.AppendAdditionalMenuItems(menu);
       try
       {
-        var kits = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6);
+        var kits = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName());
 
         Menu_AppendSeparator(menu);
         Menu_AppendItem(menu, "Select the converter you want to use:", null, false);
@@ -114,7 +114,7 @@ namespace ConnectorGrasshopper.Objects
       if (kitName == Kit?.Name) return;
       Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
       SelectedKitName = Kit.Name;
-      Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+      Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
       Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
       SpeckleGHSettings.OnMeshSettingsChanged +=
         (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponent.cs
@@ -554,7 +554,7 @@ namespace ConnectorGrasshopper.Ops
               streamId = InputWrapper.StreamId,
               commitId = myCommit.id,
               message = myCommit.message,
-              sourceApplication = VersionedHostApplications.Grasshopper
+              sourceApplication = Extras.Utilities.GetVersionedAppName()
             });
           }
           catch

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveComponentSync.cs
@@ -122,7 +122,7 @@ namespace ConnectorGrasshopper.Ops
     {
       Menu_AppendSeparator(menu);
       Menu_AppendItem(menu, "Select the converter you want to use:", null, false);
-      var kits = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6);
+      var kits = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName());
 
       foreach (var kit in kits)
         Menu_AppendItem(menu, $"{kit.Name} ({kit.Description})", (s, e) =>
@@ -212,7 +212,7 @@ namespace ConnectorGrasshopper.Ops
       try
       {
         Kit = KitManager.GetDefaultKit();
-        Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+        Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
         Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
         SpeckleGHSettings.OnMeshSettingsChanged +=
           (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
@@ -301,7 +301,7 @@ namespace ConnectorGrasshopper.Ops
               streamId = StreamWrapper.StreamId,
               commitId = myCommit.id,
               message = myCommit.message,
-              sourceApplication = VersionedHostApplications.Grasshopper
+              sourceApplication = Extras.Utilities.GetVersionedAppName()
             });
           }
           catch

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
@@ -46,7 +46,7 @@ namespace ConnectorGrasshopper.Ops
     {
       Menu_AppendSeparator(menu);
       Menu_AppendItem(menu, "Select the converter you want to use:", null, null, false);
-      var kits = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6);
+      var kits = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName());
 
       foreach (var kit in kits)
       {
@@ -68,7 +68,7 @@ namespace ConnectorGrasshopper.Ops
       if (kitName == Kit.Name) return;
 
       Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
-      Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+      Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
       Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
       SpeckleGHSettings.OnMeshSettingsChanged +=
         (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
@@ -83,7 +83,7 @@ namespace ConnectorGrasshopper.Ops
       try
       {
         Kit = KitManager.GetDefaultKit();
-        Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+        Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
         Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
         SpeckleGHSettings.OnMeshSettingsChanged +=
           (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponent.cs
@@ -490,7 +490,7 @@ namespace ConnectorGrasshopper.Ops
                 message = message,
                 objectId = BaseId,
                 streamId = ((ServerTransport)transport).StreamId,
-                sourceApplication = VersionedHostApplications.Grasshopper
+                sourceApplication = Extras.Utilities.GetVersionedAppName()
               };
 
               // Check to see if we have a previous commit; if so set it.

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendComponentSync.cs
@@ -72,7 +72,7 @@ namespace ConnectorGrasshopper.Ops
       }
 
       Kit = KitManager.Kits.FirstOrDefault(k => k.Name == kitName);
-      Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+      Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
       Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
       SpeckleGHSettings.OnMeshSettingsChanged +=
         (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
@@ -86,7 +86,7 @@ namespace ConnectorGrasshopper.Ops
       Menu_AppendSeparator(menu);
       var menuItem = Menu_AppendItem(menu, "Select the converter you want to use:", null, false);
       menuItem.Enabled = false;
-      var kits = KitManager.GetKitsWithConvertersForApp(VersionedHostApplications.Rhino6);
+      var kits = KitManager.GetKitsWithConvertersForApp(Extras.Utilities.GetVersionedAppName());
 
       foreach (var kit in kits)
       {
@@ -172,7 +172,7 @@ namespace ConnectorGrasshopper.Ops
       try
       {
         Kit = KitManager.GetDefaultKit();
-        Converter = Kit.LoadConverter(VersionedHostApplications.Rhino6);
+        Converter = Kit.LoadConverter(Extras.Utilities.GetVersionedAppName());
         Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
         SpeckleGHSettings.OnMeshSettingsChanged +=
           (sender, args) => Converter.SetConverterSettings(SpeckleGHSettings.MeshSettings);
@@ -382,7 +382,7 @@ namespace ConnectorGrasshopper.Ops
                 message = message,
                 objectId = BaseId,
                 streamId = ((ServerTransport)transport).StreamId,
-                sourceApplication = VersionedHostApplications.Grasshopper
+                sourceApplication = Extras.Utilities.GetVersionedAppName()
               };
 
               // Check to see if we have a previous commit; if so set it.

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -608,7 +608,7 @@ namespace ConnectorGrasshopper.Ops
               streamId = InputWrapper.StreamId,
               commitId = myCommit.id,
               message = myCommit.message,
-              sourceApplication = VersionedHostApplications.Grasshopper
+              sourceApplication = Extras.Utilities.GetVersionedAppName()
             });
           }
           catch

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
@@ -562,7 +562,7 @@ namespace ConnectorGrasshopper.Ops
                 message = message,
                 objectId = BaseId,
                 streamId = ((ServerTransport)transport).StreamId,
-                sourceApplication = VersionedHostApplications.Grasshopper
+                sourceApplication = Extras.Utilities.GetVersionedAppName()
               };
 
               // Check to see if we have a previous commit; if so set it.

--- a/ConnectorRhino/ConnectorRhino6/ConnectorRhino6.csproj
+++ b/ConnectorRhino/ConnectorRhino6/ConnectorRhino6.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.8</Version>
+      <Version>0.10.13</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
       <Version>0.10.13</Version>

--- a/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
+++ b/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.8</Version>
+      <Version>0.10.13</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
       <Version>0.10.13</Version>

--- a/Core/Core/Kits/Applications.cs
+++ b/Core/Core/Kits/Applications.cs
@@ -163,7 +163,8 @@ namespace Speckle.Core.Kits
   {
     public const string Rhino6 = "Rhino6";
     public const string Rhino7 = "Rhino7";
-    public const string Grasshopper = "Grasshopper";
+    public const string Grasshopper6 = "Grasshopper6";
+    public const string Grasshopper7 = "Grasshopper7";
     public const string Revit2019 = "Revit2019";
     public const string Revit2020 = "Revit2020";
     public const string Revit2021 = "Revit2021";

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/ConverterGrasshopper6.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/ConverterGrasshopper6.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Objects.Converter.Grasshopper6</AssemblyName>
+        <RootNamespace>Objects.Converter.Grasshopper</RootNamespace>
+        <PackageId>Speckle.Objects.Converter.Grasshopper6</PackageId>
+        <Version>2.1.0</Version>
+        <Authors>Speckle</Authors>
+        <Description>Converter for Grasshopper (Rhino 6 version)</Description>
+        <Copyright>Copyright (c) AEC Systems Ltd</Copyright>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageProjectUrl>https://speckle.systems/</PackageProjectUrl>
+        <PackageIcon>logo.png</PackageIcon>
+        <RepositoryUrl>https://github.com/specklesystems/speckle-sharp</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>speckle objects converter rhino grasshopper gh</PackageTags>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DefineConstants>TRACE;RHINO6;GRASSHOPPER</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DefineConstants>TRACE;RHINO6;GRASSHOPPER</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\..\..\logo.png" Link="logo.png">
+            <PackagePath></PackagePath>
+            <Pack>True</Pack>
+        </None>
+        <None Include="..\..\..\logo.png">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Grasshopper" Version="6.28.20199.17141" />
+        <PackageReference Include="RhinoCommon" Version="6.28.20199.17141" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
+        <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+    </PropertyGroup>
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsDesktopBuild)' == true">
+        <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+        <!-- We assume Objects project has been built, and folder for the Kit already exists -->
+        <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="cp '$(TargetDir)$(AssemblyName).dll' $HOME'/.config/Speckle/Kits/Objects/'" />
+    </Target>
+    <Import Project="..\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems" Label="Shared" />
+
+</Project>

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
@@ -1,0 +1,75 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net48</TargetFramework>
+        <Version>2.1.0</Version>
+        <Title>Objects.Converter.GrasshopperRhino7</Title>
+        <Description></Description>
+        <TargetExt>.dll</TargetExt>
+        <PackageId>Speckle.Objects.Converter.Rhino7</PackageId>
+        <Authors>Speckle</Authors>
+        <Company />
+        <Product />
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageProjectUrl>https://speckle.systems/</PackageProjectUrl>
+        <PackageIcon>logo.png</PackageIcon>
+        <RepositoryUrl>https://github.com/specklesystems/speckle-sharp</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>speckle objects converter rhino grasshopper gh</PackageTags>
+        <AssemblyName>Objects.Converter.Grasshopper7</AssemblyName>
+        <RootNamespace>Objects.Converter.Grasshopper7</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <EmbeddedResource Include="EmbeddedResources\**\*" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Grasshopper" Version="7.4.21078.1001" />
+        <PackageReference Include="RhinoCommon" Version="7.4.21078.1001" IncludeAssets="compile;build" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
+        <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Folder Include="Properties\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\..\..\..\logo.png">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
+
+    <PropertyGroup Condition="$(Configuration) == 'Debug' AND $([MSBuild]::IsOSPlatform(Windows))">
+        <StartProgram>C:\Program Files\Rhino 7\System\Rhino.exe</StartProgram>
+        <StartArguments></StartArguments>
+        <StartAction>Program</StartAction>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DefineConstants>TRACE;RHINO7;GRASSHOPPER</DefineConstants>
+        <PlatformTarget>x64</PlatformTarget>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DefineConstants>TRACE;RHINO7;GRASSHOPPER</DefineConstants>
+        <PlatformTarget>x64</PlatformTarget>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+    </PropertyGroup>
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsDesktopBuild)' == true">
+        <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+        <!-- We assume Objects project has been built, and folder for the Kit already exists -->
+        <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="cp '$(TargetDir)$(AssemblyName).dll' $HOME'/.config/Speckle/Kits/Objects/'" />
+    </Target>
+    <Import Project="..\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems" Label="Shared" />
+
+</Project>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -1,4 +1,4 @@
-﻿using Grasshopper.Kernel.Types;
+using Grasshopper.Kernel.Types;
 using Objects.Geometry;
 using Objects.Primitive;
 using Objects.Other;
@@ -38,12 +38,14 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh : ISpeckleConverter
   {
-#if RHINO6
+#if RHINO6 && GRASSHOPPER
+    public static string RhinoAppName = VersionedHostApplications.Grasshopper6;
+#elif RHINO7 && GRASSHOPPER
+    public static string RhinoAppName = VersionedHostApplications.Grasshopper7;
+#elif RHINO6
     public static string RhinoAppName = VersionedHostApplications.Rhino6;
-    public static string GrasshopperAppName = VersionedHostApplications.Grasshopper;
 #elif RHINO7
     public static string RhinoAppName = VersionedHostApplications.Rhino7;
-    public static string GrasshopperAppName = VersionedHostApplications.Grasshopper;
 #endif
 
     public enum MeshSettings
@@ -68,12 +70,7 @@ namespace Objects.Converter.RhinoGh
 
     public IEnumerable<string> GetServicedApplications()
     {
-
-#if RHINO6
-      return new string[] { RhinoAppName, VersionedHostApplications.Grasshopper };
-#elif RHINO7
-      return new string[] {RhinoAppName};
-#endif   
+      return new[] {RhinoAppName};
     }
 
     public HashSet<Exception> ConversionErrors { get; private set; } = new HashSet<Exception>();

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -1,4 +1,4 @@
-using Grasshopper.Kernel.Types;
+﻿using Grasshopper.Kernel.Types;
 using Objects.Geometry;
 using Objects.Primitive;
 using Objects.Other;
@@ -669,13 +669,15 @@ case RH.SubD _:
         case RH.Brep _:
         case NurbsSurface _:
           return true;
-        // TODO: This types are not supported in GH!
+        
+#if !GRASSHOPPER
+        // This types are not supported in GH!
         case ViewInfo _:
         case InstanceDefinition _:
         case InstanceObject _:
         case TextEntity _:
           return true;
-
+#endif
         default:
 
           return false;
@@ -706,7 +708,8 @@ case RH.SubD _:
         case Surface _:
           return true;
 
-        //TODO: This types are not supported in GH!
+#if !GRASSHOPPER
+        // This types are not supported in GH!
         case Pointcloud _:
         case DisplayStyle _:
         case ModelCurve _:
@@ -718,6 +721,7 @@ case RH.SubD _:
         case RenderMaterial _:
         case Text _:
           return true;
+#endif
 
         default:
           return false;

--- a/Objects/Objects.sln
+++ b/Objects/Objects.sln
@@ -90,6 +90,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterTeklaStructures202
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterTeklaStructures2020", "Converters\ConverterTeklaStructures\ConverterTeklaStructures2020\ConverterTeklaStructures2020.csproj", "{08EE146E-9F7A-4C82-B790-688FE4532CA7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper6", "Converters\ConverterRhinoGh\ConverterGrasshopper6\ConverterGrasshopper6.csproj", "{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper7", "Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Converters\ConverterTeklaStructures\ConverterTeklaStructuresShared\ConverterTeklaStructuresShared.projitems*{08ee146e-9f7a-4c82-b790-688fe4532ca7}*SharedItemsImports = 5
@@ -236,6 +240,14 @@ Global
 		{08EE146E-9F7A-4C82-B790-688FE4532CA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08EE146E-9F7A-4C82-B790-688FE4532CA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08EE146E-9F7A-4C82-B790-688FE4532CA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -281,6 +293,8 @@ Global
 		{7FFDAB72-145D-4490-9892-FAC5F1D72B17} = {98B557B0-CD26-40DE-9703-A27F07A942E3}
 		{ADC53DC0-0592-4F13-B456-65ADCB2164A1} = {98B557B0-CD26-40DE-9703-A27F07A942E3}
 		{08EE146E-9F7A-4C82-B790-688FE4532CA7} = {98B557B0-CD26-40DE-9703-A27F07A942E3}
+		{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF} = {1A35077C-2936-4A3D-8D48-65F39F76D999}
+		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA} = {1A35077C-2936-4A3D-8D48-65F39F76D999}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DA57EC2E-0A9E-4F59-B1F7-A65F76A74B74}


### PR DESCRIPTION
## Description

Splits the Rhino converter into 2 new Grasshopper specific converters for each specific version of Rhino (6 and 7)
This allows for support of SubD geometry, and also prevents conversion for un-supported types in Grasshopper, or conversions that required baking to Rhino, that used to throw errors in GH; such as BlockInstance, BlockDefinition, RenderMaterial, Views, Hatches, etc.

Individual conversions can be added in the future to deal with this
- Fixes #923
- Fixes #952

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

Grasshopper connector no longer shares the converter with Rhino6, instead, it now will be packaged with it's own versioned converters for Rhino 6 and 7 (`Objects.Converters.Grasshopper6.dll`...)

This is not that much of a breaking change per-se, but it is quite a critical change.

## How has this been tested?

- Manual Tests (please write what did you do?)

Ensured that:
- Grasshopper picked up the new converters instead of the Rhino ones.
- Grasshopper would pick the. correct converter based on the current Rhino version
- Things in rhino continue to work as normal
- Grasshopper no longer tries to convert unsupported types (render material, block instance...)

## Docs

- No updates needed


