### PR TITLE
feat(autocadcivil): add proxyentity conversion to speckle

### DIFF
--- a/Core/Core/Models/Utilities.cs
+++ b/Core/Core/Models/Utilities.cs
@@ -99,21 +99,28 @@ namespace Speckle.Core.Models
       var appProps = new Base();
       appProps["class"] = t.Name;
 
-      // set primitive writeable props 
-      foreach (var propInfo in t.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public))
+      try
       {
-        if (ignore != null && ignore.Contains(propInfo.Name)) continue;
-        if (IsMeaningfulProp(propInfo, o, out object propValue))
-          appProps[propInfo.Name] = propValue;
-      }
-      if (getParentProps)
-      {
-        foreach (var propInfo in t.BaseType.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public))
+        // set primitive writeable props 
+        foreach (var propInfo in t.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public))
         {
           if (ignore != null && ignore.Contains(propInfo.Name)) continue;
           if (IsMeaningfulProp(propInfo, o, out object propValue))
             appProps[propInfo.Name] = propValue;
         }
+        if (getParentProps)
+        {
+          foreach (var propInfo in t.BaseType.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public))
+          {
+            if (ignore != null && ignore.Contains(propInfo.Name)) continue;
+            if (IsMeaningfulProp(propInfo, o, out object propValue))
+              appProps[propInfo.Name] = propValue;
+          }
+        }
+      }
+      catch(Exception e)
+      {
+
       }
 
       return appProps;

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -990,6 +990,10 @@ namespace Objects.Converter.AutocadCivil
       var _proxy = new Base();
       _proxy["bbox"] = BoxToSpeckle(proxy.GeometricExtents);
       var props = Utilities.GetApplicationProps(proxy, typeof(ProxyEntity), false);
+      props["ApplicationDescription"] = proxy.ApplicationDescription;
+      props["OriginalClassName"] = proxy.OriginalClassName;
+      props["OriginalDxfName"] = proxy.OriginalDxfName;
+      props["ProxyFlags"] = proxy.ProxyFlags;
       if (props != null) _proxy[AutocadPropName] = props;
 
       return _proxy;

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -71,6 +71,7 @@ namespace Objects.Converter.AutocadCivil
     public void SetContextObjects(List<ApplicationObject> objects) => ContextObjects = objects;
 
     public void SetPreviousContextObjects(List<ApplicationObject> objects) => throw new NotImplementedException();
+
     public void SetConverterSettings(object settings)
     {
       throw new NotImplementedException("This converter does not have any settings.");
@@ -141,6 +142,9 @@ namespace Objects.Converter.AutocadCivil
               break;
             case PolyFaceMesh o:
               @base = MeshToSpeckle(o);
+              break;
+            case ProxyEntity o:
+              @base = ProxyEntityToSpeckle(o);
               break;
             case SubDMesh o:
               @base = MeshToSpeckle(o);
@@ -383,6 +387,7 @@ namespace Objects.Converter.AutocadCivil
             case AcadDB.Polyline3d _:
             case AcadDB.Surface _:
             case AcadDB.PolyFaceMesh _:
+            case AcadDB.ProxyEntity _:
             case AcadDB.Region _:
             case SubDMesh _:
             case Solid3d _:
@@ -448,7 +453,6 @@ namespace Objects.Converter.AutocadCivil
         case Text _:
 
         case Alignment _:
-
         case ModelCurve _:
           return true;
 


### PR DESCRIPTION
## Description & motivation
Proxy entities are sent as `Base` from AutoCAD / Civil3D to Speckle with properties attached and a bbox. Unable to retrieve display geometry for now.

*note* No displayable geometry is attached, so not viewable in the web viewer.
Requested by the community here: [https://speckle.community/t/acad-proxy-entity-not-being-sent-to-speckle/2818](https://speckle.community/t/acad-proxy-entity-not-being-sent-to-speckle/2818)
*note* in order to send the displayed meshes as requested by the community, they must be accessed via direct conversion. See #1527 

Fixes #1228

## Changes:

- `ProxyEntityToSpeckle()` conversion added to AutocadCivil connector

## Screenshots:
[https://speckle.xyz/streams/638d3b1f83/commits/558ab0be64](https://speckle.xyz/streams/638d3b1f83/commits/558ab0be64)


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have updated or added relevant documentation.

