### PR TITLE
fix(revit): updated GetElementType method to return bool with logging

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -482,7 +482,7 @@ namespace Objects.Converter.Revit
 
     #region  element types
 
-    private T GetElementType<T>(string family, string type, ApplicationObject appObj)
+    private bool GetElementType<T>(string family, string type, ApplicationObject appObj, out T value)
     {
       List<ElementType> types = new FilteredElementCollector(Doc).WhereElementIsElementType().OfClass(typeof(T)).ToElements().Cast<ElementType>().ToList();
 
@@ -493,7 +493,8 @@ namespace Objects.Converter.Revit
         if (match is FamilySymbol fs && !fs.IsActive)
           fs.Activate();
 
-        return (T)(object)match;
+        value = (T)(object)match;
+        return true;
       }
 
       //match family
@@ -506,7 +507,8 @@ namespace Objects.Converter.Revit
           if (match is FamilySymbol fs && !fs.IsActive)
             fs.Activate();
 
-          return (T)(object)match;
+          value = (T)(object)match;
+          return true;
         }
       }
 
@@ -520,15 +522,17 @@ namespace Objects.Converter.Revit
           if (match is FamilySymbol fs && !fs.IsActive)
             fs.Activate();
 
-          return (T)(object)match;
+          value = (T)(object)match;
+          return true;
         }
       }
 
       appObj.Log.Add($"Could not find any family symbol to use.");
-      throw new Speckle.Core.Logging.SpeckleException($"Could not find any family symbol to use.");
+      value = default(T);
+      return false;
     }
 
-    private T GetElementType<T>(Base element, ApplicationObject appObj)
+    private bool GetElementType<T>(Base element, ApplicationObject appObj, out T value)
     {
       List<ElementType> types = new List<ElementType>();
       ElementFilter filter = GetCategoryFilter(element);
@@ -542,7 +546,8 @@ namespace Objects.Converter.Revit
       {
         var name = string.IsNullOrEmpty(element["category"].ToString()) ? typeof(T).Name : element["category"].ToString();
         appObj.Log.Add($"Could not find any family to use for category {name}.");
-        throw new Exception($"Could not find any family to use for category {name}.");
+        value = default(T);
+        return false;
       }
 
       var family = element["family"] as string;
@@ -581,7 +586,8 @@ namespace Objects.Converter.Revit
       if (match is FamilySymbol fs && !fs.IsActive)
         fs.Activate();
 
-      return (T)(object)match;
+      value = (T)(object)match;
+      return true;
     }
 
     private ElementFilter GetCategoryFilter(Base element)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -482,7 +482,7 @@ namespace Objects.Converter.Revit
 
     #region  element types
 
-    private T GetElementType<T>(string family, string type)
+    private T GetElementType<T>(string family, string type, ApplicationObject appObj)
     {
       List<ElementType> types = new FilteredElementCollector(Doc).WhereElementIsElementType().OfClass(typeof(T)).ToElements().Cast<ElementType>().ToList();
 
@@ -500,7 +500,7 @@ namespace Objects.Converter.Revit
       match = types.FirstOrDefault(x => x.FamilyName == family);
       if (match != null)
       {
-        Report.Log($"Missing type [{family} - {type}] was replaced with [{match.FamilyName} - {match.Name}]");
+        appObj.Log.Add($"Missing type [{family} - {type}] was replaced with [{match.FamilyName} - {match.Name}]");
         if (match != null)
         {
           if (match is FamilySymbol fs && !fs.IsActive)
@@ -514,7 +514,7 @@ namespace Objects.Converter.Revit
       if (types.Any())
       {
         match = types.FirstOrDefault();
-        Report.Log($"Missing family and type, the following family and type were used: {match.FamilyName} - {match.Name}");
+        appObj.Log.Add($"Missing family and type, the following family and type were used: {match.FamilyName} - {match.Name}");
         if (match != null)
         {
           if (match is FamilySymbol fs && !fs.IsActive)
@@ -524,27 +524,25 @@ namespace Objects.Converter.Revit
         }
       }
 
+      appObj.Log.Add($"Could not find any family symbol to use.");
       throw new Speckle.Core.Logging.SpeckleException($"Could not find any family symbol to use.");
     }
 
-    private T GetElementType<T>(Base element)
+    private T GetElementType<T>(Base element, ApplicationObject appObj)
     {
       List<ElementType> types = new List<ElementType>();
       ElementFilter filter = GetCategoryFilter(element);
 
       if (filter != null)
-      {
         types = new FilteredElementCollector(Doc).WhereElementIsElementType().OfClass(typeof(T)).WherePasses(filter).ToElements().Cast<ElementType>().ToList();
-      }
       else
-      {
         types = new FilteredElementCollector(Doc).WhereElementIsElementType().OfClass(typeof(T)).ToElements().Cast<ElementType>().ToList();
-      }
 
       if (types.Count == 0)
       {
         var name = string.IsNullOrEmpty(element["category"].ToString()) ? typeof(T).Name : element["category"].ToString();
-        throw new Speckle.Core.Logging.SpeckleException($"Could not find any family to use for category {name}.");
+        appObj.Log.Add($"Could not find any family to use for category {name}.");
+        throw new Exception($"Could not find any family to use for category {name}.");
       }
 
       var family = element["family"] as string;
@@ -558,21 +556,17 @@ namespace Objects.Converter.Revit
       //}
 
       if (!string.IsNullOrEmpty(family) && !string.IsNullOrEmpty(type))
-      {
         match = types.FirstOrDefault(x => x.FamilyName == family && x.Name == type);
-      }
 
       //some elements only have one family so we didn't add such prop our schema
       if (match == null && string.IsNullOrEmpty(family) && !string.IsNullOrEmpty(type))
-      {
         match = types.FirstOrDefault(x => x.Name == type);
-      }
 
       if (match == null && !string.IsNullOrEmpty(family)) // try and match the family only.
       {
         match = types.FirstOrDefault(x => x.FamilyName == family);
         if (match != null) //inform user that the type is different!
-          Report.Log($"Missing type. Family: {family} Type: {type}\nType was replaced with: {match.FamilyName}, {match.Name}");
+          appObj.Log.Add($"Missing type. Family: {family} Type: {type}\nType was replaced with: {match.FamilyName}, {match.Name}");
 
       }
       if (match == null) // okay, try something!
@@ -581,13 +575,11 @@ namespace Objects.Converter.Revit
           match = types.Cast<WallType>().Where(o => o.Kind == WallKind.Basic).Cast<ElementType>().FirstOrDefault();
         if (match == null)
           match = types.First();
-        Report.Log($"Missing type. Family: {family} Type: {type}\nType was replaced with: {match.FamilyName}, {match.Name}");
+        appObj.Log.Add($"Missing type. Family: {family} Type: {type}\nType was replaced with: {match.FamilyName}, {match.Name}");
       }
 
       if (match is FamilySymbol fs && !fs.IsActive)
-      {
         fs.Activate();
-      }
 
       return (T)(object)match;
     }
@@ -1028,11 +1020,11 @@ namespace Objects.Converter.Revit
     /// <param name="curveArray">The revit <see cref="CurveArray"/> to add the line to.</param>
     /// <param name="line">The <see cref="Line"/> to be added.</param>
     /// <returns>True if the line was added, false otherwise.</returns>
-    public bool TryAppendLineSafely(CurveArray curveArray, Line line)
+    public bool TryAppendLineSafely(CurveArray curveArray, Line line, ApplicationObject appObj)
     {
       if (IsLineTooShort(line))
       {
-        Report.Log("Some lines in the CurveArray where ignored due to being smaller than the allowed curve length.");
+        appObj.Log.Add("Some lines in the CurveArray where ignored due to being smaller than the allowed curve length.");
         return false;
       }
       try
@@ -1042,7 +1034,7 @@ namespace Objects.Converter.Revit
       }
       catch (Exception e)
       {
-        Report.LogConversionError(e);
+        appObj.Log.Add(e.Message);
         return false;
       }
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
@@ -22,7 +22,11 @@ namespace Objects.Converter.Revit
       }
 
       string familyName = speckleAc["family"] as string != null ? speckleAc["family"] as string : "";
-      DB.FamilySymbol familySymbol = GetElementType<DB.FamilySymbol>(speckleAc, appObj);
+      if (!GetElementType<FamilySymbol>(speckleAc, appObj, out FamilySymbol familySymbol))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
       if (familySymbol.FamilyName != familyName)
       {
         appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not find adaptive component {familyName}");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
@@ -22,7 +22,7 @@ namespace Objects.Converter.Revit
       }
 
       string familyName = speckleAc["family"] as string != null ? speckleAc["family"] as string : "";
-      DB.FamilySymbol familySymbol = GetElementType<DB.FamilySymbol>(speckleAc);
+      DB.FamilySymbol familySymbol = GetElementType<DB.FamilySymbol>(speckleAc, appObj);
       if (familySymbol.FamilyName != familyName)
       {
         appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not find adaptive component {familyName}");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
@@ -31,7 +31,12 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleBeam, appObj);
+      if (!GetElementType<FamilySymbol>(speckleBeam, appObj, out DB.FamilySymbol familySymbol))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
+
       var baseLine = CurveToNative(speckleBeam.baseLine).get_Item(0);
       DB.Level level = null;
       DB.FamilyInstance revitBeam = null;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
@@ -31,7 +31,7 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleBeam);
+      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleBeam, appObj);
       var baseLine = CurveToNative(speckleBeam.baseLine).get_Item(0);
       DB.Level level = null;
       DB.FamilyInstance revitBeam = null;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
@@ -23,7 +23,11 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var cableTrayType = GetElementType<CableTrayType>(speckleCableTray, appObj);
+      if (!GetElementType<CableTrayType>(speckleCableTray, appObj, out CableTrayType cableTrayType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
 
       Element cableTray = null;
       if (speckleCableTray.baseCurve is Line)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
@@ -23,7 +23,7 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var cableTrayType = GetElementType<CableTrayType>(speckleCableTray);
+      var cableTrayType = GetElementType<CableTrayType>(speckleCableTray, appObj);
 
       Element cableTray = null;
       if (speckleCableTray.baseCurve is Line)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
@@ -66,7 +66,7 @@ namespace Objects.Converter.Revit
         level = ConvertLevelToRevit(LevelFromCurve(outline.get_Item(0)), out levelState);
       }
 
-      var ceilingType = GetElementType<CeilingType>(speckleCeiling);
+      var ceilingType = GetElementType<CeilingType>(speckleCeiling, appObj);
 
       var docObj = GetExistingElementByApplicationId(speckleCeiling.applicationId);
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
@@ -66,7 +66,11 @@ namespace Objects.Converter.Revit
         level = ConvertLevelToRevit(LevelFromCurve(outline.get_Item(0)), out levelState);
       }
 
-      var ceilingType = GetElementType<CeilingType>(speckleCeiling, appObj);
+      if (!GetElementType<CeilingType>(speckleCeiling, appObj, out CeilingType ceilingType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
 
       var docObj = GetExistingElementByApplicationId(speckleCeiling.applicationId);
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -23,7 +23,7 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn);
+      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn, appObj);
       var baseLine = CurveToNative(speckleColumn.baseLine).get_Item(0);
 
       // If the start point elevation is higher than the end point elevation, reverse the line.

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -23,7 +23,12 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleColumn, appObj);
+      if (!GetElementType<FamilySymbol>(speckleColumn, appObj, out DB.FamilySymbol familySymbol))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
+
       var baseLine = CurveToNative(speckleColumn.baseLine).get_Item(0);
 
       // If the start point elevation is higher than the end point elevation, reverse the line.

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -37,7 +37,7 @@ namespace Objects.Converter.Revit
       Element duct = null;
       if (speckleDuct.baseCurve == null || speckleDuct.baseCurve is Line)
       {
-        var ductType = GetElementType<DuctType>(speckleDuct);
+        var ductType = GetElementType<DuctType>(speckleDuct, appObj);
 
         DB.Line baseLine = (speckleDuct.baseCurve != null) ? LineToNative(speckleDuct.baseCurve as Line) : LineToNative(speckleDuct.baseLine);
         XYZ startPoint = baseLine.GetEndPoint(0);
@@ -48,7 +48,7 @@ namespace Objects.Converter.Revit
       }
       else if (speckleDuct.baseCurve is Polyline polyline)
       {
-        var ductType = GetElementType<FlexDuctType>(speckleDuct);
+        var ductType = GetElementType<FlexDuctType>(speckleDuct, appObj);
 
         var speckleRevitFlexDuct = speckleDuct as RevitFlexDuct;
         var points = polyline.GetPoints().Select(o => PointToNative(o)).ToList();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -37,7 +37,11 @@ namespace Objects.Converter.Revit
       Element duct = null;
       if (speckleDuct.baseCurve == null || speckleDuct.baseCurve is Line)
       {
-        var ductType = GetElementType<DuctType>(speckleDuct, appObj);
+        if (!GetElementType<DuctType>(speckleDuct, appObj, out DuctType ductType))
+        {
+          appObj.Update(status: ApplicationObject.State.Failed);
+          return appObj;
+        }
 
         DB.Line baseLine = (speckleDuct.baseCurve != null) ? LineToNative(speckleDuct.baseCurve as Line) : LineToNative(speckleDuct.baseLine);
         XYZ startPoint = baseLine.GetEndPoint(0);
@@ -48,7 +52,11 @@ namespace Objects.Converter.Revit
       }
       else if (speckleDuct.baseCurve is Polyline polyline)
       {
-        var ductType = GetElementType<FlexDuctType>(speckleDuct, appObj);
+        if (!GetElementType<FlexDuctType>(speckleDuct, appObj, out FlexDuctType ductType))
+        {
+          appObj.Update(status: ApplicationObject.State.Failed);
+          return appObj;
+        }
 
         var speckleRevitFlexDuct = speckleDuct as RevitFlexDuct;
         var points = polyline.GetPoints().Select(o => PointToNative(o)).ToList();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
@@ -71,7 +71,11 @@ namespace Objects.Converter.Revit
       Doc.Regenerate();
       Reference faceRef = GetFaceRef(mass);
 
-      var wallType = GetElementType<WallType>(speckleWall, appObj);
+      if (!GetElementType<WallType>(speckleWall, appObj, out WallType wallType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
       if (!FaceWall.IsWallTypeValidForFaceWall(Doc, wallType.Id))
       {
         appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Wall type {wallType.Name} not valid for facewall");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
@@ -71,7 +71,7 @@ namespace Objects.Converter.Revit
       Doc.Regenerate();
       Reference faceRef = GetFaceRef(mass);
 
-      var wallType = GetElementType<WallType>(speckleWall);
+      var wallType = GetElementType<WallType>(speckleWall, appObj);
       if (!FaceWall.IsWallTypeValidForFaceWall(Doc, wallType.Id))
       {
         appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Wall type {wallType.Name} not valid for facewall");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -28,7 +28,12 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      DB.FamilySymbol familySymbol = GetElementType<FamilySymbol>(speckleFi, appObj);
+      if (!GetElementType<FamilySymbol>(speckleFi, appObj, out DB.FamilySymbol familySymbol))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
+
       if (docObj != null)
       {
         try

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -40,7 +40,7 @@ namespace Objects.Converter.Revit
         level = ConvertLevelToRevit(LevelFromCurve(outline.get_Item(0)), out ApplicationObject.State state);
       }
 
-      var floorType = GetElementType<FloorType>(speckleFloor);
+      var floorType = GetElementType<FloorType>(speckleFloor, appObj);
 
       // NOTE: I have not found a way to edit a slab outline properly, so whenever we bake, we renew the element. The closest thing would be:
       // https://adndevbConversionLog.Add.typepad.com/aec/2013/10/change-the-boundary-of-floorsslabs.html

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -40,7 +40,11 @@ namespace Objects.Converter.Revit
         level = ConvertLevelToRevit(LevelFromCurve(outline.get_Item(0)), out ApplicationObject.State state);
       }
 
-      var floorType = GetElementType<FloorType>(speckleFloor, appObj);
+      if (!GetElementType<FloorType>(speckleFloor, appObj, out FloorType floorType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
 
       // NOTE: I have not found a way to edit a slab outline properly, so whenever we bake, we renew the element. The closest thing would be:
       // https://adndevbConversionLog.Add.typepad.com/aec/2013/10/change-the-boundary-of-floorsslabs.html

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -491,13 +491,15 @@ namespace Objects.Converter.Revit
     /// <returns>A Revit <see cref="CurveArray"/></returns>
     public CurveArray PolylineToNative(Polyline polyline)
     {
+      var appObj = new ApplicationObject(polyline.id, polyline.speckle_type) { applicationId = polyline.applicationId };
       var curveArray = new CurveArray();
       if (polyline.value.Count == 6)
       {
         // Polyline is actually a single line
         TryAppendLineSafely(
           curveArray, 
-          new Line(polyline.value, polyline.units)
+          new Line(polyline.value, polyline.units),
+          appObj
         );
       }
       else
@@ -508,7 +510,8 @@ namespace Objects.Converter.Revit
         {
           var success = TryAppendLineSafely(
             curveArray, 
-            new Line(lastPt, pts[i] , polyline.units)
+            new Line(lastPt, pts[i] , polyline.units),
+            appObj
           );
           if(success) lastPt = pts[i];
         }
@@ -517,7 +520,8 @@ namespace Objects.Converter.Revit
         {
           TryAppendLineSafely(
             curveArray, 
-            new Line(pts[pts.Count - 1], pts[0] , polyline.units)
+            new Line(pts[pts.Count - 1], pts[0] , polyline.units),
+            appObj
           );
         }
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -27,7 +27,7 @@ namespace Objects.Converter.Revit
       }
 
       // get system info
-      var pipeType = GetElementType<DB.Plumbing.PipeType>(specklePipe);
+      var pipeType = GetElementType<DB.Plumbing.PipeType>(specklePipe, appObj);
       var systemTypes = new FilteredElementCollector(Doc).WhereElementIsElementType()
        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
       var systemFamily = speckleRevitPipe?.systemType ?? "";
@@ -59,7 +59,7 @@ namespace Objects.Converter.Revit
         case Polyline _:
         case Curve _:
           var speckleRevitFlexPipe = specklePipe as RevitFlexPipe;
-          var flexPipeType = (speckleRevitFlexPipe != null) ? GetElementType<DB.Plumbing.FlexPipeType>(speckleRevitFlexPipe) : GetElementType<DB.Plumbing.FlexPipeType>(specklePipe);
+          var flexPipeType = (speckleRevitFlexPipe != null) ? GetElementType<DB.Plumbing.FlexPipeType>(speckleRevitFlexPipe, appObj) : GetElementType<DB.Plumbing.FlexPipeType>(specklePipe, appObj);
 
           // get points
           Polyline basePoly = specklePipe.baseCurve as Polyline;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -27,7 +27,11 @@ namespace Objects.Converter.Revit
       }
 
       // get system info
-      var pipeType = GetElementType<DB.Plumbing.PipeType>(specklePipe, appObj);
+      if (!GetElementType<DB.Plumbing.PipeType>(specklePipe, appObj, out DB.Plumbing.PipeType pipeType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
       var systemTypes = new FilteredElementCollector(Doc).WhereElementIsElementType()
        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
       var systemFamily = speckleRevitPipe?.systemType ?? "";
@@ -59,7 +63,23 @@ namespace Objects.Converter.Revit
         case Polyline _:
         case Curve _:
           var speckleRevitFlexPipe = specklePipe as RevitFlexPipe;
-          var flexPipeType = (speckleRevitFlexPipe != null) ? GetElementType<DB.Plumbing.FlexPipeType>(speckleRevitFlexPipe, appObj) : GetElementType<DB.Plumbing.FlexPipeType>(specklePipe, appObj);
+          DB.Plumbing.FlexPipeType flexPipeType = null;
+          if (speckleRevitFlexPipe != null)
+          {
+            if (!GetElementType<DB.Plumbing.FlexPipeType>(speckleRevitFlexPipe, appObj, out flexPipeType))
+            {
+              appObj.Update(status: ApplicationObject.State.Failed);
+              return appObj;
+            }
+          }
+          else
+          {
+            if (!GetElementType<DB.Plumbing.FlexPipeType>(specklePipe, appObj, out flexPipeType))
+            {
+              appObj.Update(status: ApplicationObject.State.Failed);
+              return appObj;
+            }
+          }
 
           // get points
           Polyline basePoly = specklePipe.baseCurve as Polyline;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertProfileWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertProfileWall.cs
@@ -25,7 +25,7 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var wallType = GetElementType<WallType>(speckleRevitWall);
+      var wallType = GetElementType<WallType>(speckleRevitWall, appObj);
       // Level level = null;
       var structural = speckleRevitWall.structural;
       var profile = new List<DB.Curve>();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertProfileWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertProfileWall.cs
@@ -25,7 +25,11 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var wallType = GetElementType<WallType>(speckleRevitWall, appObj);
+      if (!GetElementType<WallType>(speckleRevitWall, appObj, out WallType wallType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
       // Level level = null;
       var structural = speckleRevitWall.structural;
       var profile = new List<DB.Curve>();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -25,7 +25,7 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var railingType = GetElementType<RailingType>(speckleRailing);
+      var railingType = GetElementType<RailingType>(speckleRailing, appObj);
       Level level = ConvertLevelToRevit(speckleRailing.level, out ApplicationObject.State levelState);
       if (level == null) //we currently don't support railings hosted on stairs, and these have null level
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -25,7 +25,12 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var railingType = GetElementType<RailingType>(speckleRailing, appObj);
+      if (!GetElementType<RailingType>(speckleRailing, appObj, out RailingType railingType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
+
       Level level = ConvertLevelToRevit(speckleRailing.level, out ApplicationObject.State levelState);
       if (level == null) //we currently don't support railings hosted on stairs, and these have null level
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRebar.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRebar.cs
@@ -36,7 +36,11 @@ namespace Objects.Converter.Revit
       }
 
       var rebarType = speckleRevitRebar?.barType;
-      var barType = GetElementType<RebarBarType>(speckleRebar, appObj);
+      if (!GetElementType<RebarBarType>(speckleRebar, appObj, out RebarBarType barType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
       var rebarStyle = speckleRevitRebar?.barStyle == "StirrupTie" ? RebarStyle.StirrupTie : RebarStyle.Standard;
 
       // get construction curves (only works for revit rebar due to need for host)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRebar.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRebar.cs
@@ -36,7 +36,7 @@ namespace Objects.Converter.Revit
       }
 
       var rebarType = speckleRevitRebar?.barType;
-      var barType = GetElementType<RebarBarType>(speckleRebar);
+      var barType = GetElementType<RebarBarType>(speckleRebar, appObj);
       var rebarStyle = speckleRevitRebar?.barStyle == "StirrupTie" ? RebarStyle.StirrupTie : RebarStyle.Standard;
 
       // get construction curves (only works for revit rebar due to need for host)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -40,7 +40,11 @@ namespace Objects.Converter.Revit
       else
         level = ConvertLevelToRevit(LevelFromCurve(outline.get_Item(0)), out levelState);
 
-      var roofType = GetElementType<RoofType>(speckleRoof, appObj);
+      if (!GetElementType<RoofType>(speckleRoof, appObj, out RoofType roofType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
 
       if (docObj != null)
         Doc.Delete(docObj.Id);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -40,7 +40,7 @@ namespace Objects.Converter.Revit
       else
         level = ConvertLevelToRevit(LevelFromCurve(outline.get_Item(0)), out levelState);
 
-      var roofType = GetElementType<RoofType>(speckleRoof);
+      var roofType = GetElementType<RoofType>(speckleRoof, appObj);
 
       if (docObj != null)
         Doc.Delete(docObj.Id);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -32,16 +32,15 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var wallType = GetElementType<WallType>(speckleWall);
+      var wallType = GetElementType<WallType>(speckleWall, appObj);
       Level level = null;
       var levelState = ApplicationObject.State.Unknown;
       var structural = false;
       var baseCurve = CurveToNative(speckleWall.baseLine).get_Item(0);
+
       List<string> joinSettings = new List<string>();
       if (Settings.ContainsKey("disallow-join"))
-      {
         joinSettings = new List<string>(Regex.Split(Settings["disallow-join"], @"\,\ "));
-      }
 
       if (speckleWall is RevitWall speckleRevitWall)
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -32,7 +32,12 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      var wallType = GetElementType<WallType>(speckleWall, appObj);
+      if (!GetElementType<WallType>(speckleWall, appObj, out WallType wallType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
+
       Level level = null;
       var levelState = ApplicationObject.State.Unknown;
       var structural = false;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWire.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWire.cs
@@ -27,7 +27,7 @@ namespace Objects.Converter.Revit
       var wiringType = speckleRevitWire?.wiringType == "Chamfer"
         ? DB.Electrical.WiringType.Chamfer
         : DB.Electrical.WiringType.Arc;
-      var wireType = GetElementType<DB.Electrical.WireType>(speckleWire);
+      var wireType = GetElementType<DB.Electrical.WireType>(speckleWire, appObj);
 
       // get construction points (if wire is from Revit, these are not the same as the geometry points)
       var points = new List<XYZ>();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWire.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWire.cs
@@ -27,7 +27,11 @@ namespace Objects.Converter.Revit
       var wiringType = speckleRevitWire?.wiringType == "Chamfer"
         ? DB.Electrical.WiringType.Chamfer
         : DB.Electrical.WiringType.Arc;
-      var wireType = GetElementType<DB.Electrical.WireType>(speckleWire, appObj);
+      if (!GetElementType<DB.Electrical.WireType>(speckleWire, appObj, out DB.Electrical.WireType wireType))
+      {
+        appObj.Update(status: ApplicationObject.State.Failed);
+        return appObj;
+      }
 
       // get construction points (if wire is from Revit, these are not the same as the geometry points)
       var points = new List<XYZ>();


### PR DESCRIPTION
- the `GetElementType()` methods now returns a bool to allow for easier logic checks in primary conversions
- logging has been updated so that `ApplicationObjects` are always being returned on instances of failing `GetElementType` methods instead of a speckle exception being thrown
- fixes #1498