### PR TITLE
fix(rvt): Connector projects shouldn't directly reference the converters

### DIFF
--- a/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
+++ b/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
@@ -75,10 +75,6 @@
       <Name>DesktopUI</Name>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </ProjectReference>
-    <ProjectReference Include="..\..\Objects\Converters\ConverterRevit\ConverterRevit2022\ConverterRevit2022.csproj">
-      <Project>{c74e4c61-ca68-47f9-825e-91b7a5c4546d}</Project>
-      <Name>ConverterRevit2022</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">

--- a/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
+++ b/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
@@ -75,10 +75,6 @@
       <Name>DesktopUI</Name>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </ProjectReference>
-    <ProjectReference Include="..\..\Objects\Converters\ConverterRevit\ConverterRevit2023\ConverterRevit2023.csproj">
-      <Project>{c74e4c61-ca68-47f9-825e-91b7a5c4546d}</Project>
-      <Name>ConverterRevit2023</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia">


### PR DESCRIPTION
Removes hard references from Revit 2022 and 2023 connector `csproj` files.

Not sure how this happened, but it's been there for a while 😅

All other projects seemed fine.