### PR TITLE
Revit/hosted fams

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -42,6 +42,8 @@ namespace Speckle.ConnectorRevit.UI
     /// <param name="state">StreamState passed by the UI</param>
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {
+      //make sure to instance a new copy so all values are reset correctly
+      Converter = (ISpeckleConverter)Activator.CreateInstance(Converter.GetType());
       Converter.SetContextDocument(CurrentDoc.Document);
       Converter.Report.ReportObjects.Clear();
 

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Autodesk.Revit.DB;
 using DesktopUI2.Models;
 using DesktopUI2.Models.Settings;
 using DesktopUI2.ViewModels;
@@ -115,11 +116,28 @@ namespace Speckle.ConnectorRevit.UI
             continue;
           }
 
-          var category = $"@{revitElement.Category.Name}";
-          if (commitObject[category] == null)
-            commitObject[category] = new List<Base>();
+          //is an element type, nest it under Types instead
+          if (typeof(ElementType).IsAssignableFrom(revitElement.GetType()))
+          {
+            var category = $"@{revitElement.Category.Name}";
 
-          ((List<Base>)commitObject[category]).Add(conversionResult);
+            if (commitObject["Types"] == null)
+              commitObject["Types"] = new Base();
+
+            if ((commitObject["Types"] as Base)[category] == null)
+              (commitObject["Types"] as Base)[category] = new List<Base>();
+
+            ((List<Base>)((commitObject["Types"] as Base)[category])).Add(conversionResult);
+          }
+          else
+          {
+            var category = $"@{revitElement.Category.Name}";
+            if (commitObject[category] == null)
+              commitObject[category] = new List<Base>();
+
+            ((List<Base>)commitObject[category]).Add(conversionResult);
+          }
+
 
           reportObj.Update(status: ApplicationObject.State.Created, logItem: $"Sent as {ConnectorRevitUtils.SimplifySpeckleType(conversionResult.speckle_type)}");
         }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.cs
@@ -21,6 +21,8 @@ namespace Speckle.ConnectorRevit.UI
 
     public Timer SelectionTimer;
 
+    //Only use an instance of the converter as a local variable to avoid conflicts if multiple sending/receiving
+    //operations are happening at the same time
     public ISpeckleConverter Converter { get; set; } = KitManager.GetDefaultKit().LoadConverter(ConnectorRevitUtils.RevitAppName);
 
     public List<Exception> ConversionErrors { get; set; } = new List<Exception>();


### PR DESCRIPTION
Fixes: #1502

The converter was reused when sending and not re-initialized each time, this led to the `ConvertedObjectsList` collection to never be cleared, and so hosted elements figured as already sent.

I made sure it is re-initialized each time and made it a local variable to avoid conflicts when multiple send/receive ops might be happening simultaneously.