### PR TITLE
refactor(autocad): better performance for mesh creation

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -1523,15 +1523,8 @@ namespace Objects.Converter.AutocadCivil
                   var faceIndices = new List<int>();
                   foreach (var n in e.Nodes)
                   {
-                    if (!_vertices.Contains(n.Point))
-                    {
-                      faceIndices.Add(_vertices.Count);
-                      _vertices.Add(n.Point);
-                    }
-                    else
-                    {
-                      faceIndices.Add(_vertices.IndexOf(n.Point));
-                    }
+                    faceIndices.Add(_vertices.Count);
+                    _vertices.Add(n.Point);
                     n.Dispose();
                   }
 


### PR DESCRIPTION
## Description
 Because meshes no longer need unique vertices, can remove costly methods in the Brep/Surface to Mesh conversion.

## Type of change

## How has this been tested?

- Manual Tests

## Docs

- No updates needed
