### PR TITLE
fix(ci): Do not persist_to_workspace unless it's a tag build

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -135,10 +135,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           shell: cmd.exe #does not work in powershell
           environment:
             SLUG: << parameters.slug >>
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - speckle-sharp-ci-tools/Installers
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - persist_to_workspace:
+                root: ./
+                paths:
+                  - speckle-sharp-ci-tools/Installers
 
   deploy-connector-new:
     docker:
@@ -246,10 +249,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/netcoreapp3.1/osx-x64/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
-      - persist_to_workspace:
-          root: ./
-          paths:
-            - speckle-sharp-ci-tools/Installers
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - persist_to_workspace:
+                root: ./
+                paths:
+                  - speckle-sharp-ci-tools/Installers
 
   get-ci-tools: # Clones our ci tools and persists them to the workspace
     docker:


### PR DESCRIPTION
Aiming at reducing our storage consumption in CircleCI, we will no longer persist by default every installer.

Instead, we will only persist when the commit is a `tag` build, which is the only case where the installer result would be needed further down the pipeline.