### PR TITLE
fix(gh): Fixed Setup.Init call on Loader.cs + added comments

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Loader.cs
@@ -35,16 +35,16 @@ namespace ConnectorGrasshopper
       
       try
       {
-        typeof(Setup).InvokeMember(
-          "Init",
-          BindingFlags.Static | BindingFlags.InvokeMethod,
-          null,
-          null,
-          new object[] { version, HostApplications.Grasshopper.Slug });
+        // Using reflection instead of calling `Setup.Init` to prevent loader from exploding. See comment on Catch clause.
+        typeof(Setup).GetMethod("Init", BindingFlags.Public | BindingFlags.Static)
+                     .Invoke(null, new object[] { version, HostApplications.Grasshopper.Slug });
       }
-      catch (MissingMethodException e)
+      catch (Exception e)
       {
-        Console.WriteLine(e);
+        // This is here to ensure that other older versions of core (which did not have the Setup class) don't bork our connector initialisation.
+        // The only way this can happen right now is if a 3rd party plugin includes the Core dll in their distribution (which they shouldn't ever do).
+        // Recommended practice is to assume that our connector would be installed alongside theirs.
+        Log.CaptureException(e);
       }
 
       Grasshopper.Instances.DocumentServer.DocumentAdded += CanvasCreatedEvent;


### PR DESCRIPTION
## Description

- Fixes issue where Mixpanel was not receiving the events from Grasshopper properly tagged, leading to non-realistic a massive drop in MAU on our dashboard.

I did a quick test and ended up keeping the reflection call, but fixed it so that it would work as expected. This should not be an issue unless a 3rd party plugin that uses speckle has an older version of core that did not contain `Setup.Init` (quite old, but can happen)

We should be back to normal MAU tracking in no time




## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)

## Docs

- No updates needed

