### PR TITLE
Revit: Adds Pretty Mesh conversion to all Revit versions

### DIFF
--- a/ConnectorRevit/ConnectorRevit.sln
+++ b/ConnectorRevit/ConnectorRevit.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorRevit2023", "Conne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AvaloniaHwndHost", "..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj", "{D8576AEE-6EF4-4BD7-B024-864653EC41E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterDxf", "..\Objects\Converters\ConverterDxf\ConverterDxf\ConverterDxf.csproj", "{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{236cff40-7dda-4cc5-84a9-b1df6f0985ef}*SharedItemsImports = 5
@@ -204,6 +206,14 @@ Global
 		{D8576AEE-6EF4-4BD7-B024-864653EC41E5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D8576AEE-6EF4-4BD7-B024-864653EC41E5}.Release|x64.ActiveCfg = Release|Any CPU
 		{D8576AEE-6EF4-4BD7-B024-864653EC41E5}.Release|x64.Build.0 = Release|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Debug|x64.Build.0 = Debug|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Release|x64.ActiveCfg = Release|Any CPU
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -228,6 +238,7 @@ Global
 		{236CFF40-7DDA-4CC5-84A9-B1DF6F0985EF} = {0FED0483-A54F-44EE-88FB-2FA6BAD13891}
 		{586A5A37-93F6-427E-8DF8-C10DB4D6822A} = {89C98BAA-C2BC-4EAF-AB97-C513A5A2372D}
 		{D8576AEE-6EF4-4BD7-B024-864653EC41E5} = {39F07EF9-5867-4062-886D-2417C86305C2}
+		{64A2BFC9-8711-4C9D-A1B4-BEE678C8E640} = {39F07EF9-5867-4062-886D-2417C86305C2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {650BE642-C7CC-4FF5-9EE5-8C57BF553143}

--- a/Core/Core/Kits/Applications.cs
+++ b/Core/Core/Kits/Applications.cs
@@ -170,6 +170,7 @@ namespace Speckle.Core.Kits
     public const string Revit2021 = "Revit2021";
     public const string Revit2022 = "Revit2022";
     public const string Revit2023 = "Revit2023";
+    public const string Dxf = "Dxf";
     public const string DynamoSandbox = "DynamoSandbox";
     public const string DynamoRevit = "DynamoRevit";
     public const string DynamoRevit2021 = "DynamoRevit2021";

--- a/Core/Core/Models/Extensions.cs
+++ b/Core/Core/Models/Extensions.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Speckle.Core.Models.Extensions
+{
+  public static class BaseExtensions
+  {
+    /// <summary>
+    /// Provides access to each base object to determine if they should be included in the output of the 'Flatten' function.
+    /// </summary>
+    /// <remarks>
+    /// Should return 'true' if the object is to be included in the output, 'false' otherwise.
+    /// </remarks>
+    public delegate bool FlattenPredicate(Base @base);
+    
+    /// <summary>
+    /// Provides access to each base object in the traverse function, and decides whether the traverse function should continue traversing it's children or not.
+    /// </summary>
+    /// <remarks>
+    /// Should return 'true' if you wish to stop the traverse behaviour, 'false' otherwise.
+    /// </remarks>
+    public delegate bool BaseRecursionBreaker(Base @base);
+
+    /// <summary>
+    /// Traverses through an object and returns it's inner <see cref="Base"/> objects, or a subselection of them.
+    /// </summary>
+    /// <param name="obj">The object to flatten.</param>
+    /// <param name="unique">True if you wish to filter out duplicate objects, false otherwise</param>
+    /// <param name="predicate">Determines whether an object should be included in the output.</param>
+    /// <param name="recursionBreaker">Determines whether an object should include it's children in the output.</param>
+    /// <returns>A flat <see cref="IEnumerable"/> of <see cref="Base"/> objects.</returns>
+    public static IEnumerable<Base> Flatten(this Base obj, bool unique, FlattenPredicate predicate = null,
+                                            BaseRecursionBreaker recursionBreaker = null)
+    {
+      // TODO: Cache solution could be improved.
+      var result = Enumerable.Empty<Base>();
+      var cache = new HashSet<string>();
+      obj.Traverse(b =>
+      {
+        // Stop if we've already encountered the object and the unique flag is true.
+        if (unique && cache.Contains(b.id)) return true;
+        cache.Add(b.id);
+        
+        // Add to result if predicate returns true. If no predicate is found, the element will be added by default.
+        if (predicate?.Invoke(b) ?? true)
+          result = result.Append(b);
+        
+        // Return the result of the recursionBreaker function.
+        // If no recursionBreaker is found, it will continue recurring through the objects children.
+        return recursionBreaker?.Invoke(b) ?? false;
+      });
+      return result;
+    }
+    
+    /// <summary>
+    /// Traverses the specified <see cref="Base"/> object, and all of it's children, with a callback to access each of them and break the traverse execution.
+    /// </summary>
+    /// <param name="obj">The <see cref="Base"/> object to traverse.</param>
+    /// <param name="recursionBreaker">Delegate function to access each <see cref="Base"/> object as it's traversed, and allows for control to stop the traverse behaviour on it's children.</param>
+    public static void Traverse(this Base obj, BaseRecursionBreaker recursionBreaker) => Traverse((object)obj, recursionBreaker);
+    
+    /// <summary>
+    /// The private implementation of the traverse function for Base objects.
+    /// It accepts an <see cref="object"/> to allow recursive calls through lists and dicts.
+    /// This was designed to work with <see cref="Base"/> objects,
+    /// and you should use the publicly facing version: <see cref="Traverse"/>
+    /// </summary>
+    /// <param name="obj">The object to traverse</param>
+    /// <param name="recursionBreaker">Delegate function to access each <see cref="Base"/> object as it's traversed, and allows for control to stop the traverse behaviour on it's children.</param>
+    private static void Traverse(object obj, BaseRecursionBreaker recursionBreaker)
+    {
+      switch (obj)
+      {
+        case Base @base:
+        {
+          // Break if recursionBraker says so. Continue by default.
+          if (recursionBreaker?.Invoke(@base) ?? false) break;
+          foreach (var prop in @base.GetDynamicMemberNames())
+            Traverse(@base[prop], recursionBreaker);
+          break;
+        }
+        case IDictionary dict:
+          foreach (var dictValue in dict.Values)
+            Traverse(dictValue, recursionBreaker);
+          break;
+        case IEnumerable enumerable:
+          foreach (var listValue in enumerable)
+            Traverse(listValue, recursionBreaker);
+          break;
+      }
+    }
+  }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterDxf.Tests.csproj
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterDxf.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\..\..\netDxf\netDxf\netDxf.csproj" />
+      <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
+      <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+      <ProjectReference Include="..\ConverterDxf\ConverterDxf.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterFixture.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterFixture.cs
@@ -1,0 +1,35 @@
+using System;
+using Speckle.Core.Models;
+using Xunit;
+using Dxf = netDxf;
+using Dxfe = netDxf.Entities;
+
+namespace ConverterDxf.Tests
+{
+    public class ConverterFixture: IDisposable
+    {
+        public SpeckleDxfConverter Converter;
+        public Dxf.DxfDocument Doc;
+
+        public ConverterFixture()
+        {
+            Converter = new SpeckleDxfConverter();
+            Doc = new Dxf.DxfDocument();
+            Converter.SetContextDocument(Doc);
+        }
+
+        public T AssertAndConvertToNative<T>(Base @base)
+        {
+            Assert.True(Converter.CanConvertToNative(@base));
+            var dxfObject = Converter.ConvertToNative(@base);
+            Assert.NotNull(dxfObject);
+            Assert.IsAssignableFrom<T>(dxfObject);
+            return (T)dxfObject;
+        }
+
+        public void Dispose()
+        {
+            Converter = null;
+        }
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterSetup.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterSetup.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
+
+namespace ConverterDxf.Tests
+{
+    public static class ConverterSetup
+    {
+        public static string TestStream = "https://latest.speckle.dev/streams/24c3741255/branches/1%20standard/meters";
+        
+        public static IEnumerable<T> FetchAllObjectsOfType<T>(string streamUrl) where T: Base 
+            => Speckle.Core.Api.Helpers.Receive(streamUrl)
+                      .Result
+                      .Flatten(true, b => b is T).Cast<T>();
+        
+        public static IEnumerable<object[]> GetTestMemberData<T>() where T: Base => 
+            FetchAllObjectsOfType<T>(TestStream).Select(v => new object[] { v });
+
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/BrepTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/BrepTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using Objects.Geometry;
+using Xunit;
+using Dxf = netDxf;
+using Dxfe = netDxf.Entities;
+
+namespace ConverterDxf.Tests.Geometry
+{
+    public class BrepTests : IClassFixture<ConverterFixture>
+    {
+        private readonly ConverterFixture fixture = new ConverterFixture();
+
+        public static IEnumerable<object[]> BrepData => ConverterSetup.GetTestMemberData<Brep>();
+
+        [Theory]
+        [MemberData(nameof(BrepData))]
+        public void CanConvert_BrepToPrettyNative(Brep mesh)
+        {
+            fixture.Converter.Settings.PrettyMeshes = true;
+            var dxfMeshEntities = fixture.AssertAndConvertToNative<IEnumerable<Dxfe.EntityObject>>(mesh).ToList();
+            Assert.NotEmpty(dxfMeshEntities);
+            Assert.All(dxfMeshEntities, o => Assert.True(o is Dxfe.Face3D || o is Dxfe.Line));
+            // TODO: Add better tests for the BREP fallback to mesh
+        }
+        
+        [Theory]
+        [MemberData(nameof(BrepData))]
+        public void CanConvert_BrepToNative(Brep mesh)
+        {
+            fixture.Converter.Settings.PrettyMeshes = false;
+            var dxfMeshes = fixture.AssertAndConvertToNative<IEnumerable<Dxfe.Mesh>>(mesh);
+            Assert.NotEmpty(dxfMeshes);
+            // TODO: Add better tests for the BREP fallback to mesh
+        }
+
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/CurveTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/CurveTests.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Objects.Geometry;
+using Xunit;
+using Dxf = netDxf;
+using Dxfe = netDxf.Entities;
+
+namespace ConverterDxf.Tests.Geometry
+{
+    public class CurveTests : IClassFixture<ConverterFixture>
+    {
+        private readonly ConverterFixture fixture = new ConverterFixture();
+    
+        public static IEnumerable<object[]> LineData => ConverterSetup.GetTestMemberData<Line>();
+
+        [Theory]
+        [MemberData(nameof(LineData))]
+        public void CanConvert_LineToNative(Line line)
+        {
+            var dxfLine = fixture.AssertAndConvertToNative<Dxfe.Line>(line);
+            // TODO: Add line specific tests.
+        }
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/MeshTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/MeshTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using Objects.Geometry;
+using Xunit;
+using Dxf = netDxf;
+using Dxfe = netDxf.Entities;
+
+namespace ConverterDxf.Tests.Geometry
+{
+    public class MeshTests : IClassFixture<ConverterFixture>
+    {
+        private readonly ConverterFixture fixture = new ConverterFixture();
+
+        public static IEnumerable<object[]> MeshData => ConverterSetup.GetTestMemberData<Mesh>();
+
+        [Theory]
+        [MemberData(nameof(MeshData))]
+        public void CanConvert_MeshToPrettyNative(Mesh mesh)
+        {
+            fixture.Converter.Settings.PrettyMeshes = true;
+            var dxfMeshEntities = fixture.AssertAndConvertToNative<IEnumerable<Dxfe.EntityObject>>(mesh).ToList();
+            Assert.NotEmpty(dxfMeshEntities);
+            Assert.All(dxfMeshEntities, o => Assert.True(o is Dxfe.Face3D || o is Dxfe.Line));
+        }
+        
+        [Theory]
+        [MemberData(nameof(MeshData))]
+        public void CanConvert_MeshToNative(Mesh mesh)
+        {
+            fixture.Converter.Settings.PrettyMeshes = false;
+            var dxfMesh = fixture.AssertAndConvertToNative<Dxfe.Mesh>(mesh);
+            //TODO: Add mesh specific tests
+            Assert.Equal(mesh.vertices.Count, dxfMesh.Vertexes.Count * 3);
+        }
+
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/VectorTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/VectorTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Objects.Geometry;
+using Xunit;
+using Dxf = netDxf;
+using Dxfe = netDxf.Entities;
+
+namespace ConverterDxf.Tests.Geometry
+{
+    public class VectorTests : IClassFixture<ConverterFixture>
+    {
+        private readonly ConverterFixture fixture = new ConverterFixture();
+
+        public static IEnumerable<object[]> PointData => ConverterSetup.GetTestMemberData<Point>();
+        public static IEnumerable<object[]> VectorData => ConverterSetup.GetTestMemberData<Vector>();
+
+        [Theory]
+        [MemberData(nameof(PointData))]
+        public void CanConvert_PointToNative(Point pt)
+        {
+            var dxfPt = fixture.AssertAndConvertToNative<Dxfe.Point>(pt);
+            Assert.Equal(pt.x, dxfPt.Position.X);
+            Assert.Equal(pt.y, dxfPt.Position.Y);
+            Assert.Equal(pt.z, dxfPt.Position.Z);
+        }
+
+        [Theory]
+        [MemberData(nameof(VectorData))]
+        public void CanConvert_VectorToNative(Vector v)
+        {
+            var dxfVector = fixture.AssertAndConvertToNative<Dxf.Vector3>(v);
+            Assert.Equal(v.x, dxfVector.X);
+            Assert.Equal(v.y, dxfVector.Y);
+            Assert.Equal(v.z, dxfVector.Z);
+        }
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf.sln
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.sln
@@ -1,0 +1,47 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterDxf", "ConverterDxf\ConverterDxf.csproj", "{42423E5D-1191-48AF-BD53-B6CB2A54AAF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Objects", "..\..\Objects\Objects.csproj", "{98A11A2C-1607-433B-B8BF-474C73880963}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "..\..\..\Core\Core\Core.csproj", "{4846C3AD-B7A8-45DA-8887-02004C299121}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Local Dependencies", "Local Dependencies", "{838B0DF2-67B3-4C4C-AD2F-4FC09B142D7B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "netDxf", "..\..\..\..\netDxf\netDxf\netDxf.csproj", "{FD5AE5CE-34CF-4FB7-BFF5-FF552285F273}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterDxf.Tests", "ConverterDxf.Tests\ConverterDxf.Tests.csproj", "{C237E12E-AE3B-4229-9D6B-B60D1DD6422E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{42423E5D-1191-48AF-BD53-B6CB2A54AAF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42423E5D-1191-48AF-BD53-B6CB2A54AAF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42423E5D-1191-48AF-BD53-B6CB2A54AAF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42423E5D-1191-48AF-BD53-B6CB2A54AAF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98A11A2C-1607-433B-B8BF-474C73880963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98A11A2C-1607-433B-B8BF-474C73880963}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98A11A2C-1607-433B-B8BF-474C73880963}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98A11A2C-1607-433B-B8BF-474C73880963}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4846C3AD-B7A8-45DA-8887-02004C299121}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4846C3AD-B7A8-45DA-8887-02004C299121}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4846C3AD-B7A8-45DA-8887-02004C299121}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4846C3AD-B7A8-45DA-8887-02004C299121}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD5AE5CE-34CF-4FB7-BFF5-FF552285F273}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD5AE5CE-34CF-4FB7-BFF5-FF552285F273}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD5AE5CE-34CF-4FB7-BFF5-FF552285F273}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD5AE5CE-34CF-4FB7-BFF5-FF552285F273}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C237E12E-AE3B-4229-9D6B-B60D1DD6422E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C237E12E-AE3B-4229-9D6B-B60D1DD6422E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C237E12E-AE3B-4229-9D6B-B60D1DD6422E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C237E12E-AE3B-4229-9D6B-B60D1DD6422E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4846C3AD-B7A8-45DA-8887-02004C299121} = {838B0DF2-67B3-4C4C-AD2F-4FC09B142D7B}
+		{98A11A2C-1607-433B-B8BF-474C73880963} = {838B0DF2-67B3-4C4C-AD2F-4FC09B142D7B}
+		{FD5AE5CE-34CF-4FB7-BFF5-FF552285F273} = {838B0DF2-67B3-4C4C-AD2F-4FC09B142D7B}
+	EndGlobalSection
+EndGlobal

--- a/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
@@ -9,9 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\..\netDxf\netDxf\netDxf.csproj" />
       <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" ExcludeAssets="runtime" />
       <ProjectReference Include="..\..\..\Objects\Objects.csproj" ExcludeAssets="runtime" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Speckle.netDxf" Version="3.0.0" />
     </ItemGroup>
     
     <PropertyGroup>

--- a/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
@@ -5,6 +5,7 @@
         <AssemblyName>Objects.ConverterDxf</AssemblyName>
         <LangVersion>9</LangVersion>
         <Nullable>disable</Nullable>
+        <RootNamespace>Objects.Converters.DxfConverter</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Objects.ConverterDxf</AssemblyName>
+        <LangVersion>9</LangVersion>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\..\..\netDxf\netDxf\netDxf.csproj" />
+      <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" ExcludeAssets="runtime" />
+      <ProjectReference Include="..\..\..\Objects\Objects.csproj" ExcludeAssets="runtime" />
+    </ItemGroup>
+    
+    <PropertyGroup>
+        <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
+    </PropertyGroup>
+    
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsDesktopBuild)' == true">
+        <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\$(ProjectName)\&quot;" />
+        <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="cp '$(TargetDir)$(AssemblyName).dll' $HOME'/.config/Speckle/Kits/Objects/'" />
+        <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="cp '$(TargetDir)netDxf.dll' $HOME'/.config/Speckle/Kits/Objects/'" />
+    </Target>
+</Project>

--- a/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxfSettings.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxfSettings.cs
@@ -1,4 +1,4 @@
-namespace ConverterDxf
+namespace Objects.Converters.DxfConverter
 {
     public class ConverterDxfSettings
     {

--- a/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxfSettings.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxfSettings.cs
@@ -1,0 +1,8 @@
+namespace ConverterDxf
+{
+    public class ConverterDxfSettings
+    {
+        public bool PrettyMeshes = true;
+        public bool BrepsAsMeshes = true;
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Speckle.Core.Models;
 
-namespace ConverterDxf
+namespace Objects.Converters.DxfConverter
 {
     public partial class SpeckleDxfConverter
     {

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Speckle.Core.Models;
+
+namespace ConverterDxf
+{
+    public partial class SpeckleDxfConverter
+    {
+        public void SetContextDocument(object doc)
+        {
+            switch (doc)
+            {
+                case null: // Create a new in-memory document
+                    Doc = new netDxf.DxfDocument();
+                    break;
+                case string str: // Load up an existing document
+                    Doc = netDxf.DxfDocument.Load(str);
+                    break;
+            }
+        }
+
+        public void SaveContextDocument(string path)
+        {
+            Doc?.Save(path);
+        }
+
+        public void SetContextObjects(List<ApplicationPlaceholderObject> objects)
+        {
+            // No context tracking
+        }
+
+        public void SetPreviousContextObjects(List<ApplicationPlaceholderObject> objects)
+        {
+            // No context tracking
+        }
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using Speckle.Core.Models;
-
+using Speckle.netDxf;
 namespace Objects.Converters.DxfConverter
 {
     public partial class SpeckleDxfConverter
@@ -10,10 +10,10 @@ namespace Objects.Converters.DxfConverter
             switch (doc)
             {
                 case null: // Create a new in-memory document
-                    Doc = new netDxf.DxfDocument();
+                    Doc = new DxfDocument();
                     break;
                 case string str: // Load up an existing document
-                    Doc = netDxf.DxfDocument.Load(str);
+                    Doc = DxfDocument.Load(str);
                     break;
             }
         }

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Objects.Geometry;
+using Dxf = netDxf;
+using Dxfe = netDxf.Entities;
+
+namespace ConverterDxf
+{
+    public partial class SpeckleDxfConverter
+    {
+        public netDxf.Vector3 VectorToNative(Point pt) => VectorToNative(new Vector(pt));
+        public netDxf.Vector3 VectorToNative(Vector pt) => new(pt.x, pt.y, pt.z);
+        public netDxf.Entities.Point PointToNative(Point pt) => new(VectorToNative(pt));
+
+        public netDxf.Entities.Line LineToNative(Line line) =>
+            new(VectorToNative(line.start), VectorToNative(line.end));
+
+        public Dxfe.Mesh MeshToNative(Mesh mesh) => new(
+            mesh.GetPoints().Select(VectorToNative),
+            mesh.GetFaceIndices()
+        );
+
+        public IEnumerable<Dxfe.EntityObject> MeshToNativePretty(Mesh mesh)
+        {
+            var topology = mesh.GetMeshEdgeFaces();
+            return MeshFacesToNative(topology).Concat<Dxfe.EntityObject>(MeshEdgesToNative(topology));
+        }
+
+        private IEnumerable<Dxfe.Line> MeshEdgesToNative(MeshTopologyResult topology,
+                                                         string edgeLayerName = "Mesh boundaries") =>
+            topology.EdgeFaceConnection
+                    .Where((kv) => kv.Value.Count == 1)
+                    .Select(kv =>
+                     {
+                         var (iA, iB) = kv.Key;
+                         var line = new Dxfe.Line(
+                             VectorToNative(topology.Vertices[iA]),
+                             VectorToNative(topology.Vertices[iB]));
+                         line.Layer = new Dxf.Tables.Layer(edgeLayerName);
+                         return line;
+                     });
+
+        private IEnumerable<Dxfe.Face3D> MeshFacesToNative(MeshTopologyResult topology, string layerName = "Mesh Faces")
+        {
+            var vertices = topology.Vertices.Select(VectorToNative).ToList();
+            return topology.Faces.Select(indices =>
+            {
+                var points = indices.Select(i => vertices[i]).ToList();
+                Dxfe.Face3D face;
+                switch (points.Count)
+                {
+                    case 3:
+                        face = new Dxfe.Face3D(points[0], points[1], points[2]);
+                        break;
+                    case 4:
+                        face = new Dxfe.Face3D(points[0], points[1], points[2], points[3]);
+                        break;
+                    default:
+                        Report.Log("Ignoring n-gon face, currently unsupported.");
+                        return null;
+                }
+
+                face.EdgeFlags = (Dxfe.Face3DEdgeFlags)15; // All edges hidden!
+                face.Layer = new Dxf.Tables.Layer(layerName);
+                return face;
+            }).Where(f => f != null);
+        }
+
+
+        public IEnumerable<Dxfe.EntityObject> BrepToNative(Brep brep)
+        {
+            return Settings.PrettyMeshes 
+                ? brep.displayValue.SelectMany(MeshToNativePretty) 
+                : brep.displayValue.Select(MeshToNative);
+        }
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
@@ -4,8 +4,11 @@ using System.Linq;
 using Objects.Geometry;
 using Dxf = netDxf;
 using Dxfe = netDxf.Entities;
+using Line = Objects.Geometry.Line;
+using Mesh = Objects.Geometry.Mesh;
+using Point = Objects.Geometry.Point;
 
-namespace ConverterDxf
+namespace Objects.Converters.DxfConverter
 {
     public partial class SpeckleDxfConverter
     {

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Objects.Geometry;
-using Dxf = netDxf;
-using Dxfe = netDxf.Entities;
+using Dxf = Speckle.netDxf;
+using Dxfe = Speckle.netDxf.Entities;
 using Line = Objects.Geometry.Line;
 using Mesh = Objects.Geometry.Mesh;
 using Point = Objects.Geometry.Point;
@@ -12,11 +12,11 @@ namespace Objects.Converters.DxfConverter
 {
     public partial class SpeckleDxfConverter
     {
-        public netDxf.Vector3 VectorToNative(Point pt) => VectorToNative(new Vector(pt));
-        public netDxf.Vector3 VectorToNative(Vector pt) => new(pt.x, pt.y, pt.z);
-        public netDxf.Entities.Point PointToNative(Point pt) => new(VectorToNative(pt));
+        public Dxf.Vector3 VectorToNative(Point pt) => VectorToNative(new Vector(pt));
+        public Dxf.Vector3 VectorToNative(Vector pt) => new(pt.x, pt.y, pt.z);
+        public Dxf.Entities.Point PointToNative(Point pt) => new(VectorToNative(pt));
 
-        public netDxf.Entities.Line LineToNative(Line line) =>
+        public Dxf.Entities.Line LineToNative(Line line) =>
             new(VectorToNative(line.start), VectorToNative(line.end));
 
         public Dxfe.Mesh MeshToNative(Mesh mesh) => new(

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Settings.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Settings.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ConverterDxf
+{
+    public partial class SpeckleDxfConverter
+    {
+        public void SetConverterSettings(object settings) => SetConverterSettings((ConverterDxfSettings)settings);
+
+        private void SetConverterSettings(ConverterDxfSettings settings)
+        {
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        }
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Settings.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Settings.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ConverterDxf
+namespace Objects.Converters.DxfConverter
 {
     public partial class SpeckleDxfConverter
     {

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Dxf = netDxf;
-using Dxfe = netDxf.Entities;
-using Speckle.Core.Models;
 using Objects.Geometry;
 using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using Dxf = netDxf;
+using Line = Objects.Geometry.Line;
+using Mesh = Objects.Geometry.Mesh;
+using Point = Objects.Geometry.Point;
 
-namespace ConverterDxf
+namespace Objects.Converters.DxfConverter
 {
     public partial class SpeckleDxfConverter : ISpeckleConverter
     {

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Objects.Geometry;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
-using Dxf = netDxf;
+using Dxf = Speckle.netDxf;
 using Line = Objects.Geometry.Line;
 using Mesh = Objects.Geometry.Mesh;
 using Point = Objects.Geometry.Point;

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dxf = netDxf;
+using Dxfe = netDxf.Entities;
+using Speckle.Core.Models;
+using Objects.Geometry;
+using Speckle.Core.Kits;
+
+namespace ConverterDxf
+{
+    public partial class SpeckleDxfConverter : ISpeckleConverter
+    {
+        public Dxf.DxfDocument Doc;
+        public string Description => "The Objects DXF Converter";
+        public string Name => "Speckle DXF Converter";
+        public string Author => "Speckle Systems";
+        public string WebsiteOrEmail => "https://speckle.systems";
+
+        public ProgressReport Report { get; } = new();
+        public ConverterDxfSettings Settings = new();
+        public ReceiveMode ReceiveMode { get; set; } = ReceiveMode.Create;
+
+        // TODO: Convert to Speckle is currently not supported.
+        public List<Base> ConvertToSpeckle(List<object> objects) => throw new NotImplementedException();
+        public bool CanConvertToSpeckle(object @object) => throw new NotImplementedException();
+        public Base ConvertToSpeckle(object @object) => throw new NotImplementedException();
+
+        
+        public bool CanConvertToNative(Base @base)
+        {
+            switch (@base)
+            {
+                case Vector _:
+                case Point _:
+                case Line _:
+                case Mesh _:
+                case Brep _:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        public object ConvertToNative(Base @base)
+        {
+            switch (@base)
+            {
+                case Point pt:
+                    return PointToNative(pt);
+                case Vector vector:
+                    return VectorToNative(vector);
+                case Line line:
+                    return LineToNative(line);
+                case Mesh mesh:
+                    if (Settings.PrettyMeshes)
+                        return MeshToNativePretty(mesh);
+                    return MeshToNative(mesh);
+                case Brep brep:
+                    return BrepToNative(brep);
+                default:
+                    return null!;
+            }
+        }
+        
+        public List<object> ConvertToNative(List<Base> objects) => objects.Select(ConvertToNative).ToList();
+
+        public IEnumerable<string> GetServicedApplications() => new[] { VersionedHostApplications.Dxf };
+    }
+}

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Objects.Geometry;
@@ -11,7 +11,7 @@ using Point = Objects.Geometry.Point;
 
 namespace Objects.Converters.DxfConverter
 {
-    public partial class SpeckleDxfConverter : ISpeckleConverter
+    public partial class SpeckleDxfConverter
     {
         public Dxf.DxfDocument Doc;
         public string Description => "The Objects DXF Converter";

--- a/Objects/Converters/ConverterDxf/ConverterDxf/Utilities.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/Utilities.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Objects.Geometry;
 
-namespace ConverterDxf
+namespace Objects.Converters.DxfConverter
 {
     public struct MeshTopologyResult
     {

--- a/Objects/Converters/ConverterDxf/ConverterDxf/Utilities.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/Utilities.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Objects.Geometry;
+
+namespace ConverterDxf
+{
+    public struct MeshTopologyResult
+    {
+        public List<Point> Vertices;
+        public List<int[]> Faces;
+        public ConcurrentDictionary<Tuple<int, int>, ConcurrentBag<int>> EdgeFaceConnection;
+    }
+    
+    public static class Utilities
+    {
+        public static MeshTopologyResult GetMeshEdgeFaces(this Mesh mesh)
+        {
+            var result = new ConcurrentDictionary<Tuple<int,int>, ConcurrentBag<int>>();
+            var faces = mesh.GetFaceIndices().ToList();
+            var vertices = mesh.GetPoints();
+            var faceIndex = 0;
+            foreach (var indices in faces)
+            {
+                for (var j = 0; j < indices.Length; j++)
+                {
+                    var iA = indices[j];
+                    var iB = indices[(j + 1) % indices.Length];
+                    var temp = iA;
+                    iA = temp < iB ? iA : iB;
+                    iB = temp < iB ? iB : temp;
+                    var connectedFaces = result.GetOrAdd(new Tuple<int, int>(iA,iB), new ConcurrentBag<int>());
+                    connectedFaces.Add(faceIndex);
+                }
+                faceIndex++;
+            }
+            
+            return new MeshTopologyResult()
+            {
+                Vertices =  vertices,
+                Faces = faces,
+                EdgeFaceConnection = result
+            };
+        }
+        public static IEnumerable<int[]> GetFaceIndices(this Mesh mesh)
+        {
+            var i = 0;
+            while (i < mesh.faces.Count)
+            {
+                var n = mesh.faces[i];
+                if (n < 3) n += 3; // 0 -> 3, 1 -> 4 to preserve backwards compatibility
+
+                var points = mesh.faces.GetRange(i + 1, n).ToArray();
+                yield return points;
+                i += n + 1;
+            }
+        }
+    }
+}

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoRevit/ConverterDynamoRevit.csproj
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoRevit/ConverterDynamoRevit.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    <ProjectReference Include="..\..\ConverterDxf\ConverterDxf\ConverterDxf.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Objects/Converters/ConverterRevit/ConverterRevit2019/ConverterRevit2019.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2019/ConverterRevit2019.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    <ProjectReference Include="..\..\ConverterDxf\ConverterDxf\ConverterDxf.csproj" />
   </ItemGroup>
 
 

--- a/Objects/Converters/ConverterRevit/ConverterRevit2020/ConverterRevit2020.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2020/ConverterRevit2020.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    <ProjectReference Include="..\..\ConverterDxf\ConverterDxf\ConverterDxf.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>

--- a/Objects/Converters/ConverterRevit/ConverterRevit2021/ConverterRevit2021.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2021/ConverterRevit2021.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    <ProjectReference Include="..\..\ConverterDxf\ConverterDxf\ConverterDxf.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>

--- a/Objects/Converters/ConverterRevit/ConverterRevit2022/ConverterRevit2022.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2022/ConverterRevit2022.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    <ProjectReference Include="..\..\ConverterDxf\ConverterDxf\ConverterDxf.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>

--- a/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
     <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
+    <ProjectReference Include="..\..\ConverterDxf\ConverterDxf\ConverterDxf.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -346,7 +346,7 @@ namespace Objects.Converter.Revit
           return ModelCurveToNative(o);
 
         case Geometry.Brep o:
-          return MeshToDxfImport(o.displayValue[0]);
+          //return MeshToDxfImport(o.displayValue[0]);
           return DirectShapeToNative(o);
 
         case Geometry.Mesh o:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -346,9 +346,11 @@ namespace Objects.Converter.Revit
           return ModelCurveToNative(o);
 
         case Geometry.Brep o:
+          return MeshToDxfImport(o.displayValue[0]);
           return DirectShapeToNative(o);
 
         case Geometry.Mesh o:
+          return MeshToDxfImport(o);
           return DirectShapeToNative(o);
 
         // non revit built elems

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -108,6 +108,7 @@ namespace Objects.Converter.Revit
       catch (Exception e)
       {
         Report.LogConversionError(new Exception(e.Message));
+        return MeshToDxfImport(brep.displayValue[0]);
         var mesh = brep.displayValue.SelectMany(m => MeshToNative(m, parentMaterial: brep["renderMaterial"] as RenderMaterial));
         revitDs.SetShape(mesh.ToArray());
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -10,8 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using Autodesk.Revit.ApplicationServices;
-using ConverterDxf;
+using Objects.Converters.DxfConverter;
 using Arc = Objects.Geometry.Arc;
 using Curve = Objects.Geometry.Curve;
 using DB = Autodesk.Revit.DB;
@@ -25,7 +24,6 @@ using Spiral = Objects.Geometry.Spiral;
 using Surface = Objects.Geometry.Surface;
 using Units = Speckle.Core.Kits.Units;
 using Vector = Objects.Geometry.Vector;
-using netDxf;
 
 namespace Objects.Converter.Revit
 {
@@ -668,10 +666,10 @@ namespace Objects.Converter.Revit
       
       var dxfMesh = dxfConverter.ConvertToNative(mesh);
       
-      if (dxfMesh is IEnumerable<netDxf.Entities.EntityObject> collection)
+      if (dxfMesh is IEnumerable<Speckle.netDxf.Entities.EntityObject> collection)
         dxfConverter.Doc.Entities.Add(collection.ToList().Where(x => x!= null));
       else
-        dxfConverter.Doc.Entities.Add(dxfMesh as netDxf.Entities.EntityObject);
+        dxfConverter.Doc.Entities.Add(dxfMesh as Speckle.netDxf.Entities.EntityObject);
       
       var folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Speckle", "Temp",
         "Dxf");
@@ -697,6 +695,7 @@ namespace Objects.Converter.Revit
       //File.Delete(path);
       var el = Doc.GetElement(elementId);
       el.Pinned = false;
+      
       return new ApplicationPlaceholderObject()
       {
         id = mesh.id, 

--- a/Objects/Objects.sln
+++ b/Objects/Objects.sln
@@ -82,6 +82,7 @@ EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ConverterCSIShared", "Converters\ConverterCSI\ConverterCSIShared\ConverterCSIShared.shproj", "{5BBDE14E-50F8-4D6E-8E35-747667AD4A09}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterSAP2000", "Converters\ConverterCSI\ConverterSAP2000\ConverterSAP2000.csproj", "{79AA475D-7CDE-4501-90CE-9A0D9D0DB023}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ConverterTeklaStructures", "ConverterTeklaStructures", "{98B557B0-CD26-40DE-9703-A27F07A942E3}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ConverterTeklaStructuresShared", "Converters\ConverterTeklaStructures\ConverterTeklaStructuresShared\ConverterTeklaStructuresShared.shproj", "{7FFDAB72-145D-4490-9892-FAC5F1D72B17}"
@@ -93,6 +94,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper6", "Converters\ConverterRhinoGh\ConverterGrasshopper6\ConverterGrasshopper6.csproj", "{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper7", "Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterDxf", "Converters\ConverterDxf\ConverterDxf\ConverterDxf.csproj", "{C6E9DE1F-2CFF-44AC-9B9A-E71783DF6633}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -248,6 +251,10 @@ Global
 		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6E9DE1F-2CFF-44AC-9B9A-E71783DF6633}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6E9DE1F-2CFF-44AC-9B9A-E71783DF6633}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6E9DE1F-2CFF-44AC-9B9A-E71783DF6633}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6E9DE1F-2CFF-44AC-9B9A-E71783DF6633}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -295,6 +302,7 @@ Global
 		{08EE146E-9F7A-4C82-B790-688FE4532CA7} = {98B557B0-CD26-40DE-9703-A27F07A942E3}
 		{1DC0A8F4-1F14-47E8-8456-9D8E9C0E6CFF} = {1A35077C-2936-4A3D-8D48-65F39F76D999}
 		{5A7671D6-57A1-4422-9EBB-79F3C724C0BA} = {1A35077C-2936-4A3D-8D48-65F39F76D999}
+		{C6E9DE1F-2CFF-44AC-9B9A-E71783DF6633} = {CCC09288-CE76-4FDB-B0C9-220112F88CD9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DA57EC2E-0A9E-4F59-B1F7-A65F76A74B74}


### PR DESCRIPTION
## Description

Adds a new way to import meshes and incompatible Breps as meshes with hidden edges.

<img width="872" alt="Screenshot 2022-06-26 at 19 09 26" src="https://user-images.githubusercontent.com/2316535/175927013-05ada22a-20cb-4108-8304-b997541e492e.png">

This is based on our new `Speckle.netDxf` nuget and the `ConverterDxf` project (found in this repo).

The Revit converter uses the 
TODO

- [ ] Discuss with Bilal if we use direct import, a family with an import, or allow for both options.
- [ ] Proper handling of scaling factor by units, some can be set on the doc, others must be done using scale factor.
- [ ] Add option to choose "pretty vs ugly" meshes on the stream "Advanced Settings Page"
- [ ] Update installer to package ConverterDxf and Speckle.netDxf alongside the connector

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- No updates needed
- Have already been updated
- Will be updated ASAP

