### PR TITLE
feat(gh): Added ability for the receiver to fetch public streams with an old account

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -24,6 +24,7 @@ using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -424,8 +425,20 @@ namespace ConnectorGrasshopper.Ops
       try
       {
         ApiClient?.Dispose();
-        var acc = await wrapper.GetAccount();
-        ApiClient = new Client(acc);
+        Account account = null;
+        try
+        {
+          account = wrapper?.GetAccount().Result;
+        }
+        catch (Exception e)
+        {
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.ToFormattedString());
+          account = new Account
+          {
+            id = wrapper?.StreamId, serverInfo = new ServerInfo() { url = wrapper?.ServerUrl }, token = "", refreshToken = ""
+          };
+        }
+        ApiClient = new Client(account);
         ApiClient.SubscribeCommitCreated(StreamWrapper.StreamId);
         ApiClient.OnCommitCreated += ApiClient_OnCommitCreated;
       }
@@ -543,22 +556,10 @@ namespace ConnectorGrasshopper.Ops
             }
           });
         };
+        
+        Speckle.Core.Logging.Analytics.TrackEvent(receiveComponent.ApiClient.Account, Speckle.Core.Logging.Analytics.Events.Receive, new Dictionary<string, object>() { { "auto", receiveComponent.AutoReceive } });
 
-        Client client;
-        try
-        {
-          client = new Client(InputWrapper?.GetAccount().Result);
-        }
-        catch (Exception e)
-        {
-          RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message));
-          Done();
-          return;
-        }
-
-        Speckle.Core.Logging.Analytics.TrackEvent(client.Account, Speckle.Core.Logging.Analytics.Events.Receive, new Dictionary<string, object>() { { "auto", receiveComponent.AutoReceive } });
-
-        var remoteTransport = new ServerTransport(InputWrapper?.GetAccount().Result, InputWrapper?.StreamId);
+        var remoteTransport = new ServerTransport(receiveComponent.ApiClient.Account, InputWrapper?.StreamId);
         remoteTransport.TransportName = "R";
 
         // Means it's a copy paste of an empty non-init component; set the record and exit fast unless ReceiveOnOpen is true.
@@ -575,7 +576,7 @@ namespace ConnectorGrasshopper.Ops
         var t = Task.Run(async () =>
         {
           ((VariableInputReceiveComponent)Parent).PrevReceivedData = null;
-          var myCommit = await GetCommit(InputWrapper, client, (level, message) =>
+          var myCommit = await GetCommit(InputWrapper, receiveComponent.ApiClient, (level, message) =>
           {
             RuntimeMessages.Add((level, message));
 
@@ -607,7 +608,7 @@ namespace ConnectorGrasshopper.Ops
 
           try
           {
-            await client.CommitReceived(new CommitReceivedInput
+            await receiveComponent.ApiClient.CommitReceived(new CommitReceivedInput
             {
               streamId = InputWrapper.StreamId,
               commitId = myCommit.id,


### PR DESCRIPTION
The way the `Client` is implemented does not allow for the fetching of data without an Account for that server being present in the system. This makes sense to some degree, but not necessarily so when you're dealing with _public streams_ in _public servers_

I added a modification in the `Receiver` that will pass in a "fake account" with the basic info set so that the client will not throw an exception.

**Bonus**: removed local redundant client creation in favor of `ApiClient`

**Possible better workaround**

This solution could be pushed up to `Core`, so that the `StreamWrapper` would provide the correct "fake account" for any url, including ones that you don't have setup yet.