### PR TITLE
fix(autocad): handles mesh face negative vertex index

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -1388,14 +1388,15 @@ namespace Objects.Converter.AutocadCivil
               var indices = new List<int>();
               for (short i = 0; i < 4; i++)
               {
-                short index = o.GetVertexAt(i);
-                if (index != 0)
-                  indices.Add(index);
+                short index = o.GetVertexAt(i); 
+                if (index == 0) continue;
+                var adjustedIndex = index > 0 ? index - 1 : Math.Abs(index) - 1; // vertices are 1 indexed, and can be negative (hidden)
+                indices.Add(adjustedIndex);
               }
-              if (indices.Count == 4) // vertex index starts at 1 sigh
-                faces.AddRange(new List<int> { 1, indices[0] - 1, indices[1] - 1, indices[2] - 1, indices[3] - 1 });
+              if (indices.Count == 4)
+                faces.AddRange(new List<int> { 1, indices[0], indices[1], indices[2], indices[3] });
               else
-                faces.AddRange(new List<int> { 0, indices[0] - 1, indices[1] - 1, indices[2] - 1 });
+                faces.AddRange(new List<int> { 0, indices[0], indices[1], indices[2] });
               break;
           }
         }


### PR DESCRIPTION
## Description & motivation
Autocad mesh faces can have negative vertex indices, which indicates a hidden vertex. This was resulting in distorted meshes with a vertex at the origin, reported by the community at: [https://speckle.community/t/autocad-commit-creating-lines-from-origin-point-in-speckle/2817](https://speckle.community/t/autocad-commit-creating-lines-from-origin-point-in-speckle/2817)

Fixes #1441

## Changes:

AutocadCivil `MeshToSpeckle` conversion

## Screenshots:

Before: 
![image](https://user-images.githubusercontent.com/16748799/185130722-2c6a325a-0dae-414f-af05-2d78ec4b43bb.png)

After:
![image](https://user-images.githubusercontent.com/16748799/185131154-8bd69a8c-cc71-4a99-852a-6cbf384754d0.png)


## Validation of changes:


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.

