### PR TITLE
fix(core): catch failed deserialization 🙅‍♀️🥣

### DIFF
--- a/Core/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Core/Api/Operations/Operations.Receive.cs
@@ -109,10 +109,21 @@ namespace Speckle.Core.Api
         if (serializerVersion == SerializerVersion.V1)
           localRes = JsonConvert.DeserializeObject<Base>(objString, settings);
         else
-          localRes = serializerV2.Deserialize(objString);
+        {
+          try
+          {
+            localRes = serializerV2.Deserialize(objString);
+          }
+          catch ( Exception e )
+          {
+            if ( serializerV2.OnErrorAction == null ) throw;
+            serializerV2.OnErrorAction.Invoke($"A deserialization error has occurred: {e.Message}", e);
+            return null;
+          }
+        }
 
         if ((disposeTransports || !hasUserProvidedLocalTransport) && localTransport is IDisposable dispLocal) dispLocal.Dispose();
-        if (disposeTransports && remoteTransport != null && remoteTransport is IDisposable dispRempte) dispRempte.Dispose();
+        if (disposeTransports && remoteTransport != null && remoteTransport is IDisposable dispRemote) dispRemote.Dispose();
 
         return localRes;
       }
@@ -139,7 +150,18 @@ namespace Speckle.Core.Api
       if (serializerVersion == SerializerVersion.V1)
         res = JsonConvert.DeserializeObject<Base>(objString, settings);
       else
-        res = serializerV2.Deserialize(objString);
+      {
+        try
+        {
+          res = serializerV2.Deserialize(objString);
+        }
+        catch ( Exception e )
+        {
+          if ( serializerV2.OnErrorAction == null ) throw;
+          serializerV2.OnErrorAction.Invoke($"A deserialization error has occurred: {e.Message}", e);
+          return null;
+        }
+      }
 
       if ((disposeTransports || !hasUserProvidedLocalTransport) && localTransport is IDisposable dl) dl.Dispose();
       if (disposeTransports && remoteTransport is IDisposable dr) dr.Dispose();

--- a/Core/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Core/Api/Operations/Operations.Receive.cs
@@ -117,7 +117,8 @@ namespace Speckle.Core.Api
           catch ( Exception e )
           {
             if ( serializerV2.OnErrorAction == null ) throw;
-            serializerV2.OnErrorAction.Invoke($"A deserialization error has occurred: {e.Message}", e);
+            serializerV2.OnErrorAction.Invoke($"A deserialization error has occurred: {e.Message}", new SpeckleException(
+              $"A deserialization error has occurred: {e.Message}", e));
             return null;
           }
         }


### PR DESCRIPTION
closes DUI2: Type error on deserialisation crashes host application #1164

- catch in `Operations.Receive` and use `onErrorAction` if exists
- if there isn't an action, then we can throw the exception
- none of the connectors expect the deserialisation to throw an exception
and I don't wanna add a catch in each and every one of them
so this is the fix for now
- need to ping @teocomi re the logging bc it is super unhelpful atm
- i tried so long to get this to be handled within the deserialisation so that
you don't fail the whole receive, but it didn't work and i cba
and cristi agreed this is fine for now
- cristi want's to look @ why it's so slow for some reason

- this is the unhelpful logging i get; will fix when teo is free to chat
![image](https://user-images.githubusercontent.com/7717434/161785652-e64cfa31-97b2-4b29-87c7-8c2b9c5e8cfb.png)


## Description

- Fixes #1164

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests

## Docs

- No updates needed

