### PR TITLE
fix(revit): workaround for #1469

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Entry/SpeckleRevitCommand2.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/SpeckleRevitCommand2.cs
@@ -105,7 +105,7 @@ namespace Speckle.ConnectorRevit.Entry
         TaskDialog mainDialog = new TaskDialog("Dockable Panel Issue");
         mainDialog.MainInstruction = "Dockable Panel Issue";
         mainDialog.MainContent =
-            "Revit cannot properly register Dockable Panels when launched double-clicking a Revit file. "
+            "Revit cannot properly register Dockable Panels when launched by double-clicking a Revit file. "
             + "Please close and re-open Revit without launching a file OR open/create a new project to trigger the Speckle panel registration.";
 
 

--- a/ConnectorRevit/ConnectorRevit/Entry/SpeckleRevitCommand2.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/SpeckleRevitCommand2.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Autodesk.Revit.Attributes;
@@ -29,8 +30,7 @@ namespace Speckle.ConnectorRevit.Entry
 
     public static ConnectorBindingsRevit2 Bindings { get; set; }
 
-    internal static UIApplication uiapp;
-
+    private static Panel _panel { get; set; }
 
 
     internal static DockablePaneId PanelId = new DockablePaneId(new Guid("{0A866FB8-8FD5-4DE8-B24B-56F4FA5B0836}"));
@@ -52,12 +52,16 @@ namespace Speckle.ConnectorRevit.Entry
 
     public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
     {
-      uiapp = commandData.Application;
 
       if (UseDockablePanel)
       {
-        var panel = commandData.Application.GetDockablePane(PanelId);
-        panel.Show();
+        try
+        {
+          RegisterPane();
+          var panel = App.AppInstance.GetDockablePane(PanelId);
+          panel.Show();
+        }
+        catch { }
       }
       else
         CreateOrFocusSpeckle();
@@ -65,6 +69,55 @@ namespace Speckle.ConnectorRevit.Entry
 
 
       return Result.Succeeded;
+    }
+
+    internal static void RegisterPane()
+    {
+      if (!UseDockablePanel)
+        return;
+
+      var registered = DockablePane.PaneIsRegistered(PanelId);
+      var created = DockablePane.PaneExists(PanelId);
+
+      if (registered && created)
+      {
+        _panel.Init();
+        return;
+      }
+
+      if (!registered)
+      {
+        //Register dockable panel
+        var viewModel = new MainViewModel(Bindings);
+        _panel = new Panel
+        {
+          DataContext = viewModel
+        };
+        App.AppInstance.RegisterDockablePane(PanelId, "Speckle", _panel);
+        _panel.Init();
+      }
+      created = DockablePane.PaneExists(PanelId);
+
+      //if revit was launched double-clicking on a Revit file, we're screwed
+      //could maybe show the old window?
+      if (!created && App.AppInstance.Application.Documents.Size > 0)
+      {
+        TaskDialog mainDialog = new TaskDialog("Dockable Panel Issue");
+        mainDialog.MainInstruction = "Dockable Panel Issue";
+        mainDialog.MainContent =
+            "Revit cannot properly register Dockable Panels when launched double-clicking a Revit file. "
+            + "Please close and re-open Revit without launching a file OR open/create a new project to trigger the Speckle panel registration.";
+
+
+        // Set footer text. Footer text is usually used to link to the help document.
+        mainDialog.FooterText =
+            "<a href=\"https://github.com/specklesystems/speckle-sharp/issues/1469 \">"
+            + "Click here for more info</a>";
+
+        mainDialog.Show();
+
+      }
+
     }
 
     public static void CreateOrFocusSpeckle(bool showWindow = true)
@@ -104,7 +157,7 @@ namespace Speckle.ConnectorRevit.Entry
 
           if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
           {
-            var parentHwnd = uiapp.MainWindowHandle;
+            var parentHwnd = App.AppInstance.MainWindowHandle;
             var hwnd = MainWindow.PlatformImpl.Handle.Handle;
             SetWindowLongPtr(hwnd, GWL_HWNDPARENT, parentHwnd);
           }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Events.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Events.cs
@@ -52,6 +52,7 @@ namespace Speckle.ConnectorRevit.UI
       RevitApp.Application.DocumentCreated += Application_DocumentCreated;
       RevitApp.Application.DocumentCreating += Application_DocumentCreating;
       RevitApp.Application.DocumentOpened += Application_DocumentOpened;
+      RevitApp.Application.DocumentOpening += Application_DocumentOpening; ;
       RevitApp.Application.DocumentClosed += Application_DocumentClosed;
       RevitApp.Application.DocumentSaved += Application_DocumentSaved;
       RevitApp.Application.DocumentSynchronizingWithCentral += Application_DocumentSynchronizingWithCentral;
@@ -63,8 +64,10 @@ namespace Speckle.ConnectorRevit.UI
       // thus triggering the focus on a new project
     }
 
+    private void Application_DocumentOpening(object sender, Autodesk.Revit.DB.Events.DocumentOpeningEventArgs e)
+    {
 
-
+    }
 
     private void Application_DocumentCreating(object sender, Autodesk.Revit.DB.Events.DocumentCreatingEventArgs e)
     {
@@ -136,8 +139,7 @@ namespace Speckle.ConnectorRevit.UI
         if (e.Document == null || e.PreviousActiveView == null || e.Document.GetHashCode() == e.PreviousActiveView.Document.GetHashCode())
           return;
 
-        if (SpeckleRevitCommand2.UseDockablePanel)
-          (App.Panel as Panel).Init();
+        SpeckleRevitCommand2.RegisterPane();
 
         var streams = GetStreamsInFile();
         UpdateSavedStreams(streams);
@@ -181,8 +183,7 @@ namespace Speckle.ConnectorRevit.UI
     { }
     private void Application_DocumentCreated(object sender, Autodesk.Revit.DB.Events.DocumentCreatedEventArgs e)
     {
-      if (SpeckleRevitCommand2.UseDockablePanel)
-        (App.Panel as Panel).Init();
+      SpeckleRevitCommand2.RegisterPane();
 
       //clear saved streams if opening a new doc
       if (UpdateSavedStreams != null)
@@ -191,15 +192,14 @@ namespace Speckle.ConnectorRevit.UI
 
     private void Application_DocumentOpened(object sender, Autodesk.Revit.DB.Events.DocumentOpenedEventArgs e)
     {
-      if (SpeckleRevitCommand2.UseDockablePanel)
-        (App.Panel as Panel).Init();
 
       var streams = GetStreamsInFile();
       if (streams != null && streams.Count != 0)
       {
         if (SpeckleRevitCommand2.UseDockablePanel)
         {
-          var panel = RevitApp.GetDockablePane(SpeckleRevitCommand2.PanelId);
+          SpeckleRevitCommand2.RegisterPane();
+          var panel = App.AppInstance.GetDockablePane(SpeckleRevitCommand2.PanelId);
           panel.Show();
         }
         else


### PR DESCRIPTION
## Description

- Workaround for #1469

This is a workaround just to let the user know Revit cannot correctly register Dockable panels when launched from a file, instead of showing an error message.

Other possible solutions:
- try to create/open a doc in the background (i tried and failed)
- launch the old windowed UI (possible conflicts)

We should merge this in 2.7 and release a hotfix.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?


- Manual Tests (please write what did you do?)

## Docs

- No updates needed

