### PR TITLE
Fix(Revit): support one-faced solid geometries (like mass floor)

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -186,7 +186,7 @@ namespace Objects.Converter.Revit
       {
         if (geometryObject is Solid gSolid) // already solid
         {
-          if (gSolid.Faces.Size > 0 && Math.Abs(gSolid.Volume) > 0) // skip invalid solid
+          if (gSolid.Faces.Size > 0 && Math.Abs(gSolid.SurfaceArea) > 0) // skip invalid solid
             solids.Add(gSolid);
         }
         else if (geometryObject is GeometryInstance gInstance) // find solids from GeometryInstance


### PR DESCRIPTION
## Description & motivation

There are certain geomtry representation of elements like MassLevelData that is a solid with volume 0 but still valid as it has one face.

Fixes #891

## Changes:

- In the `GetSolids` method of the `ConverterRevit` class (file: ConvertMeshUtils), the condition for invalid solids had been changed from `if (gSolid.Faces.Size > 0 && Math.Abs(gSolid.Volume) > 0)` to `if (gSolid.Faces.Size > 0 && Math.Abs(gSolid.SurfaceArea) > 0)`. Changing the check from volume to surface area will account for solid that has only one face.


## Screenshots:

![Screenshot 2022-08-31 141536](https://user-images.githubusercontent.com/50090593/187676070-54b16556-3606-4131-aa07-7df675edab1b.png)

## Validation of changes:

Manual tests for sending mass floors from Revit.
