### PR TITLE
Revit: Categories & Core: account and permissions

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -127,7 +127,7 @@ namespace Speckle.ConnectorRevit
       return new FilteredWorksetCollector(doc).Where(x => x.Kind == WorksetKind.UserWorkset).Select(x => x.Name).ToList();
     }
 
-    private async static Task<List<string>> GetParameterNamesAsync(Document doc)
+    private static async Task<List<string>> GetParameterNamesAsync(Document doc)
     {
       var els = new FilteredElementCollector(doc)
         .WhereElementIsNotElementType()
@@ -164,7 +164,7 @@ namespace Speckle.ConnectorRevit
       return GetParameterNamesAsync(doc).Result;
     }
 
-    private async static Task<List<string>> GetViewNamesAsync(Document doc)
+    private static async Task<List<string>> GetViewNamesAsync(Document doc)
     {
       var els = new FilteredElementCollector(doc)
         .WhereElementIsNotElementType()
@@ -210,7 +210,7 @@ namespace Speckle.ConnectorRevit
       return false;
     }
 
-   
+
 
     //list of currently supported Categories (for sending only)
     //exact copy of the one in the ConverterRevitShared.Categories
@@ -286,7 +286,31 @@ namespace Speckle.ConnectorRevit
       BuiltInCategory.OST_Cornices,
       BuiltInCategory.OST_Walls,
       BuiltInCategory.OST_Windows,
-      BuiltInCategory.OST_Wire
+      BuiltInCategory.OST_Wire,
+      BuiltInCategory.OST_Casework,
+      BuiltInCategory.OST_CurtainWallPanels,
+      BuiltInCategory.OST_CurtainWallMullions,
+      BuiltInCategory.OST_Entourage,
+      BuiltInCategory.OST_Furniture,
+      BuiltInCategory.OST_FurnitureSystems,
+      BuiltInCategory.OST_Planting,
+      BuiltInCategory.OST_PlumbingFixtures,
+      BuiltInCategory.OST_Ramps,
+      BuiltInCategory.OST_SpecialityEquipment,
+      BuiltInCategory.OST_Rebar,
+#if !REVIT2019 && !REVIT2020 && !REVIT2021
+      BuiltInCategory.OST_AudioVisualDevices,
+      BuiltInCategory.OST_FireProtection,
+      BuiltInCategory.OST_FoodServiceEquipment,
+      BuiltInCategory.OST_Hardscape,
+      BuiltInCategory.OST_MedicalEquipment,
+      BuiltInCategory.OST_Signage,
+      BuiltInCategory.OST_TemporaryStructure,
+      BuiltInCategory.OST_VerticalCirculation,
+#endif
+#if !REVIT2019 && !REVIT2020 && !REVIT2021 && !REVIT2022
+       BuiltInCategory.OST_MechanicalControlDevices,
+#endif
   };
   }
 }

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -532,9 +532,9 @@ namespace Speckle.Core.Api
     /// </summary>
     /// <param name="permissionInput"></param>
     /// <returns></returns>
-    public Task<bool> StreamGrantPermission(StreamGrantPermissionInput permissionInput)
+    public Task<bool> StreamUpdatePermission(StreamUpdatePermissionInput permissionInput)
     {
-      return StreamGrantPermission(CancellationToken.None, permissionInput);
+      return StreamUpdatePermission(CancellationToken.None, permissionInput);
     }
 
     /// <summary>
@@ -543,7 +543,7 @@ namespace Speckle.Core.Api
     /// <param name="cancellationToken"></param>
     /// <param name="permissionInput"></param>
     /// <returns></returns>
-    public async Task<bool> StreamGrantPermission(CancellationToken cancellationToken, StreamGrantPermissionInput permissionInput)
+    public async Task<bool> StreamUpdatePermission(CancellationToken cancellationToken, StreamUpdatePermissionInput permissionInput)
     {
       try
       {
@@ -551,8 +551,8 @@ namespace Speckle.Core.Api
         {
           Query =
           @"
-          mutation streamGrantPermission($permissionParams: StreamGrantPermissionInput!) {
-            streamGrantPermission(permissionParams:$permissionParams)
+          mutation streamUpdatePermission($permissionParams: StreamUpdatePermissionInput!) {
+            streamUpdatePermission(permissionParams:$permissionParams)
           }",
           Variables = new
           {
@@ -565,7 +565,7 @@ namespace Speckle.Core.Api
         if (res.Errors != null)
           throw new SpeckleException("Could not grant permission", res.Errors);
 
-        return (bool)res.Data["streamGrantPermission"];
+        return (bool)res.Data["streamUpdatePermission"];
       }
       catch (Exception e)
       {

--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -20,7 +20,7 @@ namespace Speckle.Core.Api
     public bool isPublic { get; set; } = true;
   }
 
-  public class StreamGrantPermissionInput
+  public class StreamUpdatePermissionInput
   {
     public string streamId { get; set; }
     public string userId { get; set; }

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -253,6 +253,27 @@ namespace Speckle.Core.Credentials
     }
 
     /// <summary>
+    /// Changes the default account
+    /// </summary>
+    /// <returns></returns>
+    public static void ChangeDefaultAccount(string id)
+    {
+      foreach (var account in GetAccounts())
+      {
+        if (account.id != id)
+        {
+          account.isDefault = false;
+        }
+        else
+        {
+          account.isDefault = true;
+        }
+
+        AccountStorage.UpdateObject(account.id, JsonConvert.SerializeObject(account));
+      }
+    }
+
+    /// <summary>
     /// Removes an account
     /// </summary>
     /// <param name="id">ID of the account to remove</param>

--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -108,10 +108,10 @@ namespace TestsIntegration
     }
 
     [Test, Order(30)]
-    public async Task StreamGrantPermission()
+    public async Task StreamUpdatePermission()
     {
-      var res = await myClient.StreamGrantPermission(
-        new StreamGrantPermissionInput
+      var res = await myClient.StreamUpdatePermission(
+        new StreamUpdatePermissionInput
         {
           streamId = streamId,
           userId = secondUserAccount.userInfo.id,

--- a/DesktopUI/DesktopUI/Streams/Dialogs/ShareStreamDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/Dialogs/ShareStreamDialogViewModel.cs
@@ -126,7 +126,7 @@ namespace Speckle.DesktopUI.Streams
     {
       try
       {
-        var res = await StreamState.Client.StreamGrantPermission(new StreamGrantPermissionInput()
+        var res = await StreamState.Client.StreamUpdatePermission(new StreamUpdatePermissionInput()
         {
           streamId = StreamState.Stream.id,
           role = SelectedRole.Role,

--- a/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamCreateDialogViewModel.cs
@@ -220,7 +220,7 @@ namespace Speckle.DesktopUI.Streams
 
         foreach (var user in Collaborators)
         {
-          var res = await client.StreamGrantPermission(new StreamGrantPermissionInput()
+          var res = await client.StreamUpdatePermission(new StreamUpdatePermissionInput()
           {
             streamId = streamId,
             userId = user.id,

--- a/DesktopUI/DesktopUI/Streams/StreamUpdateObjectsDialogViewModel.cs
+++ b/DesktopUI/DesktopUI/Streams/StreamUpdateObjectsDialogViewModel.cs
@@ -174,7 +174,7 @@ namespace Speckle.DesktopUI.Streams
       {
         try
         {
-          var res = await StreamState.Client.StreamGrantPermission(new StreamGrantPermissionInput()
+          var res = await StreamState.Client.StreamUpdatePermission(new StreamUpdatePermissionInput()
           {
             role = Role.Role,
             streamId = StreamState.Stream.id,

--- a/DesktopUI2/DesktopUI2/ViewModels/Share/CollaboratorsViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/Share/CollaboratorsViewModel.cs
@@ -213,7 +213,7 @@ namespace DesktopUI2.ViewModels.Share
         {
           try
           {
-            await _stream.StreamState.Client.StreamGrantPermission(new StreamGrantPermissionInput { userId = user.Id, streamId = _stream.StreamState.StreamId, role = "stream:contributor" });
+            await _stream.StreamState.Client.StreamUpdatePermission(new StreamUpdatePermissionInput { userId = user.Id, streamId = _stream.StreamState.StreamId, role = "stream:contributor" });
           }
           catch (Exception e)
           {

--- a/DesktopUI2/DesktopUI2/ViewModels/Share/SendingViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/Share/SendingViewModel.cs
@@ -147,7 +147,7 @@ namespace DesktopUI2.ViewModels.Share
         {
           try
           {
-            await FileStream.Client.StreamGrantPermission(new StreamGrantPermissionInput { userId = user.Id, streamId = FileStream.StreamId, role = "stream:contributor" });
+            await FileStream.Client.StreamUpdatePermission(new StreamUpdatePermissionInput { userId = user.Id, streamId = FileStream.StreamId, role = "stream:contributor" });
           }
           catch (Exception e)
           {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -112,7 +112,32 @@ namespace Objects.Converter.Revit
       BuiltInCategory.OST_Cornices,
       BuiltInCategory.OST_Walls,
       BuiltInCategory.OST_Windows,
-      BuiltInCategory.OST_Wire
+      BuiltInCategory.OST_Wire,
+      BuiltInCategory.OST_Casework,
+      BuiltInCategory.OST_CurtainWallPanels,
+      BuiltInCategory.OST_CurtainWallMullions,
+      BuiltInCategory.OST_Entourage,
+      BuiltInCategory.OST_Furniture,
+      BuiltInCategory.OST_FurnitureSystems,
+      BuiltInCategory.OST_Planting,
+      BuiltInCategory.OST_PlumbingFixtures,
+      BuiltInCategory.OST_Ramps,
+      BuiltInCategory.OST_SpecialityEquipment,
+      BuiltInCategory.OST_Rebar,
+#if !REVIT2019 && !REVIT2020 && !REVIT2021
+      BuiltInCategory.OST_AudioVisualDevices,
+      BuiltInCategory.OST_FireProtection,
+      BuiltInCategory.OST_FoodServiceEquipment,
+      BuiltInCategory.OST_Hardscape,
+      BuiltInCategory.OST_MedicalEquipment,
+      BuiltInCategory.OST_Signage,
+      BuiltInCategory.OST_TemporaryStructure,
+      BuiltInCategory.OST_VerticalCirculation,
+#endif
+#if !REVIT2019 && !REVIT2020 && !REVIT2021 && !REVIT2022
+       BuiltInCategory.OST_MechanicalControlDevices,
+#endif
+
   };
 
     public static RevitCategory GetSchemaBuilderCategoryFromBuiltIn(string builtInCategory)


### PR DESCRIPTION
## Description

- adds method in AccountManager to update the default account
- renames StreamGrantPermission to StreamUpdatePermission to align with latest server changes

## Type of change

- Breaking change: the change to StreamUpdatePermission is breaking!

## How has this been tested?

- Manual Tests
## Docs

- No updates needed


