### PR TITLE
Fix: materialType not being set for structural objects sent from Revit

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
@@ -287,7 +287,7 @@ namespace Objects.Converter.Revit
           var concreteMaterial = new Concrete
           {
             name = stickFamily.Document.GetElement(stickFamily.StructuralMaterialId).Name,
-            //type = Structural.MaterialType.Concrete,
+            materialType = Structural.MaterialType.Concrete,
             grade = null,
             designCode = null,
             codeYear = null,
@@ -311,7 +311,7 @@ namespace Objects.Converter.Revit
           var steelMaterial = new Steel
           {
             name = stickFamily.Document.GetElement(stickFamily.StructuralMaterialId).Name,
-            //type = Structural.MaterialType.Steel,
+            materialType = Structural.MaterialType.Steel,
             grade = materialAsset.Name,
             designCode = null,
             codeYear = null,
@@ -331,7 +331,7 @@ namespace Objects.Converter.Revit
           var timberMaterial = new Timber
           {
             name = structMat.Document.GetElement(structMat.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Timber,
+            materialType = Structural.MaterialType.Timber,
             grade = materialAsset.WoodGrade,
             designCode = null,
             codeYear = null,
@@ -587,8 +587,8 @@ namespace Objects.Converter.Revit
         case StructuralMaterialType.Concrete:
           var concreteMaterial = new Concrete
           {
-             name = stickFamily.Document.GetElement(revitStick.MaterialId).Name,
-            //type = Structural.MaterialType.Concrete,
+            name = stickFamily.Document.GetElement(revitStick.MaterialId).Name,
+            materialType = Structural.MaterialType.Concrete,
             grade = null,
             designCode = null,
             codeYear = null,
@@ -612,7 +612,7 @@ namespace Objects.Converter.Revit
           var steelMaterial = new Steel
           {
             name = stickFamily.Document.GetElement(revitStick.MaterialId).Name,
-            //type = Structural.MaterialType.Steel,
+            materialType = Structural.MaterialType.Steel,
             grade = materialAsset.Name,
             designCode = null,
             codeYear = null,
@@ -632,7 +632,7 @@ namespace Objects.Converter.Revit
           var timberMaterial = new Timber
           {
             name = structMat.Document.GetElement(structMat.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Timber,
+            materialType = Structural.MaterialType.Timber,
             grade = materialAsset.WoodGrade,
             designCode = null,
             codeYear = null,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
@@ -168,7 +168,7 @@ namespace Objects.Converter.Revit
           var concreteMaterial = new Concrete
           {
             name = structMaterial.Document.GetElement(structMaterial.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Concrete,
+            materialType = Structural.MaterialType.Concrete,
             grade = null,
             designCode = null,
             codeYear = null,
@@ -192,7 +192,7 @@ namespace Objects.Converter.Revit
           var steelMaterial = new Steel
           {
             name = structMaterial.Document.GetElement(structMaterial.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Steel,
+            materialType = Structural.MaterialType.Steel,
             grade = materialAsset.Name,
             designCode = null,
             codeYear = null,
@@ -212,7 +212,7 @@ namespace Objects.Converter.Revit
           var timberMaterial = new Timber
           {
             name = structMaterial.Document.GetElement(structMaterial.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Timber,
+            materialType = Structural.MaterialType.Timber,
             grade = materialAsset.WoodGrade,
             designCode = null,
             codeYear = null,
@@ -326,7 +326,7 @@ namespace Objects.Converter.Revit
           var concreteMaterial = new Concrete
           {
             name = structMaterial.Document.GetElement(structMaterial.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Concrete,
+            materialType = Structural.MaterialType.Concrete,
             grade = null,
             designCode = null,
             codeYear = null,
@@ -350,7 +350,7 @@ namespace Objects.Converter.Revit
           var steelMaterial = new Steel
           {
             name = structMaterial.Document.GetElement(structMaterial.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Steel,
+            materialType = Structural.MaterialType.Steel,
             grade = materialAsset.Name,
             designCode = null,
             codeYear = null,
@@ -370,7 +370,7 @@ namespace Objects.Converter.Revit
           var timberMaterial = new Timber
           {
             name = structMaterial.Document.GetElement(structMaterial.StructuralAssetId).Name,
-            //type = Structural.MaterialType.Timber,
+            materialType = Structural.MaterialType.Timber,
             grade = materialAsset.WoodGrade,
             designCode = null,
             codeYear = null,

--- a/Objects/Objects/Structural/Material/Concrete.cs
+++ b/Objects/Objects/Structural/Material/Concrete.cs
@@ -18,7 +18,7 @@ namespace Objects.Structural.Materials
 
     public Concrete() 
     {
-      this.materialType = MaterialType.Concrete;
+      materialType = MaterialType.Concrete;
     }
 
     [SchemaInfo("Concrete", "Creates a Speckle structural material for concrete (to be used in structural analysis models)", "Structural", "Materials")]

--- a/Objects/Objects/Structural/Material/Concrete.cs
+++ b/Objects/Objects/Structural/Material/Concrete.cs
@@ -16,10 +16,7 @@ namespace Objects.Structural.Materials
     public double maxAggregateSize { get; set; }
     public bool lightweight { get; set; } //whether or not it's a lightweight concrete
 
-    public Concrete() 
-    {
-      materialType = MaterialType.Concrete;
-    }
+    public Concrete() { }
 
     [SchemaInfo("Concrete", "Creates a Speckle structural material for concrete (to be used in structural analysis models)", "Structural", "Materials")]
     public Concrete(string name, string grade = null, string designCode = null, string codeYear = null, double elasticModulus = 0, double compressiveStrength = 0, double tensileStrength = 0, double flexuralStrength = 0, double maxCompressiveStrain = 0, double maxTensileStrain = 0, double maxAggregateSize = 0, bool lightweight = false, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double thermalExpansivity = 0, double dampingRatio = 0)

--- a/Objects/Objects/Structural/Material/Concrete.cs
+++ b/Objects/Objects/Structural/Material/Concrete.cs
@@ -6,39 +6,42 @@ using Objects.Geometry;
 
 namespace Objects.Structural.Materials
 {
-    public class Concrete : Material 
+  public class Concrete : Material
+  {
+    public double compressiveStrength { get; set; } //forgo using "strength" property in Material class
+    public double tensileStrength { get; set; } //design calc impacts
+    public double flexuralStrength { get; set; } //design calc impacts
+    public double maxCompressiveStrain { get; set; } //failure strain
+    public double maxTensileStrain { get; set; }
+    public double maxAggregateSize { get; set; }
+    public bool lightweight { get; set; } //whether or not it's a lightweight concrete
+
+    public Concrete() 
     {
-        public double compressiveStrength { get; set; } //forgo using "strength" property in Material class
-        public double tensileStrength { get; set; } //design calc impacts
-        public double flexuralStrength { get; set; } //design calc impacts
-        public double maxCompressiveStrain { get; set; } //failure strain
-        public double maxTensileStrain { get; set; }
-        public double maxAggregateSize { get; set; }
-        public bool lightweight { get; set; } //whether or not it's a lightweight concrete
-
-        public Concrete() { }
-
-        [SchemaInfo("Concrete", "Creates a Speckle structural material for concrete (to be used in structural analysis models)", "Structural", "Materials")]
-        public Concrete(string name, string grade = null, string designCode = null, string codeYear = null, double elasticModulus = 0, double compressiveStrength = 0, double tensileStrength = 0, double flexuralStrength = 0, double maxCompressiveStrain = 0, double maxTensileStrain = 0, double maxAggregateSize = 0, bool lightweight = false, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double thermalExpansivity = 0, double dampingRatio = 0)
-        {
-            this.name = name;
-            this.grade = grade;
-            this.materialType = MaterialType.Concrete;
-            this.designCode = designCode;
-            this.codeYear = codeYear;
-            this.elasticModulus = elasticModulus;
-            this.compressiveStrength = compressiveStrength;
-            this.tensileStrength = tensileStrength;
-            this.flexuralStrength = flexuralStrength;
-            this.maxCompressiveStrain = maxCompressiveStrain;            
-            this.maxTensileStrain = maxTensileStrain;
-            this.maxAggregateSize = maxAggregateSize;
-            this.lightweight = lightweight;
-            this.poissonsRatio = poissonsRatio;
-            this.shearModulus = shearModulus;
-            this.density = density;
-            this.thermalExpansivity = thermalExpansivity;
-            this.dampingRatio = dampingRatio;
-        }
+      this.materialType = MaterialType.Concrete;
     }
+
+    [SchemaInfo("Concrete", "Creates a Speckle structural material for concrete (to be used in structural analysis models)", "Structural", "Materials")]
+    public Concrete(string name, string grade = null, string designCode = null, string codeYear = null, double elasticModulus = 0, double compressiveStrength = 0, double tensileStrength = 0, double flexuralStrength = 0, double maxCompressiveStrain = 0, double maxTensileStrain = 0, double maxAggregateSize = 0, bool lightweight = false, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double thermalExpansivity = 0, double dampingRatio = 0)
+    {
+      this.name = name;
+      this.grade = grade;
+      this.materialType = MaterialType.Concrete;
+      this.designCode = designCode;
+      this.codeYear = codeYear;
+      this.elasticModulus = elasticModulus;
+      this.compressiveStrength = compressiveStrength;
+      this.tensileStrength = tensileStrength;
+      this.flexuralStrength = flexuralStrength;
+      this.maxCompressiveStrain = maxCompressiveStrain;
+      this.maxTensileStrain = maxTensileStrain;
+      this.maxAggregateSize = maxAggregateSize;
+      this.lightweight = lightweight;
+      this.poissonsRatio = poissonsRatio;
+      this.shearModulus = shearModulus;
+      this.density = density;
+      this.thermalExpansivity = thermalExpansivity;
+      this.dampingRatio = dampingRatio;
+    }
+  }
 }

--- a/Objects/Objects/Structural/Material/Steel.cs
+++ b/Objects/Objects/Structural/Material/Steel.cs
@@ -12,10 +12,7 @@ namespace Objects.Structural.Materials
     public double ultimateStrength { get; set; } //ultimateStress
     public double maxStrain { get; set; } //failureStrain
     public double strainHardeningModulus { get; set; }
-    public Steel() 
-    {
-      materialType = MaterialType.Steel;
-    }
+    public Steel() { }
 
     [SchemaInfo("Steel", "Creates a Speckle structural material for steel (to be used in structural analysis models)", "Structural", "Materials")]
     public Steel(string name, string grade = null, string designCode = null, string codeYear = null, double elasticModulus = 0, double yieldStrength = 0, double ultimateStrength = 0, double maxStrain = 0, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double alpha = 0, double dampingRatio = 0)

--- a/Objects/Objects/Structural/Material/Steel.cs
+++ b/Objects/Objects/Structural/Material/Steel.cs
@@ -14,7 +14,7 @@ namespace Objects.Structural.Materials
     public double strainHardeningModulus { get; set; }
     public Steel() 
     {
-      this.materialType = MaterialType.Steel;
+      materialType = MaterialType.Steel;
     }
 
     [SchemaInfo("Steel", "Creates a Speckle structural material for steel (to be used in structural analysis models)", "Structural", "Materials")]

--- a/Objects/Objects/Structural/Material/Steel.cs
+++ b/Objects/Objects/Structural/Material/Steel.cs
@@ -6,31 +6,34 @@ using Objects.Geometry;
 
 namespace Objects.Structural.Materials
 {
-    public class Steel : Material
+  public class Steel : Material
+  {
+    public double yieldStrength { get; set; } //or yieldStress
+    public double ultimateStrength { get; set; } //ultimateStress
+    public double maxStrain { get; set; } //failureStrain
+    public double strainHardeningModulus { get; set; }
+    public Steel() 
     {
-        public double yieldStrength { get; set; } //or yieldStress
-        public double ultimateStrength { get; set; } //ultimateStress
-        public double maxStrain { get; set; } //failureStrain        
-        public double strainHardeningModulus { get; set; }
-        public Steel() { }
-
-        [SchemaInfo("Steel", "Creates a Speckle structural material for steel (to be used in structural analysis models)", "Structural", "Materials")]
-        public Steel(string name, string grade = null, string designCode = null, string codeYear = null, double elasticModulus = 0, double yieldStrength = 0, double ultimateStrength = 0, double maxStrain = 0, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double alpha = 0, double dampingRatio = 0)
-        {
-            this.name = name;
-            this.grade = grade;
-            this.materialType = MaterialType.Steel;
-            this.designCode = designCode;
-            this.codeYear = codeYear;
-            this.elasticModulus = elasticModulus;
-            this.yieldStrength = yieldStrength;
-            this.ultimateStrength = ultimateStrength;
-            this.maxStrain = maxStrain;
-            this.poissonsRatio = poissonsRatio;
-            this.shearModulus = shearModulus;
-            this.density = density;
-            this.thermalExpansivity = thermalExpansivity;
-            this.dampingRatio = dampingRatio;
-        }
+      this.materialType = MaterialType.Steel;
     }
+
+    [SchemaInfo("Steel", "Creates a Speckle structural material for steel (to be used in structural analysis models)", "Structural", "Materials")]
+    public Steel(string name, string grade = null, string designCode = null, string codeYear = null, double elasticModulus = 0, double yieldStrength = 0, double ultimateStrength = 0, double maxStrain = 0, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double alpha = 0, double dampingRatio = 0)
+    {
+      this.name = name;
+      this.grade = grade;
+      this.materialType = MaterialType.Steel;
+      this.designCode = designCode;
+      this.codeYear = codeYear;
+      this.elasticModulus = elasticModulus;
+      this.yieldStrength = yieldStrength;
+      this.ultimateStrength = ultimateStrength;
+      this.maxStrain = maxStrain;
+      this.poissonsRatio = poissonsRatio;
+      this.shearModulus = shearModulus;
+      this.density = density;
+      this.thermalExpansivity = thermalExpansivity;
+      this.dampingRatio = dampingRatio;
+    }
+  }
 }

--- a/Objects/Objects/Structural/Material/Timber.cs
+++ b/Objects/Objects/Structural/Material/Timber.cs
@@ -10,10 +10,7 @@ namespace Objects.Structural.Materials
   {
     //missing timber-specific properties? parallel to grain, perpendicular to grain
     public string species { get; set; }
-    public Timber() 
-    {
-      materialType = MaterialType.Timber;
-    }
+    public Timber() { }
 
     [SchemaInfo("Timber", "Creates a Speckle structural material for timber (to be used in structural analysis models)", "Structural", "Materials")]
     public Timber(string name, string species = null, string grade = null, string designCode = null, string codeYear = null, double strength = 0, double elasticModulus = 0, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double thermalExpansivity = 0, double dampingRatio = 0)

--- a/Objects/Objects/Structural/Material/Timber.cs
+++ b/Objects/Objects/Structural/Material/Timber.cs
@@ -6,28 +6,31 @@ using Objects.Geometry;
 
 namespace Objects.Structural.Materials
 {
-    public class Timber : Material
+  public class Timber : Material
+  {
+    //missing timber-specific properties? parallel to grain, perpendicular to grain
+    public string species { get; set; }
+    public Timber() 
     {
-        //missing timber-specific properties? parallel to grain, perpendicular to grain 
-        public string species { get; set; }
-        public Timber() { }
-
-        [SchemaInfo("Timber", "Creates a Speckle structural material for timber (to be used in structural analysis models)", "Structural", "Materials")]
-        public Timber(string name, string species = null, string grade = null, string designCode = null, string codeYear = null, double strength = 0, double elasticModulus = 0, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double thermalExpansivity = 0, double dampingRatio = 0)
-        {
-            this.name = name;
-            this.grade = grade;
-            this.species = species;
-            this.materialType = MaterialType.Timber; 
-            this.designCode = designCode;
-            this.codeYear = codeYear;
-            this.strength = strength;
-            this.elasticModulus = elasticModulus;
-            this.poissonsRatio = poissonsRatio;
-            this.shearModulus = shearModulus;
-            this.density = density;
-            this.thermalExpansivity = thermalExpansivity;
-            this.dampingRatio = dampingRatio;
-        }
+      this.materialType = MaterialType.Timber;
     }
+
+    [SchemaInfo("Timber", "Creates a Speckle structural material for timber (to be used in structural analysis models)", "Structural", "Materials")]
+    public Timber(string name, string species = null, string grade = null, string designCode = null, string codeYear = null, double strength = 0, double elasticModulus = 0, double poissonsRatio = 0, double shearModulus = 0, double density = 0, double thermalExpansivity = 0, double dampingRatio = 0)
+    {
+      this.name = name;
+      this.grade = grade;
+      this.species = species;
+      this.materialType = MaterialType.Timber;
+      this.designCode = designCode;
+      this.codeYear = codeYear;
+      this.strength = strength;
+      this.elasticModulus = elasticModulus;
+      this.poissonsRatio = poissonsRatio;
+      this.shearModulus = shearModulus;
+      this.density = density;
+      this.thermalExpansivity = thermalExpansivity;
+      this.dampingRatio = dampingRatio;
+    }
+  }
 }

--- a/Objects/Objects/Structural/Material/Timber.cs
+++ b/Objects/Objects/Structural/Material/Timber.cs
@@ -12,7 +12,7 @@ namespace Objects.Structural.Materials
     public string species { get; set; }
     public Timber() 
     {
-      this.materialType = MaterialType.Timber;
+      materialType = MaterialType.Timber;
     }
 
     [SchemaInfo("Timber", "Creates a Speckle structural material for timber (to be used in structural analysis models)", "Structural", "Materials")]


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

All structural material types coming from Revit were set as concrete (0 in the MaterialType enum) because the materialType property was never being set. Now it is being set.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- set materialType value in empty constructor for Concrete, Steel, and Timber classes
- fixed some tab spacing to match the convention of the rest of our code

<!---

- Item 1
- Item 2

-->

## Validation of changes:

Manual tests of sending in Revit

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
