### PR TITLE
fix(gh): Handle renderMaterial in breps, with Solid and Mesh output handled

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -5,6 +5,8 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Objects.BuiltElements.Revit;
+using Objects.Other;
 using DB = Autodesk.Revit.DB;
 using DirectShape = Objects.BuiltElements.Revit.DirectShape;
 using Mesh = Objects.Geometry.Mesh;
@@ -42,7 +44,7 @@ namespace Objects.Converter.Revit
             }
             catch (Exception e)
             {
-              var mesh = brep.displayValue.SelectMany(m => MeshToNative(m));
+              var mesh = brep.displayValue.SelectMany(m => MeshToNative(m, parentMaterial: brep["renderMaterial"] as RenderMaterial));
               converted.AddRange(mesh);
             }
             break;
@@ -90,7 +92,7 @@ namespace Objects.Converter.Revit
       {
         Doc.Delete(docObj.Id);
       }
-
+      
       var catId = Doc.Settings.Categories.get_Item(cat).Id;
       var revitDs = DB.DirectShape.CreateElement(Doc, catId);
       revitDs.ApplicationId = brep.applicationId;
@@ -106,7 +108,7 @@ namespace Objects.Converter.Revit
       catch (Exception e)
       {
         Report.LogConversionError(new Exception(e.Message));
-        var mesh = brep.displayValue.SelectMany(m => MeshToNative(m));
+        var mesh = brep.displayValue.SelectMany(m => MeshToNative(m, parentMaterial: brep["renderMaterial"] as RenderMaterial));
         revitDs.SetShape(mesh.ToArray());
       }
       Report.Log($"Converted DirectShape {revitDs.Id}");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -582,7 +582,7 @@ namespace Objects.Converter.Revit
 
     // Insipred by
     // https://github.com/DynamoDS/DynamoRevit/blob/master/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
-    public IList<GeometryObject> MeshToNative(Mesh mesh, TessellatedShapeBuilderTarget target = TessellatedShapeBuilderTarget.Mesh, TessellatedShapeBuilderFallback fallback = TessellatedShapeBuilderFallback.Salvage)
+    public IList<GeometryObject> MeshToNative(Mesh mesh, TessellatedShapeBuilderTarget target = TessellatedShapeBuilderTarget.Mesh, TessellatedShapeBuilderFallback fallback = TessellatedShapeBuilderFallback.Salvage, RenderMaterial parentMaterial = null)
     {
       var tsb = new TessellatedShapeBuilder() { Fallback = fallback, Target = target, GraphicsStyleId = ElementId.InvalidElementId };
 
@@ -591,8 +591,8 @@ namespace Objects.Converter.Revit
 
       var vertices = ArrayToPoints(mesh.vertices, mesh.units);
 
-      ElementId materialId = RenderMaterialToNative(mesh["renderMaterial"] as RenderMaterial);
-
+      ElementId materialId = RenderMaterialToNative(parentMaterial ?? (mesh["renderMaterial"] as RenderMaterial));
+      
       int i = 0;
       while (i < mesh.faces.Count)
       {
@@ -890,6 +890,7 @@ namespace Objects.Converter.Revit
           break;
       }
 
+      var materialId = RenderMaterialToNative(brep["renderMaterial"] as RenderMaterial);
       using var builder = new BRepBuilder(bRepType);
 
       builder.SetAllowShortEdges();
@@ -899,7 +900,8 @@ namespace Objects.Converter.Revit
       foreach (var face in brep.Faces)
       {
         var faceId = builder.AddFace(SurfaceToNative(face.Surface), face.OrientationReversed);
-
+        builder.SetFaceMaterialId(faceId, materialId);
+        
         foreach (var loop in face.Loops)
         {
           var loopId = builder.AddLoop(faceId);


### PR DESCRIPTION
## Description

- Adds support for materials in BrepToNative conversion, and it's respective MeshToNative conversion if it fails

![image](https://user-images.githubusercontent.com/2316535/174529679-24202d4c-af42-45d1-9499-964dd0587a85.png)

![image](https://user-images.githubusercontent.com/2316535/174529683-40c508e5-da54-490e-93c4-9827ed97c88d.png)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

Tested it working on compatible BREPs that are successfully converted to Solids, and also some who's conversion fails and it's displayValue is used instead.

## Docs

- No updates needed


