### PR TITLE
fix(gh): Get account fail when no OriginalInput was set in the StreamWrapper

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -396,6 +396,10 @@ namespace ConnectorGrasshopper.Ops
         AutoReceive = false;
         StreamWrapper = wrapper;
         LastInfoMessage = null;
+        Task.Run(async () =>
+        {
+          await ResetApiClient(wrapper);
+        });
         return;
       }
 

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -200,7 +200,7 @@ namespace Speckle.Core.Credentials
       }
 
       // Step 1: check if direct account id (?u=)
-      if (OriginalInput.Contains("?u="))
+      if (OriginalInput != null && OriginalInput.Contains("?u="))
       {
         var userId = OriginalInput.Split(new string[] { "?u=" }, StringSplitOptions.None)[1];
         var acc = AccountManager.GetAccounts().FirstOrDefault(acc => acc.userInfo.id == userId);


### PR DESCRIPTION
Fixes an issue where `commitUrl` would not reset the ApiClient, leading to null exceptions or errors because the client was not refreshed.

Also uncovered a smaller issue with the `commitUrl` from the output of the `Send node` would be missing the `OriginalInput` string, leading to a null error if connected to a receive node.