### PR TITLE
feat(rhino): add brep and subd support for rhino bim topography

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/BIMElements/BIMElementCommands.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/BIMElements/BIMElementCommands.cs
@@ -42,7 +42,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Brep);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Brep });
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.Wall.ToString(), doc, false);
@@ -56,7 +56,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Brep);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Brep });
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.Floor.ToString(), doc, false);
@@ -70,7 +70,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Curve);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Curve });
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.Column.ToString(), doc, false);
@@ -84,7 +84,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Curve);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Curve });
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.Beam.ToString(), doc, false);
@@ -98,7 +98,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Curve);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Curve });
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.Pipe.ToString(), doc, false);
@@ -112,7 +112,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Curve);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Curve });
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.Duct.ToString(), doc, false);
@@ -126,7 +126,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Brep);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Brep });
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.FaceWall.ToString(), doc, false);
@@ -140,7 +140,7 @@ namespace SpeckleRhino
 
       protected override Result RunCommand(RhinoDoc doc, RunMode mode)
       {
-        var selectedObjects = GetObjectSelection(ObjectType.Mesh);
+        var selectedObjects = GetObjectSelection(new List<ObjectType> { ObjectType.Mesh , ObjectType.Brep, ObjectType.SubD});
         if (selectedObjects == null)
           return Result.Cancel;
         ApplySchema(selectedObjects, SchemaObjectFilter.SupportedSchema.Topography.ToString(), doc, false);
@@ -399,8 +399,9 @@ namespace SpeckleRhino
     }
 
     #region helper methods
-    private static List<RhinoObject> GetObjectSelection(ObjectType filter = ObjectType.AnyObject)
+    private static List<RhinoObject> GetObjectSelection(List<ObjectType> filter = null)
     {
+      filter = filter ?? new List<ObjectType> { ObjectType.AnyObject };
       // Construct an objects getter
       var getObj = new GetObject();
       getObj.SetCommandPrompt("Select geometry");
@@ -409,7 +410,7 @@ namespace SpeckleRhino
       getObj.EnableClearObjectsOnEntry(false);
       getObj.EnableUnselectObjectsOnExit(false);
       getObj.DeselectAllBeforePostSelect = false;
-      getObj.GeometryFilter = filter;
+      getObj.GeometryFilter = filter.Aggregate((a,b) => a | b);
 
       // Get objects
       for (; ; )

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/BIMElements/BIMElementFilter.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/BIMElements/BIMElementFilter.cs
@@ -186,9 +186,20 @@ namespace SpeckleRhino
         case SupportedSchema.Topography:
           try
           {
-            Mesh mesh = obj.Geometry as Mesh;
-            if (!mesh.IsClosed)
-              return true;
+            switch (obj.Geometry)
+            {
+              case Mesh o:
+                if (!o.IsClosed) return true;
+                break;
+              case Brep o:
+                if (!o.IsSolid) return true;
+                break;
+#if RHINO7
+              case SubD o:
+                if (!o.IsSolid) return true;
+                break;
+#endif
+            }
           }
           catch { }
           break;
@@ -240,14 +251,13 @@ namespace SpeckleRhino
             SupportedSchema.Roof };
           break;
         case ObjectType.Mesh:
+        case ObjectType.PolysrfFilter:
+        case ObjectType.Brep:
+        case ObjectType.Extrusion:
           objSchemas = new List<SupportedSchema>
           {
             SupportedSchema.Topography
           };
-          break;
-        case ObjectType.PolysrfFilter:
-        case ObjectType.Brep:
-        case ObjectType.Extrusion:
           break;
         default:
           break;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -253,13 +253,25 @@ namespace Objects.Converter.RhinoGh
       return new RV.RevitFaceWall(family, type, BrepToSpeckle(brep), null) { units = ModelUnits };
     }
 
+    public Topography BrepToTopography(RH.Brep brep)
+    {
+      brep.Repair(Doc.ModelAbsoluteTolerance);
+      var displayMesh = GetBrepDisplayMesh(brep);
+      return new Topography(MeshToSpeckle(displayMesh)) { units = ModelUnits };
+    }
+
     public Topography MeshToTopography(RH.Mesh mesh)
     {
-      if (mesh.IsClosed)
-        return null;
-
       return new Topography(MeshToSpeckle(mesh)) { units = ModelUnits };
     }
+
+#if RHINO7
+    public Topography MeshToTopography(RH.SubD subD)
+    {
+      var speckleMesh = MeshToSpeckle(subD);
+      return speckleMesh != null ? new Topography(speckleMesh) { units = ModelUnits } : null;
+    }
+#endif
 
     public RV.AdaptiveComponent InstanceToAdaptiveComponent(InstanceObject instance, string[] args)
     {
@@ -366,7 +378,7 @@ namespace Objects.Converter.RhinoGh
       return nativeObjects;
     } 
 
-    #region CIVIL
+#region CIVIL
 
     // alignment
     public RH.Curve AlignmentToNative(Alignment alignment)
@@ -385,6 +397,6 @@ namespace Objects.Converter.RhinoGh
       return joined.First();
     }
 
-    #endregion
+#endregion
   }
 }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -821,28 +821,9 @@ namespace Objects.Converter.RhinoGh
       //   f.RebuildEdges(tol, false, false);
       // }
       // Create complex
-      var joinedMesh = new RH.Mesh();
-      if (previewMesh == null)
-      {
-        var mySettings = MeshingParameters.Default;
-        switch (SelectedMeshSettings)
-        {
-          case MeshSettings.Default:
-            mySettings = new MeshingParameters(0.05, 0.05);
-            break;
-          case MeshSettings.CurrentDoc:
-            mySettings = MeshingParameters.DocumentCurrentSetting(Doc);
-            break;
-        }
-        joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
-        joinedMesh.Weld(Math.PI);
-      }
-      else
-      {
-        joinedMesh = previewMesh;
-      }
+      var displayMesh = previewMesh != null ? previewMesh : GetBrepDisplayMesh(brep);
 
-      var spcklBrep = new Brep(displayValue: MeshToSpeckle(joinedMesh, u), provenance: RhinoAppName, units: u);
+      var spcklBrep = new Brep(displayValue: MeshToSpeckle(displayMesh, u), provenance: RhinoAppName, units: u);
 
       // Vertices, uv curves, 3d curves and surfaces
       spcklBrep.Vertices = brep.Vertices
@@ -957,6 +938,25 @@ namespace Objects.Converter.RhinoGh
       spcklBrep.bbox = BoxToSpeckle(new RH.Box(brep.GetBoundingBox(false)), u);
       
       return spcklBrep;
+    }
+
+    private RH.Mesh GetBrepDisplayMesh(RH.Brep brep)
+    {
+      var joinedMesh = new RH.Mesh();
+
+      var mySettings = MeshingParameters.Default;
+      switch (SelectedMeshSettings)
+      {
+        case MeshSettings.Default:
+          mySettings = new MeshingParameters(0.05, 0.05);
+          break;
+        case MeshSettings.CurrentDoc:
+          mySettings = MeshingParameters.DocumentCurrentSetting(Doc);
+          break;
+      }
+      joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
+      joinedMesh.Weld(Math.PI);
+      return joinedMesh;
     }
 
     /// <summary>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -133,16 +133,16 @@ namespace Objects.Converter.RhinoGh
         material = RenderMaterialToSpeckle(ro.GetMaterial(true));
         style = DisplayStyleToSpeckle(ro.Attributes);
 
-        if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
-          schema = ConvertToSpeckleBE(ro, reportObj) ?? ConvertToSpeckleStr(ro, reportObj);
-
-        attributes = ro.Attributes;
-
         // Fast way to get the displayMesh, try to get the mesh rhino shows on the viewport when available.
         // This will only return a mesh if the object has been displayed in any mode other than Wireframe.
         if (ro is BrepObject || ro is ExtrusionObject)
           displayMesh = GetRhinoRenderMesh(ro);
-        
+
+        if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
+          schema = ConvertToSpeckleBE(ro, reportObj, displayMesh) ?? ConvertToSpeckleStr(ro, reportObj);
+
+        attributes = ro.Attributes;
+
         if (!(@object is InstanceObject)) // block instance check
           @object = ro.Geometry;
       }
@@ -229,13 +229,9 @@ namespace Objects.Converter.RhinoGh
 #if RHINO7
         case RH.SubD o:
           if (o.HasBrepForm)
-          {
             @base = BrepToSpeckle(o.ToBrep(new SubDToBrepOptions()),null, displayMesh);
-          }
           else
-          {
             @base = MeshToSpeckle(o);
-          }
           break;
 #endif
         case RH.Extrusion o:
@@ -261,7 +257,6 @@ namespace Objects.Converter.RhinoGh
           break;
         case Rhino.Geometry.Dimension o:
           @base = DimensionToSpeckle(o);
-          Report.Log($"Converted Dimension");
           break;
         default:
           if (reportObj != null)
@@ -300,7 +295,7 @@ namespace Objects.Converter.RhinoGh
       return objects.Select(x => ConvertToSpeckle(x)).ToList();
     }
 
-    public Base ConvertToSpeckleBE(object @object, ApplicationObject reportObj)
+    public Base ConvertToSpeckleBE(object @object, ApplicationObject reportObj, RH.Mesh displayMesh)
     {
       // get schema if it exists
       RhinoObject obj = @object as RhinoObject;
@@ -366,6 +361,10 @@ namespace Objects.Converter.RhinoGh
               schemaBase = BrepToDirectShape(o, args);
               break;
 
+            case "Topography":
+              schemaBase = displayMesh != null ? MeshToTopography(displayMesh) :  BrepToTopography(o);
+              break;
+
             default:
               reportObj.Update(logItem: $"{schema} creation from {o.ObjectType} is not supported");
               break;
@@ -394,6 +393,10 @@ namespace Objects.Converter.RhinoGh
             case "DirectShape":
               schemaBase = ExtrusionToDirectShape(o, args);
               break;
+            
+            case "Topography":
+              schemaBase = displayMesh != null ? MeshToTopography(displayMesh) : MeshToTopography(o.GetMesh(MeshType.Default));
+              break;
 
             default:
               reportObj.Update(logItem: $"{schema} creation from {o.ObjectType} is not supported");
@@ -417,6 +420,15 @@ namespace Objects.Converter.RhinoGh
               break;
           }
           break;
+
+#if RHINO7
+        case RH.SubD o:
+          if (o.HasBrepForm)
+            schemaBase = displayMesh != null ? MeshToTopography(displayMesh) : BrepToTopography(o.ToBrep(new SubDToBrepOptions()));
+          else
+            schemaBase = MeshToTopography(o);
+          break;
+#endif
 
         default:
           reportObj.Update(logItem: $"{obj.ObjectType} is not supported in schema conversions.");

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -125,7 +125,7 @@ namespace Objects.Converter.RhinoGh
       Base @base = null;
       Base schema = null;
       ApplicationObject reportObj = null;
-      List<string> notes = new List<string>();
+      var notes = new List<string>();
 
       if (@object is RhinoObject ro)
       {
@@ -277,6 +277,7 @@ namespace Objects.Converter.RhinoGh
         @base["displayStyle"] = style;
       if (schema != null)
       {
+        notes.Add($"Attached {schema.speckle_type} schema");
         schema["renderMaterial"] = material;
         @base["@SpeckleSchema"] = schema;
       }
@@ -302,7 +303,7 @@ namespace Objects.Converter.RhinoGh
       string schema = GetSchema(obj, out string[] args);
 
       Base schemaBase = null;
-      List<string> notes = null;
+      var notes = new List<string>();
       if (obj is InstanceObject)
       {
         if (schema == "AdaptiveComponent")
@@ -435,11 +436,8 @@ namespace Objects.Converter.RhinoGh
           break;
       }
       reportObj.Log.AddRange(notes);
-      if (schemaBase != null)
-        reportObj.Log.Add($"Created {schema} schema from {obj.GetType()}");
-      else
-        reportObj.Update(logItem: $"{schema} schema creation from {obj.GetType()} failed");
-      Report.UpdateReportObject(reportObj);
+      if (schemaBase == null)
+        reportObj.Update(logItem: $"{schema} schema creation failed");
       return schemaBase;
     }
 


### PR DESCRIPTION
## Description
Allows users to assign topography schema to non-solid breps and subds
Also fixed a null error bug on rhino bim schema conversions

- Closes #1485 
- Fixes #1486 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How has this been tested?

- Manual Tests

## Docs

- Will be updated ASAP

