### PR TITLE
fix(Rhino): send everything bug

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -195,7 +195,16 @@ namespace SpeckleRhino
 
       foreach (var id in objs)
       {
-        RhinoObject obj = Doc.Objects.FindId(new Guid(id));
+        RhinoObject obj = null;
+        try
+        {
+          obj = Doc.Objects.FindId(new Guid(id)); // this is a rhinoobj
+        }
+        catch
+        {
+          continue; // this was a named view!
+        }
+        
         if (obj != null)
         {
           if (deselect) obj.Select(false, true, false, true, true, true);

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -684,7 +684,8 @@ namespace SpeckleRhino
         {
           viewIndex = Doc.NamedViews.FindByName(applicationId); // try get view
         }
-        ApplicationObject reportObj = new ApplicationObject(applicationId, Formatting.ObjectDescriptor(obj));
+        var descriptor = obj != null ? Formatting.ObjectDescriptor(obj) : "Named View";
+        ApplicationObject reportObj = new ApplicationObject(applicationId, descriptor);
 
         if (obj != null)
         {

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
@@ -192,6 +192,7 @@ namespace SpeckleRhino
   {
     public static string ObjectDescriptor(RhinoObject obj)
     {
+      if (obj == null) return String.Empty;
       var simpleType = obj.ObjectType.ToString();
       return obj.HasName ? $"{simpleType}" : $"{simpleType} {obj.Name}";
     }


### PR DESCRIPTION
## Description & motivation

Bug reported by @AlanRynne : rhino connector hangs when using the send everything filter.

While testing, also found that named views selection in the report causes a crash, which is also resolved in this fix

Caused by null exception when sending named views

## Changes:
Rhino connector

## Validation of changes:

Sent some views

