### PR TITLE
adding material handling for mep elements. ducts, ductfittings, ducta…

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -956,8 +956,8 @@ namespace Objects.Converter.Revit
             if(e.Category.Id == categories.get_Item(BuiltInCategory.OST_PipeFitting).Id ||
                 e.Category.Id == categories.get_Item(BuiltInCategory.OST_DuctFitting).Id ||
                 e.Category.Id == categories.get_Item(BuiltInCategory.OST_DuctAccessory).Id ||
-                e.Category.Id == categories.get_Item(BuiltInCategory.OST_PipeAccessory).Id ||
-                e.Category.Id == categories.get_Item(BuiltInCategory.OST_MechanicalEquipment).Id)
+                e.Category.Id == categories.get_Item(BuiltInCategory.OST_PipeAccessory).Id)
+                //e.Category.Id == categories.get_Item(BuiltInCategory.OST_MechanicalEquipment).Id)
             {
                 result = true;
             }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -106,10 +106,12 @@ namespace Objects.Converter.Revit
         length = GetParamValue<double>(revitDuct, BuiltInParameter.CURVE_ELEM_LENGTH),
         velocity = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_VELOCITY),
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
-        displayValue = GetElementMesh(revitDuct)
-      };
+        displayValue = GetElementMesh(revitDuct),
+        };
+        speckleDuct["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitDuct);
 
-      var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
+
+        var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
       speckleDuct.systemName = typeElem.Name;
 
       GetAllRevitParamsAndIds(speckleDuct, revitDuct,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -107,11 +107,11 @@ namespace Objects.Converter.Revit
         velocity = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_VELOCITY),
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
         displayValue = GetElementMesh(revitDuct),
-        };
-        speckleDuct["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitDuct);
+      };
+      speckleDuct["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitDuct);
 
 
-        var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
+      var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
       speckleDuct.systemName = typeElem.Name;
 
       GetAllRevitParamsAndIds(speckleDuct, revitDuct,
@@ -120,6 +120,8 @@ namespace Objects.Converter.Revit
           "RBS_CURVE_HEIGHT_PARAM", "RBS_CURVE_WIDTH_PARAM", "RBS_CURVE_DIAMETER_PARAM", "CURVE_ELEM_LENGTH",
           "RBS_START_LEVEL_PARAM", "RBS_VELOCITY"
         });
+
+      Report.Log($"Converted Duct {revitDuct.Id}");
 
       return speckleDuct;
     }
@@ -149,6 +151,8 @@ namespace Objects.Converter.Revit
         displayValue = GetElementMesh(revitDuct)
       };
 
+      speckleDuct["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitDuct);
+
       var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
       speckleDuct.systemName = typeElem.Name;
 
@@ -159,7 +163,7 @@ namespace Objects.Converter.Revit
           "RBS_START_LEVEL_PARAM", "RBS_VELOCITY"
         });
 
-      Report.Log($"Converted Duct {revitDuct.Id}");
+      Report.Log($"Converted FlexDuct {revitDuct.Id}");
 
       return speckleDuct;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -108,10 +108,17 @@ namespace Objects.Converter.Revit
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
         displayValue = GetElementMesh(revitDuct),
       };
-      speckleDuct["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitDuct);
 
+            var material = ConverterRevit.GetMEPSystemMaterial(revitDuct);
 
-      var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
+            foreach (var mesh in speckleDuct.displayValue)
+            {
+                if (material != null)
+                    mesh["renderMaterial"] = material;
+            }
+
+            var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
+
       speckleDuct.systemName = typeElem.Name;
 
       GetAllRevitParamsAndIds(speckleDuct, revitDuct,
@@ -150,8 +157,13 @@ namespace Objects.Converter.Revit
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
         displayValue = GetElementMesh(revitDuct)
       };
+            var material = ConverterRevit.GetMEPSystemMaterial(revitDuct);
 
-      speckleDuct["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitDuct);
+            foreach (var mesh in speckleDuct.displayValue)
+            {
+                if (material != null)
+                    mesh["renderMaterial"] = material;
+            }
 
       var typeElem = Doc.GetElement(revitDuct.MEPSystem.GetTypeId());
       speckleDuct.systemName = typeElem.Name;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -186,7 +186,8 @@ namespace Objects.Converter.Revit
       }
 
       speckleFi.displayValue = GetElementMesh(revitFi, GetAllFamSubElements(revitFi));
-
+      
+      speckleFi["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitFi);
       GetAllRevitParamsAndIds(speckleFi, revitFi);
 
       #region sub elements capture

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -186,8 +186,15 @@ namespace Objects.Converter.Revit
       }
 
       speckleFi.displayValue = GetElementMesh(revitFi, GetAllFamSubElements(revitFi));
-      
-      speckleFi["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitFi);
+
+            var material = ConverterRevit.GetMEPSystemMaterial(revitFi);
+
+            foreach (var mesh in speckleFi.displayValue)
+            {
+                if (material != null)
+                    mesh["renderMaterial"] = material;
+            }
+
       GetAllRevitParamsAndIds(speckleFi, revitFi);
 
       #region sub elements capture

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -107,6 +107,8 @@ namespace Objects.Converter.Revit
         displayValue = GetElementMesh(revitPipe)
       };
 
+            specklePipe["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitPipe);
+
       GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
       {
         "RBS_PIPING_SYSTEM_TYPE_PARAM",

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -107,9 +107,15 @@ namespace Objects.Converter.Revit
         displayValue = GetElementMesh(revitPipe)
       };
 
-            specklePipe["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitPipe);
+            var material = ConverterRevit.GetMEPSystemMaterial(revitPipe);
 
-      GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
+            foreach (var mesh in specklePipe.displayValue)
+            {
+                if (material != null)
+                    mesh["renderMaterial"] = material;
+            }
+
+            GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
       {
         "RBS_PIPING_SYSTEM_TYPE_PARAM",
         "RBS_SYSTEM_CLASSIFICATION_PARAM",
@@ -144,10 +150,16 @@ namespace Objects.Converter.Revit
         level = ConvertAndCacheLevel(revitPipe, BuiltInParameter.RBS_START_LEVEL_PARAM),
         displayValue = GetElementMesh(revitPipe)
       };
-            
-            specklePipe["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitPipe);
 
-      GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
+            var material = ConverterRevit.GetMEPSystemMaterial(revitPipe);
+
+            foreach (var mesh in specklePipe.displayValue)
+            {
+                if (material != null)
+                    mesh["renderMaterial"] = material;
+            }
+
+            GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
       {
         "RBS_SYSTEM_CLASSIFICATION_PARAM",
         "RBS_PIPING_SYSTEM_TYPE_PARAM",

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -144,6 +144,8 @@ namespace Objects.Converter.Revit
         level = ConvertAndCacheLevel(revitPipe, BuiltInParameter.RBS_START_LEVEL_PARAM),
         displayValue = GetElementMesh(revitPipe)
       };
+            
+            specklePipe["renderMaterial"] = ConverterRevit.GetMEPSystemMaterial(revitPipe);
 
       GetAllRevitParamsAndIds(specklePipe, revitPipe, new List<string>
       {
@@ -154,8 +156,9 @@ namespace Objects.Converter.Revit
         "CURVE_ELEM_LENGTH",
         "RBS_START_LEVEL_PARAM",
       });
+            Report.Log($"Converted FlexPipe {revitPipe.Id}");
 
-      return specklePipe;
+            return specklePipe;
     }
   }
 }


### PR DESCRIPTION
…ccessory, same for pipes and mep equipment is implemented and tested locally.

## Description

- Fixes #1099

## Type of change

- New feature 
support for revit materials in mep elements added. The material is taken from the assigned system and its type. So the user can control the coloring for ex. pipes accoring to local standards. In Germany cold water supply is green, while heating return is blue and so one.

## How has this been tested?

Tested locally in Revit 2022 and some local MEP projects. It depends on the project settings and materials used.

## Docs

- No updates needed


