### PR TITLE
fix(revit): improved reporting for geometry and blocks

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Receive.cs
@@ -215,14 +215,6 @@ namespace Speckle.ConnectorRevit.UI
               obj.Update(status: o.Status, createdIds: o.CreatedIds, converted: o.Converted, log: o.Log);
               progress.Report.UpdateReportObject(obj);
               break;
-            case Group o:
-              var convAppObj = converter.Report.GetReportObject(obj.OriginalId, out int convIndex) ? converter.Report.ReportObjects[convIndex] : null;
-              if (convAppObj != null)
-              {
-                obj.Update(status: convAppObj.Status, createdIds: convAppObj.CreatedIds, converted: convAppObj.Converted,log: convAppObj.Log);
-                progress.Report.UpdateReportObject(obj);
-              }
-              break;
             default:
               break;
           }

--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -165,8 +165,8 @@ namespace Speckle.Core.Models
       if (status.HasValue) Status = status.Value;
       if (log != null) log.Where(o => !string.IsNullOrEmpty(o) && !Log.Contains(o))?.ToList().ForEach(o => Log.Add(o));
       if (!string.IsNullOrEmpty(logItem) && !Log.Contains(logItem)) Log.Add(logItem);
-      if (convertedItem != null) Converted.Add(convertedItem);
-      if (converted != null) converted.Where(o => o != null)?.ToList().ForEach(o => Converted.Add(o));
+      if (convertedItem != null && !Converted.Contains(convertedItem)) Converted.Add(convertedItem);
+      if (converted != null) converted.Where(o => o != null && !Converted.Contains(o))?.ToList().ForEach(o => Converted.Add(o));
     }
   }
 
@@ -186,7 +186,7 @@ namespace Speckle.Core.Models
     {
       if (GetReportObject(obj.OriginalId, out int index))
       {
-        ReportObjects[index].Update(createdIds: obj.CreatedIds, log: obj.Log);
+        ReportObjects[index].Update(createdIds: obj.CreatedIds, converted: obj.Converted, log: obj.Log);
         if (obj.Status != ApplicationObject.State.Unknown)
           ReportObjects[index].Update(status: obj.Status);
         return ReportObjects[index];

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
@@ -17,7 +17,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleAc.id, speckleAc.speckle_type) { applicationId = speckleAc.applicationId };
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem:$"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
@@ -21,7 +21,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleBeam.id, speckleBeam.speckle_type) { applicationId = speckleBeam.applicationId };
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
@@ -19,7 +19,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleCableTray.id, speckleCableTray.speckle_type) { applicationId = speckleCableTray.applicationId };
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
@@ -39,7 +39,14 @@ namespace Objects.Converter.Revit
 #if REVIT2022
     public ApplicationObject CeilingToNative(Ceiling speckleCeiling)
     {
+      var docObj = GetExistingElementByApplicationId(speckleCeiling.applicationId);
       var appObj = new ApplicationObject(speckleCeiling.id, speckleCeiling.speckle_type) { applicationId = speckleCeiling.applicationId };
+      if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
+      {
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem:$"ApplicationId already exists in document, new object ignored.");
+        return appObj;
+      }
+      
       if (speckleCeiling.outline == null)
       {
         appObj.Update(status: ApplicationObject.State.Failed, logItem: "Missing an outline curve.");
@@ -69,13 +76,6 @@ namespace Objects.Converter.Revit
       if (!GetElementType<CeilingType>(speckleCeiling, appObj, out CeilingType ceilingType))
       {
         appObj.Update(status: ApplicationObject.State.Failed);
-        return appObj;
-      }
-
-      var docObj = GetExistingElementByApplicationId(speckleCeiling.applicationId);
-      if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
-      {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
         return appObj;
       }
    

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -15,7 +15,13 @@ namespace Objects.Converter.Revit
   {
     public ApplicationObject ColumnToNative(Column speckleColumn)
     {
+      var docObj = GetExistingElementByApplicationId(speckleColumn.applicationId);
       var appObj = new ApplicationObject(speckleColumn.id, speckleColumn.speckle_type) { applicationId = speckleColumn.applicationId };
+      if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
+      {
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
+        return appObj;
+      }
 
       if (speckleColumn.baseLine == null)
       {
@@ -60,13 +66,6 @@ namespace Objects.Converter.Revit
       }
 
       //try update existing 
-      var docObj = GetExistingElementByApplicationId(speckleColumn.applicationId);
-      
-      if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
-      {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
-        return appObj;
-      }
 
       bool isUpdate = false;
       if (docObj != null)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCurves.cs
@@ -47,7 +47,7 @@ namespace Objects.Converter.Revit
         DB.ModelCurve revitCurve = Doc.Create.NewModelCurve(baseCurve, NewSketchPlaneFromCurve(baseCurve, Doc));
         appObj.Update(createdId: revitCurve.UniqueId);
       }
-
+      appObj.Update(status: ApplicationObject.State.Created);
       return appObj;
     }
 
@@ -80,7 +80,7 @@ namespace Objects.Converter.Revit
 
         appObj.Update(createdId: revitCurve.UniqueId, convertedItem: revitCurve);
       }
-
+      appObj.Update(status: ApplicationObject.State.Created);
       return appObj;
     }
 
@@ -110,8 +110,10 @@ namespace Objects.Converter.Revit
       {
         // use display value if curve fails (prob a closed, periodic curve or a non-planar nurbs)
         if (speckleLine is IDisplayValue<Geometry.Polyline> d)
-          return ModelCurvesFromEnumerator(CurveToNative(d.displayValue).GetEnumerator(),
-            speckleLine, appObj);
+        {
+          appObj.Update(logItem: $"Curve failed conversion (probably a closed period curve or non-planar nurbs): used polyline display value instead.");
+          return ModelCurvesFromEnumerator(CurveToNative(d.displayValue).GetEnumerator(), speckleLine, appObj);
+        }
         else
         {
           appObj.Update(status: ApplicationObject.State.Failed, logItem: e.Message);
@@ -134,9 +136,11 @@ namespace Objects.Converter.Revit
         else
           revitCurve = Doc.Create.NewModelCurve(curve, NewSketchPlaneFromCurve(curve, Doc));
 
-        appObj.Update(createdId: revitCurve.UniqueId, convertedItem: revitCurve);
+        if (revitCurve != null)
+          appObj.Update(createdId: revitCurve.UniqueId, convertedItem: revitCurve);
       }
-
+      if (appObj.CreatedIds.Count > 1) appObj.Update(logItem: $"Created as {appObj.CreatedIds.Count} model curves");
+      appObj.Update(status: ApplicationObject.State.Created);
       return appObj;
     }
 
@@ -186,7 +190,7 @@ namespace Objects.Converter.Revit
 
         appObj.Update(createdId: revitCurve.UniqueId, convertedItem: revitCurve);
       }
-
+      appObj.Update(status: ApplicationObject.State.Created, logItem: $"Created as {appObj.CreatedIds.Count} detail curves");
       return appObj;
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -60,7 +60,7 @@ namespace Objects.Converter.Revit
       if (existing != null)
       {
         appObj = existing;
-        appObj.Update(status: ApplicationObject.State.Skipped);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: existing.CreatedIds.FirstOrDefault(), convertedItem: existing.Converted.FirstOrDefault(), logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -20,7 +20,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleDuct.id, speckleDuct.speckle_type) { applicationId = speckleDuct.applicationId };
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
       

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFaceWall.cs
@@ -22,7 +22,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleWall.id, speckleWall.speckle_type) { applicationId = speckleWall.applicationId };
       if (revitWall != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitWall.UniqueId, convertedItem: revitWall);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitWall.UniqueId, convertedItem: revitWall, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -24,7 +24,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleFi.id, speckleFi.speckle_type) { applicationId = speckleFi.applicationId };
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -14,7 +14,13 @@ namespace Objects.Converter.Revit
   {
     public ApplicationObject FloorToNative(BuiltElements.Floor speckleFloor)
     {
+      var docObj = GetExistingElementByApplicationId(speckleFloor.applicationId);
       var appObj = new ApplicationObject(speckleFloor.id, speckleFloor.speckle_type) { applicationId = speckleFloor.applicationId };
+      if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
+      {
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
+        return appObj;
+      }
 
       if (speckleFloor.outline == null)
       {
@@ -49,12 +55,7 @@ namespace Objects.Converter.Revit
       // NOTE: I have not found a way to edit a slab outline properly, so whenever we bake, we renew the element. The closest thing would be:
       // https://adndevbConversionLog.Add.typepad.com/aec/2013/10/change-the-boundary-of-floorsslabs.html
       // This would only work if the floors have the same number (and type!!!) of outline curves. 
-      var docObj = GetExistingElementByApplicationId(speckleFloor.applicationId);
-      if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
-      {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
-        return appObj;
-      }
+      
 
       if (docObj != null)
         Doc.Delete(docObj.Id);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -594,7 +594,7 @@ namespace Objects.Converter.Revit
       return speckleMesh;
     }
 
-    // Insipred by
+    // Inspired by
     // https://github.com/DynamoDS/DynamoRevit/blob/master/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
     public IList<GeometryObject> MeshToNative(Mesh mesh, TessellatedShapeBuilderTarget target = TessellatedShapeBuilderTarget.Mesh, TessellatedShapeBuilderFallback fallback = TessellatedShapeBuilderFallback.Salvage, RenderMaterial parentMaterial = null)
     {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGridLine.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGridLine.cs
@@ -17,7 +17,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleGridline.id, speckleGridline.speckle_type) { applicationId = speckleGridline.applicationId };
       if (revitGrid != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitGrid.UniqueId, convertedItem: revitGrid);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitGrid.UniqueId, convertedItem: revitGrid, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertOpening.cs
@@ -21,7 +21,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleOpening.id, speckleOpening.speckle_type) { applicationId = speckleOpening.applicationId };
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -22,7 +22,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(specklePipe.id, specklePipe.speckle_type) { applicationId = specklePipe.applicationId };
       if (docObj != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertProfileWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertProfileWall.cs
@@ -15,7 +15,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleRevitWall.id, speckleRevitWall.speckle_type) { applicationId = speckleRevitWall.applicationId };
       if (revitWall != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitWall.UniqueId, convertedItem: revitWall);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitWall.UniqueId, convertedItem: revitWall, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -15,7 +15,7 @@ namespace Objects.Converter.Revit
       var appObj = new ApplicationObject(speckleRailing.id, speckleRailing.speckle_type) { applicationId = speckleRailing.applicationId };
       if (revitRailing != null && ReceiveMode == Speckle.Core.Kits.ReceiveMode.Ignore)
       {
-        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitRailing.UniqueId, convertedItem: revitRailing);
+        appObj.Update(status: ApplicationObject.State.Skipped, createdId: revitRailing.UniqueId, convertedItem: revitRailing, logItem: $"ApplicationId already exists in document, new object ignored.");
         return appObj;
       }
      


### PR DESCRIPTION
## Description & motivation
Previously, curves and blocks were not being correctly logged on receive in the report. This is been fixed.
Also, updated report nots for the `ignore` setting to reflect that objects were skipped because an existing object was found
Includes new updating and ignoring fixes for block to native conversions.

Fixes #1522
Fixes #1508

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.

