### PR TITLE
fix(revit): updated preprocessor directives for revit topo

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertTopography.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertTopography.cs
@@ -31,7 +31,7 @@ namespace Objects.Converter.Revit
           pts.Add(PointToNative(point));
         }
 
-#if REVIT2022 || REVIT2023
+#if !REVIT2019
         facets.Capacity += (int) (displayMesh.faces.Count / 4f) * 3;
         int j = 0;
         while (j < displayMesh.faces.Count)
@@ -47,7 +47,7 @@ namespace Objects.Converter.Revit
         Doc.Delete(docObj.Id);
       }
       TopographySurface revitSurface = null;
-#if REVIT2022 || REVIT2023
+#if !REVIT2019
       revitSurface = TopographySurface.Create(Doc, pts, facets);
 #else
       revitSurface = TopographySurface.Create(Doc, pts);


### PR DESCRIPTION
## Description
Previous Revit topo pr wrongly assumed the new `Create()` method was only available starting Revit 2022: this updates the preprocessor directive to apply for all versions later than 2019

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Tests not required

## Docs

- No updates needed

