### PR TITLE
feat(gh): When a `name` is available, include it in our GH_Goo.ToString() result

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Speckle.IGH_Goo.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Extras/Speckle.IGH_Goo.cs
@@ -89,8 +89,17 @@ namespace ConnectorGrasshopper.Extras
     public override string ToString()
     {
       if (Value == null) return "";
+      var name = Value["Name"] ?? Value["name"];
+
       if (Value.GetType().IsSubclassOf(typeof(Base)))
-        return $"Speckle {Value.GetType().Name}";
+      {
+        var baseString = $"Speckle {Value.GetType().Name}";
+        if (name != null)
+        {
+          baseString += $" [{name}]";
+        }
+        return baseString;
+      }
       return "Speckle Object";
       
       //return $"{(Value != null && Value.speckle_type == "" ? "Speckle.Base" : Value?.speckle_type)}";


### PR DESCRIPTION
Connecting a `Base` object in a panel yielded a result such as `Speckle Object`, `Speckle DirectShape`, `Speckle RevitWall` etc...

This change allows to also print the `name` property of a given object, if it is available and it is not null.

The name will be surrounded by `[]` and placed after the original text describing the type.

<img width="651" alt="Screenshot 2022-08-30 at 19 36 08" src="https://user-images.githubusercontent.com/2316535/187506286-c27078cf-db02-47f4-a41c-dc23fda1f314.png">
