### PR TITLE
Revert GH DataTree dynamic chunking

### DIFF
--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -135,7 +135,7 @@ namespace Speckle.ConnectorDynamo.Functions
       return result;
     }
 
-    private static Regex dataTreePathRegex => new Regex(@"^(@\(\d+\))?(?<path>\{\d+(;\d+)*\})$");
+    private static Regex dataTreePathRegex => new Regex(@"^(@(\(\d+\))?)?(?<path>\{\d+(;\d+)*\})$");
     
     public static bool IsDataTree(Base @base)
     {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -85,7 +85,8 @@ namespace ConnectorGrasshopper.Extras
         if (cancellationToken.IsCancellationRequested)
           break;
         var key = path.ToString();
-        var chunkingPrefix = $"@({chunkLength})";
+        //TODO: Rolled back chunking due to issue with detaching children. Revisit this once done.
+        var chunkingPrefix = $"@";
         var value = dataInput.get_Branch(path);
         var converted = new List<object>();
         foreach (var item in value)
@@ -101,7 +102,7 @@ namespace ConnectorGrasshopper.Extras
       return @base;
     }
 
-    private static string dataTreePathPattern = @"^(@\(\d+\))?(?<path>\{\d+(;\d+)*\})$";
+    private static string dataTreePathPattern = @"^(@(\(\d+\))?)?(?<path>\{\d+(;\d+)*\})$";
     
     /// <summary>
     ///   Converts a <see cref="Base"/> object into a Grasshopper <see cref="DataTree{T}"/>.


### PR DESCRIPTION
## Description

- Rolls back dynamic chunking while we look into #1339

## Type of change

- Revert change

## How has this been tested?

- Manual Tests:

Tested dynamo and grasshopper against chunked data trees and new non-chunked data trees while we look into the issue.

## Docs

- No updates needed

