### PR TITLE
Fixed issue with MEP elements with null or unknown MEP systems

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -109,18 +109,20 @@ namespace Objects.Converter.Revit
         displayValue = GetElementMesh(revitDuct),
       };
 
-      var material = ConverterRevit.GetMEPSystemMaterial(revitDuct);
-      if (material != null)
+      if (revitDuct.MEPSystem != null)
       {
-        foreach (var mesh in speckleDuct.displayValue)
+        var material = ConverterRevit.GetMEPSystemMaterial(revitDuct);
+        if (material != null)
         {
-          mesh["renderMaterial"] = material;
+          foreach (var mesh in speckleDuct.displayValue)
+          {
+            mesh["renderMaterial"] = material;
+          }
         }
+
+        var typeElem = revitDuct.Document.GetElement(revitDuct.MEPSystem.GetTypeId());
+        speckleDuct.systemName = typeElem.Name;
       }
-
-      var typeElem = revitDuct.Document.GetElement(revitDuct.MEPSystem.GetTypeId());
-
-      speckleDuct.systemName = typeElem.Name;
 
       GetAllRevitParamsAndIds(speckleDuct, revitDuct,
         new List<string>
@@ -158,18 +160,21 @@ namespace Objects.Converter.Revit
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
         displayValue = GetElementMesh(revitDuct)
       };
-      
-      var material = ConverterRevit.GetMEPSystemMaterial(revitDuct);
-      if (material != null)
-      {
-        foreach (var mesh in speckleDuct.displayValue)
-        {
-          mesh["renderMaterial"] = material;
-        }
-      }
 
-      var typeElem = revitDuct.Document.GetElement(revitDuct.MEPSystem.GetTypeId());
-      speckleDuct.systemName = typeElem.Name;
+      if (revitDuct.MEPSystem != null)
+      {
+        var material = ConverterRevit.GetMEPSystemMaterial(revitDuct);
+        if (material != null)
+        {
+          foreach (var mesh in speckleDuct.displayValue)
+          {
+            mesh["renderMaterial"] = material;
+          }
+        }
+
+        var typeElem = revitDuct.Document.GetElement(revitDuct.MEPSystem.GetTypeId());
+        speckleDuct.systemName = typeElem.Name;
+      }
 
       GetAllRevitParamsAndIds(speckleDuct, revitDuct,
         new List<string>

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -108,7 +108,6 @@ namespace Objects.Converter.Revit
       };
 
       var material = ConverterRevit.GetMEPSystemMaterial(revitPipe);
-      
       if (material != null)
       {
         foreach (var mesh in specklePipe.displayValue)
@@ -153,6 +152,7 @@ namespace Objects.Converter.Revit
         displayValue = GetElementMesh(revitPipe)
       };
 
+      
       var material = ConverterRevit.GetMEPSystemMaterial(revitPipe);
       
       if (material != null)


### PR DESCRIPTION
## Description

- Fixed issue with MEP elements that do not have a system will fail to convert ToSpeckle.

## Type of change

- Bug fix (non-breaking)

## How has this been tested?

- Autodesk MEP sample file on Revit 2021. (which contains ducts with a null system)

## Docs

- No updates needed

