### PR TITLE
fix(dui2): disables send/receive preview button if binding returns null

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/ConnectorBinding.cs
+++ b/ConnectorArchicad/ConnectorArchicad/ConnectorBinding.cs
@@ -98,7 +98,7 @@ namespace Archicad.Launcher
       return new List<ReceiveMode> { ReceiveMode.Create };
     }
 
-    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }
@@ -119,7 +119,7 @@ namespace Archicad.Launcher
       // TODO!
     }
 
-    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }

--- a/ConnectorArchicad/ConnectorArchicad/ConnectorBinding.cs
+++ b/ConnectorArchicad/ConnectorArchicad/ConnectorBinding.cs
@@ -101,7 +101,6 @@ namespace Archicad.Launcher
     public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       return null;
-      // TODO!
     }
 
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
@@ -120,9 +119,9 @@ namespace Archicad.Launcher
       // TODO!
     }
 
-    public override void PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
-      // TODO!
+      return null;
     }
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -161,7 +161,6 @@ namespace Speckle.ConnectorAutocadCivil.UI
     public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       return null;
-      // TODO!
     }
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
     {
@@ -513,9 +512,9 @@ namespace Speckle.ConnectorAutocadCivil.UI
     #endregion
 
     #region sending
-    public override async void PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
-      // TODO!
+      return null;
     }
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -187,7 +187,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
     #endregion
 
     #region receiving 
-    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }
@@ -548,7 +548,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
     #endregion
 
     #region sending
-    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
@@ -16,10 +16,9 @@ namespace Speckle.ConnectorCSI.UI
 {
   public partial class ConnectorBindingsCSI : ConnectorBindings
   {
-    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
-      // TODO!
     }
 
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
@@ -17,9 +17,9 @@ namespace Speckle.ConnectorCSI.UI
 {
   public partial class ConnectorBindingsCSI : ConnectorBindings
   {
-    public override void PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
-      // TODO!
+      return null;
     }
 
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
@@ -17,7 +17,7 @@ namespace Speckle.ConnectorCSI.UI
 {
   public partial class ConnectorBindingsCSI : ConnectorBindings
   {
-    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }

--- a/ConnectorMicroStation/ConnectorMicroStationOpenShared/UI/Bindings2.cs
+++ b/ConnectorMicroStation/ConnectorMicroStationOpenShared/UI/Bindings2.cs
@@ -198,6 +198,11 @@ namespace Speckle.ConnectorMicroStationOpen.UI
     #endregion
 
     #region receiving
+    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    {
+      return null;
+    }
+
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
     {
       var kit = KitManager.GetDefaultKit();
@@ -444,6 +449,11 @@ namespace Speckle.ConnectorMicroStationOpen.UI
     #endregion
 
     #region sending
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    {
+      return null;
+    }
+
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {
       var kit = KitManager.GetDefaultKit();
@@ -848,17 +858,6 @@ namespace Speckle.ConnectorMicroStationOpen.UI
 
     public override void ResetDocument()
     {
-      // TODO!
-    }
-
-    public override void PreviewSend(StreamState state, ProgressViewModel progress)
-    {
-      // TODO!
-    }
-
-    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
-    {
-      return null;
       // TODO!
     }
     #endregion

--- a/ConnectorMicroStation/ConnectorMicroStationOpenShared/UI/Bindings2.cs
+++ b/ConnectorMicroStation/ConnectorMicroStationOpenShared/UI/Bindings2.cs
@@ -198,7 +198,7 @@ namespace Speckle.ConnectorMicroStationOpen.UI
     #endregion
 
     #region receiving
-    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }
@@ -449,7 +449,7 @@ namespace Speckle.ConnectorMicroStationOpen.UI
     #endregion
 
     #region sending
-    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Receive.cs
@@ -25,10 +25,9 @@ namespace Speckle.ConnectorRevit.UI
     public List<ApplicationObject> Preview { get; set; } = new List<ApplicationObject>();
     public Dictionary<string, Base> StoredObjects = new Dictionary<string, Base>();
 
-    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
-      // TODO!
     }
 
     /// <summary>

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -19,10 +19,10 @@ namespace Speckle.ConnectorRevit.UI
     // used to store the Stream State settings when sending/receiving
     private List<ISetting> CurrentSettings { get; set; }
 
-    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
-      // if this is a "can preview" check, return an empty string
-      if (state == null && progress == null) return String.Empty;
+      // handle dry runs so this method passes DUI2 implementation check without firing
+      if (isDryRun) return String.Empty;
 
       var filterObjs = GetSelectionFilterObjects(state.Filter);
       foreach (var filterObj in filterObjs)

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -21,6 +21,9 @@ namespace Speckle.ConnectorRevit.UI
 
     public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
+      // if this is a "can preview" check, return an empty string
+      if (state == null && progress == null) return String.Empty;
+
       var filterObjs = GetSelectionFilterObjects(state.Filter);
       foreach (var filterObj in filterObjs)
       {

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -19,7 +19,7 @@ namespace Speckle.ConnectorRevit.UI
     // used to store the Stream State settings when sending/receiving
     private List<ISetting> CurrentSettings { get; set; }
 
-    public override void PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
       var filterObjs = GetSelectionFilterObjects(state.Filter);
       foreach (var filterObj in filterObjs)
@@ -34,6 +34,7 @@ namespace Speckle.ConnectorRevit.UI
         progress.Report.Log(reportObj);
       }
       SelectClientObjects(filterObjs.Select(o => o.UniqueId).ToList());
+      return "success";
     }
 
     /// <summary>

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -633,7 +633,7 @@ namespace SpeckleRhino
     #endregion
 
     #region sending
-    public override void PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
       var filterObjs = GetObjectsFromFilter(state.Filter);
 
@@ -641,6 +641,7 @@ namespace SpeckleRhino
       Doc.Objects.UnselectAll(false);
       SelectClientObjects(filterObjs);
       Doc.Views.Redraw();
+      return "success";
     }
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -233,6 +233,9 @@ namespace SpeckleRhino
     #region receiving 
     public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
+      // if this is a "can preview" check, return an new streamstate
+      if (state == null && progress == null) return new StreamState();
+
       // first check if commit is the same and preview objects have already been generated
       Commit commit = await GetCommitFromState(state, progress);
 
@@ -635,6 +638,9 @@ namespace SpeckleRhino
     #region sending
     public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
+      // if this is a "can preview" check, return an empty string
+      if (state == null && progress == null) return String.Empty;
+
       var filterObjs = GetObjectsFromFilter(state.Filter);
 
       // TODO: instead of selection, consider saving current visibility of objects in doc, hiding everything except selected, and restoring original states on cancel
@@ -822,7 +828,7 @@ namespace SpeckleRhino
     private List<string> GetObjectsFromFilter(ISelectionFilter filter)
     {
       var objs = new List<string>();
-
+      if (filter == null) return objs;
       switch (filter.Slug)
       {
         case "manual":

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -231,10 +231,10 @@ namespace SpeckleRhino
     #endregion
 
     #region receiving 
-    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
-      // if this is a "can preview" check, return an new streamstate
-      if (state == null && progress == null) return new StreamState();
+      // handle dry runs so this method passes DUI2 implementation check without firing
+      if (isDryRun) return new StreamState();
 
       // first check if commit is the same and preview objects have already been generated
       Commit commit = await GetCommitFromState(state, progress);
@@ -636,10 +636,10 @@ namespace SpeckleRhino
     #endregion
 
     #region sending
-    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
-      // if this is a "can preview" check, return an empty string
-      if (state == null && progress == null) return String.Empty;
+      // handle dry runs so this method passes DUI2 implementation check without firing
+      if (isDryRun) return String.Empty;
 
       var filterObjs = GetObjectsFromFilter(state.Filter);
 

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructure.Send.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructure.Send.cs
@@ -25,9 +25,9 @@ namespace Speckle.ConnectorTeklaStructures.UI
 
     private List<ISetting> CurrentSettings { get; set; }
 
-    public override void PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async System.Threading.Tasks.Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
-      // TODO!
+      return null;
     }
 
     public override async System.Threading.Tasks.Task<string> SendStream(StreamState state, ProgressViewModel progress)

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructure.Send.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructure.Send.cs
@@ -25,7 +25,7 @@ namespace Speckle.ConnectorTeklaStructures.UI
 
     private List<ISetting> CurrentSettings { get; set; }
 
-    public override async System.Threading.Tasks.Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async System.Threading.Tasks.Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Receive.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Receive.cs
@@ -19,7 +19,7 @@ namespace Speckle.ConnectorTeklaStructures.UI
   public partial class ConnectorBindingsTeklaStructures : ConnectorBindings
   {
     #region receiving
-    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
       return null;
     }

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Receive.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Receive.cs
@@ -17,9 +17,13 @@ using System.Threading.Tasks;
 namespace Speckle.ConnectorTeklaStructures.UI
 {
   public partial class ConnectorBindingsTeklaStructures : ConnectorBindings
-
   {
     #region receiving
+    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    {
+      return null;
+    }
+
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
     {
       Exceptions.Clear();

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Selection.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Selection.cs
@@ -55,13 +55,6 @@ namespace Speckle.ConnectorTeklaStructures.UI
             };
     }
 
-    public override async System.Threading.Tasks.Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
-    {
-      await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(200));
-      return new StreamState();
-      // TODO!
-    }
-
     public override void ResetDocument()
     {
       // TODO!

--- a/DesktopUI2/DesktopUI2/ConnectorBindings.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorBindings.cs
@@ -124,7 +124,7 @@ namespace DesktopUI2
     /// <param name="state"></param>
     /// <param name="progress"></param>
     /// <returns></returns>
-    public abstract void PreviewSend(StreamState state, ProgressViewModel progress);
+    public abstract Task<string> PreviewSend(StreamState state, ProgressViewModel progress);
 
     /// <summary>
     /// Receives stream data from the server

--- a/DesktopUI2/DesktopUI2/ConnectorBindings.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorBindings.cs
@@ -123,8 +123,9 @@ namespace DesktopUI2
     /// </summary>
     /// <param name="state"></param>
     /// <param name="progress"></param>
+    /// <param name="isDryRun">Indicates if this is a dry run to determine if the method is implemented or not without firing</param>
     /// <returns></returns>
-    public abstract Task<string> PreviewSend(StreamState state, ProgressViewModel progress);
+    public abstract Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false);
 
     /// <summary>
     /// Receives stream data from the server
@@ -138,8 +139,9 @@ namespace DesktopUI2
     /// </summary>
     /// <param name="state"></param>
     /// <param name="progress"></param>
+    /// <param name="isDryRun">Indicates if this is a dry run to determine if the method is implemented or not without firing</param>
     /// <returns></returns>
-    public abstract Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress);
+    public abstract Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false);
 
     /// <summary>
     /// Adds the current selection to the provided client.

--- a/DesktopUI2/DesktopUI2/DummyBindings.cs
+++ b/DesktopUI2/DesktopUI2/DummyBindings.cs
@@ -266,8 +266,10 @@ namespace DesktopUI2
       // TODO!
     }
 
-    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
+      if (isDryRun) return new StreamState();
+
       var pd = new ConcurrentDictionary<string, int>();
       pd["A1"] = 1;
       pd["A2"] = 1;
@@ -371,8 +373,10 @@ namespace DesktopUI2
       return state;
     }
 
-    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress, bool isDryRun = false)
     {
+      if (isDryRun) return String.Empty;
+
       // Let's fake some progress barsssss
       //progress.Report.Log("Starting fake sending");
       var pd = new ConcurrentDictionary<string, int>();

--- a/DesktopUI2/DesktopUI2/DummyBindings.cs
+++ b/DesktopUI2/DesktopUI2/DummyBindings.cs
@@ -371,7 +371,7 @@ namespace DesktopUI2
       return state;
     }
 
-    public override async void PreviewSend(StreamState state, ProgressViewModel progress)
+    public override async Task<string> PreviewSend(StreamState state, ProgressViewModel progress)
     {
       // Let's fake some progress barsssss
       //progress.Report.Log("Starting fake sending");
@@ -387,7 +387,7 @@ namespace DesktopUI2
         if (progress.CancellationTokenSource.Token.IsCancellationRequested)
         {
           //progress.Report.Log("Fake sending was cancelled");
-          return;
+          return null;
         }
 
         progress.Report.Log("Done fake task " + i);
@@ -412,7 +412,7 @@ namespace DesktopUI2
           //state.Errors.Add(e);
         }
       }
-      return;
+      return "success" ;
     }
 
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -1129,9 +1129,34 @@ namespace DesktopUI2.ViewModels
     [DependsOn(nameof(SelectedCommit))]
     [DependsOn(nameof(SelectedFilter))]
     [DependsOn(nameof(IsReceiver))]
-    private bool CanPreviewCommand(object parameter)
+    private async Task<bool> CanPreviewCommand(object parameter)
     {
-      return IsReady();
+      var preCheck = IsReady();
+      if (preCheck)
+      {
+        try
+        {
+          // test for not implemented exception
+          string sendRes = null;
+          StreamState receiveRes = null;
+          if (IsReceiver)
+          {
+            var res = await Bindings.PreviewReceive(new StreamState(), new ProgressViewModel());
+            if (res == null) return false;
+          }
+          else
+          {
+            var res = await Bindings.PreviewSend(new StreamState(), new ProgressViewModel());
+            if (res == null) return false;
+          }
+        }
+        catch
+        {
+          return false;
+        }
+      }
+
+      return preCheck;
     }
 
     private bool IsReady()

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -1136,9 +1136,9 @@ namespace DesktopUI2.ViewModels
       {
         // test for unimplemented binding returning null
         if (IsReceiver)
-          preCheck = Bindings.PreviewReceive(null, null).Result == null ? false : true;
+          preCheck = Bindings.PreviewReceive(StreamState, Progress, true).Result == null ? false : true;
         else
-          preCheck = Bindings.PreviewSend(null, null).Result == null ? false : true;
+          preCheck = Bindings.PreviewSend(StreamState, Progress, true).Result == null ? false : true;
       }
 
       return preCheck;

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -1129,31 +1129,16 @@ namespace DesktopUI2.ViewModels
     [DependsOn(nameof(SelectedCommit))]
     [DependsOn(nameof(SelectedFilter))]
     [DependsOn(nameof(IsReceiver))]
-    private async Task<bool> CanPreviewCommand(object parameter)
+    private bool CanPreviewCommand(object parameter)
     {
       var preCheck = IsReady();
       if (preCheck)
       {
-        try
-        {
-          // test for not implemented exception
-          string sendRes = null;
-          StreamState receiveRes = null;
-          if (IsReceiver)
-          {
-            var res = await Bindings.PreviewReceive(new StreamState(), new ProgressViewModel());
-            if (res == null) return false;
-          }
-          else
-          {
-            var res = await Bindings.PreviewSend(new StreamState(), new ProgressViewModel());
-            if (res == null) return false;
-          }
-        }
-        catch
-        {
-          return false;
-        }
+        // test for unimplemented binding returning null
+        if (IsReceiver)
+          preCheck = Bindings.PreviewReceive(null, null).Result == null ? false : true;
+        else
+          preCheck = Bindings.PreviewSend(null, null).Result == null ? false : true;
       }
 
       return preCheck;


### PR DESCRIPTION
## Description & motivation

Disables the DUI2 `PreviewSend` and `PreviewReceive` buttons if the connector binding method returns null. This includes updating all connectors so that `PreviewSend` returned `Task<string>` instead of `void`.

Implementation notes:
- The original issue came from crahses on repeated click with the original preview button enabled, but bindings returning null or void. Better to disable for better metrics as well.
- This is achieved with a `Can` method check on the DUI2 stream view control that is bound to `Preview`, and is accomplished by triggering the `PreviewSend` or `PreviewReceive` bindings with `null` arguments.
- For any connector with implemented previews, this null check needs to be in place to prevent crashes!


## Changes:

DUI2 StreamEditViewModel `CanPreview` method
All DUI2 connector `PreviewSend` methods
Rhino and Revit `PreviewSend` and Rhino `PreviewReceive` methods to handle null values from `CanPreview` check

## To-do before merge:

## Screenshots:

## Validation of changes:



