### PR TITLE
fix: Avalonia version bump was missing 2023 Acad and Civil projects

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocad2023/ConnectorAutocad2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2023/ConnectorAutocad2023.csproj
@@ -57,13 +57,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.15</Version>
+      <Version>0.10.16</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.15</Version>
+      <Version>0.10.16</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.15</Version>
+      <Version>0.10.16</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>

--- a/ConnectorAutocadCivil/ConnectorCivil2023/ConnectorCivil2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2023/ConnectorCivil2023.csproj
@@ -58,13 +58,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">
-      <Version>0.10.15</Version>
+      <Version>0.10.16</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.10.15</Version>
+      <Version>0.10.16</Version>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI">
-      <Version>0.10.15</Version>
+      <Version>0.10.16</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.AssemblyVersion">
       <Version>1.3.0</Version>


### PR DESCRIPTION
## Description

- Bumps version of Acad and Civil 2023 projects to Avalonia 0.10.16
- 
## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

Potentially breaking in some ways, requires further testing in the release.


