### PR TITLE
fix(gh): Switched to using unit name from Enum instead of localised units

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -356,7 +356,7 @@ namespace ConnectorGrasshopper
         Tracker.TrackNodeRun("Create Schema Object", Name);
 
 
-      var units = Units.GetUnitsFromString(Rhino.RhinoDoc.ActiveDoc.GetUnitSystemName(true, false, false, false));
+      var units = Units.GetUnitsFromString(Rhino.RhinoDoc.ActiveDoc.ModelUnitSystem.ToString());
 
       List<object> cParamsValues = new List<object>();
       var cParams = SelectedConstructor.GetParameters();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -342,7 +342,7 @@ namespace ConnectorGrasshopper
         Tracker.TrackNodeRun("Create Schema Object", Name);
 
 
-      var units = Units.GetUnitsFromString(Rhino.RhinoDoc.ActiveDoc.GetUnitSystemName(true, false, false, false));
+      var units = Units.GetUnitsFromString(Rhino.RhinoDoc.ActiveDoc.ModelUnitSystem.ToString());
 
       List<object> cParamsValues = new List<object>();
       var cParams = SelectedConstructor.GetParameters();


### PR DESCRIPTION
## Description

- Fixes issue where non-english installations of Rhino would cause an error as we expect english named units.

The solution is to use the `ToString()` method of the `UnitSystem` which will always be in english regardless of the language it was installed in.

Reported in the forum: https://speckle.community/t/how-create-revit-geometry-from-grasshopper/3351

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests (please write what did you do?)


Tested the fix in isolation and also some schema nodes while having Rhino set to Spanish.

## Docs

- No updates needed
