### PR TITLE
fix(gh): Mac installer missing GH converter due sln config misconfiguration

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperUtils/ConnectorGrasshopperUtils.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopperUtils/ConnectorGrasshopperUtils.csproj
@@ -43,7 +43,7 @@
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\Core\Core\Core.csproj">
-        <Project>{b4d98d2c-e5da-463e-bf6c-68e9b77c72f3}</Project>
+        <Project>{6321CA2D-5275-42A3-A034-170A0040E19E}</Project>
         <Name>Core</Name>
       </ProjectReference>
     </ItemGroup>

--- a/ConnectorRhino/ConnectorRhino.sln
+++ b/ConnectorRhino/ConnectorRhino.sln
@@ -39,7 +39,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AvaloniaHwndHost", "..\Desk
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterGrasshopper6", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper6\ConverterGrasshopper6.csproj", "{9454D346-A629-40E0-9EE2-7C6933ED1530}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterGrasshopper7", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterGrasshopper7", "..\Objects\Converters\ConverterRhinoGh\ConverterGrasshopper7\ConverterGrasshopper7.csproj", "{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorGrasshopper", "..\ConnectorGrasshopper\ConnectorGrasshopper\ConnectorGrasshopper.csproj", "{109B3382-634B-408A-8A5C-4CD09CB92641}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -198,8 +198,8 @@ Global
 		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Debug|x64.Build.0 = Debug|Any CPU
-		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Release Mac|Any CPU.ActiveCfg = Debug|Any CPU
-		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Release Mac|Any CPU.Build.0 = Debug|Any CPU
+		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
+		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Release Mac|Any CPU.Build.0 = Release|Any CPU
 		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Release Mac|x64.ActiveCfg = Debug|Any CPU
 		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Release Mac|x64.Build.0 = Debug|Any CPU
 		{9454D346-A629-40E0-9EE2-7C6933ED1530}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -214,8 +214,8 @@ Global
 		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Debug|x64.Build.0 = Debug|Any CPU
-		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Release Mac|Any CPU.ActiveCfg = Debug|Any CPU
-		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Release Mac|Any CPU.Build.0 = Debug|Any CPU
+		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
+		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Release Mac|Any CPU.Build.0 = Release|Any CPU
 		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Release Mac|x64.ActiveCfg = Debug|Any CPU
 		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Release Mac|x64.Build.0 = Debug|Any CPU
 		{CAE61AC4-E81A-4E69-8DD0-07B7CDF77E2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -230,8 +230,8 @@ Global
 		{109B3382-634B-408A-8A5C-4CD09CB92641}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{109B3382-634B-408A-8A5C-4CD09CB92641}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{109B3382-634B-408A-8A5C-4CD09CB92641}.Debug|x64.Build.0 = Debug|Any CPU
-		{109B3382-634B-408A-8A5C-4CD09CB92641}.Release Mac|Any CPU.ActiveCfg = Debug|Any CPU
-		{109B3382-634B-408A-8A5C-4CD09CB92641}.Release Mac|Any CPU.Build.0 = Debug|Any CPU
+		{109B3382-634B-408A-8A5C-4CD09CB92641}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
+		{109B3382-634B-408A-8A5C-4CD09CB92641}.Release Mac|Any CPU.Build.0 = Release|Any CPU
 		{109B3382-634B-408A-8A5C-4CD09CB92641}.Release Mac|x64.ActiveCfg = Debug|Any CPU
 		{109B3382-634B-408A-8A5C-4CD09CB92641}.Release Mac|x64.Build.0 = Debug|Any CPU
 		{109B3382-634B-408A-8A5C-4CD09CB92641}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -246,8 +246,8 @@ Global
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Debug|x64.Build.0 = Debug|Any CPU
-		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release Mac|Any CPU.ActiveCfg = Debug|Any CPU
-		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release Mac|Any CPU.Build.0 = Debug|Any CPU
+		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
+		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release Mac|Any CPU.Build.0 = Release|Any CPU
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release Mac|x64.ActiveCfg = Debug|Any CPU
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release Mac|x64.Build.0 = Debug|Any CPU
 		{E2A8E961-6DB6-4474-9E31-0C00FEB4A067}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -262,8 +262,8 @@ Global
 		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Debug|x64.Build.0 = Debug|Any CPU
-		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Release Mac|Any CPU.ActiveCfg = Debug|Any CPU
-		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Release Mac|Any CPU.Build.0 = Debug|Any CPU
+		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
+		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Release Mac|Any CPU.Build.0 = Release|Any CPU
 		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Release Mac|x64.ActiveCfg = Debug|Any CPU
 		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Release Mac|x64.Build.0 = Debug|Any CPU
 		{E20D7D1E-0FF7-49A5-9AA9-9430901F92BB}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/ConverterGrasshopper6.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/ConverterGrasshopper6.csproj
@@ -15,6 +15,7 @@
         <RepositoryUrl>https://github.com/specklesystems/speckle-sharp</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>speckle objects converter rhino grasshopper gh</PackageTags>
+        <RhinoPluginType>none</RhinoPluginType>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
@@ -5,7 +5,6 @@
         <Version>2.1.0</Version>
         <Title>Objects.Converter.Grasshopper7</Title>
         <Description></Description>
-        <TargetExt>.dll</TargetExt>
         <PackageId>Speckle.Objects.Converter.Grasshopper7</PackageId>
         <Authors>Speckle</Authors>
         <Company />
@@ -19,6 +18,7 @@
         <PackageTags>speckle objects converter rhino grasshopper gh</PackageTags>
         <AssemblyName>Objects.Converter.Grasshopper7</AssemblyName>
         <RootNamespace>Objects.Converter.Rhino</RootNamespace>
+        <RhinoPluginType>none</RhinoPluginType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhino6/ConverterRhino6.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhino6/ConverterRhino6.csproj
@@ -15,6 +15,7 @@
     <RepositoryUrl>https://github.com/specklesystems/speckle-sharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>speckle objects converter rhino grasshopper gh</PackageTags>
+    <RhinoPluginType>none</RhinoPluginType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhino7/ConverterRhino7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhino7/ConverterRhino7.csproj
@@ -19,6 +19,7 @@
     <PackageTags>speckle objects converter rhino</PackageTags>
     <AssemblyName>Objects.Converter.Rhino7</AssemblyName>
     <RootNamespace>Objects.Converter.Rhino</RootNamespace>
+    <RhinoPluginType>none</RhinoPluginType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mac Installer for 2.8 is missing the Grasshopper converter, which causes it to fail when loading the default kit.

This was caused by the `Release Mac` config running some of the projects on `Debug` config, hence none of the converters would be found by our installer zip logic.

Additionally, added csproj flag to prevent VSCode from naming the converters as `gha`