### PR TITLE
Replaced StreamReader.Peek()

### DIFF
--- a/Core/Core/Transports/Server.cs
+++ b/Core/Core/Transports/Server.cs
@@ -479,7 +479,8 @@ namespace Speckle.Core.Transports
       {
         using (var reader = new StreamReader(stream, Encoding.UTF8))
         {
-          while (reader.Peek() > 0)
+          string line;
+          while ((line = reader.ReadLine()) != null)
           {
             if (CancellationToken.IsCancellationRequested)
             {
@@ -487,7 +488,6 @@ namespace Speckle.Core.Transports
               return false;
             }
 
-            var line = reader.ReadLine();
             var pcs = line.Split(new char[] { '\t' }, count: 2);
             targetTransport.SaveObject(pcs[0], pcs[1]);
 

--- a/Core/Core/Transports/ServerUtils/ServerAPI.cs
+++ b/Core/Core/Transports/ServerUtils/ServerAPI.cs
@@ -139,15 +139,14 @@ namespace Speckle.Core.Transports.ServerUtils
       {
         using (var reader = new StreamReader(childrenStream, Encoding.UTF8))
         {
-          while (reader.Peek() > 0)
+          string line;
+          while ((line = reader.ReadLine()) != null)
           {
             if (CancellationToken.IsCancellationRequested)
               return;
 
-            var line = reader.ReadLine();
             var pcs = line.Split(new char[] { '\t' }, count: 2);
             onObjectCallback(pcs[0], pcs[1]);
-
           }
         }
       }


### PR DESCRIPTION
Replaced Peek() function because of issue that occurs only in .net6.0 when downloading large object (e.g. 8000+ child objects) using the Speckle "ServerTransport"

## Description
Because of a .net6.0 issue with StreamReader.Peek() see: https://github.com/dotnet/runtime/issues/68983
The ServerTransport is using the .Peek() function to find the end of the stream and stop reading more object lines.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

-The changes to the Speckle Transport have been tested in a separate console app tool referencing the Speckle.Core project. It also has been tested as a Copy/CustomTransport supplied to the Operations.Receive in various production/test environments as a quick fix, it has not been tested as part of a development build of Speckle.Core 2.6.x

## Docs

- No updates needed

