### PR TITLE
fix(autocad): improves polycurve conversions

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -521,8 +521,36 @@ namespace Objects.Converter.AutocadCivil
 
       return (reverseDirection) ? segment.GetReverseParameterCurve() : segment;
     }
-    // polylines can only support curve segments of type circular arc. c
-    // currently, this will collapse 3d polycurves into 2d since there is no polycurve class that can contain 3d polylines with nonlinear segments
+    private bool IsPolycurvePlanar(Polycurve polycurve)
+    {
+      double? z = null;
+      foreach (var segment in polycurve.segments)
+      {
+        switch (segment)
+        {
+          case Line o:
+            if (z == null) z = o.start.z;
+            if (o.start.z != z || o.end.z != z) return false;
+            break;
+          case Arc o:
+            if (z == null) z = o.startPoint.z;
+            if (o.startPoint.z != z || o.midPoint.z != z || o.endPoint.z != z) return false;
+            break;
+          case Curve o:
+            if (z == null) z = o.points[2];
+            for (int i = 2; i < o.points.Count; i += 3)
+              if (o.points[i] != z) return false;
+            break;
+          case Spiral o:
+            if (z == null) z = o.startPoint.z;
+            if (o.startPoint.z != z || o.endPoint.z != z) return false;
+            break;
+        }
+      }
+      return true;
+    }
+
+    // polylines can only support curve segments of type circular arc.
     public AcadDB.Polyline PolycurveToNativeDB(Polycurve polycurve)
     {
       AcadDB.Polyline polyline = new AcadDB.Polyline() { Closed = polycurve.closed };
@@ -560,10 +588,6 @@ namespace Objects.Converter.AutocadCivil
           default:
             return null;
         }
-      }
-      for (int i = 0; i < polycurve.segments.Count; i++)
-      {
-        
       }
 
       return polyline;
@@ -666,20 +690,35 @@ namespace Objects.Converter.AutocadCivil
       return curve;
     }
     // handles polycurves with spline segments: bakes segments individually and then joins
-    // TODO: can use this for 3d polycurves with arc segments (needs an IsPlanar property)
-    public Spline PolycurveSplineToNativeDB(Polycurve polycurve)
+    public AcadDB.Curve PolycurveSplineToNativeDB(Polycurve polycurve)
     {
-      AcadDB.Curve firstSegment = CurveToNativeDB(polycurve.segments[0]);
-      List<AcadDB.Curve> otherSegments = new List<AcadDB.Curve>();
-      for (int i = 1; i < polycurve.segments.Count; i++)
+      BlockTableRecord modelSpaceRecord = Doc.Database.GetModelSpace();
+
+      Entity first = null;
+      List<Entity> others = new List<Entity>();
+      for (int i = 0; i < polycurve.segments.Count; i++)
       {
         var converted = CurveToNativeDB(polycurve.segments[i]);
         if (converted == null)
-          return null;
-        otherSegments.Add(converted);
+          continue;
+
+        var newEntity = Trans.GetObject(modelSpaceRecord.Append(converted), OpenMode.ForWrite) as Entity;
+        if (first == null)
+          first = newEntity;
+        else
+          others.Add(newEntity);
       }
-      firstSegment.JoinEntities(otherSegments.ToArray());
-      return firstSegment.Spline;
+
+      try
+      {
+        first.JoinEntities(others.ToArray());
+        return first as Spline;
+      }
+      catch (Exception e)
+      {
+        Report.ConversionLog.Add("Could not join Polycurve segments: segments converted individually.");
+        return null;
+      }
     }
 
     // Curve

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -327,11 +327,15 @@ public static string AutocadAppName = VersionedHostApplications.Autocad2022;
           break;
 
         case Polycurve o:
-          var splineSegments = o.segments.Where(s => s is Curve);
-          if (splineSegments.Count() > 0)
+          bool convertAsSpline = (o.segments.Where(s => !(s is Line) && !(s is Arc)).Count() > 0) ? true : false;
+          if (!convertAsSpline) convertAsSpline = IsPolycurvePlanar(o) ? false : true;
+          if (convertAsSpline)
           {
             acadObj = PolycurveSplineToNativeDB(o);
-            Report.Log($"Created Polycurve {o.id} as Spline");
+            if (acadObj == null)
+              Report.Log($"Created Polycurve {o.id} as individual segments");
+            else
+              Report.Log($"Created Polycurve {o.id} as Spline");
             break;
           }
           else


### PR DESCRIPTION
Previously, nonplanar polycurve with nonlinear segments were being squashed into planar curves. Now they are converted as splines, or individual segments if spline conversion fails.

## Description

- Fixes #701

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests 

## Docs

- No updates needed


