### PR TITLE
fix(dui2/rhino): preview and report bugs

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/ConnectorBinding.cs
+++ b/ConnectorArchicad/ConnectorArchicad/ConnectorBinding.cs
@@ -98,10 +98,10 @@ namespace Archicad.Launcher
       return new List<ReceiveMode> { ReceiveMode.Create };
     }
 
+    public override bool CanPreviewReceive => false;
     public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       return null;
-      // TODO!
     }
 
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
@@ -120,9 +120,10 @@ namespace Archicad.Launcher
       // TODO!
     }
 
+    public override bool CanPreviewSend => false;
     public override void PreviewSend(StreamState state, ProgressViewModel progress)
     {
-      // TODO!
+      return;
     }
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -187,10 +187,10 @@ namespace Speckle.ConnectorAutocadCivil.UI
     #endregion
 
     #region receiving 
+    public override bool CanPreviewReceive => false;
     public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       return null;
-      // TODO!
     }
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
     {
@@ -549,6 +549,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
     #endregion
 
     #region sending
+    public override bool CanPreviewSend => false;
     public override async void PreviewSend(StreamState state, ProgressViewModel progress)
     {
       // TODO!

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
@@ -16,10 +16,10 @@ namespace Speckle.ConnectorCSI.UI
 {
   public partial class ConnectorBindingsCSI : ConnectorBindings
   {
+    public override bool CanPreviewReceive => false;
     public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       return null;
-      // TODO!
     }
 
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
@@ -17,6 +17,7 @@ namespace Speckle.ConnectorCSI.UI
 {
   public partial class ConnectorBindingsCSI : ConnectorBindings
   {
+    public override bool CanPreviewSend => false;
     public override void PreviewSend(StreamState state, ProgressViewModel progress)
     {
       // TODO!

--- a/ConnectorMicroStation/ConnectorMicroStationOpenShared/UI/Bindings2.cs
+++ b/ConnectorMicroStation/ConnectorMicroStationOpenShared/UI/Bindings2.cs
@@ -198,6 +198,12 @@ namespace Speckle.ConnectorMicroStationOpen.UI
     #endregion
 
     #region receiving
+    public override bool CanPreviewReceive => false;
+    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    {
+      return null;
+    }
+
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
     {
       var kit = KitManager.GetDefaultKit();
@@ -444,6 +450,12 @@ namespace Speckle.ConnectorMicroStationOpen.UI
     #endregion
 
     #region sending
+    public override bool CanPreviewSend => false;
+    public override void PreviewSend(StreamState state, ProgressViewModel progress)
+    {
+      return;
+    }
+
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {
       var kit = KitManager.GetDefaultKit();
@@ -848,17 +860,6 @@ namespace Speckle.ConnectorMicroStationOpen.UI
 
     public override void ResetDocument()
     {
-      // TODO!
-    }
-
-    public override void PreviewSend(StreamState state, ProgressViewModel progress)
-    {
-      // TODO!
-    }
-
-    public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
-    {
-      return null;
       // TODO!
     }
     #endregion

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Receive.cs
@@ -25,6 +25,8 @@ namespace Speckle.ConnectorRevit.UI
     public List<ApplicationObject> Preview { get; set; } = new List<ApplicationObject>();
     public Dictionary<string, Base> StoredObjects = new Dictionary<string, Base>();
 
+    public override bool CanPreviewReceive => false;
+
     public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       return null;

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Send.cs
@@ -18,6 +18,7 @@ namespace Speckle.ConnectorRevit.UI
   {
     // used to store the Stream State settings when sending/receiving
     private List<ISetting> CurrentSettings { get; set; }
+    public override bool CanPreviewSend => true;
 
     public override void PreviewSend(StreamState state, ProgressViewModel progress)
     {

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructure.Send.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructure.Send.cs
@@ -25,9 +25,10 @@ namespace Speckle.ConnectorTeklaStructures.UI
 
     private List<ISetting> CurrentSettings { get; set; }
 
+    public override bool CanPreviewSend => false;
     public override void PreviewSend(StreamState state, ProgressViewModel progress)
     {
-      // TODO!
+      return;
     }
 
     public override async System.Threading.Tasks.Task<string> SendStream(StreamState state, ProgressViewModel progress)

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Receive.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Receive.cs
@@ -20,6 +20,12 @@ namespace Speckle.ConnectorTeklaStructures.UI
 
   {
     #region receiving
+    public override bool CanPreviewReceive => false;
+    public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
+    {
+      return null;
+    }
+
     public override async Task<StreamState> ReceiveStream(StreamState state, ProgressViewModel progress)
     {
       Exceptions.Clear();

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Selection.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.Selection.cs
@@ -55,13 +55,6 @@ namespace Speckle.ConnectorTeklaStructures.UI
             };
     }
 
-    public override async System.Threading.Tasks.Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
-    {
-      await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(200));
-      return new StreamState();
-      // TODO!
-    }
-
     public override void ResetDocument()
     {
       // TODO!

--- a/DesktopUI2/DesktopUI2/ConnectorBindings.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorBindings.cs
@@ -44,6 +44,23 @@ namespace DesktopUI2
       return false;
     }
 
+    #region abstract properties
+
+    /// <summary>
+    /// Indicates if previewing send has been implemented
+    /// </summary>
+    /// <returns></returns>
+    public abstract bool CanPreviewSend { get; }
+
+    /// <summary>
+    /// Indicates if previewing receive has been implemented
+    /// </summary>
+    /// <returns></returns>
+    public abstract bool CanPreviewReceive { get; }
+
+    #endregion
+
+
     #region abstract methods
 
     /// <summary>
@@ -125,6 +142,7 @@ namespace DesktopUI2
     /// <param name="progress"></param>
     /// <returns></returns>
     public abstract void PreviewSend(StreamState state, ProgressViewModel progress);
+
 
     /// <summary>
     /// Receives stream data from the server

--- a/DesktopUI2/DesktopUI2/DummyBindings.cs
+++ b/DesktopUI2/DesktopUI2/DummyBindings.cs
@@ -266,6 +266,7 @@ namespace DesktopUI2
       // TODO!
     }
 
+    public override bool CanPreviewReceive => true;
     public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       var pd = new ConcurrentDictionary<string, int>();
@@ -371,6 +372,7 @@ namespace DesktopUI2
       return state;
     }
 
+    public override bool CanPreviewSend => true;
     public override async void PreviewSend(StreamState state, ProgressViewModel progress)
     {
       // Let's fake some progress barsssss

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -47,6 +47,12 @@ namespace DesktopUI2.ViewModels
       get => _previewOn;
       set
       {
+        if (value == false && value != _previewOn)
+        {
+          if (Progress.IsPreviewProgressing)
+            Progress.IsPreviewProgressing = false;
+          Bindings.ResetDocument();
+        }
         this.RaiseAndSetIfChanged(ref _previewOn, value);
       }
     }
@@ -159,6 +165,10 @@ namespace DesktopUI2.ViewModels
       get => _isReceiver;
       set
       {
+        if (value != _isReceiver)
+        {
+          PreviewOn = false;
+        }
         this.RaiseAndSetIfChanged(ref _isReceiver, value);
         this.RaisePropertyChanged(nameof(BranchesViewModel));
       }
@@ -1131,7 +1141,10 @@ namespace DesktopUI2.ViewModels
     [DependsOn(nameof(IsReceiver))]
     private bool CanPreviewCommand(object parameter)
     {
-      return IsReady();
+      bool previewImplemented = IsReceiver ? Bindings.CanPreviewReceive : Bindings.CanPreviewSend;
+      if (previewImplemented)
+        return IsReady();
+      else return false;
     }
 
     private bool IsReady()

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -62,6 +62,7 @@ namespace Objects.Converter.RhinoGh
     }
     public string ViewToNative(View3D view)
     {
+      var bakedViewName = string.Empty;
       Rhino.RhinoApp.InvokeOnUiThread((Action)delegate {
 
         RhinoView _view = Doc.Views.ActiveView;
@@ -97,14 +98,14 @@ namespace Objects.Converter.RhinoGh
           viewport.ChangeToParallelProjection(true);
 
         var commitInfo = GetCommitInfo();
-        var viewName = $"{commitInfo } - {view.name}";
+        bakedViewName = $"{commitInfo } - {view.name}";
 
-        Doc.NamedViews.Add(viewName, viewport.Id);
+        Doc.NamedViews.Add(bakedViewName, viewport.Id);
       });
 
       //ConversionErrors.Add(sdfasdfaf);
 
-      return "baked";
+      return bakedViewName;
     }
 
     private void AttachViewParams(Base speckleView, ViewInfo view)


### PR DESCRIPTION
## Description & motivation
While testing, discovered that toggling preview send and receive on and off was creating report issues in rhino, and null converter was casuing crashes. Also, the preview button was enabled even if the method was not implemented. This fix includes:

DUI: 
- disabling the preview button on send/receive if the corresponding method has not been implemented. The most stable option for doing that was a bit messy: added 2 new abstract prop bindings

Rhino:
- named views and blocks were previously not being baked on receive if previewed first, this has been fixed
- converter throwing null exception in switching between preview send and receive, fixed
- report objects not being updated when toggling between send and receive or toggling the preview button on/off, fixed
- preview not automatically clearing and view refreshing when swapping between send and receive tabs, fixed

Haven't been able to repro, but should:
Closes #1575

## Changes:

Connector bindings for DUI2
Rhino connector
