### PR TITLE
GH: SOM reported bug fixes

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
@@ -39,7 +39,7 @@ namespace ConnectorGrasshopper.Extras
         switch (Owner.Kind)
         {
           case GH_ParamKind.input:
-            (Owner as GenericAccessParam)?.InheritNickname();
+            (Owner as SpeckleStatefulParam)?.InheritNickname();
             return GH_ObjectResponse.Handled;
           case GH_ParamKind.output:
             Clipboard.SetText(DocObject.NickName);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStatefulParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStatefulParam.cs
@@ -214,7 +214,7 @@ namespace ConnectorGrasshopper.Extras
         {
           ghParam.NewInstanceGuid();
           ghParam.Attributes.Selected = false;
-          ghParam.Attributes.Pivot = new PointF(this.Attributes.Pivot.X + 40f, this.Attributes.Pivot.Y);
+          ghParam.Attributes.Pivot = new PointF(Attributes.Parent.Bounds.Right + ghParam.Attributes.Bounds.Width/2 + 15f, Attributes.Pivot.Y);
           ghParam.Attributes.ExpireLayout();
           ghParam.MutableNickName = true;
           if (ghParam.Attributes is GH_FloatingParamAttributes)

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -421,11 +421,18 @@ namespace ConnectorGrasshopper.Ops
 
     private async Task ResetApiClient(StreamWrapper wrapper)
     {
-      ApiClient?.Dispose();
-      var acc = await wrapper.GetAccount();
-      ApiClient = new Client(acc);
-      ApiClient.SubscribeCommitCreated(StreamWrapper.StreamId);
-      ApiClient.OnCommitCreated += ApiClient_OnCommitCreated;
+      try
+      {
+        ApiClient?.Dispose();
+        var acc = await wrapper.GetAccount();
+        ApiClient = new Client(acc);
+        ApiClient.SubscribeCommitCreated(StreamWrapper.StreamId);
+        ApiClient.OnCommitCreated += ApiClient_OnCommitCreated;
+      }
+      catch (Exception e)
+      {
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+      }
     }
 
     private void ApiClient_OnCommitCreated(object sender, CommitInfo e)

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -260,7 +260,10 @@ namespace Speckle.Core.Api
 
         if (res.Errors != null)
           throw new SpeckleException("Could not get streams", res.Errors);
-
+        if (res.Data?.user == null)
+        {
+          throw new SpeckleException("User is not authenticated, or the credentials were not valid. Check the provided account is still valid, remove it from manager and add it again.");
+        }
         return res.Data.user.streams.items;
       }
       catch (Exception e)


### PR DESCRIPTION
Closes #1499

- Account details issue was related to the `StreamsGet` function in Core not expecting the user to be `null`, which can be if there are no provided credentials, the credentials are invalid, or the user does not exist anymore. I added a better exception for that case to provide more clarity to the user.
![Screenshot 2022-08-11 at 11 22 17](https://user-images.githubusercontent.com/2316535/184102973-24933809-a160-486e-80a8-b0313845373e.png)

- `T0: One or more errors ocurred` while sending. This seems to be related to the first item, but I haven't managed to repro so this one remains **unfixed**. Could have been caused by a faulty connection. We checked the server logs but nothing showed up. Tried invalidating my token to verify if this would replicate the error, but I got the expected warnings 👇🏼
![Screenshot 2022-08-11 at 11 23 18](https://user-images.githubusercontent.com/2316535/184103172-b9ace69b-2525-460a-89b4-fa3e0c9c1680.png)

- Renaming input. behaviour on the Send component should now work as expected.
![2022-08-11 11 25 01](https://user-images.githubusercontent.com/2316535/184104003-7cab5500-893a-407c-ae62-1f5120329412.gif)

- **Slow renaming** was caused (at least in the provided example file) by the **grasshopper auto save feature**, deactivating it made everything work smoothly again. This is usually caused by having too many internalised objects that need to be serialised before saving the GH document.

- Extract parameter nodes not being placed properly: It should now work exactly as the original "ExtractParameter", same offset and position, but since we're talking about outputs, it would go to the right of the node.
![2022-08-11 11 28 49](https://user-images.githubusercontent.com/2316535/184104365-6c013c84-3fbc-473d-81b4-ec04d06734e1.gif)

