### PR TITLE
Revit: Fixed references to document field in ToSpeckle conversion functions

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
@@ -73,7 +73,7 @@ namespace Objects.Converter.Revit
     private AdaptiveComponent AdaptiveComponentToSpeckle(DB.FamilyInstance revitAc)
     {
       var speckleAc = new AdaptiveComponent();
-      speckleAc.family = Doc.GetElement(revitAc.GetTypeId()).Name;
+      speckleAc.family = revitAc.Document.GetElement(revitAc.GetTypeId()).Name;
       speckleAc.basePoints = GetAdaptivePoints(revitAc);
       speckleAc.flipped = AdaptiveComponentInstanceUtils.IsInstanceFlipped(revitAc);
       speckleAc.displayValue = GetElementMesh(revitAc);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
@@ -104,7 +104,7 @@ namespace Objects.Converter.Revit
         Report.Log($"Beam has no valid baseline, converting as generic element {revitBeam.Id}");
         return RevitElementToSpeckle(revitBeam);
       }
-      var symbol = Doc.GetElement(revitBeam.GetTypeId()) as FamilySymbol;
+      var symbol = revitBeam.Document.GetElement(revitBeam.GetTypeId()) as FamilySymbol;
 
       var speckleBeam = new RevitBeam();
       speckleBeam.family = symbol.FamilyName;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLevel.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLevel.cs
@@ -159,12 +159,12 @@ namespace Objects.Converter.Revit
         return null;
       }
 
-      return ConvertAndCacheLevel(param.AsElementId());
+      return ConvertAndCacheLevel(param.AsElementId(), elem.Document);
     }
 
-    private RevitLevel ConvertAndCacheLevel(ElementId id)
+    private RevitLevel ConvertAndCacheLevel(ElementId id, Document doc)
     {
-      var level = Doc.GetElement(id) as DB.Level;
+      var level = doc.GetElement(id) as DB.Level;
 
       if (level == null) return null;
       if (!Levels.ContainsKey(level.Name))

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLocation.cs
@@ -3,6 +3,7 @@ using Autodesk.Revit.DB.Structure;
 using Objects.BuiltElements;
 using Speckle.Core.Models;
 using System;
+using Objects.BuiltElements.Revit;
 using DB = Autodesk.Revit.DB;
 using Line = Objects.Geometry.Line;
 using Point = Objects.Geometry.Point;
@@ -14,7 +15,7 @@ namespace Objects.Converter.Revit
   {
     public Base LocationToSpeckle(DB.Element revitElement)
     {
-      if (revitElement is FamilyInstance familyInstance)
+      if (revitElement is DB.FamilyInstance familyInstance)
       {
         //vertical columns are point based, and the point does not reflect the actual vertical location
         if (Categories.columnCategories.Contains(familyInstance.Category) ||
@@ -60,7 +61,7 @@ namespace Objects.Converter.Revit
     /// </summary>
     /// <param name="loc"></param>
     /// <returns></returns>
-    private Base TryGetLocationAsCurve(FamilyInstance familyInstance)
+    private Base TryGetLocationAsCurve(DB.FamilyInstance familyInstance)
     {
       if (familyInstance.CanHaveAnalyticalModel())
       {
@@ -71,7 +72,14 @@ namespace Objects.Converter.Revit
           return CurveToSpeckle(analyticalModel.GetCurve()) as Base;
         }
       }
-      var point = PointToSpeckle((familyInstance.Location as LocationPoint).Point);
+
+      Point point = familyInstance.Location switch
+      {
+        LocationPoint p => PointToSpeckle(p.Point),
+        LocationCurve c => PointToSpeckle(c.Curve.GetEndPoint(0)),
+        _ => null,
+      };
+      
       try
       {
         //apply offset transform and create line

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -96,8 +96,8 @@ namespace Objects.Converter.Revit
       speckleSpace.name = revitSpace.Name;
       speckleSpace.number = revitSpace.Number;
       speckleSpace.basePoint = (Point)LocationToSpeckle(revitSpace);
-      speckleSpace.level = ConvertAndCacheLevel(revitSpace.LevelId);
-      speckleSpace.topLevel = ConvertAndCacheLevel(revitSpace.get_Parameter(BuiltInParameter.ROOM_UPPER_LEVEL).AsElementId());
+      speckleSpace.level = ConvertAndCacheLevel(revitSpace.LevelId, revitSpace.Document);
+      speckleSpace.topLevel = ConvertAndCacheLevel(revitSpace.get_Parameter(BuiltInParameter.ROOM_UPPER_LEVEL).AsElementId(), revitSpace.Document);
       speckleSpace.baseOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_LOWER_OFFSET);
       speckleSpace.topOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_UPPER_OFFSET);
       speckleSpace.outline = profiles[0];

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWire.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWire.cs
@@ -88,7 +88,7 @@ namespace Objects.Converter.Revit
         family = revitWire.get_Parameter(BuiltInParameter.ELEM_FAMILY_PARAM).AsValueString(),
         type = revitWire.get_Parameter(BuiltInParameter.ELEM_TYPE_PARAM).AsValueString(),
         wiringType = revitWire.get_Parameter(BuiltInParameter.RBS_ELEC_WIRE_TYPE).AsValueString(),
-        level = ConvertAndCacheLevel(revitWire.ReferenceLevel.Id)
+        level = ConvertAndCacheLevel(revitWire.ReferenceLevel.Id, revitWire.Document)
       };
 
       // construction geometry for creating the wire on receive (doesn't match geometry points 🙃)


### PR DESCRIPTION
- Fixes issue with sending linked document from Revit
- There were still a few places where we were using the main (current) document when converting elements ToSpeckle.
- For elements in linked documents, this was leading to a variety of null reference exceptions etc.

- Also fixed an issue with sending family Instances that use a `LocationCurve` instead of a `LocationPoint` 
