### PR TITLE
fix(rhino): init issue fix attempt

### DIFF
--- a/ConnectorRhino/ConnectorRhino.sln
+++ b/ConnectorRhino/ConnectorRhino.sln
@@ -37,25 +37,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorRhino6", "Connecto
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AvaloniaHwndHost", "..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj", "{D484DB4F-FB51-478F-B8F9-8FE3370AB392}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper6", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper6\ConverterGrasshopper6.csproj", "{9454D346-A629-40E0-9EE2-7C6933ED1530}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterGrasshopper6", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper6\ConverterGrasshopper6.csproj", "{9454D346-A629-40E0-9EE2-7C6933ED1530}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper7", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterGrasshopper7", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorGrasshopper", "..\ConnectorGrasshopper\ConnectorGrasshopper\ConnectorGrasshopper.csproj", "{109B3382-634B-408A-8A5C-4CD09CB92641}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorGrasshopper", "..\ConnectorGrasshopper\ConnectorGrasshopper\ConnectorGrasshopper.csproj", "{109B3382-634B-408A-8A5C-4CD09CB92641}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorGrasshopperUtils", "..\ConnectorGrasshopper\ConnectorGrasshopperUtils\ConnectorGrasshopperUtils.csproj", "{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiskTransport", "..\Core\Transports\DiskTransport\DiskTransport.csproj", "{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiskTransport", "..\Core\Transports\DiskTransport\DiskTransport.csproj", "{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{6c851417-514b-4e45-9553-408377535b68}*SharedItemsImports = 5
-		ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems*{a64acbf9-db82-4839-af99-57ed2e7989f4}*SharedItemsImports = 5
-		ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems*{b7376ec8-5d3e-47d2-96a7-748552f14c39}*SharedItemsImports = 13
-		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{b74cb8c1-187b-46a6-b20b-92b8c129f3ee}*SharedItemsImports = 13
-		ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems*{d648bb69-b992-4d34-906e-7a547374b86c}*SharedItemsImports = 5
-		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{f1703d03-3edb-4389-add9-39c52c6aea19}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Mac|Any CPU = Debug Mac|Any CPU
 		Debug Mac|x64 = Debug Mac|x64
@@ -296,5 +288,15 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1BFED19F-741B-4E11-95C0-753E2058B3D2}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{6c851417-514b-4e45-9553-408377535b68}*SharedItemsImports = 5
+		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{9454d346-a629-40e0-9ee2-7c6933ed1530}*SharedItemsImports = 5
+		ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems*{a64acbf9-db82-4839-af99-57ed2e7989f4}*SharedItemsImports = 5
+		ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems*{b7376ec8-5d3e-47d2-96a7-748552f14c39}*SharedItemsImports = 13
+		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{b74cb8c1-187b-46a6-b20b-92b8c129f3ee}*SharedItemsImports = 13
+		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{cae61ac4-e81a-4e69-8dd0-07b7cdf77e2e}*SharedItemsImports = 5
+		ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems*{d648bb69-b992-4d34-906e-7a547374b86c}*SharedItemsImports = 5
+		..\Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{f1703d03-3edb-4389-add9-39c52c6aea19}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -20,23 +20,33 @@ namespace SpeckleRhino
     public ConnectorBindingsRhino Bindings { get; private set; }
     public MainViewModel ViewModel { get; private set; }
 
+    private bool _initialized;
+
     public SpeckleRhinoConnectorPlugin()
     {
       Instance = this;
-#if !DEBUG
-      Init();
-#endif
     }
 
     internal void Init()
     {
+      try
+      {
+        if (_initialized)
+          return;
 
-      SpeckleCommand.InitAvalonia();
-      Bindings = new ConnectorBindingsRhino();
-      ViewModel = new MainViewModel(Bindings);
+        SpeckleCommand.InitAvalonia();
+        Bindings = new ConnectorBindingsRhino();
+        ViewModel = new MainViewModel(Bindings);
 
-      RhinoDoc.BeginOpenDocument += RhinoDoc_BeginOpenDocument;
-      RhinoDoc.EndOpenDocument += RhinoDoc_EndOpenDocument;
+        RhinoDoc.BeginOpenDocument += RhinoDoc_BeginOpenDocument;
+        RhinoDoc.EndOpenDocument += RhinoDoc_EndOpenDocument;
+
+        _initialized = true;
+      }
+      catch (Exception ex)
+      {
+
+      }
 
     }
 
@@ -84,6 +94,8 @@ namespace SpeckleRhino
     /// </summary>
     protected override LoadReturnCode OnLoad(ref string errorMessage)
     {
+      Init();
+
 #if !MAC
       System.Type panelType = typeof(Panel);
       // Register my custom panel class type with Rhino, the custom panel my be display

--- a/ConnectorRhino/ConnectorRhino6/Properties/AssemblyInfo.cs
+++ b/ConnectorRhino/ConnectorRhino6/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("d648bb69-b992-4d34-906e-7a547374b86c")]
+[assembly: Guid("8dd5f30b-a13d-4a24-abdc-3e05c8c87143")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/ConnectorRhino/ConnectorRhino7/Properties/AssemblyInfo.cs
+++ b/ConnectorRhino/ConnectorRhino7/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a64acbf9-db82-4839-af99-57ed2e7989f4")]
+[assembly: Guid("8dd5f30b-a13d-4a24-abdc-3e05c8c87143")]
 
 // Version information for an assembly consists of the following four values:
 //


### PR DESCRIPTION
## Description

- Fixes an initialization error in Rhino

I was not able to consistently reproduce this, but it seemed to happen on first load, right after install.
Since the connector and DUI2 were initialized in the Plugin constructor, I think this caused some sort of race condition.

Initialization logic has been moved to the `loaded` event, this means the plugin will only be started when users call the `Speckle` command or have the Panel open.