### PR TITLE
fix: Added missing CSI toggle in top-menu

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
@@ -162,7 +162,7 @@ namespace ConnectorGrasshopper
       var tabsMenu = speckleMenu.DropDown.Items.Add("Tabs") as ToolStripMenuItem;
       var warn = tabsMenu.DropDown.Items.Add("Changes require restarting Rhino to take effect.");
       warn.Enabled = false;
-      new List<string> { "BIM", "Revit", "Structural", "ETABS", "GSA", "Tekla" }.ForEach(s =>
+      new List<string> { "BIM", "Revit", "Structural", "ETABS", "GSA", "Tekla", "CSI" }.ForEach(s =>
          {
            var category = $"Speckle 2 {s}";
            var mi = tabsMenu.DropDown.Items.Add(category) as ToolStripMenuItem;


### PR DESCRIPTION
New CSI category was auto-generated without adding the new category on the disable tabs menu.

Just added the missing category to the list.

P.S.: I should talk to Jedd about best way's of automating this without much trouble.