### PR TITLE
HOTFIX: Release included broken feature expected for 2.7 + DSO BeforeSolveInstance fix

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/BaseComponents/SelectKitTaskCapableComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/BaseComponents/SelectKitTaskCapableComponentBase.cs
@@ -144,7 +144,15 @@ namespace ConnectorGrasshopper.Objects
 
     protected override void BeforeSolveInstance()
     {
-      Converter?.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+      try
+      {
+
+        Converter?.SetContextDocument(Rhino.RhinoDoc.ActiveDoc);
+      }
+      catch (Exception e)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,$"Failed to set document context:\n\t{e.Message}");
+      }
       base.BeforeSolveInstance();
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Utilities.cs
@@ -424,7 +424,7 @@ namespace ConnectorGrasshopper.Extras
         return value;
 
 
-      if (converter.CanConvertToSpeckle(value))
+      if (converter != null && converter.CanConvertToSpeckle(value))
       {
         var result = converter.ConvertToSpeckle(value);  
         result.applicationId = refId;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/DeconstructSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/DeconstructSpeckleObjectTaskComponent.cs
@@ -258,16 +258,23 @@ namespace ConnectorGrasshopper.Objects
 
     protected override void BeforeSolveInstance()
     {
-      if (RunCount == -1)
+      try
       {
-        Console.WriteLine("No iter has run");
-        var x = Params.Input[0].VolatileData;
-        var tree = x as GH_Structure<IGH_Goo>;
-        if (tree != null)
+        if (RunCount == -1)
         {
-          outputList = GetOutputList(tree);
-          AutoCreateOutputs();
+          Console.WriteLine("No iter has run");
+          var x = Params.Input[0].VolatileData;
+          var tree = x as GH_Structure<IGH_Goo>;
+          if (tree != null)
+          {
+            outputList = GetOutputList(tree);
+            AutoCreateOutputs();
+          }
         }
+      }
+      catch (Exception e)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,$"Failed to fetch outputs:\n\t{e.Message}");
       }
       base.BeforeSolveInstance();
     }
@@ -279,7 +286,7 @@ namespace ConnectorGrasshopper.Objects
 
       foreach (var ghGoo in speckleObjects.AllData(true))
       {
-        object converted;
+        object converted = null;
         if (ghGoo is GH_SpeckleBase ghBase)
         {
           converted = ghBase.Value;

--- a/Objects/Objects/Other/MaterialQuantity.cs
+++ b/Objects/Objects/Other/MaterialQuantity.cs
@@ -23,6 +23,8 @@ namespace Objects.Other
         public string units { get; set; }
 
 
+        public MaterialQuantity() { }
+        
         [Speckle.Core.Kits.SchemaInfo("MaterialQuantity", "Creates the quantity of a material")]
         public MaterialQuantity(Objects.Other.Material m, double volume, double  area, string units)
         {


### PR DESCRIPTION
## Description

- Fixes #1366
MaterialQuantity class did not have a default empty constructor, which made deserialisation fail for all objects that had an instance as a child.

- Fixes #1367 
DSO BeforeSolveInstance call assumed a converter was available, but disabling conversion would null it and would raise an exception when it attempted to use it.
Fixed `TryConvertToSpeckle` to not assume a Converter will be provided, and check for null there.
This fixes any issues in any other nodes that used this.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

Manually tested provided streams in the forum to reproduce the error, and can no longer reproduce after fix.

## Docs

- No updates needed

