### PR TITLE
fix(rhino/acad): sends saved selection objs from manual filter

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -677,7 +677,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
       switch (filter.Slug)
       {
         case "manual":
-          return GetSelectedObjects();
+          return filter.Selection;
         case "all":
           return Doc.ConvertibleObjects(converter);
         case "layer":

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -729,7 +729,7 @@ namespace SpeckleRhino
       switch (filter.Slug)
       {
         case "manual":
-          return GetSelectedObjects();
+          return filter.Selection;
         case "all":
           objs = Doc.Objects.Where(obj => obj.Visible).Select(obj => obj.Id.ToString()).ToList();
           objs.AddRange(Doc.NamedViews.Select(o => o.Name).ToList());


### PR DESCRIPTION
## Description

Changed sending with the manual selection filter to send the saved selection instead of currently selected objs

- Fixes #1238

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests 

## Docs

- No updates needed

