### PR TITLE
using units from speckle instead of etabs default

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
@@ -25,6 +25,11 @@ namespace Objects.Converter.CSI
         return null;
       }
     }
+    public double ScaleToNative(double value, string units)
+    {
+      var f = Speckle.Core.Kits.Units.GetConversionFactor(units, ModelUnits());
+      return value * f;
+    }
     public static List<string> GetAllFrameNames(cSapModel model)
     {
       int num = 0;

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertArea.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertArea.cs
@@ -29,9 +29,9 @@ namespace Objects.Converter.CSI
 
       foreach (Node point in area.topology)
       {
-        X.Add(point.basePoint.x);
-        Y.Add(point.basePoint.y);
-        Z.Add(point.basePoint.z);
+        X.Add(ScaleToNative(point.basePoint.x, point.basePoint.units));
+        Y.Add(ScaleToNative(point.basePoint.y, point.basePoint.units));
+        Z.Add(ScaleToNative(point.basePoint.z, point.basePoint.units));
       }
       double[] x = X.ToArray();
       double[] y = Y.ToArray();

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertFrame.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertFrame.cs
@@ -31,31 +31,43 @@ namespace Objects.Converter.CSI
         Property1DToNative(element1D.property);
         Model.PropFrame.GetNameList(ref number, ref properties);
       }
+      Point end1node;
+      Point end2node;
       if (baseline != null)
       {
-        Point end1node = baseline.start;
-        Point end2node = baseline.end;
-        if (properties.Contains(element1D.property.name))
-        {
-          Model.FrameObj.AddByCoord(end1node.x, end1node.y, end1node.z, end2node.x, end2node.y, end2node.z, ref newFrame, element1D.property.name);
-        }
-        else
-        {
-          Model.FrameObj.AddByCoord(end1node.x, end1node.y, end1node.z, end2node.x, end2node.y, end2node.z, ref newFrame);
-        }
+        end1node = baseline.start;
+        end2node = baseline.end;
       }
       else
       {
-        Point end1node = element1D.end1Node.basePoint;
-        Point end2node = element1D.end2Node.basePoint;
-        if (properties.Contains(element1D.property.name))
-        {
-          Model.FrameObj.AddByCoord(end1node.x, end1node.y, end1node.z, end2node.x, end2node.y, end2node.z, ref newFrame, element1D.property.name);
-        }
-        else
-        {
-          Model.FrameObj.AddByCoord(end1node.x, end1node.y, end1node.z, end2node.x, end2node.y, end2node.z, ref newFrame);
-        }
+        end1node = element1D.end1Node.basePoint;
+        end2node = element1D.end2Node.basePoint;
+      }
+
+      if (properties.Contains(element1D.property.name))
+      {
+        Model.FrameObj.AddByCoord(
+          ScaleToNative(end1node.x, end1node.units),
+          ScaleToNative(end1node.y, end1node.units),
+          ScaleToNative(end1node.z, end1node.units),
+          ScaleToNative(end2node.x, end2node.units),
+          ScaleToNative(end2node.y, end2node.units),
+          ScaleToNative(end2node.z, end2node.units),
+          ref newFrame,
+          element1D.property.name
+        );
+      }
+      else
+      {
+        Model.FrameObj.AddByCoord(
+          ScaleToNative(end1node.x, end1node.units),
+          ScaleToNative(end1node.y, end1node.units),
+          ScaleToNative(end1node.z, end1node.units),
+          ScaleToNative(end2node.x, end2node.units),
+          ScaleToNative(end2node.y, end2node.units),
+          ScaleToNative(end2node.z, end2node.units),
+          ref newFrame
+        );
       }
 
       bool[] end1Release = null;

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertLine.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertLine.cs
@@ -15,7 +15,15 @@ namespace Objects.Converter.CSI
       string newFrame = "";
       Point end1node = line.start;
       Point end2node = line.end;
-      Model.FrameObj.AddByCoord(end1node.x, end1node.y, end1node.z, end2node.x, end2node.y, end2node.z, ref newFrame);
+      Model.FrameObj.AddByCoord(
+        ScaleToNative(end1node.x, end1node.units),
+        ScaleToNative(end1node.y, end1node.units),
+        ScaleToNative(end1node.z, end1node.units),
+        ScaleToNative(end2node.x, end2node.units),
+        ScaleToNative(end2node.y, end2node.units),
+        ScaleToNative(end2node.z, end2node.units),
+        ref newFrame
+      );
       return line.applicationId;
     }
 

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertPoint.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertPoint.cs
@@ -22,7 +22,12 @@ namespace Objects.Converter.CSI
       }
       var point = speckleStructNode.basePoint;
       string name = "";
-      Model.PointObj.AddCartesian(point.x, point.y, point.z, ref name);
+      Model.PointObj.AddCartesian(
+        ScaleToNative(point.x, point.units),
+        ScaleToNative(point.y, point.units),
+        ScaleToNative(point.z, point.units),
+        ref name
+      );
       if (speckleStructNode.restraint != null)
       {
         var restraint = RestraintToNative(speckleStructNode.restraint);


### PR DESCRIPTION
## Description

Receiving in ETABS always defers to the default units in the program. Which leads to most of my models coming from Revit (in feet) to be 1/12 of their actual size when received in ETABS (which defaults to inches for imperial units)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)
Receiving and sending different models to make sure everything works as expected

## Docs

- No updates needed

