### PR TITLE
Patch(Rhino): Temporarily disable Rhino on Mac and delay `Init` call

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
@@ -65,7 +65,11 @@ namespace SpeckleRhino
 #endif
 
 #if MAC
-      CreateOrFocusSpeckle();
+      var msg = "Speckle is temporarily disabled on Rhino due to a critical bug regarding Rhino's top-menu commands. Please use Grasshopper instead while we fix this.";
+      RhinoApp.CommandLineOut.WriteLine(msg);
+      Rhino.UI.Dialogs.ShowMessage(msg, "Speckle has been disabled", Rhino.UI.ShowMessageButton.OK, Rhino.UI.ShowMessageIcon.Exclamation);
+      return Result.Nothing;
+      //CreateOrFocusSpeckle();
 #endif
       Rhino.UI.Panels.OpenPanel(typeof(Panel).GUID);
 

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia;
@@ -13,11 +13,13 @@ namespace SpeckleRhino
 {
   public class SpeckleCommand : Command
   {
-    #region Avalonia parent window
+#region Avalonia parent window
+#if !MAC
     [DllImport("user32.dll", SetLastError = true)]
     static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr value);
     const int GWL_HWNDPARENT = -8;
-    #endregion
+#endif
+#endregion
 
     public static SpeckleCommand Instance { get; private set; }
 
@@ -29,7 +31,7 @@ namespace SpeckleRhino
 
     private static CancellationTokenSource Lifetime = null;
 
-    private static Avalonia.Application AvaloniaApp { get; set; }
+    public static Avalonia.Application AvaloniaApp { get; set; }
 
     public SpeckleCommand()
     {
@@ -73,6 +75,7 @@ namespace SpeckleRhino
 
     public static void CreateOrFocusSpeckle()
     {
+      SpeckleRhinoConnectorPlugin.Instance.Init();
       if (MainWindow == null)
       {
         var viewModel = new MainViewModel(SpeckleRhinoConnectorPlugin.Instance.Bindings);

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,7 +28,7 @@ namespace SpeckleRhino
       Instance = this;
     }
 
-    internal void Init()
+    public void Init()
     {
       try
       {
@@ -95,7 +95,6 @@ namespace SpeckleRhino
     /// </summary>
     protected override LoadReturnCode OnLoad(ref string errorMessage)
     {
-      Init();
 
 #if !MAC
       System.Type panelType = typeof(Panel);
@@ -144,6 +143,10 @@ namespace SpeckleRhino
       return LoadReturnCode.Success;
     }
 
+#if MAC
+    public override PlugInLoadTime LoadTime => PlugInLoadTime.Disabled;
+#else
     public override PlugInLoadTime LoadTime => PlugInLoadTime.AtStartup;
+#endif
   }
 }

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -144,7 +144,7 @@ namespace SpeckleRhino
     }
 
 #if MAC
-    public override PlugInLoadTime LoadTime => PlugInLoadTime.Disabled;
+    public override PlugInLoadTime LoadTime => PlugInLoadTime.Disabled; // Temporarily disabled due to top-menu overtake by Avalonia. Waiting fix.
 #else
     public override PlugInLoadTime LoadTime => PlugInLoadTime.AtStartup;
 #endif


### PR DESCRIPTION
Disable Rhino Connector on Mac only to prevent issue #1277.

> THIS IS NOT A FIX, JUST A PATCH.

TODO:
- [x] Mac connector does respond to the Disabled flag
- [x] Mac connector does not load Avalonia **ever** (for now!! 😅)
- [x] Win connector is not broken by these changes

### Reason

#1277 

Avalonia is not playing nice with Rhino at the moment, causing it to hijack the top-menu and making any items un-clickable.

This only happens as soon as we call the `Init` method inside our `Plugin` class, so I moved the initialisation to whenever we call `CreateOrShowSpeckle()`.

This allows me to directly show a warning on Mac before any Avalonia logic get's executed.

### "Solution"

For now, the warning directs the user's to use Speckle Grasshopper, as it is installed alongside Rhino and does not suffer from these problems.

![image](https://user-images.githubusercontent.com/2316535/188435880-e4d431f9-fd5d-4998-8a45-e0d8abeded33.png)

If necessary, the plugin can still be enabled manually from the settings page (this will cause the menu issue to occurr though... but the connector works fine otherwise.

![image](https://user-images.githubusercontent.com/2316535/188435954-3785131d-28d6-4040-8cae-e48a7d6ed867.png)
