### PR TITLE
rhino: changes user attributes from dict to base

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -1,16 +1,17 @@
-﻿using Grasshopper.Kernel.Types;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Drawing;
+
+using Rhino;
+using Rhino.DocObjects;
+using Grasshopper.Kernel.Types;
+
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
 using Objects.Geometry;
 using Objects.Primitive;
 using Objects.Other;
-using Rhino;
-using Rhino.Geometry;
-using Rhino.DocObjects;
-using Speckle.Core.Kits;
-using Speckle.Core.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Objects.Converter.RhinoGh
 {
@@ -46,6 +47,64 @@ namespace Objects.Converter.RhinoGh
 
     #region app props
     public static string RhinoPropName = "RhinoProps";
+    private static string UserStrings = "userStrings";
+    private static string UserDictionary = "userDictionary";
+
+    /// <summary>
+    /// Attaches user strings, user dictionaries, and object name from a RhinoObject to  Base
+    /// </summary>
+    /// <param name="obj">The converted Base object to attach info to</param>
+    /// <param name="nativeObj">The Rhino object containing info</param>
+    /// <returns></returns>
+    public void GetUserInfo(Base obj, RhinoObject nativeObj)
+    {
+      var userStringsBase = new Base();
+      var userDictionaryBase = new Base();
+
+      var userStrings = nativeObj.Attributes.GetUserStrings();
+      userStrings.AllKeys.ToList().ForEach(k => userStringsBase[k] = userStrings[k]);
+      ParseArchivableToDictionary(userDictionaryBase, nativeObj.Attributes.UserDictionary);
+
+      obj[UserStrings] = userStringsBase;
+      obj[UserDictionary] = userDictionaryBase;
+
+      if (nativeObj.HasName) obj["name"] = nativeObj.Name;
+    }
+
+    /// <summary>
+    /// Copies an ArchivableDictionary to a Base
+    /// </summary>
+    /// <param name="target"></param>
+    /// <param name="dict"></param>
+    private void ParseArchivableToDictionary(Base target, Rhino.Collections.ArchivableDictionary dict)
+    {
+      foreach (var key in dict.Keys)
+      {
+        var obj = dict[key];
+        switch (obj)
+        {
+          case Rhino.Collections.ArchivableDictionary o:
+            var nested = new Base();
+            ParseArchivableToDictionary(nested, o);
+            target[key] = nested;
+            continue;
+
+          case double _:
+          case bool _:
+          case int _:
+          case string _:
+          case IEnumerable<double> _:
+          case IEnumerable<bool> _:
+          case IEnumerable<int> _:
+          case IEnumerable<string> _:
+            target[key] = obj;
+            continue;
+
+          default:
+            continue;
+        }
+      }
+    }
     #endregion
 
     #region Units

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -56,19 +56,19 @@ namespace Objects.Converter.RhinoGh
     /// <param name="obj">The converted Base object to attach info to</param>
     /// <param name="nativeObj">The Rhino object containing info</param>
     /// <returns></returns>
-    public void GetUserInfo(Base obj, RhinoObject nativeObj)
+    public void GetUserInfo(Base obj, ObjectAttributes attributes)
     {
       var userStringsBase = new Base();
       var userDictionaryBase = new Base();
 
-      var userStrings = nativeObj.Attributes.GetUserStrings();
+      var userStrings = attributes.GetUserStrings();
       userStrings.AllKeys.ToList().ForEach(k => userStringsBase[k] = userStrings[k]);
-      ParseArchivableToDictionary(userDictionaryBase, nativeObj.Attributes.UserDictionary);
+      ParseArchivableToDictionary(userDictionaryBase, attributes.UserDictionary);
 
       obj[UserStrings] = userStringsBase;
       obj[UserDictionary] = userDictionaryBase;
 
-      if (nativeObj.HasName) obj["name"] = nativeObj.Name;
+      if (!string.IsNullOrEmpty(attributes.Name)) obj["name"] = attributes.Name;
     }
 
     /// <summary>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -297,12 +297,14 @@ namespace Objects.Converter.RhinoGh
           throw new NotSupportedException();
       }
 
+      if (@base is null) return @base;
+
+      if (@object is RhinoObject _ro)
+        GetUserInfo(@base, _ro);
       if (material != null)
         @base["renderMaterial"] = material;
-
       if (style != null)
         @base["displayStyle"] = style;
-
       if (schema != null)
       {
         schema["renderMaterial"] = material;
@@ -513,7 +515,6 @@ namespace Objects.Converter.RhinoGh
     {
       return objects.Select(x => ConvertToSpeckleStr(x)).ToList();
     }
-
 
     public object ConvertToNative(Base @object)
     {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -122,6 +122,7 @@ namespace Objects.Converter.RhinoGh
       RenderMaterial material = null;
       RH.Mesh displayMesh = null;
       DisplayStyle style = null;
+      ObjectAttributes attributes = null;
       Base @base = null;
       Base schema = null;
       if (@object is RhinoObject ro)
@@ -131,10 +132,12 @@ namespace Objects.Converter.RhinoGh
 
         if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
           schema = ConvertToSpeckleBE(ro) ?? ConvertToSpeckleStr(ro);
-        
+
+        attributes = ro.Attributes;
+
         // Fast way to get the displayMesh, try to get the mesh rhino shows on the viewport when available.
         // This will only return a mesh if the object has been displayed in any mode other than Wireframe.
-        if(ro is BrepObject || ro is ExtrusionObject)
+        if (ro is BrepObject || ro is ExtrusionObject)
           displayMesh = GetRhinoRenderMesh(ro);
         
         if (!(@object is InstanceObject)) // block instance check
@@ -299,8 +302,8 @@ namespace Objects.Converter.RhinoGh
 
       if (@base is null) return @base;
 
-      if (@object is RhinoObject _ro)
-        GetUserInfo(@base, _ro);
+      if (attributes != null)
+        GetUserInfo(@base, attributes);
       if (material != null)
         @base["renderMaterial"] = material;
       if (style != null)


### PR DESCRIPTION
## Description
Previously, user strings and user dictionaries were being sent as dictionaries in Rhino. They are now attached as `Base`.
Also checks for `name` prop on receive.

Attaching user info has been moved from the connector to the converter

- Fixes #1333

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests: user strings, names, and dicts in rhino

## Docs

- No updates needed

