### PR TITLE
Rhino 7 will now output the correct PBR material properties

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -21,6 +21,7 @@ using Text = Objects.Other.Text;
 using RH = Rhino.DocObjects;
 using RenderMaterial = Objects.Other.RenderMaterial;
 using Rhino;
+using Rhino.Render;
 
 namespace Objects.Converter.RhinoGh
 {
@@ -66,36 +67,71 @@ namespace Objects.Converter.RhinoGh
         existing = Doc.RenderMaterials.FirstOrDefault(x => x.Name == speckleName);
       if (existing != null)
         return existing;
-      
+
+      Rhino.Render.RenderMaterial rm;
+//#if RHINO6
       var rhinoMaterial = new Material
       {
         Name = speckleName,
         DiffuseColor = Color.FromArgb(speckleMaterial.diffuse),
         EmissionColor = Color.FromArgb(speckleMaterial.emissive),
-        Transparency = 1 - speckleMaterial.opacity,
-        Reflectivity = speckleMaterial.metalness
+        Transparency = 1 - speckleMaterial.opacity
       };
+      rm = Rhino.Render.RenderMaterial.CreateBasicMaterial(rhinoMaterial, Doc);
+//#else
+      //TODO Convert materials as PhysicallyBasedMaterial 
+      // var pbrRenderMaterial = RenderContentType.NewContentFromTypeId(ContentUuids.PhysicallyBasedMaterialType, Doc) as Rhino.Render.RenderMaterial;
+      // RH.Material simulatedMaterial = pbrRenderMaterial.SimulatedMaterial(RenderTexture.TextureGeneration.Allow);
+      // RH.PhysicallyBasedMaterial pbr = simulatedMaterial.PhysicallyBased;
+      //
+      // pbr.BaseColor = ARBGToColor4f(speckleMaterial.diffuse);
+      // pbr.Emission = ARBGToColor4f(speckleMaterial.emissive);
+      // pbr.Opacity = speckleMaterial.opacity;
+      // pbr.Metallic = speckleMaterial.metalness;
+      // pbr.Roughness = speckleMaterial.roughness;
+      //
+      // rm = Rhino.Render.RenderMaterial.FromMaterial(pbr.Material, Doc);
+      // rm.Name = speckleName;
+//#endif
       
-      var renderMaterial = Rhino.Render.RenderMaterial.CreateBasicMaterial(rhinoMaterial, Doc);
-      Doc.RenderMaterials.Add(renderMaterial);
+      Doc.RenderMaterials.Add(rm);
 
-      return renderMaterial;
+      return rm;
     }
     public RenderMaterial RenderMaterialToSpeckle(Material material)
     {
       var renderMaterial = new RenderMaterial();
       if (material == null) return renderMaterial;
 
-      renderMaterial.name = (material.Name == null) ? "default" : material.Name; // default rhino material has no name or id
+      renderMaterial.name = material.Name ?? "default"; // default rhino material has no name or id
+#if RHINO6
+      
       renderMaterial.diffuse = material.DiffuseColor.ToArgb();
       renderMaterial.emissive = material.EmissionColor.ToArgb();
       renderMaterial.opacity = 1 - material.Transparency;
-      renderMaterial.metalness = material.Reflectivity;
-
+      
       // for some reason some default material transparency props are 1 when they shouldn't be - use this hack for now
       if ((renderMaterial.name.ToLower().Contains("glass") || renderMaterial.name.ToLower().Contains("gem")) && renderMaterial.opacity == 0)
         renderMaterial.opacity = 0.3;
-
+#else
+      Material matToUse = material;
+      if(!material.IsPhysicallyBased)
+      {
+        matToUse = new Material();
+        matToUse.CopyFrom(material);
+        matToUse.ToPhysicallyBased();
+      }
+      using (var rm = Rhino.Render.RenderMaterial.FromMaterial(matToUse, null))
+      {
+        RH.PhysicallyBasedMaterial pbrMaterial = rm.ConvertToPhysicallyBased(RenderTexture.TextureGeneration.Allow);
+        renderMaterial.diffuse = pbrMaterial.BaseColor.AsSystemColor().ToArgb();
+        renderMaterial.emissive = pbrMaterial.Emission.AsSystemColor().ToArgb();
+        renderMaterial.opacity = pbrMaterial.Opacity;
+        renderMaterial.metalness = pbrMaterial.Metallic;
+        renderMaterial.roughness = pbrMaterial.Roughness;
+      }
+#endif
+      
       return renderMaterial;
     }
 
@@ -362,6 +398,12 @@ namespace Objects.Converter.RhinoGh
         _text.TextVerticalAlignment = Enum.TryParse(text["verticalAlignment"] as string, out TextVerticalAlignment vertical) ? vertical : TextVerticalAlignment.Middle;
 
       return _text;
+    }
+
+    public Color4f ARBGToColor4f(int argb)
+    {
+      var systemColor = Color.FromArgb(argb);
+      return Color4f.FromArgb(systemColor.A, systemColor.R, systemColor.G, systemColor.B);
     }
   }
 }


### PR DESCRIPTION
## Description

This issue:
 - Rhino materials often don't follow a Physically Based shading workflow. And yet, materials have PBR like properties.
 - Previously, our ToSpeckle conversion was trying to use these properties, and also trying to fit them into our "metalic/roughness" workflow, which lead to some highly undesirable results (like "plaster" and "plastic" materials having a metalness of 100%)
- See https://speckle.community/t/speckle-2-4-0-connector-changes-enhanced-material-support/2442/9

The Fix:
- In Rhino 7, there are functions exposed for converting Rhino preset materials into Rhino PBR materials. This PR updates ToSpeckle conversion to use these. This also removes the need for the hacky opacity work around for glass/gem material (atleast, just for Rhino 7)
- For Rhino 6 API, these functions are not available, so the best we can do is just to ignore metalness and only convert base color, transparency, and emissivity. This will still be somewhat lossy.
- This solves the ToSpeckle part of https://github.com/specklesystems/speckle-sharp/issues/1145

What isn't fixed:
- For ToNative conversion, and `metalness`/`roughness` properties are ignored.
- For Rhino 7, we can in theory convert materials to `PhysicallBasedMaterial`s. I did have a quick go at implementing this, but unsuccessfully. Since this is lower priority, this will can be fixed later. (tracked in https://github.com/specklesystems/speckle-sharp/issues/1145)


### Screenshots!
Ground Truth (cycles)
![image](https://user-images.githubusercontent.com/45512892/161976183-88c1f3f6-ab99-4e48-bb2d-2c98faf79916.png)
![image](https://user-images.githubusercontent.com/45512892/161976804-82d5ca4b-7dea-4bc1-ac26-6a64403b55d6.png)

---

Before this PR:
![image](https://user-images.githubusercontent.com/45512892/161974166-b9e900c2-9db9-4dca-b434-9bb034824fa9.png)

---

After this PR:
![image](https://user-images.githubusercontent.com/45512892/161974223-908fa0ae-ef16-4919-aa67-ee5deb9b01d1.png)

## Type of change

- Bug fix - Fixed bad conversion logic of `metalness` property.
- New feature - (Rhino 7) added proper PBR ToSpeckle conversion logic.

## How has this been tested?

- Rhino 6 is untested (because, in theory the code is unchanged, and it builds fine)
- Rhino 7 has been tested with the Rhino test stream, PBR materials stream, and then sending a few random preset materials.

## Docs

- No updates needed
unless we want to mention Rhino 6's limitation?
