### PR TITLE
fix(revit): duct internal dimensions from imperial units

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -77,9 +77,7 @@ namespace Objects.Converter.Revit
         TrySetParam(duct, BuiltInParameter.RBS_CURVE_DIAMETER_PARAM, speckleRevitDuct.diameter, speckleRevitDuct.units);
         TrySetParam(duct, BuiltInParameter.CURVE_ELEM_LENGTH, speckleRevitDuct.length, speckleRevitDuct.units);
         TrySetParam(duct, BuiltInParameter.RBS_VELOCITY, speckleRevitDuct.velocity, speckleRevitDuct.units);
-
-
-
+        
         SetInstanceParameters(duct, speckleRevitDuct);
       }
 
@@ -106,9 +104,9 @@ namespace Objects.Converter.Revit
         family = revitDuct.DuctType.FamilyName,
         type = revitDuct.DuctType.Name,
         baseCurve = baseLine,
-        diameter = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_DIAMETER_PARAM),
-        height = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_HEIGHT_PARAM),
-        width = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_WIDTH_PARAM),
+        diameter = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_DIAMETER_PARAM, unitsOverride: ModelUnits),
+        height = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_HEIGHT_PARAM, unitsOverride: ModelUnits),
+        width = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_WIDTH_PARAM, unitsOverride: ModelUnits),
         length = GetParamValue<double>(revitDuct, BuiltInParameter.CURVE_ELEM_LENGTH),
         velocity = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_VELOCITY),
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
@@ -156,9 +154,9 @@ namespace Objects.Converter.Revit
         family = revitDuct.FlexDuctType.FamilyName,
         type = revitDuct.FlexDuctType.Name,
         baseCurve = polyline,
-        diameter = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_DIAMETER_PARAM),
-        height = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_HEIGHT_PARAM),
-        width = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_WIDTH_PARAM),
+        diameter = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_DIAMETER_PARAM, unitsOverride: ModelUnits),
+        height = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_HEIGHT_PARAM, unitsOverride: ModelUnits),
+        width = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_CURVE_WIDTH_PARAM, unitsOverride: ModelUnits),
         length = GetParamValue<double>(revitDuct, BuiltInParameter.CURVE_ELEM_LENGTH),
         startTangent = VectorToSpeckle(revitDuct.StartTangent),
         endTangent = VectorToSpeckle(revitDuct.EndTangent),

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -39,9 +39,9 @@ namespace Objects.Converter.Revit
       return UnitUtils.ConvertToInternalUnits(value, new ForgeTypeId(UnitsToNative(units)));
     }
 
-    public double ScaleToSpeckle(double value)
+    public double ScaleToSpeckle(double value, string units = null)
     {
-      return UnitUtils.ConvertFromInternalUnits(value, RevitLengthTypeId);
+      return UnitUtils.ConvertFromInternalUnits(value, units == null ? RevitLengthTypeId : new ForgeTypeId(UnitsToNative(units)));
     }
 
     //new units api introduced in 2021, bleah
@@ -140,9 +140,9 @@ namespace Objects.Converter.Revit
     /// <param name="value"></param>
     /// <param name="units"></param>
     /// <returns></returns>
-    public double ScaleToSpeckle(double value)
+    public double ScaleToSpeckle(double value, string units = null)
     {
-      return UnitUtils.ConvertFromInternalUnits(value, RevitLengthTypeId);
+      return UnitUtils.ConvertFromInternalUnits(value, units == null ? RevitLengthTypeId : UnitsToNative(units));
     }
 
     private string UnitsToSpeckle(DisplayUnitType type)


### PR DESCRIPTION
## Description

Adds an optional `units` param to `ScaleToSpeckle` in order to allow for particular unit conversions when necessary.

Uses this in the `GetParamValue` and `ParameterToSpeckle` when needing to override the display units in order to get the value in model units.

in imperial, internal duct dimensions such as height, width, diameter are in inches while the model units are in feet.
this meant that eg 12 was set as the diameter for a duct which would be received as 12 feet instead of 12 inches.
as far as i can tell, this only affects mechanical. however keep an eye out for other possible scenarios like this where we are setting the value of a parameter to the actual speckle object

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests with the built elements test file

## Docs

- No updates needed


