### PR TITLE
GH: Fix Create Schema Object list input and rename options.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/GenericAccessParam.cs
@@ -39,7 +39,8 @@ namespace ConnectorGrasshopper.Extras
         switch (Owner.Kind)
         {
           case GH_ParamKind.input:
-            (Owner as SpeckleStatefulParam)?.InheritNickname();
+            if(Owner.MutableNickName)
+              (Owner as SpeckleStatefulParam)?.InheritNickname();
             return GH_ObjectResponse.Handled;
           case GH_ParamKind.output:
             Clipboard.SetText(DocObject.NickName);

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStatefulParam.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/SpeckleStatefulParam.cs
@@ -14,6 +14,8 @@ namespace ConnectorGrasshopper.Extras
   {
     public override GH_Exposure Exposure => GH_Exposure.hidden;
     public bool Detachable { get; set; } = true;
+
+    public bool CanInheritNames { get; set; } = true;
     public override Guid ComponentGuid => new Guid("5B5A49FC-ACDE-4C09-9317-9C466374C163");
 
     public override GH_StateTagList StateTags
@@ -82,7 +84,7 @@ namespace ConnectorGrasshopper.Extras
     public override void AddSource(IGH_Param source, int index)
     {
       base.AddSource(source, index);
-      if (KeyWatcher.TabPressed)
+      if (MutableNickName && KeyWatcher.TabPressed)
         InheritNickname();
       
     }
@@ -99,9 +101,9 @@ namespace ConnectorGrasshopper.Extras
       }
       
       Menu_AppendSeparator(menu);
-
-      Menu_AppendInheritNickname(menu);
       
+      Menu_AppendInheritNickname(menu);
+
       Menu_AppendSeparator(menu);
 
       Menu_AppendCustomMenuItems(menu);
@@ -187,7 +189,7 @@ namespace ConnectorGrasshopper.Extras
       Menu_AppendItem(
         menu,
         "Inherit names",
-        (sender, args) => { InheritNickname(); });
+        (sender, args) => { InheritNickname(); }, MutableNickName);
     }
     
     // Decompiled from Grasshopper implementation and modified for output recipient.

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
@@ -73,7 +73,7 @@ namespace ConnectorGrasshopper
       objectItem.ToolTipText = "The default behaviour. Output will be the specified object schema.";
 
       var tagItem =
-        schemaConversionHeader.DropDownItems.Add($"Convert as {mainParam.Name ?? "geometry"} with {Name} attached") as
+        schemaConversionHeader.DropDownItems.Add($"Convert as {mainParam?.Name ?? "geometry"} with {Name} attached") as
           ToolStripMenuItem;
       tagItem.Checked = UseSchemaTag;
       tagItem.Enabled = mainParam != null;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -470,7 +470,7 @@ namespace ConnectorGrasshopper
       {
         var type = inputValue.GetType();
         var propertyInfo = type.GetProperty("Value");
-        var value = propertyInfo.GetValue(inputValue);
+        var value = propertyInfo?.GetValue(inputValue);
         return value;
       }
 
@@ -482,11 +482,11 @@ namespace ConnectorGrasshopper
     {
       if (!values.Any()) return null;
 
-      var listElementType = t.GetElementType();
-      var list = (IList)Array.CreateInstance(listElementType, values.Count);
-      for (int i = 0; i < values.Count; i++)
+      var list = (IList)Activator.CreateInstance(t);
+      var listElementType = list.GetType().GetGenericArguments().Single();
+      foreach (var value in values)
       {
-        list[i] = (ConvertType(listElementType, values[i], param.Name));
+        list.Add(ConvertType(listElementType, value, param.Name));
       }
 
       return list;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -214,7 +214,7 @@ namespace ConnectorGrasshopper
       }
 
       // Create new param based on property name
-      Param_GenericObject newInputParam = new Param_GenericObject();
+      SpeckleStatefulParam newInputParam = new SpeckleStatefulParam();
       newInputParam.Name = propName;
       newInputParam.NickName = propName;
       newInputParam.MutableNickName = false;

--- a/ConnectorRhino/ConnectorRhino.sln
+++ b/ConnectorRhino/ConnectorRhino.sln
@@ -42,6 +42,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterGrasshopper7", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorGrasshopper", "..\ConnectorGrasshopper\ConnectorGrasshopper\ConnectorGrasshopper.csproj", "{109B3382-634B-408A-8A5C-4CD09CB92641}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9454D346-A629-40E0-9EE2-7C6933ED1530} = {9454D346-A629-40E0-9EE2-7C6933ED1530}
+		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E} = {CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}
+		{EAA8D25F-A118-4B16-BC6C-A71463B3C53D} = {EAA8D25F-A118-4B16-BC6C-A71463B3C53D}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorGrasshopperUtils", "..\ConnectorGrasshopper\ConnectorGrasshopperUtils\ConnectorGrasshopperUtils.csproj", "{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}"
 EndProject


### PR DESCRIPTION
Reported here https://speckle.community/t/adaptive-component-error/3369/2

Issue seems to be two:
- Null reference errors being thrown while grabbing Lists using reflection
- Null reference errors being thrown on the menu popup, preventing it from showing up.

Bonus:
- Fixed wrong Param type on the Create Schema Node. It will now use the `StatefulSpeckleParam` for better control.
- Disabled name inherit behaviour if `MutableNickname` is false.
