### PR TITLE
fix(gh): Search for Name instead of nickname as it is consistent across UI settings

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -746,7 +746,7 @@ namespace ConnectorGrasshopper.Ops
         var prop = ReceivedObject[name];
         var treeBuilder = new TreeBuilder(converter) { ConvertToNative = converter != null };
         var data = treeBuilder.Build(prop);
-        var param = Parent.Params.Output.FindIndex(p => p.NickName == name || p.NickName == name.Substring(1));
+        var param = Parent.Params.Output.FindIndex(p => p.Name == name || p.Name == name.Substring(1));
         var ighP = Parent.Params.Output[param];
         if (ighP is SendReceiveDataParam srParam)
         {
@@ -778,14 +778,14 @@ namespace ConnectorGrasshopper.Ops
 
     private bool OutputMismatch() =>
       outputList.Count != Parent.Params.Output.Count
-      || outputList.Where((t, i) => Parent.Params.Output[i].NickName != t).Any();
+      || outputList.Where((t, i) => Parent.Params.Output[i].Name != t).Any();
 
     private bool HasSingleRename()
     {
       var equalLength = outputList.Count == Parent?.Params.Output.Count;
       if (!equalLength) return false;
-
-      var diffParams = Parent?.Params.Output.Where(param => !outputList.Contains(param.NickName) && !outputList.Contains("@" + param.NickName));
+      
+      var diffParams = Parent?.Params.Output.Where(param => !outputList.Contains(param.Name) && !outputList.Contains("@" + param.Name));
       return diffParams.Count() == 1;
     }
     private void AutoCreateOutputs(Base @base)
@@ -797,11 +797,11 @@ namespace ConnectorGrasshopper.Ops
 
       Parent.RecordUndoEvent("Creating Outputs");
       if (HasSingleRename())
-      {
-        var diffParams = Parent.Params.Output.Where(param => !outputList.Contains(param.NickName));
+      { 
+        var diffParams = Parent.Params.Output.Where(param => !outputList.Contains(param.Name));
         var diffOut = outputList
           .Where(name =>
-            !Parent.Params.Output.Select(p => p.NickName)
+            !Parent.Params.Output.Select(p => p.Name)
               .Contains(name));
 
         var newName = diffOut.First();


### PR DESCRIPTION
Adds released hotfix in `grasshopper/2.4.2` to `main`.

This is the exact same commit as 54e83787ff77fc2fbffa324a6ff4343cc1dd2f79, but was not directly merged as the prior changes were squashed into `main`.

I'm cherrypicking this change and applying it directly to prevent any weird merge history conflicts from happening.

Reported in the forum: https://speckle.community/t/speckle-grasshopper-stream-receive-broken/2501