### PR TITLE
fix(rh): changes behaviour of objects to inherit color from material.

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -398,11 +398,7 @@ namespace SpeckleRhino
         }
         else if (obj[@"renderMaterial"] is Base renderMaterial)
         {
-          if (renderMaterial["diffuse"] is int color)
-          {
-            attributes.ColorSource = ObjectColorSource.ColorFromObject;
-            attributes.ObjectColor = Color.FromArgb(color);
-          }
+          attributes.ColorSource = ObjectColorSource.ColorFromMaterial;
         }
 
         // assign layer


### PR DESCRIPTION
## Description

- Fixes #1250 

We now deal with object color using Rhino's `ObjectColorByMaterial` default, preventing the case were the alpha channel of a color would be used as the display color of an object, causing it to be invisible on non-render visualisation nodes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)
Reviewed live with @clairekuang and @JR-Morgan 

## Docs

- No updates needed

