### PR TITLE
fix(obj): Interval length parenthesis 🙃

### DIFF
--- a/Objects/Objects/Primitive/Interval.cs
+++ b/Objects/Objects/Primitive/Interval.cs
@@ -24,6 +24,6 @@ namespace Objects.Primitive
       return base.ToString() + $"[{this.start}, {this.end}]";
     }
 
-    [JsonIgnore] public double Length => Math.Abs(end ?? 0 - start ?? 0);
+    [JsonIgnore] public double Length => Math.Abs((end ?? 0) - (start ?? 0));
   }
 }


### PR DESCRIPTION
Fixes #1478

Pretty simple bug, doesn't require much explanation.

Interval length required some parenthesis to properly do the operations in order.