### PR TITLE
fix(core): do not call sentry before it has initialized

### DIFF
--- a/Core/Core/Transports/SQLite.cs
+++ b/Core/Core/Transports/SQLite.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using Speckle.Core.Api;
-using Speckle.Core.Logging;
 
 namespace Speckle.Core.Transports
 {
@@ -46,8 +45,6 @@ namespace Speckle.Core.Transports
 
     public SQLiteTransport(string basePath = null, string applicationName = "Speckle", string scope = "Data")
     {
-      Log.AddBreadcrumb("New SqlLite Transport");
-
       if (basePath == null)
         basePath = Helpers.UserApplicationDataPath;
       _BasePath = basePath;


### PR DESCRIPTION
Using the email hash as a unique id in Sentry created a race condition, removing the `Log.AddBreadcrumb` resolves it as no other Sentry call is made before it has finished initializing