### PR TITLE
CORE: Allows for `Item` to be set as a dynamic or typed prop in `Base`-derived objects

### DIFF
--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -12,6 +12,25 @@ namespace Tests
   [TestFixture]
   public class BaseTests
   {
+    [Test]
+    public void CanGetSetDynamicItemProp()
+    {
+      var @base = new Base();
+      @base["Item"] = "Item";
+
+      Assert.AreEqual(@base["Item"], "Item");
+    }
+
+    [Test]
+    public void CanGetSetTypedItemProp()
+    {
+      var @base = new ObjectWithItemProp();
+      @base.Item = "baz";
+
+      Assert.AreEqual(@base["Item"], "baz");
+      Assert.AreEqual(@base.Item, "baz");
+    }
+
     [Test(Description = "Checks if validation is performed in property names")]
     public void CanValidatePropNames()
     {
@@ -159,6 +178,11 @@ namespace Tests
     public class SampleProp
     {
       public string name { get; set; }
+    }
+
+    public class ObjectWithItemProp : Base
+    {
+      public string Item { get; set; } = "Item";
     }
   }
 }


### PR DESCRIPTION
+ other minor cleanups: caches reflection calls & DRYs the GetProperties() calls. 

Regarding the `Item` prop discussions, please see this discourse thread: https://speckle.community/t/why-do-i-keep-forgetting-base-objects-cant-use-item-as-a-dynamic-member/3246/4

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
## How has this been tested?

- Unit Tests + Added new tests to cover both dynamic and typed `Item` props

## Docs

- No updates needed


