### PR TITLE
fix(rvt): Create circle if arc has 360 deg

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -197,6 +197,13 @@ namespace Objects.Converter.Revit
         endAngle = (double)arc.endAngle;
       }
       var plane = PlaneToNative(arc.plane);
+
+      if (Point.Distance(arc.startPoint, arc.endPoint) < 1E-6)
+      {
+        // Endpoints coincide, it's a circle.
+        return DB.Arc.Create(plane, ScaleToNative(arc.radius ?? 0, arc.units), startAngle, endAngle);
+      }
+      
       return DB.Arc.Create(PointToNative(arc.startPoint), PointToNative(arc.endPoint), PointToNative(arc.midPoint));
       //return Arc.Create( plane.Origin, (double) arc.Radius * Scale, startAngle, endAngle, plane.XVec, plane.YVec );
     }


### PR DESCRIPTION
## Description

- Fixes small bug discovered in Arc conversion, where an arc with 360 degrees would throw an error, as the default conversion method uses the 3 point arc approach.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests 

Tested arcs, and solids that were composed of arcs, to ensure it was working on all cases.

## Docs

- No updates needed
