### PR TITLE
Objects: null point equality operator fix

### DIFF
--- a/Objects/Objects/Geometry/Point.cs
+++ b/Objects/Objects/Geometry/Point.cs
@@ -100,13 +100,17 @@ namespace Objects.Geometry
       point.y / val,
       point.z / val, point.units);
 
-    public static bool operator ==(Point point1, Point point2) =>
-      !(point1 is null) &&
-      !(point2 is null) &&
-      point1.units == point2.units &&
-      point1.x == point2.x &&
-      point1.y == point2.y &&
-      point1.z == point2.z;
+    public static bool operator ==(Point point1, Point point2)
+    {
+      if (point1 is null && point2 is null) return true;
+      if (point1 is null ^ point2 is null) return false;
+      
+      return point1.units == point2.units &&
+        point1.x == point2.x &&
+        point1.y == point2.y &&
+        point1.z == point2.z;
+    }
+
 
     public static bool operator !=(Point point1, Point point2) => !(point1 == point2);
 

--- a/Objects/Tests/Geometry/PointTests.cs
+++ b/Objects/Tests/Geometry/PointTests.cs
@@ -1,0 +1,51 @@
+﻿
+using NUnit.Framework;
+using Objects.Geometry;
+
+namespace Tests.Geometry
+{
+    [TestFixture, TestOf(typeof(Point))]
+    public class PointTests
+    {
+        
+        [Test]
+        public void TestNull()
+        {
+            Point a = null;
+            Point b = null;
+            Point c = new Point(0,0,0,null);
+            
+            Assert.True(a == b);
+            Assert.False(a != b);
+            Assert.True(b == a);
+            Assert.False(b != a);
+            
+            Assert.False(a == c);
+            Assert.True(a != c);
+            Assert.False(c == a);
+            Assert.True(c != a);
+        }
+        
+        [Test]
+        [TestCase(1, 1, 1, "m", 1, 1, 1, "m", true)] 
+        [TestCase(1, 1, 1, "m", 0, 1, 1, "m", false)]
+        [TestCase(1, 1, 1, "m", 1, 0, 1, "m", false)]
+        [TestCase(1, 1, 1, "m", 1, 1, 0, "m", false)]
+        // Units
+        [TestCase(1, 1, 1, "", 1, 1, 1, "", true)]
+        [TestCase(1, 1, 1, null, 1, 1, 1, null, true)]
+        [TestCase(1, 1, 1, "m", 1, 1, 1, "meters", false)] 
+        [TestCase(1, 1, 1, "m", 1, 1, 1, "M", false)]
+        public void TestNotEqual(
+            double x1, double y1, double z1, string units1,
+            double x2, double y2, double z2, string units2,
+            bool expectEquality)
+        {
+            Point p1 = new Point(x1, y1, z1, units1);
+            Point p2 = new Point(x2, y2, z2, units2);
+            
+            Assert.AreEqual(p1 == p2, expectEquality);
+            Assert.AreEqual(p2 == p1, expectEquality);
+        }
+    }
+}


### PR DESCRIPTION
## Description & motivation
Given a quick spin at this issue (hope you don't mind @AlanRynne)

closes #1516

## Changes:

`Point.operator==` now correctly returns true if both points are null.

## To-do before merge:
- [x] Test Revit connector (family instance to native)
I fear we may have been incorrectly relying on `basePoint == null` never being true.
https://github.com/specklesystems/speckle-sharp/blob/fa655fd5e883d5db26e7f3242352b8daa6c63965/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial%20Classes/ConvertFamilyInstance.cs#L277-L280

- [x] Check if we are overloading == incorrectly in other objects (I haven't checked)


