### PR TITLE
RH: Adds faster mesh extraction when available

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -532,7 +532,6 @@ namespace Objects.Converter.RhinoGh
       var tolerance = 0.0;
 
       curve.ToPolyline(0, 1, 0, 0, 0, 0.1, 0, 0, true).TryGetPolyline(out var poly);
-
       Polyline displayValue;
 
       if (poly.Count == 2)
@@ -805,30 +804,37 @@ namespace Objects.Converter.RhinoGh
     /// </summary>
     /// <param name="brep">BREP to be converted.</param>
     /// <returns></returns>
-    public Brep BrepToSpeckle(RH.Brep brep, string units = null)
+    public Brep BrepToSpeckle(RH.Brep brep, string units = null, RH.Mesh previewMesh = null)
     {
       var tol = Doc.ModelAbsoluteTolerance;
       //tol = 0;
       var u = units ?? ModelUnits;
-      brep.Repair(tol); //should maybe use ModelAbsoluteTolerance ?
+      brep.Repair(tol);
       // foreach (var f in brep.Faces)
       // {
       //   f.RebuildEdges(tol, false, false);
       // }
       // Create complex
       var joinedMesh = new RH.Mesh();
-      var mySettings = MeshingParameters.Default;
-      switch (SelectedMeshSettings)
+      if (previewMesh == null)
       {
-        case MeshSettings.Default:
-          mySettings = new MeshingParameters(0.05, 0.05);
-          break;
-        case MeshSettings.CurrentDoc:
-          mySettings = MeshingParameters.DocumentCurrentSetting(Doc);
-          break;
+        var mySettings = MeshingParameters.Default;
+        switch (SelectedMeshSettings)
+        {
+          case MeshSettings.Default:
+            mySettings = new MeshingParameters(0.05, 0.05);
+            break;
+          case MeshSettings.CurrentDoc:
+            mySettings = MeshingParameters.DocumentCurrentSetting(Doc);
+            break;
+        }
+        joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
+        joinedMesh.Weld(Math.PI);
       }
-      joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
-      joinedMesh.Weld(Math.PI);
+      else
+      {
+        joinedMesh = previewMesh;
+      }
 
       var spcklBrep = new Brep(displayValue: MeshToSpeckle(joinedMesh, u), provenance: RhinoAppName, units: u);
 
@@ -1002,7 +1008,7 @@ namespace Objects.Converter.RhinoGh
             rhTrim.SetTolerances(tol, tol);
           });
         });
-
+        
         newBrep.Repair(tol);
 
         return newBrep;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -640,7 +640,7 @@ namespace Objects.Converter.RhinoGh
 
       var speckleMesh = new Mesh(verts, faces, colors, textureCoordinates, u)
       {
-        volume = mesh.Volume(),
+        volume = mesh.IsClosed ? mesh.Volume() : 0,
         bbox = BoxToSpeckle(new RH.Box(mesh.GetBoundingBox(true)), u)
       };
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -129,7 +129,9 @@ namespace Objects.Converter.RhinoGh
         if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
           schema = ConvertToSpeckleBE(ro) ?? ConvertToSpeckleStr(ro);
         
-        if(ro is BrepObject)
+        // Fast way to get the displayMesh, try to get the mesh rhino shows on the viewport when available.
+        // This will only return a mesh if the object has been displayed in any mode other than Wireframe.
+        if(ro is BrepObject || ro is ExtrusionObject)
           displayMesh = GetRhinoRenderMesh(ro);
         
         if (!(@object is InstanceObject)) // block instance check

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -128,11 +128,14 @@ namespace Objects.Converter.RhinoGh
 
         if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
           schema = ConvertToSpeckleBE(ro) ?? ConvertToSpeckleStr(ro);
-
+        
+        if(ro is BrepObject)
+          displayMesh = GetRhinoRenderMesh(ro);
+        
         if (!(@object is InstanceObject)) // block instance check
           @object = ro.Geometry;
         
-        displayMesh = GetRhinoRenderMesh(ro);
+
       }
 
       switch (@object)


### PR DESCRIPTION
## Description

Improves conversion `ToNative` of `Brep` geometries by attempting to extract the RenderMesh from Rhino if available.

This step is restricted to only the RhinoObjects that are `BrepObject`, in order to only call this when needed.

The render mesh may not be found (Rhino only calculates the ones it needs, i.e. the ones you've seen or are seeing on a viewport in the current session), in this case we will default to the behaviour we were having already.

This can lead to around 30% reduction in conversion time when Breps are complex.

## Type of change

- New feature (non-breaking change which adds functionality)

Not really a new feature, rather a small improvement.

## How has this been tested?

- Manual Tests (please write what did you do?)

Tested with the exploded cathedral and the motor model we have in Drive. Both seemed to be faster in general

## Docs

- Will be updated ASAP

