### PR TITLE
fix(autocad): dynamic block visibility state value not always string

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -408,7 +408,7 @@ namespace Objects.Converter.AutocadCivil
         }
 
         foreach (DynamicBlockReferenceProperty prop in reference.DynamicBlockReferencePropertyCollection)
-          curVisibilityName = (string)prop.Value;
+          curVisibilityName = prop.Value is double o ? o.ToString() : (string)prop.Value;
         if (!string.IsNullOrEmpty(curVisibilityName)) fullName = $"{fullName}_{curVisibilityName}";
       }
 


### PR DESCRIPTION
## Description

- Fixes #1318 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests 

## Docs

- No updates needed

