### PR TITLE
fix(rh-mac): Fix crash when baking layers

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -230,31 +230,37 @@ namespace SpeckleRhino
       // get commit layer name 
       var commitLayerName = DesktopUI2.Formatting.CommitInfo(state.CachedStream.name, state.BranchName, commit.id);
 
-      // give converter a way to access the base commit layer name
-      RhinoDoc.ActiveDoc.Notes += "%%%" + commitLayerName;
+      RhinoApp.InvokeOnUiThread((Action)delegate
+     {
+       // give converter a way to access the base commit layer name
+       RhinoDoc.ActiveDoc.Notes += "%%%" + commitLayerName;
 
-      // flatten the commit object to retrieve children objs
-      int count = 0;
-      var commitObjs = FlattenCommitObject(commitObject, converter, commitLayerName, state, ref count);
+       // flatten the commit object to retrieve children objs
+       int count = 0;
+       var commitObjs = FlattenCommitObject(commitObject, converter, commitLayerName, state, ref count);
 
-      if (progress.CancellationTokenSource.Token.IsCancellationRequested)
-        return null;
+       if (progress.CancellationTokenSource.Token.IsCancellationRequested)
+         return;
 
-      foreach (var commitObj in commitObjs)
-      {
-        var (obj, layerPath) = commitObj;
-        BakeObject(obj, layerPath, state, converter);
-        conversionProgressDict["Conversion"]++;
-        progress.Update(conversionProgressDict);
-      }
+       foreach (var commitObj in commitObjs)
+       {
+         var (obj, layerPath) = commitObj;
+         BakeObject(obj, layerPath, state, converter);
+         if (progress.CancellationTokenSource.Token.IsCancellationRequested)
+           return;
+         conversionProgressDict["Conversion"]++;
+         progress.Update(conversionProgressDict);
+       }
 
-      progress.Report.Merge(converter.Report);
-      Doc.Views.Redraw();
-      Doc.EndUndoRecord(undoRecord);
+       progress.Report.Merge(converter.Report);
+       Doc.Views.Redraw();
+       Doc.EndUndoRecord(undoRecord);
 
-      // undo notes edit
-      var segments = Doc.Notes.Split(new string[] { "%%%" }, StringSplitOptions.None).ToList();
-      Doc.Notes = segments[0];
+       // undo notes edit
+       var segments = Doc.Notes.Split(new string[] { "%%%" }, StringSplitOptions.None).ToList();
+       Doc.Notes = segments[0];
+     });
+
 
       if (progress.CancellationTokenSource.Token.IsCancellationRequested)
         return null;


### PR DESCRIPTION
Fixes Rhino crashing when baking multiple layers on Mac.

Bake objects call is now done on the UI thread.