### PR TITLE
fix(gh): Fixes #1319

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -142,7 +142,9 @@ namespace ConnectorGrasshopper.Extras
     public static bool CanConvertToDataTree(Base @base)
     {
       var regex = new Regex(dataTreePathPattern);
-      var isDataTree = @base.GetDynamicMembers().All(el => regex.Match(el).Success);
+      var dynamicMembers = @base.GetDynamicMembers().ToList();
+      if (dynamicMembers.Count == 0) return false;
+      var isDataTree = dynamicMembers.All(el => regex.Match(el).Success);
       return isDataTree;
     }
     

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/DeconstructSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/DeconstructSpeckleObjectTaskComponent.cs
@@ -377,7 +377,7 @@ namespace ConnectorGrasshopper.Objects
             }
             else
             {
-              outputDict[prop.Key] = Utilities.TryConvertItemToNative(obj[prop.Key], Converter);
+              outputDict[prop.Key] = Utilities.TryConvertItemToNative(temp, Converter);
             }
             break;
         }


### PR DESCRIPTION
## Description

- Fixes #1319

IsDataTree check was assuming an object with 0 dynamic props was a DataTree, when it obviously is not.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

- Manual Tests (please write what did you do?)

Reproduced error consistently, found root cause and unable to repro after fix.

## Docs

- No updates needed

