### PR TITLE
DYN/GH: Adds better Block and Transform support

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/ToSpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/ToSpeckleTaskCapableComponent.cs
@@ -94,7 +94,7 @@ namespace ConnectorGrasshopper.Conversion
         }
 
         if (converted.GetType().IsSimpleType())
-          return new GH_ObjectWrapper(converted);
+          return Extras.Utilities.WrapInGhType(converted);
 
         return new GH_SpeckleBase { Value = converted as Base };
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Speckle.IGH_Goo.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Speckle.IGH_Goo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
@@ -27,7 +28,7 @@ namespace ConnectorGrasshopper.Extras
 
     public override bool IsValid => Value != null;
 
-    public override string TypeName => "Speckle" + (Value != null && Value.speckle_type == "" ? " Base" : " " + Value?.speckle_type);
+    public override string TypeName => ToString();
 
     public override string TypeDescription => "A Speckle Object";
 
@@ -87,7 +88,12 @@ namespace ConnectorGrasshopper.Extras
 
     public override string ToString()
     {
-      return $"{(Value != null && Value.speckle_type == "" ? "Speckle.Base" : Value?.speckle_type)}";
+      if (Value == null) return "";
+      if (Value.GetType().IsSubclassOf(typeof(Base)))
+        return $"Speckle {Value.GetType().Name}";
+      return "Speckle Object";
+      
+      //return $"{(Value != null && Value.speckle_type == "" ? "Speckle.Base" : Value?.speckle_type)}";
     }
   }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleBaseParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleBaseParam.cs
@@ -38,7 +38,7 @@ namespace ConnectorGrasshopper.Extras
         {
         }
         
-        public SpeckleBaseParam() : this("Speckle Base", "SB","Base object for Speckle",GH_ParamAccess.item)
+        public SpeckleBaseParam() : this("Speckle Object", "SO","Base object for Speckle",GH_ParamAccess.item)
         {
             
         }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
@@ -84,7 +84,7 @@ namespace ConnectorGrasshopper.Objects
           }
         default:
           Params.Output[0].Access = GH_ParamAccess.item;
-          DA.SetData(0, GH_Convert.ToGoo(value));
+          DA.SetData(0, Extras.Utilities.WrapInGhType(value));
           break;
       }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -78,7 +78,7 @@ public class BlockDefinitionSchemaComponent: CreateSchemaObjectBase {
     public override Guid ComponentGuid => new Guid("91f1164e-b519-d72f-d64b-e68bb14836e3");
     
     public override void AddedToDocument(GH_Document document){
-        SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.BlockDefinition.ctor(System.String,Objects.Geometry.Point,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.String)","Objects.Other.BlockDefinition");
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.BlockDefinition.ctor(System.String,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Geometry.Point)","Objects.Other.BlockDefinition");
         base.AddedToDocument(document);
     }
 }
@@ -1296,6 +1296,19 @@ public class Material1SchemaComponent: CreateSchemaObjectBase {
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Materials.Material.ctor(System.String,Objects.Structural.MaterialType,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Materials.Material");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class MaterialQuantitySchemaComponent: CreateSchemaObjectBase {
+     
+    public MaterialQuantitySchemaComponent(): base("MaterialQuantity", "MaterialQuantity", "Creates the quantity of a material", "Speckle 2 BIM", "Objects.Other") { }
+    
+    public override Guid ComponentGuid => new Guid("c94a9777-99bb-d501-281a-c10300309038");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.MaterialQuantity.ctor(Objects.Other.Material,System.Double,System.Double,System.String)","Objects.Other.MaterialQuantity");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/SchemaBuilderGen.cs
@@ -71,6 +71,32 @@ public class BeamSchemaComponent: CreateSchemaObjectBase {
 }
 
 // This is generated code:
+public class BlockDefinitionSchemaComponent: CreateSchemaObjectBase {
+     
+    public BlockDefinitionSchemaComponent(): base("Block Definition", "Block Definition", "A Speckle Block definition", "Speckle 2 BIM", "Objects.Other") { }
+    
+    public override Guid ComponentGuid => new Guid("91f1164e-b519-d72f-d64b-e68bb14836e3");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.BlockDefinition.ctor(System.String,Objects.Geometry.Point,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.String)","Objects.Other.BlockDefinition");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class BlockInstanceSchemaComponent: CreateSchemaObjectBase {
+     
+    public BlockInstanceSchemaComponent(): base("Block Instance", "Block Instance", "A Speckle Block Instance", "Speckle 2 BIM", "Objects.Other") { }
+    
+    public override Guid ComponentGuid => new Guid("28238ece-f2e0-fe7d-e25f-e8f8cb35e629");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.BlockInstance.ctor(Objects.Other.BlockDefinition,Objects.Other.Transform)","Objects.Other.BlockInstance");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
 public class BraceSchemaComponent: CreateSchemaObjectBase {
      
     public BraceSchemaComponent(): base("Brace", "Brace", "Creates a Speckle brace", "Speckle 2 BIM", "Structure") { }
@@ -2085,6 +2111,19 @@ public class RevitLevel1SchemaComponent: CreateSchemaObjectBase {
 }
 
 // This is generated code:
+public class RevitMaterialSchemaComponent: CreateSchemaObjectBase {
+     
+    public RevitMaterialSchemaComponent(): base("RevitMaterial", "RevitMaterial", "Creates a Speckle material", "Speckle 2 BIM", "Architecture") { }
+    
+    public override Guid ComponentGuid => new Guid("c291d027-7a6a-8950-a2aa-77e134675750");
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.Revit.RevitMaterial.ctor(System.String,System.String,System.String,System.Int32,System.Int32,System.Int32,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.Other.Revit.RevitMaterial");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
 public class RevitPipeSchemaComponent: CreateSchemaObjectBase {
      
     public RevitPipeSchemaComponent(): base("RevitPipe", "RevitPipe", "Creates a Revit pipe", "Speckle 2 Revit", "MEP") { }
@@ -2181,6 +2220,8 @@ public class RevitWallOpeningSchemaComponent: CreateSchemaObjectBase {
     public RevitWallOpeningSchemaComponent(): base("Revit Wall Opening (Deprecated)", "Revit Wall Opening (Deprecated)", "Creates a Speckle Wall opening for revit", "Speckle 2 BIM", "Architecture") { }
     
     public override Guid ComponentGuid => new Guid("a1bd278d-fab5-0034-7aba-807b66122022");
+    public override bool Obsolete => true;
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWallOpening.ctor(Objects.ICurve,Objects.BuiltElements.Revit.RevitWall)","Objects.BuiltElements.Revit.RevitWallOpening");

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -354,7 +354,7 @@ namespace Objects.Converter.Dynamo
         var arc = DS.Arc.ByCenterPointStartPointSweepAngle(
           basePlane.Origin,
           startPoint,
-          a.angleRadians.Value.ToDegrees(),
+          a.angleRadians.ToDegrees(),
           basePlane.Normal
         );
         return arc.SetDynamoProperties<DS.Arc>(GetDynamicMembersFromBase(a));

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -17,6 +17,7 @@ using Ellipse = Objects.Geometry.Ellipse;
 using Curve = Objects.Geometry.Curve;
 using Mesh = Objects.Geometry.Mesh;
 using Objects;
+using Objects.Other;
 using Spiral = Objects.Geometry.Spiral;
 using Surface = Objects.Geometry.Surface;
 using Speckle.Core.Kits;
@@ -171,10 +172,15 @@ namespace Objects.Converter.Dynamo
         PointToNative(plane.origin),
         VectorToNative(plane.xdir),
         VectorToNative(plane.ydir));
-
       return pln.SetDynamoProperties<DS.Plane>(GetDynamicMembersFromBase(plane));
     }
 
+    public CoordinateSystem TransformToNative(Transform transform)
+    {
+      return CoordinateSystem.ByMatrix(transform.value)
+        .Scale(Units.GetConversionFactor(transform.units, ModelUnits));
+    }
+    
     #endregion
 
     #region Linear

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.cs
@@ -20,6 +20,7 @@ using Mesh = Objects.Geometry.Mesh;
 using Plane = Objects.Geometry.Plane;
 using Point = Objects.Geometry.Point;
 using Spiral = Objects.Geometry.Spiral;
+using Transform = Objects.Other.Transform;
 using Vector = Objects.Geometry.Vector;
 
 namespace Objects.Converter.Dynamo
@@ -176,7 +177,9 @@ namespace Objects.Converter.Dynamo
 
         case Box o:
           return BoxToNative(o);
-
+        
+        case Transform o:
+          return TransformToNative(o);
         default:
           throw new NotSupportedException();
       }
@@ -275,6 +278,7 @@ namespace Objects.Converter.Dynamo
         case Brep _:
         case Mesh _:
         case Box _:
+        case Transform _:
           return true;
 
         default:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -32,7 +32,7 @@ namespace Objects.Converter.Revit
         switch (geometry)
         {
           case Brep brep:
-            var success = brep.TransformTo(transform, out var tbrep);
+            var success = brep.TransformTo(transform, out Brep tbrep);
             if (success)
               breps.Add(tbrep);
             else
@@ -43,7 +43,7 @@ namespace Objects.Converter.Revit
             }
             break;
           case Mesh mesh:
-            mesh.TransformTo(transform, out var tmesh);
+            mesh.TransformTo(transform, out Mesh tmesh);
             meshes.Add(tmesh);
             break;
           case ICurve curve:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -369,6 +369,29 @@ namespace Objects.Converter.RhinoGh
       return Doc.Objects.FindId(instanceId) as InstanceObject;
     }
 
+    public DisplayMaterial RenderMaterialToDisplayMaterial(RenderMaterial material)
+    {
+      var rhinoMaterial = new Material
+      {
+        Name = material.name,
+        DiffuseColor = Color.FromArgb(material.diffuse),
+        EmissionColor = Color.FromArgb(material.emissive),
+        Transparency = 1 - material.opacity
+      };
+      var displayMaterial = new DisplayMaterial(rhinoMaterial);
+      return displayMaterial;
+    }
+    
+    
+    public RenderMaterial DisplayMaterialToSpeckle(DisplayMaterial material)
+    {
+      var speckleMaterial = new RenderMaterial();
+      speckleMaterial.diffuse = material.Diffuse.ToArgb();
+      speckleMaterial.emissive = material.Emission.ToArgb();
+      speckleMaterial.opacity = 1.0 - material.Transparency;
+      return speckleMaterial;
+    }
+    
     public Transform TransformToNative(Other.Transform speckleTransform, string units = null)
     {
       var u = units ?? speckleTransform.units;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -369,8 +369,9 @@ namespace Objects.Converter.RhinoGh
       return Doc.Objects.FindId(instanceId) as InstanceObject;
     }
 
-    private Transform TransformToNative(Other.Transform speckleTransform, string units)
+    public Transform TransformToNative(Other.Transform speckleTransform, string units = null)
     {
+      var u = units ?? speckleTransform.units;
       var transform = Transform.Identity;
       var t = speckleTransform.value;
       if (t.Length != 16) return transform;
@@ -381,9 +382,9 @@ namespace Objects.Converter.RhinoGh
         {
           if (j == 3) // scale the delta values for translation transformations and set last value (divisor) to 1
             if (t[15] != 0)
-              transform[i, j] = (i != 3) ? ScaleToNative(t[count] / t[15], units) : 1;
+              transform[i, j] = (i != 3) ? ScaleToNative(t[count] / t[15], u) : 1;
             else
-              transform[i, j] = (i != 3) ? ScaleToNative(t[count], units) : 1;
+              transform[i, j] = (i != 3) ? ScaleToNative(t[count], u) : 1;
           else
             transform[i, j] = t[count];
           count++;
@@ -392,6 +393,17 @@ namespace Objects.Converter.RhinoGh
       return transform;
     }
 
+    public Other.Transform TransformToSpeckle(Transform t, string units = null)
+    {
+      var u = units ?? ModelUnits;
+      var transformArray = new double[] {
+        t.M00, t.M01, t.M02, t.M03,
+        t.M10, t.M11, t.M12, t.M13,
+        t.M20, t.M21, t.M22, t.M23,
+        t.M30, t.M31, t.M32, t.M33 };
+      return new Other.Transform(transformArray, ModelUnits);
+    }
+    
     // Text
     public Text TextToSpeckle(TextEntity text)
     {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -354,26 +354,9 @@ namespace Objects.Converter.RhinoGh
 
       // get the transform
       // rhino doesn't seem to handle transform matrices where the translation vector last value is a divisor instead of 1, so make sure last value is set to 1
-      Transform transform = Transform.Identity;
-      double[] t = instance.transform.value;
-      if (t.Length == 16)
-      {
-        int count = 0;
-        for (int i = 0; i < 4; i++)
-        {
-          for (int j = 0; j < 4; j++)
-          {
-            if (j == 3) // scale the delta values for translation transformations and set last value (divisor) to 1
-              if (t[15] != 0)
-                transform[i, j] = (i != 3) ? ScaleToNative(t[count] / t[15], instance.units) : 1;
-              else
-                transform[i, j] = (i != 3) ? ScaleToNative(t[count], instance.units) : 1;
-            else
-              transform[i, j] = t[count];
-            count++;
-          }
-        }
-      }
+      var iT = instance.transform;
+      var units = instance.units;
+      var transform = TransformToNative(iT, units);
 
       // create the instance
       if (definition == null)
@@ -384,6 +367,29 @@ namespace Objects.Converter.RhinoGh
         return null;
 
       return Doc.Objects.FindId(instanceId) as InstanceObject;
+    }
+
+    private Transform TransformToNative(Other.Transform speckleTransform, string units)
+    {
+      var transform = Transform.Identity;
+      var t = speckleTransform.value;
+      if (t.Length != 16) return transform;
+      var count = 0;
+      for (var i = 0; i < 4; i++)
+      {
+        for (var j = 0; j < 4; j++)
+        {
+          if (j == 3) // scale the delta values for translation transformations and set last value (divisor) to 1
+            if (t[15] != 0)
+              transform[i, j] = (i != 3) ? ScaleToNative(t[count] / t[15], units) : 1;
+            else
+              transform[i, j] = (i != 3) ? ScaleToNative(t[count], units) : 1;
+          else
+            transform[i, j] = t[count];
+          count++;
+        }
+      }
+      return transform;
     }
 
     // Text

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -29,6 +29,7 @@ using Polyline = Objects.Geometry.Polyline;
 using RH = Rhino.Geometry;
 using Spiral = Objects.Geometry.Spiral;
 using Surface = Objects.Geometry.Surface;
+using Transform = Objects.Other.Transform;
 using Vector = Objects.Geometry.Vector;
 using View3D = Objects.BuiltElements.View3D;
 
@@ -662,7 +663,9 @@ namespace Objects.Converter.RhinoGh
         case RenderMaterial o:
           rhinoObj = RenderMaterialToNative(o);
           break;
-
+        case Transform o:
+          rhinoObj = TransformToNative(o, Units.None);
+          break;
         default:
           Report.Log($"Skipped not supported type: {@object.GetType()} {@object.id}");
           throw new NotSupportedException();
@@ -751,6 +754,7 @@ namespace Objects.Converter.RhinoGh
         case Brep _:
         case Surface _:
         case Structural.Geometry.Element1D _:
+        case Transform _:
           return true;
 
 #if !GRASSHOPPER

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -664,7 +664,7 @@ namespace Objects.Converter.RhinoGh
           rhinoObj = RenderMaterialToNative(o);
           break;
         case Transform o:
-          rhinoObj = TransformToNative(o, Units.None);
+          rhinoObj = TransformToNative(o);
           break;
         default:
           Report.Log($"Skipped not supported type: {@object.GetType()} {@object.id}");

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -235,6 +235,10 @@ namespace Objects.Converter.RhinoGh
           @base = MeshToSpeckle(o);
           Report.Log($"Converted Mesh");
           break;
+        case RH.Transform o:
+          @base = TransformToSpeckle(o);
+          Report.Log("Converter Transform");
+          break;
 #if RHINO7
         case RH.SubD o:
           if (o.HasBrepForm)
@@ -715,6 +719,7 @@ namespace Objects.Converter.RhinoGh
         case RH.Extrusion _:
         case RH.Brep _:
         case NurbsSurface _:
+        case RH.Transform _:
           return true;
 
 #if !GRASSHOPPER

--- a/Objects/Objects/Geometry/Arc.cs
+++ b/Objects/Objects/Geometry/Arc.cs
@@ -209,14 +209,15 @@ namespace Objects.Geometry
     public bool TransformTo(Transform transform, out Arc transformed)
     {
       plane.TransformTo(transform, out Plane pln);
-      transformed = new Arc(pln,transform.ApplyToPoint(startPoint),transform.ApplyToPoint(endPoint), angleRadians, units);
+      var arc = new Arc(pln,transform.ApplyToPoint(startPoint),transform.ApplyToPoint(endPoint), angleRadians, units);
+      arc.domain = domain;
+      transformed = arc;
       return true;
     }
 
     public bool TransformTo(Transform transform, out ITransformable transformed)
     {
       var res = TransformTo(transform, out Arc arc);
-      arc.domain = domain;
       transformed = arc;
       return res;
     }

--- a/Objects/Objects/Geometry/Arc.cs
+++ b/Objects/Objects/Geometry/Arc.cs
@@ -9,178 +9,180 @@ using Speckle.Core.Logging;
 
 namespace Objects.Geometry
 {
-  public class Arc : Base, IHasBoundingBox, ICurve, IHasArea, ITransformable<Arc>
-  {
-    public double? radius { get; set; }
-    public double? startAngle { get; set; }
-
-    public double? endAngle { get; set; }
-
-    public double angleRadians { get; set; }
-
-    /// <summary>
-    /// Gets or sets the plane of the <see cref="Arc"/>. The plane origin is the <see cref="Arc"/> center.
-    /// </summary>
-    public Plane plane { get; set; }
-
-    public Interval domain { get; set; }
-
-    public Point startPoint { get; set; }
-
-    /// <summary>
-    /// Gets or sets the point at 0.5 length.
-    /// </summary>
-    public Point midPoint { get; set; }
-
-    public Point endPoint { get; set; }
-
-    public Box bbox { get; set; }
-
-    public double area { get; set; }
-
-    public double length { get; set; }
-    public string units { get; set; }
-
-    public Arc()
+    public class Arc : Base, IHasBoundingBox, ICurve, IHasArea, ITransformable<Arc>
     {
+        public double? radius { get; set; }
+        public double? startAngle { get; set; }
+
+        public double? endAngle { get; set; }
+
+        public double angleRadians { get; set; }
+
+        /// <summary>
+        /// Gets or sets the plane of the <see cref="Arc"/>. The plane origin is the <see cref="Arc"/> center.
+        /// </summary>
+        public Plane plane { get; set; }
+
+        public Interval domain { get; set; }
+
+        public Point startPoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the point at 0.5 length.
+        /// </summary>
+        public Point midPoint { get; set; }
+
+        public Point endPoint { get; set; }
+
+        public Box bbox { get; set; }
+
+        public double area { get; set; }
+
+        public double length { get; set; }
+        public string units { get; set; }
+
+        public Arc()
+        {
+        }
+
+        public Arc(Plane plane, double radius, double startAngle, double endAngle, double angleRadians,
+          string units = Units.Meters, string applicationId = null)
+        {
+            this.plane = plane;
+            this.radius = radius;
+            this.startAngle = startAngle;
+            this.endAngle = endAngle;
+            this.angleRadians = angleRadians;
+            this.applicationId = applicationId;
+            this.units = units;
+        }
+
+        /// <summary>
+        /// Initialise an `Arc` using the arc angle and the start and end points.
+        /// The radius, midpoint, start angle, and end angle will be calculated.
+        /// For now, this assumes 2D arcs on the XY plane
+        /// </summary>
+        /// <param name="startPoint">The start point of the arc</param>
+        /// <param name="endPoint">The end point of the arc</param>
+        /// <param name="angleRadians">The arc angle</param>
+        /// <param name="units">Units (defaults to "m")</param>
+        /// <param name="applicationId">ID given to the arc in the authoring programme (defaults to null)</param>
+        public Arc(Point startPoint, Point endPoint, double angleRadians, string units = Units.Meters,
+          string applicationId = null)
+          : this(
+            new Plane(startPoint, new Vector(0, 0, 1), new Vector(1, 0, 0), new Vector(0, 1, 0), units),
+            startPoint,
+            endPoint,
+            angleRadians,
+            units,
+            applicationId
+            )
+        { }
+
+        public Arc(Plane plane, Point startPoint, Point endPoint, double angleRadians, string units = Units.Meters,
+          string applicationId = null)
+        {
+            // don't be annoying
+            if (angleRadians > Math.PI * 2)
+                throw new SpeckleException("Can't create an arc with an angle greater than 2pi");
+            if (startPoint == endPoint)
+                throw new SpeckleException("Can't create an arc where the start and end points are the same");
+
+            this.units = units;
+            this.startPoint = startPoint;
+            this.endPoint = endPoint;
+            this.angleRadians = angleRadians;
+            this.applicationId = applicationId;
+
+            // find chord and chord angle which may differ from the arc angle
+            var chordMidpoint = Point.Midpoint(startPoint, endPoint);
+            var chordLength = Point.Distance(startPoint, endPoint);
+            var chordAngle = angleRadians;
+            if (chordAngle > Math.PI)
+                chordAngle -= Math.PI * 2;
+            else if (chordAngle < -Math.PI)
+                chordAngle += Math.PI * 2;
+            // use the law of cosines for an isosceles triangle to get the radius
+            radius = chordLength / Math.Sqrt(2 - 2 * Math.Cos(chordAngle));
+
+            // find the chord vector then calculate the perpendicular vector which points to the centre
+            // which can be used to find the circle centre point
+            var dir = chordAngle < 0 ? -1 : 1;
+            var centreToChord = Math.Sqrt(Math.Pow((double)radius, 2) - Math.Pow(chordLength * 0.5, 2));
+            var perp = Vector.CrossProduct(new Vector(endPoint - startPoint), plane.normal);
+            var circleCentre = chordMidpoint + new Point(perp.Unit() * centreToChord * -dir);
+            plane.origin = circleCentre;
+
+            // use the perpendicular vector in the other direction (from the centre to the arc) to find the arc midpoint
+            midPoint = angleRadians > Math.PI
+              ? chordMidpoint + new Point(perp.Unit() * ((double)radius + centreToChord) * -dir)
+              : chordMidpoint + new Point(perp.Unit() * ((double)radius - centreToChord) * dir);
+
+            // find the start angle using trig (correcting for quadrant position) and add the arc angle to get the end angle
+            startAngle = Math.Tan((startPoint.y - circleCentre.y) / (startPoint.x - circleCentre.x)) % (2 * Math.PI);
+            if (startPoint.x > circleCentre.x && startPoint.y < circleCentre.y) // Q4
+                startAngle *= -1;
+            else if (startPoint.x < circleCentre.x && startPoint.y < circleCentre.y) // Q3
+                startAngle += Math.PI;
+            else if (startPoint.x < circleCentre.x && startPoint.y > circleCentre.y) // Q2
+                startAngle = Math.PI - startAngle;
+            endAngle = startAngle + angleRadians;
+        }
+
+        public List<double> ToList()
+        {
+            var list = new List<double>();
+            list.Add(radius ?? 0);
+            list.Add(startAngle ?? 0);
+            list.Add(endAngle ?? 0);
+            list.Add(angleRadians);
+            list.Add(domain.start ?? 0);
+            list.Add(domain.end ?? 0);
+
+            list.AddRange(plane.ToList());
+            list.AddRange(startPoint.ToList());
+            list.AddRange(midPoint.ToList());
+            list.AddRange(endPoint.ToList());
+            list.Add(Units.GetEncodingFromUnit(units));
+            list.Insert(0, CurveTypeEncoding.Arc);
+            list.Insert(0, list.Count);
+            return list;
+        }
+
+        public static Arc FromList(List<double> list)
+        {
+            var arc = new Arc();
+
+            arc.radius = list[2];
+            arc.startAngle = list[3];
+            arc.endAngle = list[4];
+            arc.angleRadians = list[5];
+            arc.domain = new Interval(list[6], list[7]);
+            arc.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
+            arc.plane = Plane.FromList(list.GetRange(8, 13));
+            arc.startPoint = Point.FromList(list.GetRange(21, 3), arc.units);
+            arc.midPoint = Point.FromList(list.GetRange(24, 3), arc.units);
+            arc.endPoint = Point.FromList(list.GetRange(27, 3), arc.units);
+            arc.plane.units = arc.units;
+
+            return arc;
+        }
+
+        public bool TransformTo(Transform transform, out Arc transformed)
+        {
+            plane.TransformTo(transform, out Plane pln);
+            var arc = new Arc(pln, transform.ApplyToPoint(startPoint), transform.ApplyToPoint(endPoint), angleRadians, units);
+            arc.midPoint = transform.ApplyToPoint(midPoint);
+            arc.domain = domain;
+            transformed = arc;
+            return true;
+        }
+
+        public bool TransformTo(Transform transform, out ITransformable transformed)
+        {
+            var res = TransformTo(transform, out Arc arc);
+            transformed = arc;
+            return res;
+        }
     }
-
-    public Arc(Plane plane, double radius, double startAngle, double endAngle, double angleRadians,
-      string units = Units.Meters, string applicationId = null)
-    {
-      this.plane = plane;
-      this.radius = radius;
-      this.startAngle = startAngle;
-      this.endAngle = endAngle;
-      this.angleRadians = angleRadians;
-      this.applicationId = applicationId;
-      this.units = units;
-    }
-
-    /// <summary>
-    /// Initialise an `Arc` using the arc angle and the start and end points.
-    /// The radius, midpoint, start angle, and end angle will be calculated.
-    /// For now, this assumes 2D arcs on the XY plane
-    /// </summary>
-    /// <param name="startPoint">The start point of the arc</param>
-    /// <param name="endPoint">The end point of the arc</param>
-    /// <param name="angleRadians">The arc angle</param>
-    /// <param name="units">Units (defaults to "m")</param>
-    /// <param name="applicationId">ID given to the arc in the authoring programme (defaults to null)</param>
-    public Arc(Point startPoint, Point endPoint, double angleRadians, string units = Units.Meters,
-      string applicationId = null)
-      : this(
-        new Plane(startPoint, new Vector(0, 0, 1), new Vector(1, 0, 0), new Vector(0, 1, 0), units),
-        startPoint,
-        endPoint,
-        angleRadians,
-        units,
-        applicationId
-        ) { }
-
-    public Arc(Plane plane, Point startPoint, Point endPoint, double angleRadians, string units = Units.Meters,
-      string applicationId = null)
-    {
-      // don't be annoying
-      if (angleRadians > Math.PI * 2)
-        throw new SpeckleException("Can't create an arc with an angle greater than 2pi");
-      if (startPoint == endPoint)
-        throw new SpeckleException("Can't create an arc where the start and end points are the same");
-
-      this.units = units;
-      this.startPoint = startPoint;
-      this.endPoint = endPoint;
-      this.angleRadians = angleRadians;
-      this.applicationId = applicationId;
-
-      // find chord and chord angle which may differ from the arc angle
-      var chordMidpoint = Point.Midpoint(startPoint, endPoint);
-      var chordLength = Point.Distance(startPoint, endPoint);
-      var chordAngle = angleRadians;
-      if (chordAngle > Math.PI)
-        chordAngle -= Math.PI * 2;
-      else if (chordAngle < -Math.PI)
-        chordAngle += Math.PI * 2;
-      // use the law of cosines for an isosceles triangle to get the radius
-      radius = chordLength / Math.Sqrt(2 - 2 * Math.Cos(chordAngle));
-
-      // find the chord vector then calculate the perpendicular vector which points to the centre
-      // which can be used to find the circle centre point
-      var dir = chordAngle < 0 ? -1 : 1;
-      var centreToChord = Math.Sqrt(Math.Pow((double)radius, 2) - Math.Pow(chordLength * 0.5, 2));
-      var perp = Vector.CrossProduct(new Vector(endPoint - startPoint), plane.normal);
-      var circleCentre = chordMidpoint + new Point(perp.Unit() * centreToChord * -dir);
-      plane.origin = circleCentre;
-
-      // use the perpendicular vector in the other direction (from the centre to the arc) to find the arc midpoint
-      midPoint = angleRadians > Math.PI
-        ? chordMidpoint + new Point(perp.Unit() * ((double)radius + centreToChord) * -dir)
-        : chordMidpoint + new Point(perp.Unit() * ((double)radius - centreToChord) * dir);
-
-      // find the start angle using trig (correcting for quadrant position) and add the arc angle to get the end angle
-      startAngle = Math.Tan((startPoint.y - circleCentre.y) / (startPoint.x - circleCentre.x)) % (2 * Math.PI);
-      if (startPoint.x > circleCentre.x && startPoint.y < circleCentre.y) // Q4
-        startAngle *= -1;
-      else if (startPoint.x < circleCentre.x && startPoint.y < circleCentre.y) // Q3
-        startAngle += Math.PI;
-      else if (startPoint.x < circleCentre.x && startPoint.y > circleCentre.y) // Q2
-        startAngle = Math.PI - startAngle;
-      endAngle = startAngle + angleRadians;
-    }
-
-    public List<double> ToList()
-    {
-      var list = new List<double>();
-      list.Add(radius ?? 0);
-      list.Add(startAngle ?? 0);
-      list.Add(endAngle ?? 0);
-      list.Add(angleRadians);
-      list.Add(domain.start ?? 0);
-      list.Add(domain.end ?? 0);
-
-      list.AddRange(plane.ToList());
-      list.AddRange(startPoint.ToList());
-      list.AddRange(midPoint.ToList());
-      list.AddRange(endPoint.ToList());
-      list.Add(Units.GetEncodingFromUnit(units));
-      list.Insert(0, CurveTypeEncoding.Arc);
-      list.Insert(0, list.Count);
-      return list;
-    }
-
-    public static Arc FromList(List<double> list)
-    {
-      var arc = new Arc();
-
-      arc.radius = list[2];
-      arc.startAngle = list[3];
-      arc.endAngle = list[4];
-      arc.angleRadians = list[5];
-      arc.domain = new Interval(list[6], list[7]);
-      arc.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
-      arc.plane = Plane.FromList(list.GetRange(8, 13));
-      arc.startPoint = Point.FromList(list.GetRange(21, 3), arc.units);
-      arc.midPoint = Point.FromList(list.GetRange(24, 3), arc.units);
-      arc.endPoint = Point.FromList(list.GetRange(27, 3), arc.units);
-      arc.plane.units = arc.units;
-
-      return arc;
-    }
-
-    public bool TransformTo(Transform transform, out Arc transformed)
-    {
-      plane.TransformTo(transform, out Plane pln);
-      var arc = new Arc(pln, transform.ApplyToPoint(startPoint), transform.ApplyToPoint(endPoint), angleRadians, units);
-      arc.domain = domain;
-      transformed = arc;
-      return true;
-    }
-
-    public bool TransformTo(Transform transform, out ITransformable transformed)
-    {
-      var res = TransformTo(transform, out Arc arc);
-      transformed = arc;
-      return res;
-    }
-  }
 }

--- a/Objects/Objects/Geometry/Arc.cs
+++ b/Objects/Objects/Geometry/Arc.cs
@@ -4,18 +4,19 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Objects.Other;
 using Speckle.Core.Logging;
 
 namespace Objects.Geometry
 {
-  public class Arc : Base, IHasBoundingBox, ICurve, IHasArea
+  public class Arc : Base, IHasBoundingBox, ICurve, IHasArea, ITransformable<Arc>
   {
     public double? radius { get; set; }
     public double? startAngle { get; set; }
 
     public double? endAngle { get; set; }
 
-    public double? angleRadians { get; set; }
+    public double angleRadians { get; set; }
 
     /// <summary>
     /// Gets or sets the plane of the <see cref="Arc"/>. The plane origin is the <see cref="Arc"/> center.
@@ -117,14 +118,62 @@ namespace Objects.Geometry
         startAngle = Math.PI - startAngle;
       endAngle = startAngle + angleRadians;
     }
+    public Arc(Plane plane, Point startPoint, Point endPoint, double angleRadians, string units = Units.Meters,
+      string applicationId = null)
+    {
+      // don't be annoying
+      if ( angleRadians > Math.PI * 2 )
+        throw new SpeckleException("Can't create an arc with an angle greater than 2pi");
+      if (startPoint == endPoint)
+        throw new SpeckleException("Can't create an arc where the start and end points are the same");
 
+      this.units = units;
+      this.startPoint = startPoint;
+      this.endPoint = endPoint;
+      this.angleRadians = angleRadians;
+      this.applicationId = applicationId;
+
+      // find chord and chord angle which may differ from the arc angle
+      var chordMidpoint = Point.Midpoint(startPoint, endPoint);
+      var chordLength = Point.Distance(startPoint, endPoint);
+      var chordAngle = angleRadians;
+      if ( chordAngle > Math.PI )
+        chordAngle -= Math.PI * 2;
+      else if ( chordAngle < -Math.PI )
+        chordAngle += Math.PI * 2;
+      // use the law of cosines for an isosceles triangle to get the radius
+      radius = chordLength / Math.Sqrt(2 - 2 * Math.Cos(chordAngle));
+
+      // find the chord vector then calculate the perpendicular vector which points to the centre
+      // which can be used to find the circle centre point
+      var dir = chordAngle < 0 ? -1 : 1;
+      var centreToChord = Math.Sqrt(Math.Pow(( double )radius, 2) - Math.Pow(chordLength * 0.5, 2));
+      var perp = Vector.CrossProduct(new Vector(endPoint - startPoint), plane.normal);
+      var circleCentre = chordMidpoint + new Point(perp.Unit() * centreToChord * -dir);
+      plane.origin = circleCentre;
+
+      // use the perpendicular vector in the other direction (from the centre to the arc) to find the arc midpoint
+      midPoint = angleRadians > Math.PI
+        ? chordMidpoint + new Point(perp.Unit() * ( ( double )radius + centreToChord ) * -dir)
+        : chordMidpoint + new Point(perp.Unit() * ( ( double )radius - centreToChord ) * dir);
+
+      // find the start angle using trig (correcting for quadrant position) and add the arc angle to get the end angle
+      startAngle = Math.Tan(( startPoint.y - circleCentre.y ) / ( startPoint.x - circleCentre.x )) % ( 2 * Math.PI );
+      if ( startPoint.x > circleCentre.x && startPoint.y < circleCentre.y )       // Q4
+        startAngle *= -1;
+      else if ( startPoint.x < circleCentre.x && startPoint.y < circleCentre.y )  // Q3
+        startAngle += Math.PI;
+      else if ( startPoint.x < circleCentre.x && startPoint.y > circleCentre.y )  // Q2
+        startAngle = Math.PI - startAngle;
+      endAngle = startAngle + angleRadians;
+    }
     public List<double> ToList()
     {
       var list = new List<double>();
       list.Add(radius ?? 0);
       list.Add(startAngle ?? 0);
       list.Add(endAngle ?? 0);
-      list.Add(angleRadians ?? 0);
+      list.Add(angleRadians);
       list.Add(domain.start ?? 0);
       list.Add(domain.end ?? 0);
 
@@ -155,6 +204,21 @@ namespace Objects.Geometry
       arc.plane.units = arc.units;
 
       return arc;
+    }
+
+    public bool TransformTo(Transform transform, out Arc transformed)
+    {
+      plane.TransformTo(transform, out Plane pln);
+      transformed = new Arc(pln,transform.ApplyToPoint(startPoint),transform.ApplyToPoint(endPoint), angleRadians, units);
+      return true;
+    }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Arc arc);
+      arc.domain = domain;
+      transformed = arc;
+      return res;
     }
   }
 }

--- a/Objects/Objects/Geometry/Arc.cs
+++ b/Objects/Objects/Geometry/Arc.cs
@@ -69,60 +69,20 @@ namespace Objects.Geometry
     /// <param name="applicationId">ID given to the arc in the authoring programme (defaults to null)</param>
     public Arc(Point startPoint, Point endPoint, double angleRadians, string units = Units.Meters,
       string applicationId = null)
-    {
-      // don't be annoying
-      if ( angleRadians > Math.PI * 2 )
-        throw new SpeckleException("Can't create an arc with an angle greater than 2pi");
-      if (startPoint == endPoint)
-        throw new SpeckleException("Can't create an arc where the start and end points are the same");
+      : this(
+        new Plane(startPoint, new Vector(0, 0, 1), new Vector(1, 0, 0), new Vector(0, 1, 0), units),
+        startPoint,
+        endPoint,
+        angleRadians,
+        units,
+        applicationId
+        ) { }
 
-      this.units = units;
-      this.startPoint = startPoint;
-      this.endPoint = endPoint;
-      this.angleRadians = angleRadians;
-      this.applicationId = applicationId;
-      // TODO: 3D arcs
-      plane = new Plane(startPoint, new Vector(0, 0, 1), new Vector(1, 0, 0), new Vector(0, 1, 0), units);
-
-      // find chord and chord angle which may differ from the arc angle
-      var chordMidpoint = Point.Midpoint(startPoint, endPoint);
-      var chordLength = Point.Distance(startPoint, endPoint);
-      var chordAngle = angleRadians;
-      if ( chordAngle > Math.PI )
-        chordAngle -= Math.PI * 2;
-      else if ( chordAngle < -Math.PI )
-        chordAngle += Math.PI * 2;
-      // use the law of cosines for an isosceles triangle to get the radius
-      radius = chordLength / Math.Sqrt(2 - 2 * Math.Cos(chordAngle));
-
-      // find the chord vector then calculate the perpendicular vector which points to the centre
-      // which can be used to find the circle centre point
-      var dir = chordAngle < 0 ? -1 : 1;
-      var centreToChord = Math.Sqrt(Math.Pow(( double )radius, 2) - Math.Pow(chordLength * 0.5, 2));
-      var perp = Vector.CrossProduct(new Vector(endPoint - startPoint), plane.normal);
-      var circleCentre = chordMidpoint + new Point(perp.Unit() * centreToChord * -dir);
-      plane.origin = circleCentre;
-
-      // use the perpendicular vector in the other direction (from the centre to the arc) to find the arc midpoint
-      midPoint = angleRadians > Math.PI
-        ? chordMidpoint + new Point(perp.Unit() * ( ( double )radius + centreToChord ) * -dir)
-        : chordMidpoint + new Point(perp.Unit() * ( ( double )radius - centreToChord ) * dir);
-
-      // find the start angle using trig (correcting for quadrant position) and add the arc angle to get the end angle
-      startAngle = Math.Tan(( startPoint.y - circleCentre.y ) / ( startPoint.x - circleCentre.x )) % ( 2 * Math.PI );
-      if ( startPoint.x > circleCentre.x && startPoint.y < circleCentre.y )       // Q4
-        startAngle *= -1;
-      else if ( startPoint.x < circleCentre.x && startPoint.y < circleCentre.y )  // Q3
-        startAngle += Math.PI;
-      else if ( startPoint.x < circleCentre.x && startPoint.y > circleCentre.y )  // Q2
-        startAngle = Math.PI - startAngle;
-      endAngle = startAngle + angleRadians;
-    }
     public Arc(Plane plane, Point startPoint, Point endPoint, double angleRadians, string units = Units.Meters,
       string applicationId = null)
     {
       // don't be annoying
-      if ( angleRadians > Math.PI * 2 )
+      if (angleRadians > Math.PI * 2)
         throw new SpeckleException("Can't create an arc with an angle greater than 2pi");
       if (startPoint == endPoint)
         throw new SpeckleException("Can't create an arc where the start and end points are the same");
@@ -137,9 +97,9 @@ namespace Objects.Geometry
       var chordMidpoint = Point.Midpoint(startPoint, endPoint);
       var chordLength = Point.Distance(startPoint, endPoint);
       var chordAngle = angleRadians;
-      if ( chordAngle > Math.PI )
+      if (chordAngle > Math.PI)
         chordAngle -= Math.PI * 2;
-      else if ( chordAngle < -Math.PI )
+      else if (chordAngle < -Math.PI)
         chordAngle += Math.PI * 2;
       // use the law of cosines for an isosceles triangle to get the radius
       radius = chordLength / Math.Sqrt(2 - 2 * Math.Cos(chordAngle));
@@ -147,26 +107,27 @@ namespace Objects.Geometry
       // find the chord vector then calculate the perpendicular vector which points to the centre
       // which can be used to find the circle centre point
       var dir = chordAngle < 0 ? -1 : 1;
-      var centreToChord = Math.Sqrt(Math.Pow(( double )radius, 2) - Math.Pow(chordLength * 0.5, 2));
+      var centreToChord = Math.Sqrt(Math.Pow((double)radius, 2) - Math.Pow(chordLength * 0.5, 2));
       var perp = Vector.CrossProduct(new Vector(endPoint - startPoint), plane.normal);
       var circleCentre = chordMidpoint + new Point(perp.Unit() * centreToChord * -dir);
       plane.origin = circleCentre;
 
       // use the perpendicular vector in the other direction (from the centre to the arc) to find the arc midpoint
       midPoint = angleRadians > Math.PI
-        ? chordMidpoint + new Point(perp.Unit() * ( ( double )radius + centreToChord ) * -dir)
-        : chordMidpoint + new Point(perp.Unit() * ( ( double )radius - centreToChord ) * dir);
+        ? chordMidpoint + new Point(perp.Unit() * ((double)radius + centreToChord) * -dir)
+        : chordMidpoint + new Point(perp.Unit() * ((double)radius - centreToChord) * dir);
 
       // find the start angle using trig (correcting for quadrant position) and add the arc angle to get the end angle
-      startAngle = Math.Tan(( startPoint.y - circleCentre.y ) / ( startPoint.x - circleCentre.x )) % ( 2 * Math.PI );
-      if ( startPoint.x > circleCentre.x && startPoint.y < circleCentre.y )       // Q4
+      startAngle = Math.Tan((startPoint.y - circleCentre.y) / (startPoint.x - circleCentre.x)) % (2 * Math.PI);
+      if (startPoint.x > circleCentre.x && startPoint.y < circleCentre.y) // Q4
         startAngle *= -1;
-      else if ( startPoint.x < circleCentre.x && startPoint.y < circleCentre.y )  // Q3
+      else if (startPoint.x < circleCentre.x && startPoint.y < circleCentre.y) // Q3
         startAngle += Math.PI;
-      else if ( startPoint.x < circleCentre.x && startPoint.y > circleCentre.y )  // Q2
+      else if (startPoint.x < circleCentre.x && startPoint.y > circleCentre.y) // Q2
         startAngle = Math.PI - startAngle;
       endAngle = startAngle + angleRadians;
     }
+
     public List<double> ToList()
     {
       var list = new List<double>();
@@ -191,12 +152,12 @@ namespace Objects.Geometry
     {
       var arc = new Arc();
 
-      arc.radius = list[ 2 ];
-      arc.startAngle = list[ 3 ];
-      arc.endAngle = list[ 4 ];
-      arc.angleRadians = list[ 5 ];
-      arc.domain = new Interval(list[ 6 ], list[ 7 ]);
-      arc.units = Units.GetUnitFromEncoding(list[ list.Count - 1 ]);
+      arc.radius = list[2];
+      arc.startAngle = list[3];
+      arc.endAngle = list[4];
+      arc.angleRadians = list[5];
+      arc.domain = new Interval(list[6], list[7]);
+      arc.units = Units.GetUnitFromEncoding(list[list.Count - 1]);
       arc.plane = Plane.FromList(list.GetRange(8, 13));
       arc.startPoint = Point.FromList(list.GetRange(21, 3), arc.units);
       arc.midPoint = Point.FromList(list.GetRange(24, 3), arc.units);
@@ -209,7 +170,7 @@ namespace Objects.Geometry
     public bool TransformTo(Transform transform, out Arc transformed)
     {
       plane.TransformTo(transform, out Plane pln);
-      var arc = new Arc(pln,transform.ApplyToPoint(startPoint),transform.ApplyToPoint(endPoint), angleRadians, units);
+      var arc = new Arc(pln, transform.ApplyToPoint(startPoint), transform.ApplyToPoint(endPoint), angleRadians, units);
       arc.domain = domain;
       transformed = arc;
       return true;

--- a/Objects/Objects/Geometry/Brep.cs
+++ b/Objects/Objects/Geometry/Brep.cs
@@ -450,7 +450,7 @@ namespace Objects.Geometry
       var surfaces = new List<Surface>(Surfaces.Count);
       foreach ( var srf in Surfaces )
       {
-        srf.TransformTo(transform, out var surface);
+        srf.TransformTo(transform, out Surface surface);
         surfaces.Add(surface);
       }
 
@@ -461,7 +461,7 @@ namespace Objects.Geometry
         displayValue = displayValues,
         Surfaces = surfaces,
         Curve3D = transform.ApplyToCurves(Curve3D, out bool success3D),
-        Curve2D = transform.ApplyToCurves(Curve2D, out bool success2D),
+        Curve2D = new List<ICurve>(Curve2D),
         Vertices = transform.ApplyToPoints(Vertices),
         Edges = new List<BrepEdge>(Edges.Count),
         Loops = new List<BrepLoop>(Loops.Count),
@@ -473,7 +473,7 @@ namespace Objects.Geometry
       };
 
       foreach ( var e in Edges )
-        brep.Edges.Add(new BrepEdge(brep, e.Curve3dIndex, e.TrimIndices, e.StartIndex, e.Curve3dIndex,
+        brep.Edges.Add(new BrepEdge(brep, e.Curve3dIndex, e.TrimIndices, e.StartIndex, e.EndIndex,
           e.ProxyCurveIsReversed,
           e.Domain));
 
@@ -487,7 +487,7 @@ namespace Objects.Geometry
       foreach ( var f in Faces )
         brep.Faces.Add(new BrepFace(brep, f.SurfaceIndex, f.LoopIndices, f.OuterLoopIndex, f.OrientationReversed));
 
-      return success2D && success3D;
+      return success3D;
     }
     
     #region Obsolete Members
@@ -497,6 +497,13 @@ namespace Objects.Geometry
       set => displayValue = new List<Mesh> {value};
     }
     #endregion
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Brep brep);
+      transformed = brep;
+      return res;
+    }
   }
 
   /// <summary>

--- a/Objects/Objects/Geometry/ControlPoint.cs
+++ b/Objects/Objects/Geometry/ControlPoint.cs
@@ -4,7 +4,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
-  public class ControlPoint : Point, IHasBoundingBox, ITransformable<ControlPoint>
+  public class ControlPoint : Point, ITransformable<ControlPoint>
   {
     /// <summary>
     /// OBSOLETE - This is just here for backwards compatibility.

--- a/Objects/Objects/Geometry/Curve.cs
+++ b/Objects/Objects/Geometry/Curve.cs
@@ -10,7 +10,7 @@ using Speckle.Core.Models;
 
 namespace Objects.Geometry
 {
-  public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable, IDisplayValue<Polyline>
+  public class Curve : Base, ICurve, IHasBoundingBox, IHasArea, ITransformable<Curve>, IDisplayValue<Polyline>
   {
     public int degree { get; set; }
 
@@ -126,10 +126,10 @@ namespace Objects.Geometry
       return curve;
     }
 
-    public bool TransformTo(Transform transform, out ITransformable curve)
+    public bool TransformTo(Transform transform, out Curve transformed)
     {
       var result = displayValue.TransformTo(transform, out ITransformable polyline);
-      curve = new Curve
+      transformed = new Curve
       {
         degree = degree,
         periodic = periodic,
@@ -140,10 +140,18 @@ namespace Objects.Geometry
         displayValue = ( Polyline ) polyline,
         closed = closed,
         units =  units,
-        applicationId = applicationId
+        applicationId = applicationId,
+        domain = domain != null ? new Interval{start = domain.start, end = domain.end} : null
       };
 
       return result;
+    }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Curve curve);
+      transformed = curve;
+      return res;
     }
   }
 }

--- a/Objects/Objects/Geometry/Line.cs
+++ b/Objects/Objects/Geometry/Line.cs
@@ -11,7 +11,7 @@ using Speckle.Newtonsoft.Json;
 
 namespace Objects.Geometry
 {
-  public class Line : Base, ICurve, IHasBoundingBox, ITransformable
+  public class Line : Base, ICurve, IHasBoundingBox, ITransformable<Line>
   {
     /// <summary>
     /// OBSOLETE - This is just here for backwards compatibility.
@@ -103,16 +103,23 @@ namespace Objects.Geometry
       return line;
     }
 
-    public bool TransformTo(Transform transform, out ITransformable line)
+    public bool TransformTo(Transform transform, out Line transformed)
     {
-      line = new Line
+      transformed = new Line
       {
         start = transform.ApplyToPoint(start),
         end = transform.ApplyToPoint(end),
         applicationId = applicationId,
-        units = units
+        units = units,
+        domain = domain == null ? null : new Interval { start= domain.start, end= domain.end }
       };
-      return true;
+      return true;    }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Line line);
+      transformed = line;
+      return res;
     }
   }
 }

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -183,5 +183,12 @@ namespace Objects.Geometry
 
       return true;
     }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Mesh brep);
+      transformed = brep;
+      return res;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Plane.cs
+++ b/Objects/Objects/Geometry/Plane.cs
@@ -74,5 +74,12 @@ namespace Objects.Geometry
 
       return true;
     }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Plane plane);
+      transformed = plane;
+      return res;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Point.cs
+++ b/Objects/Objects/Geometry/Point.cs
@@ -117,5 +117,12 @@ namespace Objects.Geometry
 
     public static double Distance(Point point1, Point point2) => Math.Sqrt(
       Math.Pow(point1.x - point2.x, 2) + Math.Pow(point1.y - point2.y, 2) + Math.Pow(point1.z - point2.z, 2));
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Point pt);
+      transformed = pt;
+      return res;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Pointcloud.cs
+++ b/Objects/Objects/Geometry/Pointcloud.cs
@@ -57,5 +57,12 @@ namespace Objects.Geometry
       
       return true;
     }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Pointcloud pc);
+      transformed = pc;
+      return res;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Surface.cs
+++ b/Objects/Objects/Geometry/Surface.cs
@@ -155,5 +155,12 @@ namespace Objects.Geometry
 
       return true;
     }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      var res = TransformTo(transform, out Surface surface);
+      transformed = surface;
+      return res;
+    }
   }
 }

--- a/Objects/Objects/Geometry/Vector.cs
+++ b/Objects/Objects/Geometry/Vector.cs
@@ -152,5 +152,11 @@ namespace Objects.Geometry
       vector = transform.ApplyToVector(this);
       return true;
     }
+
+    public bool TransformTo(Transform transform, out ITransformable transformed)
+    {
+      transformed = transform.ApplyToVector(this);
+      return true;
+    }
   }
 }

--- a/Objects/Objects/Interfaces.cs
+++ b/Objects/Objects/Interfaces.cs
@@ -38,7 +38,7 @@ namespace Objects
   /// Interface for transformable objects.
   /// </summary>
   /// <typeparam name="T"></typeparam>
-  public interface ITransformable<T> where T : ITransformable<T>
+  public interface ITransformable<T>: ITransformable where T : ITransformable<T>
   {
     bool TransformTo(Transform transform, out T transformed);
   }

--- a/Objects/Objects/Objects.csproj
+++ b/Objects/Objects/Objects.csproj
@@ -20,6 +20,7 @@
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj">

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -40,7 +40,15 @@ namespace Objects.Other
     [JsonIgnore]
     public List<ITransformable> transformedGeometry => GetTransformedGeometry();
 
+    [JsonIgnore]
+    public Plane insertionPlane => GetInsertionPlane();
 
+    public Plane GetInsertionPlane()
+    {
+      var plane = new Plane(blockDefinition.basePoint,new Vector(0,0,1,units),new Vector(1,0,0,units),new Vector(0,1,0,units), units);
+      plane.TransformTo(transform, out Plane tPlane);
+      return tPlane;
+    }
 
     /// <summary>
     /// The 4x4 transform matrix.

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -32,24 +32,17 @@ namespace Objects.Other
   /// </summary>
   public class BlockInstance : Base
   {
-    /// <inheritdoc cref="GetInsertionPoint"/>
-    [JsonIgnore]
-    public Point insertionPoint => GetInsertionPoint();
+    [JsonIgnore, Obsolete("Use GetInsertionPoint method")]
+    public Point insertionPoint { get => GetInsertionPoint(); set { } }
 
     /// <inheritdoc cref="GetTransformedGeometry"/>
     [JsonIgnore]
     public List<ITransformable> transformedGeometry => GetTransformedGeometry();
 
+    /// <inheritdoc cref="GetInsertionPlane"/>
     [JsonIgnore]
     public Plane insertionPlane => GetInsertionPlane();
-
-    public Plane GetInsertionPlane()
-    {
-      var plane = new Plane(blockDefinition.basePoint,new Vector(0,0,1,units),new Vector(1,0,0,units),new Vector(0,1,0,units), units);
-      plane.TransformTo(transform, out Plane tPlane);
-      return tPlane;
-    }
-
+    
     /// <summary>
     /// The 4x4 transform matrix.
     /// </summary>
@@ -57,7 +50,6 @@ namespace Objects.Other
     /// the 3x3 sub-matrix determines scaling
     /// the 4th column defines translation, where the last value could be a divisor
     /// </remarks>
-
     public Transform transform { get; set; } = new Transform();
 
     public string units { get; set; }
@@ -89,5 +81,18 @@ namespace Objects.Other
         return res ? transformed : null;
       }).Where(b => b != null).ToList();
     }
+    
+    /// <summary>
+    /// Returns a plane representing the insertion point and orientation of this Block instance.
+    /// </summary>
+    /// <remarks>This method will skip scaling. If you need scaling, we recommend using the transform instead.</remarks>
+    /// <returns>A Plane on the insertion point of this Block Instance, with the correct 3-axis rotations.</returns>
+    public Plane GetInsertionPlane()
+    {
+      var plane = new Plane(blockDefinition.basePoint,new Vector(0,0,1,units),new Vector(1,0,0,units),new Vector(0,1,0,units), units);
+      plane.TransformTo(transform, out Plane tPlane);
+      return tPlane;
+    }
+
   }
 }

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -16,7 +16,7 @@ namespace Objects.Other
   public class BlockDefinition : Base
   {
     public string name { get; set; }
-
+    
     public Point basePoint { get; set; }
 
     [DetachProperty]
@@ -25,6 +25,15 @@ namespace Objects.Other
     public string units { get; set; }
 
     public BlockDefinition() { }
+    
+    [SchemaInfo("Block Definition","A Speckle Block definition")]
+    public BlockDefinition(string name, Point basePoint, List<Base> geometry, string units)
+    {
+      this.name = name;
+      this.basePoint = basePoint;
+      this.geometry = geometry;
+      this.units = units;
+    }
   }
 
   /// <summary>
@@ -59,6 +68,12 @@ namespace Objects.Other
 
     public BlockInstance() { }
 
+    [SchemaInfo("Block Instance", "A Speckle Block Instance")]
+    public BlockInstance(BlockDefinition blockDefinition, Transform transform)
+    {
+      this.blockDefinition = blockDefinition;
+      this.transform = transform;
+    }
     /// <summary>
     /// Retrieves Instance insertion point by applying <see cref="transform"/> to <see cref="BlockDefinition.basePoint"/>
     /// </summary>

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -42,17 +42,6 @@ namespace Objects.Other
       transform.value[12] = -basePoint.z;
       return transform;
     }
-    public List<ITransformable> GetGeometryRelativeToBasePoint()
-    {
-      var transform = GetBasePointTransform();
-      
-      return geometry.Select(b =>
-      {
-        if (!(b is ITransformable bt)) return null;
-        var res = bt.TransformTo(transform, out ITransformable transformed);
-        return res ? transformed : null;
-      }).Where(b => b != null).ToList();
-    }
   }
 
   /// <summary>

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -27,12 +27,11 @@ namespace Objects.Other
     public BlockDefinition() { }
     
     [SchemaInfo("Block Definition","A Speckle Block definition")]
-    public BlockDefinition(string name, Point basePoint, List<Base> geometry, string units)
+    public BlockDefinition(string name, List<Base> geometry, Point basePoint = null )
     {
       this.name = name;
-      this.basePoint = basePoint;
+      this.basePoint = basePoint ?? new Point();
       this.geometry = geometry;
-      this.units = units;
     }
 
     public Transform GetBasePointTransform()

--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -2,6 +2,7 @@
 using Speckle.Core.Kits;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Objects.Geometry;
 using Speckle.Core.Logging;
@@ -31,8 +32,15 @@ namespace Objects.Other
   /// </summary>
   public class BlockInstance : Base
   {
-    [JsonIgnore, Obsolete("Use GetInsertionPoint method")]
-    public Point insertionPoint { get => GetInsertionPoint(); set { } }
+    /// <inheritdoc cref="GetInsertionPoint"/>
+    [JsonIgnore]
+    public Point insertionPoint => GetInsertionPoint();
+
+    /// <inheritdoc cref="GetTransformedGeometry"/>
+    [JsonIgnore]
+    public List<ITransformable> transformedGeometry => GetTransformedGeometry();
+
+
 
     /// <summary>
     /// The 4x4 transform matrix.
@@ -58,6 +66,20 @@ namespace Objects.Other
     public Point GetInsertionPoint()
     {
       return transform.ApplyToPoint(blockDefinition.basePoint);
+    }
+    
+    /// <summary>
+    /// Returns the a copy of the Block Definition's geometry transformed with this BlockInstance's transform.
+    /// </summary>
+    /// <returns>The transformed geometry for this BlockInstance.</returns>
+    public List<ITransformable> GetTransformedGeometry()
+    {
+      return blockDefinition.geometry.Select(b =>
+      {
+        if (!(b is ITransformable bt)) return null;
+        var res = bt.TransformTo(transform, out ITransformable transformed);
+        return res ? transformed : null;
+      }).Where(b => b != null).ToList();
     }
   }
 }

--- a/Objects/Objects/Other/RenderMaterial.cs
+++ b/Objects/Objects/Other/RenderMaterial.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.Other
 {
@@ -21,9 +22,26 @@ namespace Objects.Other
     public double opacity { get; set; } = 1;
     public double metalness { get; set; } = 0;
     public double roughness { get; set; } = 1;
+    
+    [SchemaIgnore]
     public int diffuse { get; set; } = Color.LightGray.ToArgb();
+    [SchemaIgnore]
     public int emissive { get; set; } = Color.Black.ToArgb();
 
+    [JsonIgnore]
+    public Color diffuseColor
+    {
+      get => Color.FromArgb(diffuse);
+      set => diffuse = value.ToArgb();
+    }
+    
+    [JsonIgnore]
+    public Color emissiveColor
+    {
+      get => Color.FromArgb(emissive);
+      set => diffuse = value.ToArgb();
+    }
+    
     public RenderMaterial() { }
 
     [SchemaInfo("RenderMaterial", "Creates a render material.", "BIM", "Other")]

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -116,7 +116,7 @@ namespace Objects.Other
     {
       var newCoords = ApplyToVector(new List<double> {vector.x, vector.y, vector.z});
 
-      return new Geometry.Vector(newCoords[0], newCoords[1], newCoords[2], vector.units, vector.applicationId);
+      return new Vector(newCoords[0], newCoords[1], newCoords[2], vector.units, vector.applicationId);
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ namespace Objects.Other
     /// </summary>
     public List<double> ApplyToVector(List<double> vector)
     {
-      var newPoint = new List<double>(4) {vector[ 0 ], vector[ 1 ], vector[ 2 ]};
+      var newPoint = new List<double>(4) {vector[ 0 ], vector[ 1 ], vector[ 2 ], 1};
       for ( var i = 0; i < 16; i += 4 )
         newPoint[ i / 4 ] = newPoint[ 0 ] * value[ i ] + newPoint[ 1 ] * value[ i + 1 ] +
                             newPoint[ 2 ] * value[ i + 2 ];


### PR DESCRIPTION
## Description

- Adds support for `Transform` conversions in Grasshopper and Dynamo
    - Grasshopper: ToNative and ToSpeckle (to support schema node)
    - Dynamo: ToNative (as Coordinate System)
- Adds new computed property in `Block` -> `transformedGeometry` that returns the transformed geometry for that block instance
- Adds a new computed property in Block -> `insertionPlane` that returns a `Plane` already transformed into the insertion position of that Block Instance
- Improves support for `ITransformable` and makes `ITransformable<T>` inherit from it.
- Fixes some minor issues with Line and Brep transform logic.
- Adds transform support to `Arc`
- Adds new Schema constructors to `BlockInstance` and `BlockDefinition`, with its corresponding Schema nodes in Grasshopper. 
- Adds RenderMaterial<->DisplayMaterial(Grasshopper) conversion
- Minor improvements in SpeckleBaseParam.ToString() method. Will now return a more "human readable" string that clearly specifies it's a speckle object. (i.e. "Speckle Box" instead of "Objects.Geometry.Box")

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- Will be updated ASAP

