### PR TITLE
Update main with changes from 2.6.X

### DIFF
--- a/DesktopUI/DesktopUI/Utils/DummyBindings.cs
+++ b/DesktopUI/DesktopUI/Utils/DummyBindings.cs
@@ -97,7 +97,7 @@ namespace Speckle.DesktopUI.Utils
           {
             id = "123",
             name = "main",
-            commits = new Commits()
+            commits = new Speckle.Core.Api.Commits()
             {
               items = new List<Commit>()
               {
@@ -131,7 +131,7 @@ namespace Speckle.DesktopUI.Utils
           {
             id = "123",
             name = "main",
-            commits = new Commits()
+            commits = new Core.Api.Commits()
             {
               items = new List<Commit>()
               {

--- a/DesktopUI2/DesktopUI2/DummyBindings.cs
+++ b/DesktopUI2/DesktopUI2/DummyBindings.cs
@@ -192,7 +192,7 @@ namespace DesktopUI2
           {
             id = "123",
             name = "main",
-            commits = new Commits()
+            commits = new Speckle.Core.Api.Commits()
             {
               items = new List<Commit>()
               {


### PR DESCRIPTION
Changes were made and a new 2.6.5 release was triggered.

This PR is to keep `main` up to date with these changes