### PR TITLE
GH: Fixes 1112

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExpandSpeckleObjectTaskComponent.cs
@@ -302,7 +302,7 @@ namespace ConnectorGrasshopper.Objects
             break;
           case IList list:
             var items = list as List<object>;
-            if( items.Where(l => l is IList).Any())
+            if(items != null && items.Where(l => l is IList).Any())
             {
               // Nested lists need to be converted into trees :)
               var treeBuilder = new TreeBuilder(Converter) { ConvertToNative = Converter != null };

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -433,7 +433,7 @@ namespace Objects.Converter.RhinoGh
         try
         {
           //let the converter pick the best type of curve
-          myPolyc.AppendSegment((RH.Curve)ConvertToNative((Base)segment));
+          myPolyc.Append((RH.Curve)ConvertToNative((Base)segment));
         }
         catch
         { }


### PR DESCRIPTION
## Description

- Fixes #1112

Polycurves from Revit where incorrectly rendered in Rhino due to revit outputing each curve in a different direction.

In Rhino, we were using `AppendSegment`, which does not check if the curve needs reversing when it's added.

We now use `Append`, which will check the curve for continuity and reverse it if necessary, producing a valid PolyCurve in Rhino

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

Tested with provided stream, and several manually generated polycurves in GH

## Docs

- No updates needed

