### PR TITLE
fix(rvt): FamilyInstances would be incorrectly placed with no error shown to the user

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -1,4 +1,5 @@
-﻿using Autodesk.Revit.DB;
+using System;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -102,6 +103,10 @@ namespace Objects.Converter.Revit
       catch { }
 
       SetInstanceParameters(familyInstance, speckleFi);
+      if (speckleFi.mirrored)
+      {
+        Report.ConversionErrors.Add(new Exception($"Element with id {familyInstance.Id} should be mirrored, but a Revit API limitation prevented us from doing so. (speckle object id: {speckleFi.id}"));
+      }
 
       var placeholders = new List<ApplicationPlaceholderObject>()
       {
@@ -117,9 +122,9 @@ namespace Objects.Converter.Revit
     }
 
     /// <summary>
-    /// Entry point for all revit family conversions. TODO: Check for Beams and Columns and any other "dedicated" speckle elements and convert them as such rather than to the generic "family instance" object.
+    /// Entry point for all revit family conversions.
     /// </summary>
-    /// <param name="myElement"></param>
+    /// <param name="revitFi"></param>
     /// <returns></returns>
     public Base FamilyInstanceToSpeckle(DB.FamilyInstance revitFi)
     {
@@ -177,6 +182,7 @@ namespace Objects.Converter.Revit
       speckleFi.facingFlipped = revitFi.FacingFlipped;
       speckleFi.handFlipped = revitFi.HandFlipped;
       speckleFi.level = lev1 != null ? lev1 : lev2;
+      speckleFi.mirrored = revitFi.Mirrored;
 
       if (revitFi.Location is LocationPoint)
       {

--- a/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
+++ b/Objects/Objects/BuiltElements/Revit/FamilyInstance.cs
@@ -19,6 +19,7 @@ namespace Objects.BuiltElements.Revit
     public double rotation { get; set; }
     public bool facingFlipped { get; set; }
     public bool handFlipped { get; set; }
+    public bool mirrored { get; set; }
     public Base parameters { get; set; }
     public string elementId { get; set; }
 
@@ -44,6 +45,7 @@ namespace Objects.BuiltElements.Revit
       this.rotation = rotation;
       this.facingFlipped = facingFlipped;
       this.handFlipped = handFlipped;
+      this.mirrored = false;
       this.parameters = parameters.ToBase();
     }
     


### PR DESCRIPTION
## Description

- Related to #1126

Displays an error when receiving a family instance that should be mirrored, as Revit has no easy way of doing so without having a duplicate object; and also does not provide an easy way to get the `id` of that newly duplicated object.

## Type of change

- New feature (non-breaking change which adds functionality)

Added new `mirrored` prop to the `FamilyInstance` class in `Objects`.
Added new error to report specifying which objects failed to be mirrored and why.

## How has this been tested?

- Manual Tests (please write what did you do?)

Sent and received mirrored family instances and made sure report was generated.

## Docs

- No updates needed

