### PR TITLE
RVT: Improved polyline conversions

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -995,17 +995,27 @@ namespace Objects.Converter.Revit
     
     
     /// <summary>
-    /// Checks if a Speckle Line is too sort to be created in Revit.
-    /// The length of the line
+    /// Checks if a Speckle <see cref="Line"/> is too sort to be created in Revit.
     /// </summary>
-    /// <param name="line"></param>
-    /// <returns></returns>
+    /// <remarks>
+    /// The length of the line will be computed on the spot to ensure it is accurate.
+    /// </remarks>
+    /// <param name="line">The <see cref="Line"/> to be tested.</param>
+    /// <returns>true if the line is too short, false otherwise.</returns>
     public bool IsLineTooShort(Line line)
     {
       var scaleToNative = ScaleToNative(Point.Distance(line.start,line.end), line.units);
       return scaleToNative < Doc.Application.ShortCurveTolerance;
     }
 
+    /// <summary>
+    /// Attempts to append a Speckle <see cref="Line"/> onto a Revit <see cref="CurveArray"/>.
+    /// This method ensures the line is long enough to be supported.
+    /// It will also convert the line to Revit before appending it to the <see cref="CurveArray"/>.
+    /// </summary>
+    /// <param name="curveArray">The revit <see cref="CurveArray"/> to add the line to.</param>
+    /// <param name="line">The <see cref="Line"/> to be added.</param>
+    /// <returns>True if the line was added, false otherwise.</returns>
     public bool TryAppendLineSafely(CurveArray curveArray, Line line)
     {
       if (IsLineTooShort(line))

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -13,7 +13,9 @@ using DB = Autodesk.Revit.DB;
 using ElementType = Autodesk.Revit.DB.ElementType;
 using Floor = Objects.BuiltElements.Floor;
 using Level = Objects.BuiltElements.Level;
+using Line = Objects.Geometry.Line;
 using Parameter = Objects.BuiltElements.Revit.Parameter;
+using Point = Objects.Geometry.Point;
 
 namespace Objects.Converter.Revit
 {
@@ -990,5 +992,38 @@ namespace Objects.Converter.Revit
     }
 
     #endregion
+    
+    
+    /// <summary>
+    /// Checks if a Speckle Line is too sort to be created in Revit.
+    /// The length of the line
+    /// </summary>
+    /// <param name="line"></param>
+    /// <returns></returns>
+    public bool IsLineTooShort(Line line)
+    {
+      var scaleToNative = ScaleToNative(Point.Distance(line.start,line.end), line.units);
+      return scaleToNative < Doc.Application.ShortCurveTolerance;
+    }
+
+    public bool TryAppendLineSafely(CurveArray curveArray, Line line)
+    {
+      if (IsLineTooShort(line))
+      {
+        Report.Log("Some lines in the CurveArray where ignored due to being smaller than the allowed curve length.");
+        return false;
+      }
+      try
+      {
+        curveArray.Append(LineToNative(line));
+        return true;
+      }
+      catch (Exception e)
+      {
+        Report.LogConversionError(e);
+        return false;
+      }
+    }
+
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
@@ -124,8 +124,11 @@ namespace Objects.Converter.Revit
           Report.LogConversionError(e); return null;
         }
         // use display value if curve fails (prob a closed, periodic curve or a non-planar nurbs)
-        return ModelCurvesFromEnumerator(CurveToNative(((Geometry.Curve)speckleLine).displayValue).GetEnumerator(),
-          speckleLine);
+        if (speckleLine is IDisplayValue<Geometry.Polyline> d)
+          return ModelCurvesFromEnumerator(CurveToNative(d.displayValue).GetEnumerator(),
+            speckleLine);
+        else
+          return new List<ApplicationPlaceholderObject>();
       }
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -462,11 +462,12 @@ namespace Objects.Converter.Revit
 
     /// <summary>
     /// Converts a Speckle <see cref="Polyline"/> into a <see cref="CurveArray"/>.
-    /// 
+    /// </summary>
+    /// <remarks>
     /// This method will ensure that no lines smaller than the allowed length are created.
     /// If small segments are encountered, the geometry will be modified to ensure all segments have minimum length and remain connected.
     /// This will result in some vertices being ignored during conversion, which are logged in the report.
-    /// </summary>
+    /// </remarks>
     /// <param name="polyline">The Speckle <see cref="Polyline"/> to convert to Revit</param>
     /// <returns>A Revit <see cref="CurveArray"/></returns>
     public CurveArray PolylineToNative(Polyline polyline)

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -59,6 +59,7 @@ namespace Objects.Geometry
     {
       this.start = start;
       this.end = end;
+      this.length = Point.Distance(start, end);
       this.applicationId = applicationId;
       this.units = units;
     }
@@ -69,6 +70,7 @@ namespace Objects.Geometry
         throw new SpeckleException("Line from coordinate array requires 6 coordinates.");
       this.start = new Point(coordinates[0], coordinates[1], coordinates[2], units, applicationId);
       this.end = new Point(coordinates[3], coordinates[4], coordinates[5], units, applicationId);
+      this.length = Point.Distance(start, end);
       this.applicationId = applicationId;
       this.units = units;
     }


### PR DESCRIPTION
## Description

- Fixes issue in Revit where Polyline's with very short segments would completely fail to convert.
- Fixes an issue were we were assuming a `Curve` in a cast, but should have been an `IDisplayable<Polyline>` instead.
- Adds length calculation to `Line` class constructor. This is used during polyline creation to ensure no short segments are converted to Revit.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

Original offending commit: https://speckle.xyz/streams/35cc66339a/commits/cb564be587

## Docs

- No updates needed
