### PR TITLE
Filter Deprecated members from GetMembers and GetMemberNames

### DIFF
--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
@@ -191,7 +191,11 @@ namespace Speckle.Core.Models
       var names = new List<string>();
       foreach (var kvp in properties) names.Add(kvp.Key);
 
-      var pinfos = GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.GetCustomAttribute(typeof(SchemaIgnore)) == null && x.Name != "Item");
+      var pinfos = GetType()
+        .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+        .Where(x => x.GetCustomAttribute(typeof(SchemaIgnore)) == null
+                    && x.GetCustomAttribute(typeof(ObsoleteAttribute)) == null
+                    && x.Name != "Item");
       foreach (var pinfo in pinfos) names.Add(pinfo.Name);
 
       return names;
@@ -205,7 +209,8 @@ namespace Speckle.Core.Models
     {
       //typed members
       var dic = new Dictionary<string, object>();
-      var pinfos = GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.GetCustomAttribute(typeof(SchemaIgnore)) == null && x.Name != "Item");
+      var pinfos = GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public)
+        .Where(x => x.GetCustomAttribute(typeof(SchemaIgnore)) == null && x.GetCustomAttribute(typeof(ObsoleteAttribute)) == null && x.Name != "Item");
       foreach (var pi in pinfos)
         dic.Add(pi.Name, pi.GetValue(this));
       //dynamic members

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -80,19 +80,56 @@ namespace Tests
     public void CanGetMemberNames()
     {
       var @base = new SampleObject();
+      @base["dynamicProp"] = 123;
       var names = @base.GetMemberNames();
-      Assert.False(names.Contains("IgnoredSchemaProp"));
+      var propName = "IgnoredSchemaProp";
+      Assert.False(names.Contains(propName));
       Assert.False(names.Contains("DeprecatedSchemaProp"));
     }
 
-    [Test]
+    [Test(Description = "Checks that no ignored or obsolete properties are returned")]
     public void CanGetMembers()
     {
       var @base = new SampleObject();
+      @base["dynamicProp"] = 123;
+
       var names = @base.GetMembers().Keys;
       Assert.False(names.Contains("IgnoredSchemaProp"));
       Assert.False(names.Contains("DeprecatedSchemaProp"));
     }
+    
+    [Test(Description = "Checks that no ignored or obsolete properties are returned")]
+    public void CanGetDynamicMembers()
+    {
+      var @base = new SampleObject();
+      @base["dynamicProp"] = null;
+
+      var names = @base.GetDynamicMemberNames();
+      Assert.True(names.Contains("dynamicProp"));
+      Assert.True(@base["dynamicProp"] == null);
+    }
+
+    [Test]
+    public void CanSetDynamicMembers()
+    {
+      var @base = new SampleObject();
+      var key = "dynamicProp";
+      var value = "something";
+      // Can create a new dynamic member
+      @base[key] = value;
+      Assert.True((string)@base[key] == value);
+      
+      // Can overwrite existing
+      value = "some other value";
+      @base[key] = value;
+      Assert.True((string)@base[key] == value);
+      
+      // Accepts null values
+      @base[key] = null;
+      Assert.True(@base[key] == null);
+    }
+    
+    
     public class SampleObject : Base
     {
       [Chunkable]
@@ -111,15 +148,15 @@ namespace Tests
       public string @crazyProp { get; set; }
 
       [SchemaIgnore]
-      public SampleProp IgnoredSchemaProp { get; set; }
+      public string IgnoredSchemaProp { get; set; }
 
       [Obsolete("Use attached prop")]
-      public SampleProp ObsoleteSchemaProp { get; set; }
+      public string ObsoleteSchemaProp { get; set; }
       
       public SampleObject() { }
     }
 
-    public class SampleProp: Base
+    public class SampleProp
     {
       public string name { get; set; }
     }

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Tests;
@@ -74,6 +76,23 @@ namespace Tests
       Assert.AreEqual(actualNum, num);
     }
 
+    [Test(Description = "Checks that no ignored or obsolete properties are returned")]
+    public void CanGetMemberNames()
+    {
+      var @base = new SampleObject();
+      var names = @base.GetMemberNames();
+      Assert.False(names.Contains("IgnoredSchemaProp"));
+      Assert.False(names.Contains("DeprecatedSchemaProp"));
+    }
+
+    [Test]
+    public void CanGetMembers()
+    {
+      var @base = new SampleObject();
+      var names = @base.GetMembers().Keys;
+      Assert.False(names.Contains("IgnoredSchemaProp"));
+      Assert.False(names.Contains("DeprecatedSchemaProp"));
+    }
     public class SampleObject : Base
     {
       [Chunkable]
@@ -91,10 +110,16 @@ namespace Tests
 
       public string @crazyProp { get; set; }
 
+      [SchemaIgnore]
+      public SampleProp IgnoredSchemaProp { get; set; }
+
+      [Obsolete("Use attached prop")]
+      public SampleProp ObsoleteSchemaProp { get; set; }
+      
       public SampleObject() { }
     }
 
-    public class SampleProp
+    public class SampleProp: Base
     {
       public string name { get; set; }
     }

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -28,7 +28,7 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<Surface> Surfaces { get; set; }
-    [DetachProperty]
+    [DetachProperty, SchemaIgnore]
     [Chunkable(31250)]
     public List<double> SurfacesValue
     {
@@ -66,7 +66,7 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<ICurve> Curve3D { get; set; }
-    [DetachProperty]
+    [DetachProperty, SchemaIgnore]
     [Chunkable(31250)]
     public List<double> Curve3DValues
     {
@@ -86,7 +86,7 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<ICurve> Curve2D { get; set; }
-    [DetachProperty]
+    [DetachProperty, SchemaIgnore]
     [Chunkable(31250)]
     public List<double> Curve2DValues
     {
@@ -106,7 +106,7 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<Point> Vertices { get; set; }
-    [DetachProperty]
+    [DetachProperty, SchemaIgnore]
     [Chunkable(31250)]
     public List<double> VerticesValue
     {
@@ -152,7 +152,7 @@ namespace Objects.Geometry
     /// </summary>
     [JsonIgnore]
     public List<BrepTrim> Trims { get; set; }
-    [DetachProperty]
+    [DetachProperty, SchemaIgnore]
     [Chunkable(62500)]
     public List<int> TrimsValue
     {


### PR DESCRIPTION
## Description

- Fixes #1223

Added some `SchemaIgnore` attributes in the Brep class to hide unnecessary value lists.

`DynamicBase.GetMembers` and `DynamicBase.GetMemberNames` will no longer return properties flagged as `Deprecated`. This was introduced recently on our object model for `displayMesh` properties, but will be used in the future for other fields.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

- Tests not required
- Unit/Integration Tests (which?)
- Manual Tests (please write what did you do?)

## Docs

- No updates needed
- Have already been updated
- Will be updated ASAP

