### PR TITLE
CORE: Adds extension method to extract all messages from an Exception

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Drawing;
@@ -23,6 +23,7 @@ using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
+using Speckle.Core.Models.Extensions;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
 namespace ConnectorGrasshopper.Ops
@@ -509,7 +510,7 @@ namespace ConnectorGrasshopper.Ops
           var msg = exception.Message.Contains("401")
             ? $"You don't have access to this transport , or it doesn't exist."
             : exception.Message;
-          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, $"{transportName}: {msg}"));
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, $"{transportName}: {exception.ToFormattedString()}"));
           Done();
           var asyncParent = (GH_AsyncComponent)Parent;
           asyncParent.CancellationSources.ForEach(source =>

--- a/Core/Core/Models/Extensions.cs
+++ b/Core/Core/Models/Extensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -89,6 +90,32 @@ namespace Speckle.Core.Models.Extensions
             }
           }
         }
+      }
+    }
+    
+    public static string ToFormattedString(this Exception exception)
+    {
+      var messages = exception
+        .GetAllExceptions()
+        .Where(e => !string.IsNullOrWhiteSpace(e.Message))
+        .Select(e => e.Message.Trim());
+      string flattened = string.Join(Environment.NewLine + "    ", messages); // <-- the separator here
+      return flattened;
+    }
+
+    private static IEnumerable<Exception> GetAllExceptions(this Exception exception)
+    {
+      yield return exception;
+
+      if (exception is AggregateException aggrEx)
+      {
+        foreach (var innerEx in aggrEx.InnerExceptions.SelectMany(e => e.GetAllExceptions()))
+          yield return innerEx;
+      }
+      else if (exception.InnerException != null)
+      {
+        foreach (var innerEx in exception.InnerException.GetAllExceptions())
+          yield return innerEx;
       }
     }
   }

--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Newtonsoft.Json;
+﻿using Speckle.Core.Models.Extensions;
+using Speckle.Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -275,7 +276,7 @@ namespace Speckle.Core.Models
       get
       {
         lock (OperationErrorsLock)
-          return string.Join("\n", OperationErrors.Select(x => x.Message).Distinct());
+          return string.Join("\n", OperationErrors.Select(x => x.ToFormattedString()).Distinct());
       }
     }
 

--- a/Core/Tests/ExceptionTests.cs
+++ b/Core/Tests/ExceptionTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using NUnit.Framework;
+using Speckle.Core.Models.Extensions;
+namespace TestsUnit
+{
+  [TestFixture]
+  public class ExceptionTests
+  {
+    [Test]
+    public void CanPrintAllInnerExceptions()
+    {
+      var ex = new Exception("Some error");
+      var exMsg = ex.ToFormattedString();
+
+      var ex2 = new Exception("One or more errors occurred",ex);
+      var ex2Msg = ex2.ToFormattedString();
+
+      
+      var ex3 = new AggregateException("One or more errors occurred",ex2);
+      var ex3Msg = ex3.ToFormattedString();
+      
+      Assert.NotNull(ex3Msg);
+      
+    }
+  }
+}


### PR DESCRIPTION
We usually get errors that are wrapped in other errors, where the meaningful message is somewhere deep inside the nested `Exception` structure.

I've added a new Exception extension in `Speckle.Core.Models.Extensions` (may not be the best place... TBD) called `ToFormattedString()`, which will fetch all messages from an Exception and print them.

So, instead of getting a useless `One or more errors occurred` message, you will now also get all the inner errors that actually occurred, right after the initial message (one line per exception).

This does not support indenting them, as I thought it would make it weird for our reports, but it could be a nice optional thing to have.

### Why

Because `exception.ToString()` will print all the exception messages along with their call stack. Even though having the call stack is nice in some occasions, the end user doesn't really care, and we should have that information in Sentry anyway.

`ToFormattedString` is intended to be used only when an exception message is going to be displayed to the user.

The method may require some improvements, unit tests will be added as soon as we agree this is a good idea