### PR TITLE
fix(rhino): Init call in RunCommand was debug only

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
@@ -58,10 +58,6 @@ namespace SpeckleRhino
     protected override Result RunCommand(RhinoDoc doc, RunMode mode)
     {
 
-#if DEBUG
-      SpeckleRhinoConnectorPlugin.Instance.Init();
-#endif
-
 #if MAC
       var msg = "Speckle is temporarily disabled on Rhino due to a critical bug regarding Rhino's top-menu commands. Please use Grasshopper instead while we fix this.";
       RhinoApp.CommandLineOut.WriteLine(msg);
@@ -69,6 +65,7 @@ namespace SpeckleRhino
       return Result.Nothing;
       //CreateOrFocusSpeckle();
 #endif
+      SpeckleRhinoConnectorPlugin.Instance.Init();
       Rhino.UI.Panels.OpenPanel(typeof(Panel).GUID);
 
       return Result.Success;

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
@@ -65,7 +65,6 @@ namespace SpeckleRhino
       return Result.Nothing;
       //CreateOrFocusSpeckle();
 #endif
-      SpeckleRhinoConnectorPlugin.Instance.Init();
       Rhino.UI.Panels.OpenPanel(typeof(Panel).GUID);
 
       return Result.Success;

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -102,6 +102,7 @@ namespace SpeckleRhino
       // by running the MyOpenPanel command and hidden by running the MyClosePanel command.
       // You can also include the custom panel in any existing panel group by simply right
       // clicking one a panel tab and checking or un-checking the "MyPane" option.
+      Init();
       Rhino.UI.Panels.RegisterPanel(this, panelType, "Speckle", Resources.icon);
 #endif
       // Get the version number of our plugin, that was last used, from our settings file.


### PR DESCRIPTION
Fixes hard crash in Rhino Windows when loading the Speckle DUI for the first time.

This was a side-effect of having an `Init` method call wrapped in a `DEBUG` preprocessor directive, which made it work on local but not when released.