### PR TITLE
Revit/fabricationparts

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -108,7 +108,12 @@ namespace Objects.Converter.Revit
       BuiltInCategory.OST_Cornices,
       BuiltInCategory.OST_Walls,
       BuiltInCategory.OST_Windows,
-      BuiltInCategory.OST_Wire
+      BuiltInCategory.OST_Wire,
+      BuiltInCategory.OST_FabricationDuctwork,
+      BuiltInCategory.OST_FabricationPipework,
+      BuiltInCategory.OST_FabricationHangers,
+      BuiltInCategory.OST_FabricationContainment,
+      BuiltInCategory.OST_FabricationServiceElements
   };
 
     public static RevitCategory GetSchemaBuilderCategoryFromBuiltIn(string builtInCategory)


### PR DESCRIPTION
## Description

Hey there, this is an implementation for export support of Revit fabrication elements. It is implemented on top of the generic exporter, so no additional, separate exporter is added.
based on issue #1100

## Type of change

- New feature 
Adds support for fabrication elements. Other stuff should not be affected.


## How has this been tested?

- Manual Tests (please write what did you do?)
Tested it locally on my machine with Revit 2022 and fabrication elements inside revit projects

## Docs

- No updates needed


