### PR TITLE
assign value to variable 'existingLevelWithSameElevation'

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLevel.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertLevel.cs
@@ -43,7 +43,9 @@ namespace Objects.Converter.Revit
       var hasLevelWithSameName = docLevels.Any(x => x.Name == speckleLevel.name);
       Level existingLevelWithSameElevation = null;
       if (elevationMatch)
-        docLevels.FirstOrDefault(l => Math.Abs(l.Elevation - (double)speckleLevelElevation) < TOLERANCE);
+      {
+        existingLevelWithSameElevation = docLevels.FirstOrDefault(l => Math.Abs(l.Elevation - (double)speckleLevelElevation) < TOLERANCE);
+      }
 
       //a level that had been previously received
       var revitLevel = GetExistingElementByApplicationId(speckleLevel.applicationId) as DB.Level;


### PR DESCRIPTION
## Description

- Fixes https://speckle.community/t/speckle-revit-levels-bug-old-levels-not-replaced/2378/7

Currently, a level is being created for each imported object. In the gif below you can see that I import a commit and then highlight what seems to be only a few levels
![imports-level-for-each-obj](https://user-images.githubusercontent.com/43247197/178885406-be68d690-3e7f-4451-a80e-80a25a0fb496.gif)

The text may be difficult to read in the gif, but Revit is showing that I actually have 104 levels highlighted.


This behavior is now almost identical except Speckle will skip levels that already exist
![imports-needed-levels](https://user-images.githubusercontent.com/43247197/178885726-2decabe9-472d-4a3d-a7a9-01bb9972556c.gif)

There are now only 4 highlighted levels

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)
- Received several streams to check to make sure duplicate levels were not being created

## Docs

- No updates needed

