### PR TITLE
Revert "feat(dui): updates to Avalonia 0.10.16"

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
@@ -66,13 +66,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
@@ -56,13 +56,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
@@ -69,13 +69,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
@@ -59,13 +59,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
+++ b/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
@@ -87,13 +87,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="CSiAPIv1">
       <Version>1.0.0</Version>
@@ -104,7 +104,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.19.0</Version>
+      <Version>3.15.0</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Newtonsoft.Json">
       <Version>12.0.3.1</Version>

--- a/ConnectorCSI/ConnectorETABS/ConnectorETABS.csproj
+++ b/ConnectorCSI/ConnectorETABS/ConnectorETABS.csproj
@@ -81,13 +81,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="CSiAPIv1">
       <Version>1.0.0</Version>
@@ -98,7 +98,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.19.0</Version>
+      <Version>3.15.0</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Newtonsoft.Json">
       <Version>12.0.3.1</Version>

--- a/ConnectorCSI/ConnectorSAFE/ConnectorSAFE.csproj
+++ b/ConnectorCSI/ConnectorSAFE/ConnectorSAFE.csproj
@@ -81,13 +81,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="CSiAPIv1">
       <Version>1.0.0</Version>
@@ -98,7 +98,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.19.0</Version>
+      <Version>3.15.0</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Newtonsoft.Json">
       <Version>12.0.3.1</Version>

--- a/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
+++ b/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
@@ -81,13 +81,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="CSiAPIv1">
       <Version>1.0.0</Version>
@@ -98,7 +98,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.19.0</Version>
+      <Version>3.15.0</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Newtonsoft.Json">
       <Version>12.0.3.1</Version>

--- a/ConnectorCSI/DriverCSharp/DriverCSharp.csproj
+++ b/ConnectorCSI/DriverCSharp/DriverCSharp.csproj
@@ -72,13 +72,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="CSiAPIv1">
       <Version>1.0.0</Version>
@@ -89,7 +89,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.19.0</Version>
+      <Version>3.15.0</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Newtonsoft.Json">
       <Version>12.0.3.1</Version>

--- a/ConnectorRevit/ConnectorRevit2019/ConnectorRevit2019.csproj
+++ b/ConnectorRevit/ConnectorRevit2019/ConnectorRevit2019.csproj
@@ -60,13 +60,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="ModPlus.Revit.API.2019">
       <Version>1.0.0</Version>

--- a/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
+++ b/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
@@ -59,13 +59,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="ModPlus.Revit.API.2020">
       <Version>1.0.0</Version>

--- a/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
+++ b/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
@@ -59,13 +59,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="ModPlus.Revit.API.2021">
       <Version>1.0.0</Version>

--- a/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
+++ b/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
@@ -82,13 +82,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
+++ b/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
@@ -82,13 +82,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorRhino/ConnectorRhino6/ConnectorRhino6.csproj
+++ b/ConnectorRhino/ConnectorRhino6/ConnectorRhino6.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.16" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.16" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.16" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.15" />
     <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
+++ b/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.16" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.16" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.16" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.15" />
     <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/ConnectorTeklaStructures/ConnectorTeklaStructures2020/ConnectorTeklaStructures2020.csproj
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructures2020/ConnectorTeklaStructures2020.csproj
@@ -97,13 +97,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>
@@ -111,7 +111,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.19.0</Version>
+      <Version>3.15.0</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Newtonsoft.Json">
       <Version>12.0.3.1</Version>

--- a/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ConnectorTeklaStructures2021.csproj
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ConnectorTeklaStructures2021.csproj
@@ -89,13 +89,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.16</Version>
+      <Version>0.10.15</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>
@@ -103,7 +103,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.19.0</Version>
+      <Version>3.15.0</Version>
     </PackageReference>
     <PackageReference Include="Speckle.Newtonsoft.Json">
       <Version>12.0.3.1</Version>

--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -52,7 +52,7 @@
   <ItemGroup>
     <PackageReference Include="GraphQL.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Sentry" Version="3.19.0" />
+    <PackageReference Include="Sentry" Version="3.15.0" />
     <PackageReference Include="Speckle.Newtonsoft.Json" Version="12.0.3.1">
       <Aliases></Aliases>
     </PackageReference>

--- a/DesktopUI2/AvaloniaHwndHost/AvaloniaHwndHost.csproj
+++ b/DesktopUI2/AvaloniaHwndHost/AvaloniaHwndHost.csproj
@@ -15,6 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.16" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
   </ItemGroup>
 </Project>

--- a/DesktopUI2/DesktopUI2.Launcher/DesktopUI2.Launcher.csproj
+++ b/DesktopUI2/DesktopUI2.Launcher/DesktopUI2.Launcher.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.16" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.16" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.16" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DesktopUI2/DesktopUI2.WPF/DesktopUI2.WPF.csproj
+++ b/DesktopUI2/DesktopUI2.WPF/DesktopUI2.WPF.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Direct2D1" Version="0.10.16" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.16" />
+    <PackageReference Include="Avalonia.Direct2D1" Version="0.10.15" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DesktopUI2/DesktopUI2/DesktopUI2.csproj
+++ b/DesktopUI2/DesktopUI2/DesktopUI2.csproj
@@ -213,11 +213,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.16" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.16" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.16" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.16" />
-    <PackageReference Include="Material.Avalonia" Version="3.0.0-rc0.97-nightly" />
+    <PackageReference Include="Avalonia" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.15" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.15" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.15" />
+    <PackageReference Include="Material.Avalonia" Version="3.0.0-rc0.90-nightly" />
     <PackageReference Include="Material.Icons.Avalonia" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This reverts commit 9d302eec86543dffd2f18569b9d7fef8cd0cabca.

This is being reverted because it has been already squashed into the `release/2.7` branch, and should not live in `main` unless we're planning to release this as a hotfix (which I think may be dangerous, this should be tested first).

Changes are here b2e0ec8aa56ed37b4df186ee4263dc92008c5b0b