### PR TITLE
GH: Adds mac build and deploy to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ orbs:
   # Upload artifacts to s3
   aws-s3: circleci/aws-s3@2.0.0
   codecov: codecov/codecov@3.2.2
+  # Allow for waiting until docker images are ready
+  wait-for: cobli/wait-for@0.0.2
 
 # adapted from https://circleci.com/developer/orbs/orb/storytel/nugetpublish#commands-packandpublish
 commands:
@@ -26,7 +28,6 @@ commands:
             dotnet pack -c Release /p:Version="$version" -o $HOME/output <<parameters.projectfilepath>> 
             cd $HOME/output
             dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
-
 
 # Parameters of our pipeline. Most of them are booleans that indicate which project to build/test with the pattern 'run_{PROJECT_NAME}'
 parameters:
@@ -68,7 +69,6 @@ parameters:
     default: false
 
 jobs: # Each project will have individual jobs for each specific task it has to execute (build, release...)
-  
   selective-ci: # The job that selects which job to run
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
@@ -87,33 +87,32 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             {"regex": "ConnectorAutocadCivil/.*", "param_name": "run_connector_autocadcivil"},
             {"regex": "ConnectorCSI/.*", "param_name": "run_connector_csi"},
             {"regex": "ConnectorMicroStation/.*", "param_name": "run_connector_microstation"},
-            {"regex": "ConnectorTeklaStructures/.*", "param_name": "run_connector_teklastructures"}
-          ]'
-          base-branch: 'main'
-  
+            {"regex": "ConnectorTeklaStructures/.*", "param_name": "run_connector_teklastructures"}]'
+          base-branch: "main"
+
   build-core:
     executor: # Using a win executor since there are post-steps in the nuget workflow that use powershell
       name: win/default
       shell: powershell.exe
     steps:
       - checkout
-      - run: 
+      - run:
           name: Build Core
           command: dotnet build Core/Core.sln -c Release -v q
 
-  test-core: 
+  test-core:
     docker:
-      - image: 'mcr.microsoft.com/dotnet/core/sdk' # dotnet core 3.1 sdk
-      - image: 'mcr.microsoft.com/dotnet/core/sdk:2.1-focal' # dotnet core 2.1 sdk (for netstandard support on build)
+      - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
+      - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
       # Node, redis, postgres and speckle-server images for test server
-      - image: 'circleci/node:12'
-      - image: 'circleci/redis:6'
-      - image: 'circleci/postgres:12'
+      - image: "circleci/node:12"
+      - image: "circleci/redis:6"
+      - image: "circleci/postgres:12"
         environment:
           POSTGRES_DB: speckle2_test
           POSTGRES_PASSWORD: speckle
           POSTGRES_USER: speckle
-      - image: 'speckle/speckle-server:latest'
+      - image: "speckle/speckle-server:latest"
         command: ["bash", "-c", "/wait && node bin/www"]
         environment:
           POSTGRES_URL: "localhost"
@@ -121,13 +120,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           POSTGRES_PASSWORD: "speckle"
           POSTGRES_DB: "speckle2_test"
           REDIS_URL: "redis://localhost"
-          SESSION_SECRET: 'keyboard cat'
+          SESSION_SECRET: "keyboard cat"
           STRATEGY_LOCAL: "true"
-          CANONICAL_URL: 'http://localhost:3000'
+          CANONICAL_URL: "http://localhost:3000"
           WAIT_HOSTS: localhost:5432, localhost:6379
     steps:
-      - checkout 
-      - run: 
+      - checkout
+      - run:
           name: Unit Test
           command: dotnet test Core/Tests/TestsUnit.csproj -c Release -v q --logger:"junit;LogFileName={assembly}.results.xml" --results-directory=TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       - run:
@@ -146,10 +145,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       shell: powershell.exe
     steps:
       - checkout
-      - run: 
+      - run:
           name: Restore Objects
           command: nuget restore Objects/Objects.sln
-      - run: 
+      - run:
           name: Build Objects
           command: msbuild Objects/Objects.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false
 
@@ -159,10 +158,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       shell: powershell.exe
     steps:
       - checkout
-      - run: 
+      - run:
           name: Restore DesktopUI
           command: nuget restore DesktopUI/DesktopUI.sln
-      - run: 
+      - run:
           name: Build DesktopUI
           command: msbuild DesktopUI/DesktopUI.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false
       - run:
@@ -185,16 +184,16 @@ jobs: # Each project will have individual jobs for each specific task it has to 
         type: string
       slug:
         type: string
-        default: ''
+        default: ""
       installer:
         type: boolean
         default: false
     steps:
       - checkout
-      - run: 
+      - run:
           name: Restore << parameters.slnname >>
           command: nuget restore << parameters.slnname >>/<< parameters.slnname >>.sln
-      - run: 
+      - run:
           name: Build << parameters.slnname >>
           command: |
             $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.0" } else { $env:CIRCLE_TAG }
@@ -205,9 +204,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             $channel = "latest"
             if($env:CIRCLE_TAG -like "*-beta") { $channel = "beta" }    
             if(-Not [string]::IsNullOrEmpty($env:CIRCLE_TAG)) { New-Item -Force "speckle-sharp-ci-tools/Installers/<< parameters.slug >>/$channel.yml" -ItemType File -Value "version: $semver" }
-      - run: 
+      - run:
           name: Deploy?
-          command: | # stop job if not triggered by deployment workflow (parameters.installer == false)
+          command:
+            | # stop job if not triggered by deployment workflow (parameters.installer == false)
             if (-Not [System.Convert]::ToBoolean('<< parameters.installer >>') ) { 
             circleci-agent step halt 
             Write-Host "Job stopped gracefully"
@@ -216,10 +216,98 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           at: ./
       - run: # Creates the inno installer
           name: InnoSetup
-          command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\%SLUG%.iss /Sbyparam=$p    
+          command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\%SLUG%.iss /Sbyparam=$p
           shell: cmd.exe #does not work in powershell
           environment:
             SLUG: << parameters.slug >>
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - speckle-sharp-ci-tools/Installers
+
+  build-connector-mac:
+    macos:
+      xcode: 12.5.1
+    parameters:
+      slnname:
+        type: string
+      dllname:
+        type: string
+        default: ""
+      slug:
+        type: string
+        default: ""
+      installer:
+        type: boolean
+        default: false
+      converter-files:
+        type: string
+        default: ""
+      installername:
+        type: string
+        default: ""
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Install mono
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install mono
+      - run:
+          name: Build << parameters.slnname >>
+          command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/[a-zA-Z-]*\///')
+            VER=$(echo "$SEMVER" | sed -e 's/-beta//')
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:AssemblyVersionNumber=$VERSION /p:AssemblyInformationalVersion=$SEMVER /p:Version=$VERSION
+            CHANNEL="latest"
+            if [[ $CIRCLE_TAG == *-beta ]]; then CHANNEL=beta; fi
+            mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
+            if [ "${CIRCLE_TAG}" ]; then echo "version: $SEMVER" > "speckle-sharp-ci-tools/Installers/<< parameters.slug >>/$CHANNEL.yml"; fi
+      - run:
+          name: Deploy?
+          command: |
+            echo "Should we deploy this?"
+            if [[ <<parameters.installer>> == true ]]  
+              then echo "Yes! Continuing..."
+            else circleci-agent step halt
+            fi
+
+      # Compress build files
+      - run:
+          name: Install dotnet
+          command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+      - run:
+          name: Zip Objects Kit files
+          command: |
+            zip -j Objects.zip << parameters.converter-files >>
+      - run:
+          name: Zip Connector files
+          command: |
+            cd << parameters.slnname >>/<< parameters.slnname >>/bin/
+            zip -r <<parameters.dllname>>.zip ./
+      # Create installer
+      - run:
+          name: Copy files to installer
+          command: |
+            mkdir -p speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles/
+            cp Objects.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
+            cp << parameters.slnname >>/<< parameters.slnname >>/bin/<<parameters.dllname>>.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
+      - run:
+          name: Build Mac installer
+          command: ~/.dotnet/dotnet publish speckle-sharp-ci-tools/Mac/<<parameters.installername>>/<<parameters.installername>>.sln -r osx-x64 -c Release /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:PublishSingleFile=true /p:PublishReadyToRun=false
+      - run:
+          name: Zip installer
+          command: |
+            cd speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/publish
+            zip -r <<parameters.slug>>.zip ./
+      - store_artifacts:
+          path: speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/publish/<<parameters.slug>>.zip
+      - run:
+          name: Copy to installer location
+          command: cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>.zip
       - persist_to_workspace:
           root: ./
           paths:
@@ -229,7 +317,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
     docker:
       - image: cimg/base:2021.01
     steps:
-      - run: # Could not get ssh to work, so using a personal token 
+      - run: # Could not get ssh to work, so using a personal token
           name: Clone
           command: git clone https://$GITHUB_TOKEN@github.com/specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools
       - persist_to_workspace:
@@ -240,24 +328,23 @@ jobs: # Each project will have individual jobs for each specific task it has to 
   deploy: # Uploads all installers found to S3
     docker:
       - image: cimg/base:2021.01
-    steps:    
+    steps:
       - attach_workspace:
           at: ./
-      - run: 
+      - run:
           name: List contents
           command: ls -R speckle-sharp-ci-tools/Installers
       - aws-s3/copy:
-          arguments: '--recursive --endpoint=https://$SPACES_REGION.digitaloceanspaces.com --acl public-read'
+          arguments: "--recursive --endpoint=https://$SPACES_REGION.digitaloceanspaces.com --acl public-read"
           aws-access-key-id: SPACES_KEY
           aws-region: SPACES_REGION
           aws-secret-access-key: SPACES_SECRET
           from: '"speckle-sharp-ci-tools/Installers/"'
           to: s3://speckle-releases/installers/
 
-
 # The main workflows for our monorepo pipeline.
 # The main workflow is called 'ci': It is the workflow responsible of determining which projects to build/test.
-# There should be at least one workflow per project in the monorepo. Each workflow should be run only when a boolean parameter is passed that corresponds to the pattern 'run_{PROJECT_NAME}'. 
+# There should be at least one workflow per project in the monorepo. Each workflow should be run only when a boolean parameter is passed that corresponds to the pattern 'run_{PROJECT_NAME}'.
 # These parameters are set by the 'selective-ci' job.
 workflows:
   # Main workflow. Must be conditioned to the 'run_trigger_workflow' parameter to prevent recursive execution of the job.
@@ -271,7 +358,7 @@ workflows:
     when: << pipeline.parameters.run_objects >>
     jobs:
       - build-objects
-  
+
   # Core - Build/Test
   core:
     when: << pipeline.parameters.run_core >>
@@ -280,7 +367,7 @@ workflows:
       - test-core:
           requires:
             - build-core
-  
+
   # Grasshopper connector - Build/Test
   connector_grasshopper:
     when: << pipeline.parameters.run_connector_gh >>
@@ -288,8 +375,10 @@ workflows:
       - build-connector:
           name: build-connector-grasshopper
           slnname: ConnectorGrasshopper
-          dllname: SpeckleConnectorGrasshopper.gha 
-  
+          dllname: SpeckleConnectorGrasshopper.gha
+      - build-connector-mac:
+          name: build-connector-grasshopper-mac
+          slnname: ConnectorGrasshopper
   # Rhino connector - Build/Test
   connector_rhino:
     when: << pipeline.parameters.run_connector_rhino >>
@@ -297,7 +386,7 @@ workflows:
       - build-connector:
           name: build-connector-rhino
           slnname: ConnectorRhino
-          dllname: SpeckleConnectorRhino.rhp 
+          dllname: SpeckleConnectorRhino.rhp
 
   # Dynamo connector - Build/Test
   connector_dynamo:
@@ -306,8 +395,8 @@ workflows:
       - build-connector:
           name: build-connector-dynamo
           slnname: ConnectorDynamo
-          dllname: SpeckleConnectorDynamo.dll 
-  
+          dllname: SpeckleConnectorDynamo.dll
+
   # Revit Connector - Build/Test
   connector_revit:
     when: << pipeline.parameters.run_connector_revit >>
@@ -315,7 +404,7 @@ workflows:
       - build-connector:
           name: build-connector-revit
           slnname: ConnectorRevit
-          dllname: SpeckleConnectorRevit.dll 
+          dllname: SpeckleConnectorRevit.dll
 
   # AutoCAD & Civil3D Connector - Build/Test
   connector_autocadcivil:
@@ -325,22 +414,21 @@ workflows:
           name: build-connector-autocadcivil
           slnname: ConnectorAutocadCivil
           dllname: SpeckleConnectorCivil.dll
-  
+
   # ETABS Connector - Build/Test
   # connector_etabs:
   #   when: << pipeline.parameters.run_connector_etabs>>
   #   jobs:
-  #     - build-connector: 
+  #     - build-connector:
   #         name: build-connector-etabs
   #         slnname: ConnectorETABS
   #         dllname: SpeckleConnectorETABS.dll
-
 
   # MicroStation Connector - Build/Test
   connector_microstation:
     when: << pipeline.parameters.run_connector_microstation>>
     jobs:
-      - build-connector: 
+      - build-connector:
           name: build-connector-microstation
           slnname: ConnectorMicroStation
           dllname: SpeckleConnectorOpenRoads.dll
@@ -349,7 +437,7 @@ workflows:
   connector_teklastructures:
     when: << pipeline.parameters.run_connector_teklastructures>>
     jobs:
-      - build-connector: 
+      - build-connector:
           name: build-connector-teklastructures
           slnname: ConnectorTeklaStructures
           dllname: SpeckleConnectorTeklaStructures.dll
@@ -358,22 +446,22 @@ workflows:
   connector_csi:
     when: << pipeline.parameters.run_connector_csi>>
     jobs:
-      - build-connector: 
+      - build-connector:
           name: build-connector-csi
           slnname: ConnectorCSI
           dllname: SpeckleConnectorCSI.dll
   nuget:
     jobs:
-      # CORE Nuget Publish        
+      # CORE Nuget Publish
       - build-core:
           name: nuget-deploy-core
           filters:
             branches:
               ignore: /.*/ # For testing only: /ci\/.*/
-            tags: 
-              only: /^(core|nugets)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/ 
+            tags:
+              only: /^(core|nugets)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/
           post-steps:
-            - packandpublish: 
+            - packandpublish:
                 projectfilepath: Core/Core.sln
       - build-objects:
           name: nuget-deploy-objects
@@ -381,9 +469,9 @@ workflows:
             branches:
               ignore: /.*/ # For testing only: /ci\/.*/
             tags:
-              only: /^(objects|nugets)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/ 
+              only: /^(objects|nugets)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/
           post-steps:
-            - packandpublish: 
+            - packandpublish:
                 projectfilepath: Objects/Objects.sln
       - build-desktopui:
           name: nuget-deploy-desktopui
@@ -391,7 +479,7 @@ workflows:
             branches:
               ignore: /.*/ # For testing only: /ci\/.*/
             tags:
-              only: /^(desktopui|nugets)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/ 
+              only: /^(desktopui|nugets)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/
 
   # Makes installers based on which tag is provided
   # Tag has to be provided in the format "appname/1.0.0"
@@ -402,32 +490,32 @@ workflows:
           filters:
             branches:
               ignore: /.*/ # For testing only: /ci\/.*/
-            tags: # runs on any tag in the format "xyz/1.0.0" or "xyz/1.0.0-beta" -- TO UPDATE IDENTICAL LINE AT BOTTOM --        
-              only: /^(all|dynamo|revit|grasshopper|rhino|autocadcivil|revitdynamo|rhinogh|csi|etabs|sap2000|csibridge|safe|microstation|openbuildings|openrail|openroads|bentley|teklastructures)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
+            tags: # runs on any tag in the format "xyz/1.0.0" or "xyz/1.0.0-beta" -- TO UPDATE IDENTICAL LINE AT BOTTOM --
+              only: /^(all|dynamo|revit|grasshopper|grasshopper-mac|rhino|autocadcivil|revitdynamo|rhinogh|csi|etabs|sap2000|csibridge|safe|microstation|openbuildings|openrail|openroads|bentley|teklastructures)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
 
       # DYNAMO Build&Deploy
       - build-connector:
           name: build-deploy-connector-dynamo
-          slnname: ConnectorDynamo 
-          dllname: SpeckleConnectorDynamo.dll 
+          slnname: ConnectorDynamo
+          dllname: SpeckleConnectorDynamo.dll
           slug: dynamo
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
             tags:
-              only: /^(dynamo|revitdynamo|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/         
+              only: /^(dynamo|revitdynamo|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
 
       # REVIT Build&Deploy
       - build-connector:
           name: build-deploy-connector-revit
-          slnname: ConnectorRevit 
-          dllname: SpeckleConnectorRevit.dll 
+          slnname: ConnectorRevit
+          dllname: SpeckleConnectorRevit.dll
           slug: revit
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -439,10 +527,10 @@ workflows:
       - build-connector:
           name: build-deploy-connector-grasshopper
           slnname: ConnectorGrasshopper
-          dllname: SpeckleConnectorGrasshopper.gha 
+          dllname: SpeckleConnectorGrasshopper.gha
           slug: grasshopper
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -450,14 +538,34 @@ workflows:
             tags:
               only: /^(grasshopper|rhinogh|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
 
+      - build-connector-mac:
+          name: build-deploy-connector-grasshopper-mac
+          slnname: ConnectorGrasshopper
+          dllname: SpeckleGH
+          installername: SpeckleGhInstall
+          installer: true
+          slug: grasshopper-mac
+          requires:
+            - get-ci-tools
+          converter-files: "
+            Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/bin/Release/net48/Objects.dll
+            Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/bin/Release/net48/Objects.Converter.Grasshopper7.dll
+            Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/bin/Release/netstandard2.0/Objects.Converter.Grasshopper6.dll
+            "
+          filters:
+            branches:
+              ignore: /.*/ # For testing only! /ci\/.*/
+            tags:
+              only: /^(grasshopper|grasshopper-mac|rhinogh|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
+
       # RHINO Build&Deploy
       - build-connector:
           name: build-deploy-connector-rhino
-          slnname: ConnectorRhino 
-          dllname: SpeckleConnectorRhino.rhp 
+          slnname: ConnectorRhino
+          dllname: SpeckleConnectorRhino.rhp
           slug: rhino
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -468,11 +576,11 @@ workflows:
       # AUTOCAD Build&Deploy
       - build-connector:
           name: build-deploy-connector-autocad
-          slnname: ConnectorAutocadCivil 
+          slnname: ConnectorAutocadCivil
           dllname: SpeckleConnectorAutocad.dll
           slug: autocad
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -483,18 +591,18 @@ workflows:
       # CIVIL 3D Build&Deploy
       - build-connector:
           name: build-deploy-connector-civil3d
-          slnname: ConnectorAutocadCivil 
+          slnname: ConnectorAutocadCivil
           dllname: SpeckleConnectorCivil.dll
           slug: civil3d
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
             tags:
               only: /^(autocadcivil|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
-            
+
       # # ETABS Build&Deploy
       # - build-connector:
       #     name: build-deploy-connector-etabs
@@ -502,7 +610,7 @@ workflows:
       #     dllname: SpeckleConnectorETABS.dll
       #     slug: etabs
       #     installer: true
-      #     requires: 
+      #     requires:
       #       - get-ci-tools
       #     filters:
       #       branches:
@@ -517,7 +625,7 @@ workflows:
           dllname: SpeckleConnectorMicroStation.dll
           slug: microstation
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -532,14 +640,14 @@ workflows:
           dllname: SpeckleConnectorOpenBuildings.dll
           slug: openbuildings
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
             tags:
               only: /^(openbuildings|bentley|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
-      
+
       # OPENRAIL Build&Deploy
       - build-connector:
           name: build-deploy-connector-openrail
@@ -547,7 +655,7 @@ workflows:
           dllname: SpeckleConnectorOpenRail.dll
           slug: openrail
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -562,14 +670,14 @@ workflows:
           dllname: SpeckleConnectorOpenRoads.dll
           slug: openroads
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
             tags:
               only: /^(openroads|bentley|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
-      
+
       # TeklaStructures Build&Deploy
       - build-connector:
           name: build-deploy-connector-teklastructures
@@ -577,14 +685,14 @@ workflows:
           dllname: SpeckleConnectorTeklaStructures.dll
           slug: teklastructures
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
             tags:
               only: /^(teklastructures|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
-      
+
       # ETABS Build&Deploy
       - build-connector:
           name: build-deploy-connector-etabs
@@ -592,7 +700,7 @@ workflows:
           dllname: SpeckleConnectorCSI.dll
           slug: etabs
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -607,14 +715,14 @@ workflows:
           dllname: SpeckleConnectorCSI.dll
           slug: sap2000
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
             tags:
               only: /^(sap2000|csi|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
-      
+
       # SAFE Build&Deploy
       - build-connector:
           name: build-deploy-connector-safe
@@ -622,7 +730,7 @@ workflows:
           dllname: SpeckleConnectorCSI.dll
           slug: safe
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
@@ -637,22 +745,22 @@ workflows:
           dllname: SpeckleConnectorCSI.dll
           slug: csibridge
           installer: true
-          requires: 
+          requires:
             - get-ci-tools
           filters:
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/
             tags:
               only: /^(csibridge|csi|all)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
-      
-     
+
       # DEPLOY ALL CONNECTORS
       - deploy: # Will run if all the triggered workflows succeed
-          requires: 
+          requires:
             - get-ci-tools
             - build-deploy-connector-dynamo
             - build-deploy-connector-revit
             - build-deploy-connector-grasshopper
+            - build-deploy-connector-grasshopper-mac
             - build-deploy-connector-rhino
             - build-deploy-connector-autocad
             - build-deploy-connector-civil3d
@@ -667,5 +775,5 @@ workflows:
             - build-deploy-connector-teklastructures
 
           filters:
-            tags: # runs on any tag in the format "xyz/1.0.0" or "xyz/1.0.0-beta" -- TO UPDATE IDENTICAL LINE AT ~380  --    
-              only: /^(all|dynamo|revit|grasshopper|rhino|autocadcivil|revitdynamo|rhinogh|csi|etabs|sap2000|csibridge|safe|microstation|microstation|openbuildings|openrail|openroads|bentley|teklastructures)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/
+            tags: # runs on any tag in the format "xyz/1.0.0" or "xyz/1.0.0-beta" -- TO UPDATE IDENTICAL LINE AT ~380  --
+              only: /^(all|dynamo|revit|grasshopper|grasshopper-mac|rhino|autocadcivil|revitdynamo|rhinogh|csi|etabs|sap2000|csibridge|safe|microstation|microstation|openbuildings|openrail|openroads|bentley|teklastructures)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-beta)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
     parameters:
       slnname:
         type: string
-      dllname:
+      projname:
         type: string
         default: ""
       slug:
@@ -261,7 +261,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             SEMVER=$(echo "$TAG" | sed -e 's/[a-zA-Z-]*\///')
             VER=$(echo "$SEMVER" | sed -e 's/-beta//')
             VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
-            msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:AssemblyVersionNumber=$VERSION /p:AssemblyInformationalVersion=$SEMVER /p:Version=$VERSION
+            msbuild << parameters.slnname >>/<< parameters.projname >>.sln /r /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:AssemblyVersionNumber=$VERSION /p:AssemblyInformationalVersion=$SEMVER /p:Version=$VERSION
             CHANNEL="latest"
             if [[ $CIRCLE_TAG == *-beta ]]; then CHANNEL=beta; fi
             mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
@@ -286,28 +286,31 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Zip Connector files
           command: |
-            cd << parameters.slnname >>/<< parameters.slnname >>/bin/
-            zip -r <<parameters.dllname>>.zip ./
+            cd << parameters.slnname >>/<< parameters.projname >>/bin/
+            zip -r <<parameters.slug>>.zip ./
       # Create installer
       - run:
           name: Copy files to installer
           command: |
             mkdir -p speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles/
             cp Objects.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
-            cp << parameters.slnname >>/<< parameters.slnname >>/bin/<<parameters.dllname>>.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
+            cp << parameters.slnname >>/<< parameters.projname >>/bin/<<parameters.slug>>.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
       - run:
           name: Build Mac installer
-          command: ~/.dotnet/dotnet publish speckle-sharp-ci-tools/Mac/<<parameters.installername>>/<<parameters.installername>>.sln -r osx-x64 -c Release /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:PublishSingleFile=true /p:PublishReadyToRun=false
+          command: ~/.dotnet/dotnet publish speckle-sharp-ci-tools/Mac/<<parameters.installername>>/<<parameters.installername>>.sln -r osx-x64 -c Release
       - run:
           name: Zip installer
           command: |
-            cd speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/publish
+            cd speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/
             zip -r <<parameters.slug>>.zip ./
       - store_artifacts:
-          path: speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/publish/<<parameters.slug>>.zip
+          path: speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/<<parameters.slug>>.zip
       - run:
           name: Copy to installer location
-          command: cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>.zip
+          command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/[a-zA-Z-]*\///')
+            cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
       - persist_to_workspace:
           root: ./
           paths:
@@ -379,6 +382,8 @@ workflows:
       - build-connector-mac:
           name: build-connector-grasshopper-mac
           slnname: ConnectorGrasshopper
+          projname: ConnectorGrasshopper
+
   # Rhino connector - Build/Test
   connector_rhino:
     when: << pipeline.parameters.run_connector_rhino >>
@@ -541,7 +546,7 @@ workflows:
       - build-connector-mac:
           name: build-deploy-connector-grasshopper-mac
           slnname: ConnectorGrasshopper
-          dllname: SpeckleGH
+          projname: ConnectorGrasshopper
           installername: SpeckleGhInstall
           installer: true
           slug: grasshopper-mac

--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -1,293 +1,78 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{BDEC781D-F322-49B0-8001-2CA66C182174}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ConnectorGrasshopper</RootNamespace>
     <AssemblyName>SpeckleConnectorGrasshopper</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyTitle>ConnectorGrasshopper</AssemblyTitle>
+    <Product>ConnectorGrasshopper</Product>
+    <Copyright>Copyright ©  2020</Copyright>
+    <Version>1.0.0.0</Version>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <StartProgram>C:\Program Files\Rhino 6\System\Rhino.exe</StartProgram>
+    <StartArguments />
+    <StartAction>Program</StartAction>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.113.1\lib\net46\System.Data.SQLite.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Drawing" />
+    <PackageReference Include="Grasshopper" Version="6.32.20340.21001"  IncludeAssets="compile;build" />
+    <PackageReference Include="RhinoCommon" Version="6.32.20340.21001"  IncludeAssets="compile;build" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="GrasshopperAsyncComponent" Version="1.2.3" />
+    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
+  
   <ItemGroup>
-    <Compile Include="Accounts\Accounts.AccountDetails.cs" />
-    <Compile Include="Accounts\Accounts.ListAccounts.cs" />
-    <Compile Include="ComponentCategories.cs" />
-    <Compile Include="Conversion\Deprecated\Convert.ToNativeAsync.cs" />
-    <Compile Include="Conversion\Deprecated\Convert.ToSpeckleAsync.cs" />
-    <Compile Include="Conversion\Deprecated\ConvertUpgradeUtils.cs" />
-    <Compile Include="Conversion\Deprecated\Serialisation.DeserializeObject.cs" />
-    <Compile Include="Conversion\Deprecated\Serialisation.SerialiseObject.cs" />
-    <Compile Include="Conversion\DeserialiseTaskCapableComponent.cs" />
-    <Compile Include="Conversion\SerialiseTaskCapableComponent.cs" />
-    <Compile Include="Conversion\ToNativeTaskCapableComponent.cs" />
-    <Compile Include="Conversion\ToSpeckleTaskCapableComponent.cs" />
-    <Compile Include="Extras\DebounceDispatcher.cs" />
-    <Compile Include="Extras\GenericAccessParam.cs" />
-    <Compile Include="Extras\SendReceiveDataParam.cs" />
-    <Compile Include="Extras\Speckle.IGH_Goo.cs" />
-    <Compile Include="Extras\SpeckleBaseParam.cs" />
-    <Compile Include="Extras\SpeckleStatefulParam.cs" />
-    <Compile Include="Extras\SpeckleStateTag.cs" />
-    <Compile Include="Extras\SpeckleStreamParam.cs" />
-    <Compile Include="Extras\TreeBuilder.cs" />
-    <Compile Include="Extras\Utilities.cs" />
-    <Compile Include="Loader.cs" />
-    <Compile Include="Objects\CreateSpeckleObjectByKeyValueTaskComponent.cs" />
-    <Compile Include="Objects\CreateSpeckleObjectTaskComponent.cs" />
-    <Compile Include="Objects\Deprecated\CreateSpeckleObjectAsync.cs" />
-    <Compile Include="Objects\Deprecated\CreateSpeckleObjectByKeyValueAsync.cs" />
-    <Compile Include="Objects\Deprecated\ExpandSpeckleObjectAsync.cs" />
-    <Compile Include="Objects\Deprecated\ExtendSpeckleObjectAsync.cs" />
-    <Compile Include="Objects\Deprecated\ExtendSpeckleObjectByKeyValueAsync.cs" />
-    <Compile Include="Objects\Deprecated\GetObjectValueByKeyAsync.cs" />
-    <Compile Include="Objects\Deprecated\ObjectsUpgradeUtils.cs" />
-    <Compile Include="Objects\Deprecated\SelectKitAsyncComponentBase.cs" />
-    <Compile Include="Objects\ExpandSpeckleObjectTaskComponent.cs" />
-    <Compile Include="Objects\ExtendSpeckleObjectByKeyValueTaskComponent.cs" />
-    <Compile Include="Objects\ExtendSpeckleObjectTaskComponent.cs" />
-    <Compile Include="Objects\GetObjectValueByKeyTaskComponent.cs" />
-    <Compile Include="Objects\SelectKitComponentBase.cs" />
-    <Compile Include="Objects\SelectKitTaskCapableComponentBase.cs" />
-    <Compile Include="Ops\Operations.ReceiveComponentSync.cs" />
-    <Compile Include="Ops\Operations.ReceiveLocalComponent.cs" />
-    <Compile Include="Ops\Operations.SendLocalComponent.cs" />
-    <Compile Include="Ops\Operations.SendComponentSync.cs" />
-    <Compile Include="Ops\Operations.UpgradeUtils.cs" />
-    <Compile Include="Ops\Operations.VariableInputReceiveComponent.cs" />
-    <Compile Include="Ops\Operations.VariableInputSendComponent.cs" />
-    <Compile Include="SchemaBuilder\CreateSchemaObjectBase.cs" />
-    <Compile Include="SchemaBuilder\CreateSchemaObjectDialog.cs" />
-    <Compile Include="SchemaBuilder\CreateSchemaObject.cs" />
-    <Compile Include="ConnectorGrasshopperInfo.cs" />
-    <Compile Include="Ops\Operations.ReceiveComponent.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Ops\Operations.SendComponent.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
+    <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="SchemaBuilder\CSOViewModel.cs" />
-    <Compile Include="SchemaBuilder\SchemaBuilderGen.cs">
+    <Compile Update="SchemaBuilder\SchemaBuilderGen.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>SchemaBuilderGen.tt</DependentUpon>
     </Compile>
-    <Compile Include="SpeckleGHSettings.cs" />
-    <Compile Include="Streams\StreamCreateComponent.cs" />
-    <Compile Include="Streams\StreamDetailsComponent.cs" />
-    <Compile Include="Streams\StreamGetComponent.cs" />
-    <Compile Include="Streams\StreamListComponent.cs" />
-    <Compile Include="Streams\StreamUpdateComponent.cs" />
-    <Compile Include="Transports\SendReceiveTransport.cs" />
-    <Compile Include="Transports\Transports.Disk.cs" />
-    <Compile Include="Transports\Transports.Memory.cs" />
-    <Compile Include="Transports\Transports.Sqlite.cs" />
   </ItemGroup>
+  
   <ItemGroup>
-    <ProjectReference Include="..\..\Core\Core\Core.csproj">
-      <Project>{b4d98d2c-e5da-463e-bf6c-68e9b77c72f3}</Project>
-      <Name>Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Core\Transports\DiskTransport\DiskTransport.csproj">
-      <Project>{8f16a9a1-dc5f-4800-821c-336e6ccf8f9c}</Project>
-      <Name>DiskTransport</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ConnectorGrasshopperUtils\ConnectorGrasshopperUtils.csproj">
-      <Project>{e2a8e961-6db6-4474-9e31-0c00feb4a067}</Project>
-      <Name>ConnectorGrasshopperUtils</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\Core\Core\Core.csproj" />
+    <ProjectReference Include="..\..\Core\Transports\DiskTransport\DiskTransport.csproj" />
+    <ProjectReference Include="..\ConnectorGrasshopperUtils\ConnectorGrasshopperUtils.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\CreateSpeckleObject.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\CreateSpeckleObjectByKeyValue.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\CreateStream.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\Deserialize.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\DiskTransport.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\ExpandSpeckleObject.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\ExtendSpeckleObject.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\GetObjectValueByKey.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\MemoryTransport.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\Serialize.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\ServerTransport.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\SQLiteTransport.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\StreamDetails.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\StreamGet.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\StreamList.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\StreamUpdate.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\ToNative.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\ToSpeckle.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\Accounts.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\Receiver.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\Sender.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\BaseParam.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\StreamParam.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\receiveFromTransport.png" />
-    <None Include="Resources\sendToTransport.png" />
-    <None Include="Resources\docs16.png" />
-    <None Include="Resources\forum16.png" />
-    <None Include="Resources\help16.png" />
-    <None Include="Resources\tutorials16.png" />
-    <Content Include="SchemaBuilder\SchemaBuilderGen.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>SchemaBuilderGen.cs</LastGenOutput>
-    </Content>
-    <None Include="Resources\SynchronousSender.png" />
-    <None Include="Resources\SynchronousReceiver.png" />
-    <None Include="Resources\StateTag_Optional.Large.png" />
-    <None Include="Resources\StateTag_List.Large.png" />
-    <None Include="Resources\StateTag_Detach.Large.png" />
-    <None Include="Resources\StateTag_Detach.png" />
-    <None Include="Resources\StateTag_List.png" />
-    <None Include="Resources\StateTag_Optional.png" />
-    <None Include="Resources\LocalReceiver.png" />
-    <None Include="Resources\LocalSender.png" />
-    <None Include="Resources\SchemaBuilder.png" />
-    <None Include="Resources\ExtendSpeckleObjectByKeyValue.png" />
-    <Content Include="Resources\speckle-logo-bw.png" />
-    <Content Include="Resources\speckle-logo.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Grasshopper">
-      <Version>6.28.20199.17141</Version>
-      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="GrasshopperAsyncComponent">
-      <Version>1.2.3</Version>
-    </PackageReference>
-    <PackageReference Include="MSBuild.AssemblyVersion">
-      <Version>1.3.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.ComponentModel.Annotations">
-      <Version>4.7.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
   <Target Name="BeforeRebuild">
     <Message Text="Restoring T4 tool..." Importance="high" />
     <Exec Command="dotnet tool restore" />
     <Message Text="Generating T4 templates..." Importance="high" />
     <Exec Command="dotnet t4 -o $(SolutionDir)ConnectorGrasshopper\SchemaBuilder\SchemaBuilderGen.cs $(SolutionDir)ConnectorGrasshopper\SchemaBuilder\SchemaBuilderGen.tt -P=$(SolutionDir)ConnectorGrasshopper\SchemaBuilder" />
   </Target>
+  
   <Target Name="Clean">
     <RemoveDir Directories="$(TargetDir);$(AppData)\Grasshopper\Libraries\SpeckleGrasshopper2" />
   </Target>
-  <PropertyGroup>
-    <FallbackCulture>en-US</FallbackCulture>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <StartProgram>C:\Program Files\Rhino 6\System\Rhino.exe</StartProgram>
-    <StartArguments>
-    </StartArguments>
-    <StartAction>Program</StartAction>
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets')" />
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <PostBuildEvent>Copy "$(TargetPath)" "$(TargetDir)$(TargetName).gha"</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
-    <PostBuildEvent>cp "$(TargetPath)" "$(TargetDir)$(TargetName).gha"</PostBuildEvent>
-  </PropertyGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="Copy &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(TargetDir)$(AssemblyName).gha&quot;" />
+    <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="cp '$(TargetDir)$(AssemblyName).dll' '$(TargetDir)$(AssemblyName).gha'" />
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Linux'))" Command="cp '$(TargetDir)$(AssemblyName).dll' '$(TargetDir)$(AssemblyName).gha'" />
+  </Target>
 </Project>
-

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Deprecated/Convert.ToNativeAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Deprecated/Convert.ToNativeAsync.cs
@@ -2,10 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Windows.Forms;
-using ConnectorGrasshopper.Extras;
 using ConnectorGrasshopper.Objects;
-using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Deprecated/Convert.ToSpeckleAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/Deprecated/Convert.ToSpeckleAsync.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using ConnectorGrasshopper.Objects;
-using GH_IO.Serialization;
+
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStateTag.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStateTag.cs
@@ -96,8 +96,10 @@ namespace ConnectorGrasshopper.Extras
     public void RenderSpeckleTagContents(Graphics graphics)
     {
       var p = new GraphicsPath();
+      var format = StringFormat.GenericDefault;
+      format.Alignment = StringAlignment.Center;
       p.AddString(Letter, FontFamily.GenericMonospace, 1, Stage.Height - 2,
-        new Point(Stage.Location.X + 1, this.Stage.Location.Y), null);
+        new Point(Stage.Location.X + Stage.Width / 2, Stage.Location.Y - 1), format);
       
       LinearGradientBrush blueGradient = new LinearGradientBrush(Stage, Color.FromArgb(100, 10, 107, 252),
         Color.FromArgb(Convert.ToInt32((double) GH_Canvas.ZoomFadeLow), Color.FromArgb(0, 10, 107, 252)),

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectAsync.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using GrasshopperAsyncComponent;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectByKeyValueAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/CreateSpeckleObjectByKeyValueAsync.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExpandSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExpandSpeckleObjectAsync.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectAsync.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using GrasshopperAsyncComponent;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectByKeyValueAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExtendSpeckleObjectByKeyValueAsync.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
-using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using GrasshopperAsyncComponent;
 using Speckle.Core.Kits;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/GetObjectValueByKeyAsync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/GetObjectValueByKeyAsync.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
-using Grasshopper.Kernel.Types;
 using GrasshopperAsyncComponent;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ObjectsUpgradeUtils.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ObjectsUpgradeUtils.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Special;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/SelectKitAsyncComponentBase.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
-using ConnectorGrasshopper.Extras;
 using GH_IO.Serialization;
 using Grasshopper.Kernel;
-using Grasshopper.Kernel.Data;
-using Grasshopper.Kernel.Types;
 using GrasshopperAsyncComponent;
 using Sentry;
 using Speckle.Core.Kits;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Properties/AssemblyInfo.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Properties/AssemblyInfo.cs
@@ -1,18 +1,6 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("ConnectorGrasshopper")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("ConnectorGrasshopper")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
@@ -21,17 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bdec781d-f322-49b0-8001-2ca66c182174")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/ConnectorGrasshopper/ConnectorGrasshopper/packages.config
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Grasshopper" version="6.32.20340.21001" targetFramework="net472" />
-  <package id="RhinoCommon" version="6.32.20340.21001" targetFramework="net472" />
-  <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net472" />
-</packages>

--- a/ConnectorGrasshopper/README.md
+++ b/ConnectorGrasshopper/README.md
@@ -32,7 +32,7 @@ Following instructions on how to get started debugging and contributing to this 
 
 #### Dependencies
 
-All dependencies exist either on this repo (such as `Core`, `Objects`, etc...) or are installed via NuGet. 
+All dependencies exist either on this repo (such as `Core`, `Objects`, etc...) or are installed via NuGet.
 
 Worth mentioning is the use of our own asyncronous grasshopper component, which you can find here:
 
@@ -117,3 +117,5 @@ The Speckle Community hangs out on [the forum](https://discourse.speckle.works),
 ## License
 
 Unless otherwise described, the code in this repository is licensed under the Apache-2.0 License. Please note that some modules, extensions or code herein might be otherwise licensed. This is indicated either in the root of the containing folder under a different license file, or in the respective file's header. If you have any questions, don't hesitate to get in touch with us via [email](mailto:hello@speckle.systems).
+
+<!-- Fake change to force CI to run -->

--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -29,19 +29,23 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <ForceMacBuild Condition="'$(ForceMacBuild)' == ''">false</ForceMacBuild>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
     <DefineConstants>TRACE;</DefineConstants>
   </PropertyGroup>
   <Choose>
-    <When Condition="$([MSBuild]::IsOsPlatform('Windows')) Or $([MSBuild]::IsOsPlatform('Linux')) ">
-      <ItemGroup>
-        <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
-      </ItemGroup>
-    </When>
-    <When Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+    <When Condition="$(ForceMacBuild) Or $([MSBuild]::IsOsPlatform('OSX'))">
       <ItemGroup>
         <PackageReference Include="System.Data.SQLite.Mac" Version="1.0.104.2" />
+      </ItemGroup>
+    </When>
+    <When Condition="!$(ForceMacBuild) Or $([MSBuild]::IsOsPlatform('Windows')) Or $([MSBuild]::IsOsPlatform('Linux')) ">
+      <ItemGroup>
+        <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
       </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
## Description

- Added grasshopper build to CI in native macos vm
- Upgraded Grasshopper project to be a dotnet sdk to play better with mono.
- Modified some of the Grasshopper types to enable building in mac.

- New `grasshopper-mac/x.y.z` tag can be created to only release grasshopper for mac (this was done for testing purposes, but i'm keeping it since it may be useful)

- Releases will be uploaded to `installers/grasshopper-mac/grasshopper-mac-x.y.z.zip` and consumed by the manager. The yaml will also be updated to reflect the latest and beta versions properly.

- CI Build is generic and should be used for Rhino and other mac builds in the future for this repo.
## Type of change

- New feature (non-breaking change which adds functionality)

Just a new build, all code remains the same :)

## How has this been tested?

- Manual Tests (please write what did you do?)

Manually tested the installer and also through manager

## Docs

- No updates needed
- Have already been updated
- Will be updated ASAP

