### PR TITLE
fix(objects): Null reference error in GetTransformedGeometry

### DIFF
--- a/Objects/Objects/Other/Block.cs
+++ b/Objects/Objects/Other/Block.cs
@@ -104,16 +104,17 @@ namespace Objects.Other
         switch (b)
         {
           case BlockInstance bi:
-            return bi.GetTransformedGeometry().Select(b =>
+            return bi.GetTransformedGeometry()?.Select(b =>
             {
-              b.TransformTo(transform, out var childTransformed);
+              ITransformable childTransformed = null;
+              b?.TransformTo(transform, out childTransformed);
               return childTransformed;
             });
           case ITransformable bt:
             var res = bt.TransformTo(transform, out var transformed);
             return new List<ITransformable>{res ? transformed : null};
           default:
-            return null;
+            return new List<ITransformable>();
         }
       }).Where(b => b != null).ToList();
     }


### PR DESCRIPTION
## Description

- Fixes minor issue discovered when testing, where an incompatible geometry or incorrectly transformed would lead to a null reference error while expanding the object in Grasshopper.

Surely this happened in Dynamo too.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- No updates needed

