### PR TITLE
Added static accessor to `DynamicBase.GetInstanceMembers`

### DIFF
--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -101,9 +101,10 @@ namespace Tests
       var @base = new SampleObject();
       @base["dynamicProp"] = 123;
       var names = @base.GetMemberNames();
-      var propName = "IgnoredSchemaProp";
-      Assert.False(names.Contains(propName));
-      Assert.False(names.Contains("DeprecatedSchemaProp"));
+      Assert.That(names, Has.No.Member("IgnoredSchemaProp"));
+      Assert.That(names, Has.No.Member("DeprecatedSchemaProp"));
+      Assert.That(names, Has.Member("dynamicProp"));
+      Assert.That(names, Has.Member("attachedProp"));
     }
 
     [Test(Description = "Checks that no ignored or obsolete properties are returned")]
@@ -113,19 +114,21 @@ namespace Tests
       @base["dynamicProp"] = 123;
 
       var names = @base.GetMembers().Keys;
-      Assert.False(names.Contains("IgnoredSchemaProp"));
-      Assert.False(names.Contains("DeprecatedSchemaProp"));
+      Assert.That(names, Has.No.Member("IgnoredSchemaProp"));
+      Assert.That(names, Has.No.Member("DeprecatedSchemaProp"));
+      Assert.That(names, Has.Member("dynamicProp"));
+      Assert.That(names, Has.Member("attachedProp"));
     }
     
-    [Test(Description = "Checks that no ignored or obsolete properties are returned")]
+    [Test]
     public void CanGetDynamicMembers()
     {
       var @base = new SampleObject();
       @base["dynamicProp"] = null;
 
       var names = @base.GetDynamicMemberNames();
-      Assert.True(names.Contains("dynamicProp"));
-      Assert.True(@base["dynamicProp"] == null);
+      Assert.That(names, Has.Member("dynamicProp"));
+      Assert.Null(@base["dynamicProp"]);
     }
 
     [Test]
@@ -136,16 +139,16 @@ namespace Tests
       var value = "something";
       // Can create a new dynamic member
       @base[key] = value;
-      Assert.True((string)@base[key] == value);
+      Assert.AreEqual((string)@base[key],value);
       
       // Can overwrite existing
       value = "some other value";
       @base[key] = value;
-      Assert.True((string)@base[key] == value);
+      Assert.AreEqual((string)@base[key], value);
       
       // Accepts null values
       @base[key] = null;
-      Assert.True(@base[key] == null);
+      Assert.IsNull(@base[key]);
     }
     
     


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation
While creating some editor UI in Unity to inspect properties.

My current needs are to cache PropertyInfo of types inheriting `Base`, since using reflection every UI update is unacceptable.
We already cache PropertyInfo of speckle types inside `DynamicBase`.
But this data is only accessible through `GetInstanceMembers`

The problem is, I don't have an instance to call `GetInstanceMembers` on, just the `Type`
And I don't want to have to create a dummy instance of a `Type` (which I would then have to cache in the UI), just to call `GetInstanceMembers` (which just calls `GetType()` to access its internal static `propertyInfo` dictionary)

So I propose this small change. (first two lines are the important change)
https://github.com/specklesystems/speckle-sharp/blob/711238ecf7311a12e782302244f6bb06e4d20ad9/Core/Core/Models/DynamicBase.cs#L188-L200

Secondly, I also noticed that setting properties of an instance frequently, was leading to a lot of memory allocations (slow for GC, especially when done frequently). And I thought, while I was there, I'd try and tackle any low-hanging fruit, optimisation wise.


<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:
1. Added static accessor for `GetInstanceMembers` and `GetInstanceMemberNames`.

2. Small performance optimisation (mostly surrounding memory allocation) of DynamicBase methods.
All changes are non breaking.

Here are the performance results if anyone is interested!
New methods show a slight optimisation to basically all methods, in both execution time, and memory allocation. Most are very slight, and likely won't yield any tangible benefits.
But this was low hanging fruit, and (imo) only improves code readability.

![image](https://user-images.githubusercontent.com/45512892/185020376-b69afbe4-d21a-4d8e-b715-d430c469b180.png)

The biggest benefit can be seen in the `this[string]` operator (which calls `IsPropNameValid`) we can see memory allocation is roughly 10% of current method.
Here I'm testing setting a prop 1000 times. 4MB of allocated memory is not insignificant.

```
|                    Method |       Mean |    Error |   StdDev |    Gen 0 | Allocated |
|-------------------------- |-----------:|---------:|---------:|---------:|----------:|
|     SetAProperty1000Times | 3,422.0 us | 18.65 us | 16.53 us | 570.3125 |  4,398 KB |
| SetAProperty1000Times_new |   347.9 us |  0.78 us |  0.65 us |  62.0117 |    477 KB |

```
<!---

- Item 1
- Item 2

-->

## To-do before merge:
 - [ ] Maybe test a connector?  Core tests pass, and I'm reasonably confident of their quality. 

## Validation of changes:

I noticed a couple cases missed in the  `BaseTests`. Mostly surrounding `Obsolete` and `SchemaIgnore` tests.

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->



## References
https://stackoverflow.com/questions/14719104/is-there-a-benefit-of-using-isdefined-over-getcustomattributes
<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
