### PR TITLE
Nugets: Fixes Rhino7 and Grasshopper 7 publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,7 @@ commands:
           command: |
             $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "a/0.0.$($env:CIRCLE_BUILD_NUM)-beta" } else { $env:CIRCLE_TAG }
             $version = $tag.Split("/")[1]  
-            dotnet pack -c Release /p:Version="$version" -o $HOME/output <<parameters.projectfilepath>> 
-            cd $HOME/output
+            msbuild <<parameters.projectfilepath>> /p:Version="$version" /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false -t:pack
             dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
 
 # Parameters of our pipeline. Most of them are booleans that indicate which project to build/test with the pattern 'run_{PROJECT_NAME}'

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2021/ConverterAutocad2021.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2021/ConverterAutocad2021.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -20,8 +20,12 @@
     <Copyright>Copyright (c) AEC Systems Ltd</Copyright>
   </PropertyGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
   <ItemGroup>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocad2022/ConverterAutocad2022.csproj
@@ -40,8 +40,12 @@
     </None>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
@@ -25,8 +25,12 @@
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
   <ItemGroup>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -21,8 +21,12 @@
   </PropertyGroup>
 
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
   <ItemGroup>

--- a/Objects/Converters/ConverterCSI/ConverterCSIBridge/ConverterCSIBridge.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterCSIBridge/ConverterCSIBridge.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -33,8 +33,12 @@
 
   <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared" />
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterCSI/ConverterETABS/ConverterETABS.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterETABS/ConverterETABS.csproj
@@ -32,8 +32,12 @@
 
   <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared" />
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterCSI/ConverterSAFE/ConverterSAFE.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterSAFE/ConverterSAFE.csproj
@@ -32,8 +32,12 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterCSI/ConverterSAP2000/ConverterSAP2000.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterSAP2000/ConverterSAP2000.csproj
@@ -32,8 +32,12 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterMicroStation/ConverterMicroStation/ConverterMicroStation.csproj
+++ b/Objects/Converters/ConverterMicroStation/ConverterMicroStation/ConverterMicroStation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -21,8 +21,12 @@
     <DefineConstants>TRACE;MICROSTATION</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
   <ItemGroup>

--- a/Objects/Converters/ConverterMicroStation/ConverterOpenBuildings/ConverterOpenBuildings.csproj
+++ b/Objects/Converters/ConverterMicroStation/ConverterOpenBuildings/ConverterOpenBuildings.csproj
@@ -30,8 +30,12 @@
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterMicroStation/ConverterOpenRail/ConverterOpenRail.csproj
+++ b/Objects/Converters/ConverterMicroStation/ConverterOpenRail/ConverterOpenRail.csproj
@@ -30,8 +30,12 @@
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterMicroStation/ConverterOpenRoads/ConverterOpenRoads.csproj
+++ b/Objects/Converters/ConverterMicroStation/ConverterOpenRoads/ConverterOpenRoads.csproj
@@ -30,8 +30,12 @@
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/ConverterGrasshopper6.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/ConverterGrasshopper6.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Objects.Converter.Grasshopper6</AssemblyName>
-        <RootNamespace>Objects.Converter.Grasshopper</RootNamespace>
+        <RootNamespace>Objects.Converter.Rhino</RootNamespace>
         <PackageId>Speckle.Objects.Converter.Grasshopper6</PackageId>
         <Version>2.1.0</Version>
         <Authors>Speckle</Authors>
@@ -29,10 +29,6 @@
         <None Include="..\..\..\..\logo.png" Link="logo.png">
             <PackagePath></PackagePath>
             <Pack>True</Pack>
-        </None>
-        <None Include="..\..\..\logo.png">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
         </None>
     </ItemGroup>
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
@@ -3,10 +3,10 @@
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
         <Version>2.1.0</Version>
-        <Title>Objects.Converter.GrasshopperRhino7</Title>
+        <Title>Objects.Converter.Grasshopper7</Title>
         <Description></Description>
         <TargetExt>.dll</TargetExt>
-        <PackageId>Speckle.Objects.Converter.Rhino7</PackageId>
+        <PackageId>Speckle.Objects.Converter.Grasshopper7</PackageId>
         <Authors>Speckle</Authors>
         <Company />
         <Product />
@@ -18,7 +18,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>speckle objects converter rhino grasshopper gh</PackageTags>
         <AssemblyName>Objects.Converter.Grasshopper7</AssemblyName>
-        <RootNamespace>Objects.Converter.Grasshopper7</RootNamespace>
+        <RootNamespace>Objects.Converter.Rhino</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
@@ -34,9 +34,20 @@
         <PackageReference Include="RhinoCommon" Version="7.4.21078.1001" IncludeAssets="compile;build" />
     </ItemGroup>
 
+
+    <PropertyGroup>
+        <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
+        <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
+        <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    </PropertyGroup>
+    
     <ItemGroup>
-        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
-        <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj">
+            <ExcludeAssets>runtime</ExcludeAssets>
+        </ProjectReference>
+        <ProjectReference Include="..\..\..\Objects\Objects.csproj">
+            <ExcludeAssets>runtime</ExcludeAssets>
+        </ProjectReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhino6/ConverterRhino6.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhino6/ConverterRhino6.csproj
@@ -30,10 +30,6 @@
       <PackagePath></PackagePath>
       <Pack>True</Pack>
     </None>
-    <None Include="..\..\..\logo.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhino7/ConverterRhino7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhino7/ConverterRhino7.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <Version>2.1.0</Version>
-    <Title>Objects.Converter.RhinoGh7</Title>
+    <Title>Objects.Converter.Rhino7</Title>
     <Description></Description>
     <TargetExt>.dll</TargetExt>
     <PackageId>Speckle.Objects.Converter.Rhino7</PackageId>
@@ -16,7 +16,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/specklesystems/speckle-sharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>speckle objects converter rhino grasshopper gh</PackageTags>
+    <PackageTags>speckle objects converter rhino</PackageTags>
     <AssemblyName>Objects.Converter.Rhino7</AssemblyName>
     <RootNamespace>Objects.Converter.Rhino</RootNamespace>
   </PropertyGroup>
@@ -34,9 +34,19 @@
     <PackageReference Include="RhinoCommon" Version="7.4.21078.1001" IncludeAssets="compile;build" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
+    <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
+    <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+  </PropertyGroup>
+  
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
-    <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Objects\Objects.csproj">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructures2020/ConverterTeklaStructures2020.csproj
+++ b/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructures2020/ConverterTeklaStructures2020.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -31,8 +31,12 @@
 
   <Import Project="..\ConverterTeklaStructuresShared\ConverterTeklaStructuresShared.projitems" Label="Shared" />
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
 </Project>

--- a/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructures2021/ConverterTeklaStructures2021.csproj
+++ b/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructures2021/ConverterTeklaStructures2021.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,8 +14,12 @@
     <DefineConstants>TeklaStructures2021</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+  <PropertyGroup>
+    <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

- Fixes #1258 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Modified the project and the build step so that it would play nicely with netstandard and netframework projects (Grasshopper and Rhino 7 require `net48`) to compile, which  is why it broke the nuget publish in the first place.

Our `dotnet pack` step was not compatible with `net48`, so we've switched to msbuild  with packing flags.

## How has this been tested?

- Manual Tests (please write what did you do?)

Ran an alpha version and it went smoothly (including using the nugets)

## Docs

- No updates needed

