### PR TITLE
Revit & DUI fiddles

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Entry/App.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/App.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.UI;
-using DesktopUI2.ViewModels;
 using Revit.Async;
 using Speckle.ConnectorRevit.UI;
 
@@ -135,9 +135,10 @@ namespace Speckle.ConnectorRevit.Entry
 
     private void ControlledApplication_ApplicationInitialized(object sender, Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs e)
     {
-
-      AppInstance = new UIApplication(sender as Application);
-      AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(OnAssemblyResolve);
+      try
+      {
+        AppInstance = new UIApplication(sender as Application);
+        AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(OnAssemblyResolve);
 
 
 #if REVIT2019
@@ -146,21 +147,35 @@ namespace Speckle.ConnectorRevit.Entry
       var eventHandler = ExternalEvent.Create(new SpeckleExternalEventHandler(SpeckleRevitCommand.Bindings));
       SpeckleRevitCommand.Bindings.SetExecutorAndInit(eventHandler);
 #else
-      //DUI2 - pre build app, so that it's faster to open up
-      SpeckleRevitCommand2.InitAvalonia();
-      var bindings = new ConnectorBindingsRevit2(AppInstance);
-      bindings.RegisterAppEvents();
-      SpeckleRevitCommand2.Bindings = bindings;
-      SchedulerCommand.Bindings = bindings;
-      OneClickSendCommand.Bindings = bindings;
-      QuickShareCommand.Bindings = bindings;
+        //DUI2 - pre build app, so that it's faster to open up
+        SpeckleRevitCommand2.InitAvalonia();
+        var bindings = new ConnectorBindingsRevit2(AppInstance);
+        bindings.RegisterAppEvents();
+        SpeckleRevitCommand2.Bindings = bindings;
+        SchedulerCommand.Bindings = bindings;
+        OneClickSendCommand.Bindings = bindings;
+        QuickShareCommand.Bindings = bindings;
 
 
 
-      SpeckleRevitCommand2.RegisterPane();
+        SpeckleRevitCommand2.RegisterPane();
 
 #endif
-      //AppInstance.ViewActivated += new EventHandler<ViewActivatedEventArgs>(Application_ViewActivated);
+        //AppInstance.ViewActivated += new EventHandler<ViewActivatedEventArgs>(Application_ViewActivated);
+      }
+      catch (Exception ex)
+      {
+        var td = new TaskDialog("Could not load Speckle");
+        td.MainContent = "Oh no! Something went wrong while loading Speckle, please report it on the forum:";
+        td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Report issue on our Community Forum");
+
+        TaskDialogResult tResult = td.Show();
+
+        if (TaskDialogResult.CommandLink1 == tResult)
+        {
+          Process.Start("https://speckle.community/");
+        }
+      }
     }
 
     public Result OnShutdown(UIControlledApplication application)

--- a/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlClientOperations.cs
@@ -755,7 +755,7 @@ namespace Speckle.Core.Api
     /// Creates a branch on a stream.
     /// </summary>
     /// <param name="branchInput"></param>
-    /// <returns>The stream's id.</returns>
+    /// <returns>The branch id.</returns>
     public async Task<string> BranchCreate(CancellationToken cancellationToken, BranchCreateInput branchInput)
     {
       try

--- a/DesktopUI2/DesktopUI2/DesktopUI2.csproj
+++ b/DesktopUI2/DesktopUI2/DesktopUI2.csproj
@@ -73,6 +73,7 @@
     <None Remove="Views\Windows\Dialogs\AddFromUrlDialog.xaml" />
     <None Remove="Views\Windows\Dialogs\Dialog.xaml" />
     <None Remove="Views\Windows\Dialogs\MappingViewDialog.xaml" />
+    <None Remove="Views\Windows\Dialogs\NewBranchDialog.xaml" />
     <None Remove="Views\Windows\Dialogs\NewStreamDialog.xaml" />
     <None Remove="Views\Windows\QuickOpsDialog.xaml" />
     <None Remove="Views\Windows\Settings.xaml" />
@@ -210,6 +211,9 @@
     <AvaloniaXaml Include="Views\Windows\Dialogs\MappingViewDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
     </AvaloniaXaml>
+    <AvaloniaXaml Include="Views\Windows\Dialogs\NewBranchDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </AvaloniaXaml>
     <AvaloniaXaml Include="Views\Windows\Dialogs\NewStreamDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
     </AvaloniaXaml>
@@ -312,6 +316,9 @@
     </Compile>
     <Compile Update="Views\Windows\Dialogs\MappingViewDialog.xaml.cs">
       <DependentUpon>MappingViewDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Views\Windows\Dialogs\NewBranchDialog.xaml.cs">
+      <DependentUpon>NewBranchDialog.xaml</DependentUpon>
     </Compile>
     <Compile Update="Views\Windows\Dialogs\NewStreamDialog.xaml.cs">
       <DependentUpon>NewStreamDialog.xaml</DependentUpon>

--- a/DesktopUI2/DesktopUI2/ViewModels/BranchViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/BranchViewModel.cs
@@ -1,0 +1,32 @@
+﻿using ReactiveUI;
+using Speckle.Core.Api;
+
+namespace DesktopUI2.ViewModels
+{
+  public class BranchViewModel : ReactiveObject
+  {
+
+    private Branch _branch;
+    public Branch Branch
+    {
+      get => _branch;
+      set => this.RaiseAndSetIfChanged(ref _branch, value);
+
+    }
+
+    private string _icon;
+    public string Icon
+    {
+      get => _icon;
+      set => this.RaiseAndSetIfChanged(ref _icon, value);
+
+    }
+
+
+    public BranchViewModel(Branch branch, string icon = "SourceBranch")
+    {
+      Branch = branch;
+      Icon = icon;
+    }
+  }
+}

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -6,7 +6,6 @@ using DesktopUI2.Models.Filters;
 using DesktopUI2.Models.Settings;
 using DesktopUI2.ViewModels.Share;
 using DesktopUI2.Views.Pages;
-using DesktopUI2.Views.Windows;
 using DynamicData;
 using Material.Icons;
 using Material.Icons.Avalonia;
@@ -375,7 +374,7 @@ namespace DesktopUI2.ViewModels
         //receiver
         else
         {
-          if (SelectedCommit != null)
+          if (SelectedCommit != null && SelectedCommit.id != "latest")
             return $"{StreamState.ServerUrl.TrimEnd('/')}/streams/{StreamState.StreamId}/commits/{SelectedCommit.id}";
           if (SelectedBranch != null)
             return $"{StreamState.ServerUrl.TrimEnd('/')}/streams/{StreamState.StreamId}/branches/{SelectedBranch.name}";

--- a/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/Receive.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/Receive.xaml
@@ -26,10 +26,13 @@
           <TextBlock Text="Receiving " />
           <TextBlock FontWeight="Bold" Text="{Binding SelectedCommit.id, FallbackValue=?}" />
           <TextBlock Text=" from " />
-          <TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.name, FallbackValue=?}" />
+          <TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.Branch.name, FallbackValue=?}" />
         </StackPanel>
       </Expander.Header>
-      <Grid ColumnDefinitions="auto,*, auto, *" RowDefinitions="auto, auto,auto,auto">
+      <Grid
+        Margin="15,0"
+        ColumnDefinitions="auto,*, auto, *"
+        RowDefinitions="auto, auto,auto,auto">
 
         <!--  SELECT BRANCH  -->
         <icons:MaterialIcon
@@ -43,7 +46,7 @@
           Margin="5,10,5,10"
           HorizontalAlignment="Stretch"
           VerticalAlignment="Center"
-          Items="{Binding Branches}"
+          Items="{Binding BranchesViewModel}"
           PlaceholderText="Select a branch"
           SelectedItem="{Binding SelectedBranch}">
           <ComboBox.ItemTemplate>
@@ -52,10 +55,10 @@
                 <icons:MaterialIcon
                   Margin="0,0,5,0"
                   Foreground="DarkGray"
-                  Kind="SourceBranch" />
+                  Kind="{Binding Icon}" />
                 <TextBlock
                   Grid.Column="1"
-                  Text="{Binding name}"
+                  Text="{Binding Branch.name}"
                   TextTrimming="CharacterEllipsis" />
               </Grid>
             </DataTemplate>

--- a/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/Send.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/Send.xaml
@@ -27,11 +27,14 @@
           <TextBlock Text="Sending " />
           <TextBlock FontWeight="Bold" Text="{Binding SelectedFilter.Summary, FallbackValue=?}" />
           <TextBlock Text=" to " />
-          <TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.name, FallbackValue=?}" />
+          <TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.Branch.name, FallbackValue=?}" />
         </StackPanel>
       </Expander.Header>
 
-      <Grid ColumnDefinitions="auto,*,auto, *" RowDefinitions="auto, auto, auto">
+      <Grid
+        Margin="15,0"
+        ColumnDefinitions="auto,*,auto, *"
+        RowDefinitions="auto, auto, auto">
 
         <!--  SELECT BRANCH  -->
         <icons:MaterialIcon
@@ -45,19 +48,20 @@
           Margin="5,10,5,10"
           HorizontalAlignment="Stretch"
           VerticalAlignment="Center"
-          Items="{Binding Branches}"
+          Items="{Binding BranchesViewModel}"
           PlaceholderText="Select a branch"
-          SelectedItem="{Binding SelectedBranch}">
+          SelectedItem="{Binding SelectedBranch, Mode=TwoWay}">
+          <ComboBox.ItemsPanel />
           <ComboBox.ItemTemplate>
             <DataTemplate>
               <Grid ColumnDefinitions="auto,*">
                 <icons:MaterialIcon
                   Margin="0,0,5,0"
                   Foreground="DarkGray"
-                  Kind="SourceBranch" />
+                  Kind="{Binding Icon}" />
                 <TextBlock
                   Grid.Column="1"
-                  Text="{Binding name}"
+                  Text="{Binding Branch.name}"
                   TextTrimming="CharacterEllipsis" />
               </Grid>
             </DataTemplate>

--- a/DesktopUI2/DesktopUI2/Views/Scheduler.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Scheduler.xaml
@@ -61,7 +61,7 @@
           <TextBlock
             Margin="0,15,0,0"
             IsVisible="{Binding HasSavedSenders, Converter={x:Static BoolConverters.Not}}"
-            Text="Please save a stream form the main Connector UI ⚠ to continue."
+            Text="⚠ Please save a Sender Stream form the main Connector UI to continue."
             TextWrapping="Wrap" />
         </StackPanel>
       </m:Card>

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/DialogUserControl.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/DialogUserControl.cs
@@ -2,14 +2,12 @@
 using Avalonia.Input;
 using DesktopUI2.ViewModels;
 using System;
-using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DesktopUI2.Views.Windows.Dialogs
 {
-  public  class DialogUserControl : UserControl, ICloseable
+  public class DialogUserControl : UserControl, ICloseable
   {
     private object? _dialogResult;
 
@@ -43,7 +41,7 @@ namespace DesktopUI2.Views.Windows.Dialogs
     {
       _dialogResult = dialogResult;
       Closed?.Invoke(this, null);
-      MainViewModel.Instance.DialogBody=null;
+      MainViewModel.Instance.DialogBody = null;
     }
   }
 }

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewBranchDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewBranchDialog.xaml
@@ -1,0 +1,47 @@
+<UserControl
+  x:Class="DesktopUI2.Views.Windows.Dialogs.NewBranchDialog"
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  mc:Ignorable="d">
+  <Grid RowDefinitions="auto, auto, auto, auto">
+    <TextBlock
+      Margin="15,15,15,0"
+      Classes="Subtitle1"
+      Text="Create a new Branch"
+      TextTrimming="CharacterEllipsis" />
+
+    <TextBox
+      Grid.Row="1"
+      Margin="15,5"
+      Text="{Binding BranchName}"
+      Watermark="Branch Name" />
+
+    <TextBox
+      Grid.Row="2"
+      Margin="15,5"
+      Text="{Binding Description}"
+      Watermark="Description (optional)" />
+
+
+    <StackPanel
+      Grid.Row="3"
+      Margin="15"
+      HorizontalAlignment="Right"
+      Orientation="Horizontal">
+      <Button
+        Margin="0,0,10,0"
+        Classes="Outline"
+        Click="Close_Click"
+        Content="Cancel" />
+      <Button
+        Margin="0,0,10,0"
+        Click="Create_Click"
+        Content="Create" />
+
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewBranchDialog.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewBranchDialog.xaml.cs
@@ -1,0 +1,107 @@
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using DesktopUI2.ViewModels;
+using ReactiveUI;
+using Speckle.Core.Api;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace DesktopUI2.Views.Windows.Dialogs
+{
+  public partial class NewBranchDialog : DialogUserControl
+  {
+
+    public NewBranchDialog()
+    {
+      InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+      AvaloniaXamlLoader.Load(this);
+    }
+
+    public void Create_Click(object sender, RoutedEventArgs e)
+    {
+
+      this.Close(true);
+    }
+
+    public void Close_Click(object sender, RoutedEventArgs e)
+    {
+      this.Close(false);
+    }
+  }
+
+  public class NewBranchViewModel : ViewModelBase, INotifyDataErrorInfo
+  {
+    private string _valueError;
+    public bool HasErrors => throw new NotImplementedException();
+
+    public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+
+    public List<Branch> Branches { get; set; }
+
+    private string _branchName;
+
+    public string BranchName
+    {
+      get => _branchName;
+      set
+      {
+        this.RaiseAndSetIfChanged(ref _branchName, value);
+      }
+    }
+
+    private string _description;
+    public string Description
+    {
+      get => _description;
+      set
+      {
+        this.RaiseAndSetIfChanged(ref _description, value);
+      }
+    }
+
+
+    public NewBranchViewModel(List<Branch> branches)
+    {
+      this.Branches = branches;
+      this.WhenAnyValue(x => x.BranchName).Subscribe(_ => UpdateErrors());
+    }
+
+    private void UpdateErrors()
+    {
+      if (!Branches.Any(x => x.name.Equals(BranchName, StringComparison.InvariantCultureIgnoreCase)))
+      {
+        if (_valueError != null)
+        {
+          _valueError = null;
+          ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(BranchName)));
+        }
+      }
+      else
+      {
+        if (_valueError == null)
+        {
+          _valueError = "A branch with this name already exists";
+          ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(nameof(BranchName)));
+        }
+      }
+    }
+
+    public IEnumerable GetErrors(string propertyName)
+    {
+      switch (propertyName)
+      {
+        case nameof(Branches):
+          return new[] { _valueError };
+        default:
+          return null;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Minor fiddles in DUI and Revit:
- fixes the URL opened when clicking on "View Online", if in Receive mode and `latest` is selected
- adds a safety guard when Revit starts up (some users reported issues when the plugin is registered/initialized)
- adds "add new branch" option when in send mode
