### PR TITLE
fix(gh): Referenced rhino objects now have applicationId set

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -304,6 +304,9 @@ namespace ConnectorGrasshopper.Extras
     public static object TryConvertItemToSpeckle(object value, ISpeckleConverter converter, bool recursive = false, Action OnConversionProgress = null)
     {
       if (value is null) return value;
+
+      string refId = GetRefId(value);
+      
       if (value is IGH_Goo)
       {
         value = value.GetType().GetProperty("Value").GetValue(value);
@@ -315,7 +318,9 @@ namespace ConnectorGrasshopper.Extras
 
       if (converter.CanConvertToSpeckle(value))
       {
-        return converter.ConvertToSpeckle(value);
+        var result = converter.ConvertToSpeckle(value);  
+        result.applicationId = refId;
+        return result;
       }
 
       var subclass = value.GetType().IsSubclassOf(typeof(Base));
@@ -334,6 +339,39 @@ namespace ConnectorGrasshopper.Extras
         return @base2;
 
       return null;
+    }
+
+    public static string GetRefId(object value)
+    {
+      string refId = null;
+      switch (value)
+      {
+        case GH_Brep r:
+          if (r.IsReferencedGeometry)
+            refId = r.ReferenceID.ToString();
+          break;
+        case GH_Mesh r:
+          if (r.IsReferencedGeometry)
+            refId = r.ReferenceID.ToString();
+          break;
+        case GH_Line r:
+          if (r.IsReferencedGeometry)
+            refId = r.ReferenceID.ToString();
+          break;
+        case GH_Point r:
+          if (r.IsReferencedGeometry)
+            refId = r.ReferenceID.ToString();
+          break;
+        case GH_Surface r:
+          if (r.IsReferencedGeometry)
+            refId = r.ReferenceID.ToString();
+          break;
+        case GH_Curve r:
+          if (r.IsReferencedGeometry)
+            refId = r.ReferenceID.ToString();
+          break;
+      }
+      return refId;
     }
 
     /// <summary>

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
@@ -8,6 +8,7 @@ using Grasshopper.Kernel;
 using Logging = Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
+using Grasshopper.Kernel.Types;
 
 namespace ConnectorGrasshopper.Objects
 {
@@ -158,16 +159,18 @@ namespace ConnectorGrasshopper.Objects
         {
           var value = inputData[key];
 
-
           if (value is List<object> list)
           {
+
             // Value is a list of items, iterate and convert.
             List<object> converted = null;
             try
             {
+
               converted = list.Select(item =>
               {
-                return Converter != null ? Utilities.TryConvertItemToSpeckle(item, Converter) : item;
+                var result = Converter != null ? Utilities.TryConvertItemToSpeckle(item, Converter) : item;
+                return result;
               }).ToList();
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes #1103 

This works with some caveats, as the parameters loose track of whose referenced:

Some geometries like lines can never be referenced in a `GH_Line` param, which will cause it to fail to assign the applicationId's. 

![Screenshot 2022-03-30 at 13 29 39](https://user-images.githubusercontent.com/2316535/160824674-3ab0640c-56af-4614-965f-ef970d9a051b.png)

For curves, surfaces, breps and meshes it will always work as expected.

![Screenshot 2022-03-30 at 13 29 45](https://user-images.githubusercontent.com/2316535/160824638-b86d20f4-4b34-4224-a2a8-b9e401c2e4bf.png)