### PR TITLE
GH/RVT: Add support for wall openings

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grasshopper" Version="6.32.20340.21001"  IncludeAssets="compile;build" />
-    <PackageReference Include="RhinoCommon" Version="6.32.20340.21001"  IncludeAssets="compile;build" />
+    <PackageReference Include="Grasshopper" Version="6.32.20340.21001" IncludeAssets="compile;build" />
+    <PackageReference Include="RhinoCommon" Version="6.32.20340.21001" IncludeAssets="compile;build" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="GrasshopperAsyncComponent" Version="1.2.3" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
@@ -57,6 +57,13 @@
     <ProjectReference Include="..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\Core\Transports\DiskTransport\DiskTransport.csproj" />
     <ProjectReference Include="..\ConnectorGrasshopperUtils\ConnectorGrasshopperUtils.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="SchemaBuilder\SchemaBuilderGen.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SchemaBuilderGen.cs</LastGenOutput>
+    </None>
   </ItemGroup>
   
   <Target Name="BeforeRebuild">

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -1308,7 +1308,7 @@ public class NodeSchemaComponent: CreateSchemaObjectBase {
 // This is generated code:
 public class OpeningSchemaComponent: CreateSchemaObjectBase {
      
-    public OpeningSchemaComponent(): base("Opening", "Opening", "Creates a Speckle opening", "Speckle 2 BIM", "Architecture") { }
+    public OpeningSchemaComponent(): base("Arch Opening", "Arch Opening", "Creates a Speckle opening", "Speckle 2 BIM", "Architecture") { }
     
     public override Guid ComponentGuid => new Guid("087f847f-6f51-3cc9-5b7d-2cce478b46f4");
     
@@ -2081,6 +2081,19 @@ public class RevitWall1SchemaComponent: CreateSchemaObjectBase {
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWall");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class RevitWallOpeningSchemaComponent: CreateSchemaObjectBase {
+     
+    public RevitWallOpeningSchemaComponent(): base("Revit Wall Opening", "Revit Wall Opening", "Creates a Speckle Wall opening for revit", "Speckle 2 BIM", "Architecture") { }
+    
+    public override Guid ComponentGuid => new Guid("a1bd278d-fab5-0034-7aba-807b66122022");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWallOpening.ctor(Objects.ICurve,Objects.BuiltElements.Revit.RevitWall)","Objects.BuiltElements.Revit.RevitWallOpening");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -1306,6 +1306,19 @@ public class NodeSchemaComponent: CreateSchemaObjectBase {
 }
 
 // This is generated code:
+public class OpeningSchemaComponent: CreateSchemaObjectBase {
+     
+    public OpeningSchemaComponent(): base("Opening", "Opening", "Creates a Speckle opening", "Speckle 2 BIM", "Architecture") { }
+    
+    public override Guid ComponentGuid => new Guid("087f847f-6f51-3cc9-5b7d-2cce478b46f4");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Opening.ctor(Objects.ICurve)","Objects.BuiltElements.Opening");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
 public class ParameterSchemaComponent: CreateSchemaObjectBase {
      
     public ParameterSchemaComponent(): base("Parameter", "Parameter", "A Revit instance parameter to set on an element", "Speckle 2 Revit", "Families") { }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
@@ -37,7 +37,7 @@ namespace Objects.Converter.Revit
             Element existingElement;
             try
             {
-              existingElement = Doc.GetElement(rwo.elementId);
+              existingElement = GetExistingElementByApplicationId(rwo.host.applicationId);
             }
             catch (Exception e)
             {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using Autodesk.Revit.DB;
 using Objects.BuiltElements.Revit;
 using Objects.Geometry;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
-
 using DB = Autodesk.Revit.DB;
 using Point = Objects.Geometry.Point;
 
@@ -19,52 +19,80 @@ namespace Objects.Converter.Revit
 
       var docObj = GetExistingElementByApplicationId(speckleOpening.applicationId);
       if (docObj != null)
-      {
         Doc.Delete(docObj.Id);
-      }
-
-      DB.Opening revitOpening = null;
+      
+      Opening revitOpening = null;
 
       switch (speckleOpening)
       {
         case RevitWallOpening rwo:
+        {
+          // Prevent host element overriding as this will propagate upwards to other hosted elements in a wall :)
+          string elementId = null;
+          var hostElement = CurrentHostElement;
+          if (!(hostElement is Wall))
           {
-            if (CurrentHostElement as Wall == null)
-              throw new Speckle.Core.Logging.SpeckleException($"Hosted wall openings require a host wall");
-            var points = (rwo.outline as Polyline).points.Select(x => PointToNative(x)).ToList();
-            revitOpening = Doc.Create.NewOpening(CurrentHostElement as Wall, points[0], points[2]);
-            break;
+            // Try with the opening wall if it exists
+            if (rwo.host == null) throw new SpeckleException($"Hosted wall openings require a host wall");
+            Element existingElement;
+            try
+            {
+              existingElement = Doc.GetElement(rwo.elementId);
+            }
+            catch (Exception e)
+            {
+              throw new SpeckleException($"Could not find the provided host wall by it's element id.", e);
+            }
+
+            if (!(existingElement is Wall wall))
+              throw new SpeckleException($"The provided host element is not a wall.");
+            
+            hostElement = wall;
           }
+
+          var poly = rwo.outline as Polyline;
+          if (poly == null || poly.GetPoints().Count != 5)
+            throw new SpeckleException($"Curve outline for wall opening must be a rectangle-shaped polyline.");
+
+          var points = poly.GetPoints().Select(PointToNative).ToList();
+          revitOpening = Doc.Create.NewOpening((Wall)hostElement, points[0], points[2]);
+          break;
+        }
 
         case RevitVerticalOpening rvo:
-          {
-            if (CurrentHostElement == null)
-              throw new Speckle.Core.Logging.SpeckleException($"Hosted vertical openings require a host family");
-            revitOpening = Doc.Create.NewOpening(CurrentHostElement, baseCurves, true);
-            break;
-          }
+        {
+          if (CurrentHostElement == null)
+            throw new SpeckleException($"Hosted vertical openings require a host family");
+          revitOpening = Doc.Create.NewOpening(CurrentHostElement, baseCurves, true);
+          break;
+        }
 
         case RevitShaft rs:
-          {
-            var bottomLevel = ConvertLevelToRevit(rs.bottomLevel);
-            var topLevel = ConvertLevelToRevit(rs.topLevel);
-            revitOpening = Doc.Create.NewOpening(bottomLevel, topLevel, baseCurves);
-            TrySetParam(revitOpening, BuiltInParameter.WALL_USER_HEIGHT_PARAM, rs.height, rs.units);
+        {
+          var bottomLevel = ConvertLevelToRevit(rs.bottomLevel);
+          var topLevel = ConvertLevelToRevit(rs.topLevel);
+          revitOpening = Doc.Create.NewOpening(bottomLevel, topLevel, baseCurves);
+          TrySetParam(revitOpening, BuiltInParameter.WALL_USER_HEIGHT_PARAM, rs.height, rs.units);
 
-            break;
-          }
+          break;
+        }
 
         default:
           if (CurrentHostElement as Wall != null)
           {
-            var points = (speckleOpening.outline as Polyline).points.Select(x => PointToNative(x)).ToList();
+            var speckleOpeningOutline = speckleOpening.outline as Polyline;
+            if (speckleOpeningOutline == null)
+              throw new SpeckleException("Cannot create opening, outline must be a rectangle-shaped polyline.");
+            
+            var points = speckleOpeningOutline.GetPoints().Select(PointToNative).ToList();
             revitOpening = Doc.Create.NewOpening(CurrentHostElement as Wall, points[0], points[2]);
           }
           else
           {
             Report.LogConversionError(new Exception("Cannot create Opening, opening type not supported"));
-            throw new Speckle.Core.Logging.SpeckleException("Opening type not supported");
+            throw new SpeckleException("Opening type not supported");
           }
+
           break;
       }
 
@@ -72,8 +100,13 @@ namespace Objects.Converter.Revit
       {
         SetInstanceParameters(revitOpening, ro);
       }
+
       Report.Log($"Created Opening {revitOpening.Id}");
-      return new ApplicationPlaceholderObject { NativeObject = revitOpening, applicationId = speckleOpening.applicationId, ApplicationGeneratedId = revitOpening.UniqueId };
+      return new ApplicationPlaceholderObject
+      {
+        NativeObject = revitOpening, applicationId = speckleOpening.applicationId,
+        ApplicationGeneratedId = revitOpening.UniqueId
+      };
     }
 
     public BuiltElements.Opening OpeningToSpeckle(DB.Opening revitOpening)
@@ -113,9 +146,12 @@ namespace Objects.Converter.Revit
           speckleOpening = new RevitShaft();
           if (revitOpening.get_Parameter(BuiltInParameter.WALL_HEIGHT_TYPE) != null)
           {
-            ((RevitShaft)speckleOpening).topLevel = ConvertAndCacheLevel(revitOpening, BuiltInParameter.WALL_HEIGHT_TYPE);
-            ((RevitShaft)speckleOpening).bottomLevel = ConvertAndCacheLevel(revitOpening, BuiltInParameter.WALL_BASE_CONSTRAINT);
-            ((RevitShaft)speckleOpening).height = GetParamValue<double>(revitOpening, BuiltInParameter.WALL_USER_HEIGHT_PARAM);
+            ((RevitShaft)speckleOpening).topLevel =
+              ConvertAndCacheLevel(revitOpening, BuiltInParameter.WALL_HEIGHT_TYPE);
+            ((RevitShaft)speckleOpening).bottomLevel =
+              ConvertAndCacheLevel(revitOpening, BuiltInParameter.WALL_BASE_CONSTRAINT);
+            ((RevitShaft)speckleOpening).height =
+              GetParamValue<double>(revitOpening, BuiltInParameter.WALL_USER_HEIGHT_PARAM);
           }
         }
 
@@ -128,12 +164,14 @@ namespace Objects.Converter.Revit
             poly.segments.Add(CurveToSpeckle(curve));
           }
         }
+
         speckleOpening.outline = poly;
       }
 
       speckleOpening["type"] = revitOpening.Name;
 
-      GetAllRevitParamsAndIds(speckleOpening, revitOpening, new List<string> { "WALL_BASE_CONSTRAINT", "WALL_HEIGHT_TYPE", "WALL_USER_HEIGHT_PARAM" });
+      GetAllRevitParamsAndIds(speckleOpening, revitOpening,
+        new List<string> { "WALL_BASE_CONSTRAINT", "WALL_HEIGHT_TYPE", "WALL_USER_HEIGHT_PARAM" });
       Report.Log($"Converted Opening {revitOpening.Id}");
       return speckleOpening;
     }

--- a/Objects/Objects/BuiltElements/Opening.cs
+++ b/Objects/Objects/BuiltElements/Opening.cs
@@ -16,7 +16,7 @@ namespace Objects.BuiltElements
 
     public Opening() { }
 
-    //[SchemaInfo("Opening", "Creates a Speckle opening")]
+    [SchemaInfo("Arch Opening", "Creates a Speckle opening", "BIM", "Architecture")]
     public Opening(ICurve outline)
     {
       this.outline = outline;

--- a/Objects/Objects/BuiltElements/Opening.cs
+++ b/Objects/Objects/BuiltElements/Opening.cs
@@ -45,6 +45,13 @@ namespace Objects.BuiltElements.Revit
     public RevitWall host { get; set; }
 
     public RevitWallOpening() { }
+    
+    [SchemaInfo("Revit Wall Opening", "Creates a Speckle Wall opening for revit", "BIM", "Architecture")]
+    public RevitWallOpening(ICurve outline , RevitWall host = null)
+    {
+      this.outline = outline;
+      this.host = host;
+    }
   }
 
   public class RevitShaft : RevitOpening


### PR DESCRIPTION
## Description

- Fixes #970

## Type of change

- New feature (non-breaking change which adds functionality)

 ### Breakdown

Added new Schema nodes for `Opening` and `RevitWallOpening`.
Modified the wall opening conversions to throw better errors (it assumed curve was polyline, but that's not necessarily the case)
Improved edge-case where host element was set in the opening, but opening was not part of the wall's elements list.

If a RevitWallOpening is contained in the `elements` list of a wall **and** has it's host set to the wall, the converter will prioritize the parent (i.e.: the object owning the element list). Only when there is no set object we will  try to find the specified host in the document.

![2022-03-31 11 01 35](https://user-images.githubusercontent.com/2316535/161018633-ea68c8c6-ab2e-4382-929e-28f3a656690e.gif)

If the host is not found, the operation is aborted.

## How has this been tested?

- Manual Tests (please write what did you do?)

Manually sent/received walls with openings and openings alone.

## Docs

- Will be updated ASAP

