### PR TITLE
Fixes and addtion for receving as mesh in Tekla and Revit

### DIFF
--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/Util/ConnectorTeklaStructuresUtils.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/Util/ConnectorTeklaStructuresUtils.cs
@@ -6,6 +6,8 @@ using Speckle.Core.Logging;
 using System.Linq;
 using Speckle.ConnectorTeklaStructures.UI;
 using Tekla.Structures.Model;
+using Speckle.Core.Models;
+
 namespace Speckle.ConnectorTeklaStructures.Util
 {
   class ConnectorTeklaStructuresUtils
@@ -37,6 +39,7 @@ namespace Speckle.ConnectorTeklaStructures.Util
       }
       return _categories;
     }
+        
 
     #region Get List Names
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -307,6 +307,42 @@ namespace Objects.Converter.Revit
 
       return "";
     }
+    private BuiltInCategory GetObjectCategory(Base @object)
+    {
+      switch(@object)
+      {
+        case BE.Beam _:
+        case BE.Brace _:
+        case BE.TeklaStructures.TeklaContourPlate _:
+          return BuiltInCategory.OST_StructuralFraming;
+        case BE.TeklaStructures.Bolts _:
+          return BuiltInCategory.OST_StructConnectionBolts;
+        case BE.TeklaStructures.Welds _:
+          return BuiltInCategory.OST_StructConnectionWelds;
+        case BE.Floor _:
+          return BuiltInCategory.OST_Floors;
+        case BE.Ceiling _:
+          return BuiltInCategory.OST_Ceilings;
+        case BE.Column _:
+          return BuiltInCategory.OST_Columns;
+        case BE.Pipe _:
+          return BuiltInCategory.OST_PipeSegments;
+        case BE.Rebar _:
+          return BuiltInCategory.OST_Rebar;
+        case BE.Topography _: 
+          return BuiltInCategory.OST_Topography;
+        case BE.Wall _:
+          return BuiltInCategory.OST_Walls;
+        case BE.Roof _:
+          return BuiltInCategory.OST_Roofs;
+        case BE.Duct _:
+          return BuiltInCategory.OST_FabricationDuctwork;
+        case BE.CableTray _:
+          return BuiltInCategory.OST_CableTray;
+        default:
+          return BuiltInCategory.OST_GenericModel;        
+      }
+    }
 
     public object ConvertToNative(Base @object)
     {
@@ -319,8 +355,9 @@ namespace Objects.Converter.Revit
           List<GE.Mesh> displayValues = new List<GE.Mesh> { };
           var meshes = @object.GetType().GetProperty("displayValue").GetValue(@object) as List<GE.Mesh>;
           //dynamic property = propInfo;
-          //List<GE.Mesh> meshes = (List<GE.Mesh>)property;       
-          return DirectShapeToNative(meshes);
+          //List<GE.Mesh> meshes = (List<GE.Mesh>)property;
+          var cat = GetObjectCategory(@object);
+          return DirectShapeToNative(meshes, cat);
         }
         catch 
         {

--- a/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/ConverterTeklaStructures.cs
+++ b/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/ConverterTeklaStructures.cs
@@ -131,7 +131,7 @@ namespace Objects.Converter.TeklaStructures
           var meshes = @object.GetType().GetProperty("displayValue").GetValue(@object) as List<GE.Mesh>;
           //dynamic property = propInfo;
           //List<GE.Mesh> meshes = (List<GE.Mesh>)property;       
-          MeshToNative(meshes);
+          MeshToNative(@object, meshes);
           return true;
         }
         catch
@@ -148,7 +148,6 @@ namespace Objects.Converter.TeklaStructures
       {
         case BE.Beam o:
           BeamToNative(o);
-          
           return true;
         case BE.Area o:
           ContourPlateToNative(o);

--- a/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/Partial Classes/ConvertDirectShapeMesh.cs
+++ b/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/Partial Classes/ConvertDirectShapeMesh.cs
@@ -19,45 +19,60 @@ namespace Objects.Converter.TeklaStructures
 {
   public partial class ConverterTeklaStructures
   {
-    public void MeshToNative(List<GE.Mesh> displayValues)
+    public void MeshToNative(Base @object, List<GE.Mesh> displayValues)
     {
-
+      int incr = 0;
       foreach (var mesh in displayValues)
       {
+        FacetedBrep facetedBrep = CreateFacetedBrep(mesh);
 
-        var faces = mesh.faces;
-        List<List<int>> faceList = new List<List<int>> { };
-        faceList = faces.Select((x, i) => new { Index = i, Value = x })
-        .GroupBy(x => x.Index / 4)
-        .Select(x => x.Select(v => v.Value).ToList())
-        .ToList();
-        var vertices = mesh.vertices;
-        List<List<double>> verticesList = new List<List<double>> { };
-        verticesList =  vertices.Select((x, i) => new { Index = i, Value = x })
-        .GroupBy(x => x.Index / 3)
-        .Select(x => x.Select(v => v.Value).ToList())
-        .ToList();
-        Vector[] vertexs = new Vector[] { };
-        int[][] outerWires = new int[][] { };
-        var innerLoop = new Dictionary<int, int[][]> { };
-        foreach(var vertex in verticesList){
-          var teklaVectorVertex = new Vector(vertex[0], vertex[1], vertex[2]);
-          vertexs.Append(teklaVectorVertex);
-        }
-        foreach(var face in faceList){
-          var teklaFaceLoop = new[] { face[1], face[2], face[3] };
-          outerWires.Append(teklaFaceLoop);
-        }
-        var brep = new FacetedBrep(vertexs, outerWires, innerLoop);
-
+        // Add shape to catalog
+        // Each shape in catalog needs to have a unique name
+        string objectName = GetShapeName(@object);
+        string shapeName = "Speckle_" + objectName + (incr > 0 ? "_" + incr.ToString() : "");
         var shapeItem = new ShapeItem
         {
-          Name = "Test",
-          ShapeFacetedBrep = brep,
+          Name = shapeName,
+          ShapeFacetedBrep = facetedBrep,
           UpAxis = ShapeUpAxis.Z_Axis
         };
-        shapeItem.Insert();
-        //Model.CommitChanges();
+        // remove possibly pre-existing shape with same name and then insert a Speckle object shape
+        // with that name into the catalog
+        shapeItem.Delete();
+        bool result = false;
+        try
+        {
+          result = shapeItem.Insert();
+          // Fails if two shapes exist with different names but same geometry fingerprint
+        }
+        catch (Exception ex) { }
+
+        if (!result)
+        {
+          // Find pre-existing shape in catalog with same fingerprint
+          var matchingShape = CheckFingerprint(shapeItem);
+          if (matchingShape != null)
+          {
+            shapeName = matchingShape.Name;
+            result = true;
+          }
+        }
+
+        // Insert object in model
+        if (result)
+        {
+          var brep = new Brep();
+          brep.StartPoint = new Tekla.Structures.Geometry3d.Point(0, 0, 0);
+          brep.EndPoint = new Tekla.Structures.Geometry3d.Point(1000, 0, 0);
+          brep.Profile.ProfileString = shapeName;
+          brep.Material.MaterialString = "TS_Undefined";
+          brep.Position.Depth = Position.DepthEnum.MIDDLE;
+          brep.Position.Plane = Position.PlaneEnum.MIDDLE;
+          brep.Position.Rotation = Position.RotationEnum.TOP;
+          brep.Insert(); 
+        }
+
+        incr++;
       }
 
       //var vertex = new[]
@@ -93,6 +108,64 @@ namespace Objects.Converter.TeklaStructures
       //};
       //shapeItem.Insert();
       //Model.CommitChanges();
+    }
+
+    public FacetedBrep CreateFacetedBrep(GE.Mesh mesh)
+    {
+        var faces = mesh.faces;
+        List<List<int>> faceList = new List<List<int>> { };
+        faceList = faces.Select((x, i) => new { Index = i, Value = x })
+          .GroupBy(x => x.Index / 4)
+          .Select(x => x.Select(v => v.Value).ToList())
+          .ToList();
+        var vertices = mesh.vertices;
+        List<List<double>> verticesList = new List<List<double>> { };
+        verticesList = vertices.Select((x, i) => new { Index = i, Value = x })
+          .GroupBy(x => x.Index / 3)
+          .Select(x => x.Select(v => v.Value).ToList())
+          .ToList();
+        List<Vector> vertexs = new List<Vector>();
+        List<int[]> outerWires = new List<int[]>();
+        var innerLoop = new Dictionary<int, int[][]> { };
+        foreach (var vertex in verticesList)
+        {
+          var teklaVectorVertex = new Vector(vertex[0], vertex[1], vertex[2]);
+          vertexs.Add(teklaVectorVertex);
+        }
+        foreach (var face in faceList)
+        {
+          // Tekla wants the face loops in reverse
+          var teklaFaceLoop = new[] { face[3], face[2], face[1] };
+          outerWires.Add(teklaFaceLoop);
+        }
+        var brep = new FacetedBrep(vertexs.ToArray(), outerWires.ToArray(), innerLoop);
+        return brep;
+    }
+    public string GetShapeName(Base @object)
+    {
+      string name = "";
+
+      // Take application id
+      if (string.IsNullOrEmpty(name))
+        name = @object.applicationId;
+
+      // If still empty then do Speckle id but can cause failure since changes with every commit
+      if (string.IsNullOrEmpty(name))
+        name = @object.id;
+
+      return name;
+    }
+    public ShapeItem CheckFingerprint(ShapeItem si)
+    {
+      CatalogHandler catalogHandler = new CatalogHandler();
+      ShapeItemEnumerator sie = catalogHandler.GetShapeItems();
+      while(sie.MoveNext())
+      {
+        ShapeItem siItem = sie.Current;
+        if (siItem.Fingerprint == Polymesh.Fingerprint(si.ShapeFacetedBrep))
+          return siItem;
+      }
+      return null;
     }
   }
 


### PR DESCRIPTION
## Description

- Fixed receiving objects as Brep shapes in Tekla Structures.
- Added proposed method to set OST category of DirectMesh object in Revit Connector

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: Sending and receiving models using the DirectMesh setting between Tekla Structures and Revit

## Docs

- No updates needed

