### PR TITLE
FIX(ci): Nuget version picking nuget prefix instead of version.

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -16,7 +16,7 @@ commands:
           name: Publish nuget package
           command: |
             $tag = if([string]::IsNullOrEmpty($env:CIRCLE_TAG)) { "0.0.$($env:WORFKLOW_NUM)-beta/a" } else { $env:CIRCLE_TAG }
-            $version = $tag.Split("/")[0]  
+            $version = $tag.Split("/")[1]  
             msbuild <<parameters.projectfilepath>> /p:Version="$version" /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false -t:pack
             dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
           environment:


### PR DESCRIPTION
## Description

- Fixes version picking bash command grabbing the prefix `nugets` instead of the actual version number. This caused the build to not create a nuget package, and the upload step would fail.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- No updates needed

