### PR TITLE
GH: Use `ToFormattedString` everywhere + fix non-existent commit error message in receiver

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper/BaseComponents/SelectKitTaskCapableComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/BaseComponents/SelectKitTaskCapableComponentBase.cs
@@ -13,6 +13,7 @@ using Sentry;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 
 namespace ConnectorGrasshopper.Objects
 {
@@ -151,7 +152,7 @@ namespace ConnectorGrasshopper.Objects
       }
       catch (Exception e)
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,$"Failed to set document context:\n\t{e.Message}");
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,$"Failed to set document context:\n\t{e.ToFormattedString()}");
       }
       base.BeforeSolveInstance();
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/DeserialiseTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/DeserialiseTaskCapableComponent.cs
@@ -5,6 +5,7 @@ using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Speckle.Core.Api;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 
 namespace ConnectorGrasshopper
 {
@@ -63,7 +64,7 @@ namespace ConnectorGrasshopper
       catch (Exception e)
       {
         AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-          $"Cannot deserialize object at path {{{DA.ParameterTargetPath(0)}}}[{DA.ParameterTargetIndex(0)}]: {e.InnerException?.Message ?? e.Message}");
+          $"Cannot deserialize object at path {{{DA.ParameterTargetPath(0)}}}[{DA.ParameterTargetIndex(0)}]: {e.ToFormattedString()}");
         return null;
       }
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/SerialiseTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/SerialiseTaskCapableComponent.cs
@@ -6,6 +6,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Api;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 
 namespace ConnectorGrasshopper.Conversion
 {
@@ -71,7 +72,7 @@ namespace ConnectorGrasshopper.Conversion
         }
         catch (Exception e)
         {
-          AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.Message);
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.ToFormattedString());
           return null;
         }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/ToNativeTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/ToNativeTaskCapableComponent.cs
@@ -8,6 +8,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Utilities = Speckle.Core.Models.Utilities;
 
 namespace ConnectorGrasshopper.Conversion
@@ -78,7 +79,7 @@ namespace ConnectorGrasshopper.Conversion
           e = aggregateException.Flatten();
         
         Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
         return new GH_SpeckleBase();
       }
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/ToSpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Conversion/ToSpeckleTaskCapableComponent.cs
@@ -8,6 +8,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 
 namespace ConnectorGrasshopper.Conversion
 {
@@ -102,7 +103,7 @@ namespace ConnectorGrasshopper.Conversion
       {
         // If we reach this, something happened that we weren't expecting...
         Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
         return new GH_SpeckleBase();
       }
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectByKeyValueTaskComponent.cs
@@ -7,6 +7,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -55,7 +56,7 @@ namespace ConnectorGrasshopper.Objects
         foreach (var error in Converter.Report.ConversionErrors)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-            error.Message + ": " + error.InnerException?.Message);
+            error.ToFormattedString());
         }
         Converter.Report.ConversionErrors.Clear();
       }
@@ -102,7 +103,7 @@ namespace ConnectorGrasshopper.Objects
               }
               catch (Exception e)
               {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
                 hasErrors = true;
               }
 
@@ -138,7 +139,7 @@ namespace ConnectorGrasshopper.Objects
                 }
                 catch (Exception e)
                 {
-                  AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+                  AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
                   hasErrors = true;
                 }
             }
@@ -155,7 +156,7 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString());
         return null;
       }
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/CreateSpeckleObjectTaskComponent.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -124,7 +125,7 @@ namespace ConnectorGrasshopper.Objects
         foreach (var error in Converter.Report.ConversionErrors)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-            error.Message + ": " + error.InnerException?.Message);
+            error.ToFormattedString());
         }
         Converter.Report.ConversionErrors.Clear();
       }
@@ -173,7 +174,7 @@ namespace ConnectorGrasshopper.Objects
             catch (Exception e)
             {
               Logging.Log.CaptureException(e);
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"{e.Message}");
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"{e.ToFormattedString()}");
               hasErrors = true;
             }
 
@@ -184,7 +185,7 @@ namespace ConnectorGrasshopper.Objects
             catch (Exception e)
             {
               Logging.Log.CaptureException(e);
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.Message}");
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.ToFormattedString()}");
               hasErrors = true;
             }
           }
@@ -202,7 +203,7 @@ namespace ConnectorGrasshopper.Objects
             catch (Exception e)
             {
               Logging.Log.CaptureException(e);
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.Message}");
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.ToFormattedString()}");
               hasErrors = true;
             }
           }
@@ -219,7 +220,7 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString());
       }
 
       return new Base();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/DeconstructSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/DeconstructSpeckleObjectTaskComponent.cs
@@ -9,6 +9,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -90,7 +91,7 @@ namespace ConnectorGrasshopper.Objects
         foreach (var error in Converter.Report.ConversionErrors)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-            error.Message + ": " + error.InnerException?.Message);
+            error.ToFormattedString());
         }
         Converter.Report.ConversionErrors.Clear();
       }
@@ -274,7 +275,7 @@ namespace ConnectorGrasshopper.Objects
       }
       catch (Exception e)
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,$"Failed to fetch outputs:\n\t{e.Message}");
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,$"Failed to fetch outputs:\n\t{e.ToFormattedString()}");
       }
       base.BeforeSolveInstance();
     }
@@ -319,7 +320,7 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString());
         return null;
       }
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
@@ -11,6 +11,7 @@ using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -108,7 +109,7 @@ namespace ConnectorGrasshopper.Objects
         foreach (var error in Converter.Report.ConversionErrors)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-            error.Message + ": " + error.InnerException?.Message);
+            error.ToFormattedString());
         }
         Converter.Report.ConversionErrors.Clear();
       }
@@ -317,7 +318,7 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString());
         return null;
       }
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectByKeyValueTaskComponent.cs
@@ -7,6 +7,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -89,7 +90,7 @@ namespace ConnectorGrasshopper.Objects
         foreach (var error in Converter.Report.ConversionErrors)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-            error.Message + ": " + error.InnerException?.Message);
+            error.ToFormattedString());
         }
         Converter.Report.ConversionErrors.Clear();
       }
@@ -134,7 +135,7 @@ namespace ConnectorGrasshopper.Objects
               }
               catch (Exception e)
               {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
                 hasErrors = true;
               }
 
@@ -170,7 +171,7 @@ namespace ConnectorGrasshopper.Objects
                 }
                 catch (Exception e)
                 {
-                  AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+                  AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
                   hasErrors = true;
                 }
             }
@@ -187,7 +188,7 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString());
         return null;
       }
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/ExtendSpeckleObjectTaskComponent.cs
@@ -7,6 +7,7 @@ using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -165,7 +166,7 @@ namespace ConnectorGrasshopper.Objects
         foreach (var error in Converter.Report.ConversionErrors)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-            error.Message + ": " + error.InnerException?.Message);
+            error.ToFormattedString());
         }
         Converter.Report.ConversionErrors.Clear();
       }
@@ -241,7 +242,7 @@ namespace ConnectorGrasshopper.Objects
             catch (Exception e)
             {
               Logging.Log.CaptureException(e);
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"{e.Message}");
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, $"{e.ToFormattedString()}");
               hasErrors = true;
             }
 
@@ -252,7 +253,7 @@ namespace ConnectorGrasshopper.Objects
             catch (Exception e)
             {
               Logging.Log.CaptureException(e);
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.Message}");
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.ToFormattedString()}");
               hasErrors = true;
             }
           }
@@ -270,7 +271,7 @@ namespace ConnectorGrasshopper.Objects
             catch (Exception e)
             {
               Logging.Log.CaptureException(e);
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.Message}");
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"{e.ToFormattedString()}");
               hasErrors = true;
             }
           }
@@ -285,7 +286,7 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString());
       }
 
       return @base;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Objects/GetObjectValueByKeyTaskComponent.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -66,7 +67,7 @@ namespace ConnectorGrasshopper.Objects
         foreach (var error in Converter.Report.ConversionErrors)
         {
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning,
-            error.Message + ": " + error.InnerException?.Message);
+            error.ToFormattedString());
         }
         Converter.Report.ConversionErrors.Clear();
       }
@@ -122,7 +123,7 @@ namespace ConnectorGrasshopper.Objects
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString());
 
       }
       return value;

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.ReceiveComponent.cs
@@ -22,6 +22,7 @@ using Speckle.Core.Api;
 using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
@@ -472,7 +473,7 @@ namespace ConnectorGrasshopper.Ops
           // TODO: This message condition should be removed once the `link sharing` issue is resolved server-side.
           var msg = exception.Message.Contains("401")
             ? "You don't have access to this stream/transport , or it doesn't exist."
-            : exception.Message;
+            : exception.ToFormattedString();
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, $"{transportName}: { msg }"));
           Done();
           var asyncParent = (GH_AsyncComponent)Parent;
@@ -492,7 +493,7 @@ namespace ConnectorGrasshopper.Ops
         }
         catch (Exception e)
         {
-          RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message));
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
           Done();
           return;
         }
@@ -572,8 +573,7 @@ namespace ConnectorGrasshopper.Ops
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        var msg = e.InnerException?.Message ?? e.Message;
-        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, msg));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.ToFormattedString()));
         Done();
       }
     }
@@ -591,7 +591,7 @@ namespace ConnectorGrasshopper.Ops
           }
           catch (Exception e)
           {
-            OnFail(GH_RuntimeMessageLevel.Error, e.Message);
+            OnFail(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
             return null;
           }
         case StreamWrapperType.Object:

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.SendComponent.cs
@@ -20,6 +20,7 @@ using Rhino;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
@@ -309,7 +310,7 @@ namespace ConnectorGrasshopper.Ops
         }
         catch (Exception e)
         {
-          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.Message));
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.ToFormattedString()));
           Done();
           return;
         }
@@ -344,7 +345,7 @@ namespace ConnectorGrasshopper.Ops
             catch (Exception e)
             {
               // TODO: Check this with team.
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
             }
           }
 
@@ -375,7 +376,7 @@ namespace ConnectorGrasshopper.Ops
             }
             catch (Exception e)
             {
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
               continue;
             }
             
@@ -416,7 +417,7 @@ namespace ConnectorGrasshopper.Ops
           // TODO: This message condition should be removed once the `link sharing` issue is resolved server-side.
           var msg = exception.Message.Contains("401")
             ? $"You don't have access to this transport , or it doesn't exist."
-            : exception.Message;
+            : exception.ToFormattedString();
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, $"{transportName}: {msg}"));
           Done();
           var asyncParent = (GH_AsyncComponent)Parent;
@@ -522,7 +523,7 @@ namespace ConnectorGrasshopper.Ops
 
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString()));
         //Parent.Message = "Error";
         //((SendComponent)Parent).CurrentComponentState = "expired";
         Done();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.SendComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.SendComponentSync.cs
@@ -14,6 +14,7 @@ using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 using Logging = Speckle.Core.Logging;
 
@@ -275,7 +276,7 @@ namespace ConnectorGrasshopper.Ops.Deprecated
               catch (Exception e)
               {
                 // TODO: Check this with team.
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.Message);
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.ToFormattedString());
               }
             }
 
@@ -306,7 +307,7 @@ namespace ConnectorGrasshopper.Ops.Deprecated
               }
               catch (Exception e)
               {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message);
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.ToFormattedString());
                 continue;
               }
 
@@ -399,7 +400,7 @@ namespace ConnectorGrasshopper.Ops.Deprecated
             }
             catch (Exception e)
             {
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
               return null;
             }
           }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Deprecated/Operations.VariableInputSendComponent.cs
@@ -22,6 +22,7 @@ using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -375,7 +376,7 @@ namespace ConnectorGrasshopper.Ops
           }
           catch (Exception e)
           {
-            RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.Message));
+            RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.ToFormattedString()));
             Done();
             return;
           }
@@ -417,7 +418,7 @@ namespace ConnectorGrasshopper.Ops
             catch (Exception e)
             {
               // TODO: Check this with team.
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
             }
           }
 
@@ -448,7 +449,7 @@ namespace ConnectorGrasshopper.Ops
             }
             catch (Exception e)
             {
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
               continue;
             }
 
@@ -489,7 +490,7 @@ namespace ConnectorGrasshopper.Ops
           // TODO: This message condition should be removed once the `link sharing` issue is resolved server-side.
           var msg = exception.Message.Contains("401")
             ? $"You don't have access to this transport , or it doesn't exist."
-            : exception.Message;
+            : exception.ToFormattedString();
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, $"{transportName}: {msg}"));
           Done();
           var asyncParent = (GH_AsyncComponent)Parent;
@@ -595,7 +596,7 @@ namespace ConnectorGrasshopper.Ops
 
         // If we reach this, something happened that we weren't expecting...
         Log.CaptureException(e);
-        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString()));
         //Parent.Message = "Error";
         //((SendComponent)Parent).CurrentComponentState = "expired";
         Done();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.ReceiveLocalComponent.cs
@@ -11,6 +11,7 @@ using GrasshopperAsyncComponent;
 using Speckle.Core.Api;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -141,7 +142,7 @@ namespace ConnectorGrasshopper.Ops
       {
         // If we reach this, something happened that we weren't expecting...
         Logging.Log.CaptureException(e);
-        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString()));
         Parent.Message = "Error";
       }
       Done();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SendLocalComponent.cs
@@ -9,6 +9,7 @@ using GrasshopperAsyncComponent;
 using Speckle.Core.Api;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -71,7 +72,7 @@ namespace ConnectorGrasshopper.Ops
       catch (Exception e)
       {
         Console.WriteLine(e);
-        RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.Message));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
       }
 
       Done();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SyncSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SyncSendComponent.cs
@@ -15,6 +15,7 @@ using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 using Logging = Speckle.Core.Logging;
 
@@ -158,7 +159,7 @@ namespace ConnectorGrasshopper.Ops
               catch (Exception e)
               {
                 // TODO: Check this with team.
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.Message);
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.ToFormattedString());
               }
             }
 
@@ -184,7 +185,7 @@ namespace ConnectorGrasshopper.Ops
               }
               catch (Exception e)
               {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message);
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.ToFormattedString());
                 continue;
               }
 
@@ -277,7 +278,7 @@ namespace ConnectorGrasshopper.Ops
             }
             catch (Exception e)
             {
-              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
               return null;
             }
           }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputReceiveComponent.cs
@@ -448,7 +448,7 @@ namespace ConnectorGrasshopper.Ops
       }
       catch (Exception e)
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
       }
     }
 
@@ -548,7 +548,7 @@ namespace ConnectorGrasshopper.Ops
           // TODO: This message condition should be removed once the `link sharing` issue is resolved server-side.
           var msg = exception.Message.Contains("401")
             ? "You don't have access to this stream/transport , or it doesn't exist."
-            : exception.InnerException != null ? exception.InnerException.Message : exception.Message;
+            : exception.ToFormattedString();
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, $"{transportName}: { msg }"));
           Done();
           var asyncParent = (GH_AsyncComponent)Parent;
@@ -639,8 +639,7 @@ namespace ConnectorGrasshopper.Ops
       {
         // If we reach this, something happened that we weren't expecting...
         Log.CaptureException(e);
-        var msg = e.InnerException?.Message ?? e.Message;
-        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, msg));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.ToFormattedString()));
         Done();
       }
     }
@@ -658,7 +657,7 @@ namespace ConnectorGrasshopper.Ops
           }
           catch (Exception e)
           {
-            OnFail(GH_RuntimeMessageLevel.Error, e.Message);
+            OnFail(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
             return null;
           }
         case StreamWrapperType.Object:

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.VariableInputSendComponent.cs
@@ -395,7 +395,7 @@ namespace ConnectorGrasshopper.Ops
           }
           catch (Exception e)
           {
-            RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.Message));
+            RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, e.ToFormattedString()));
             Done();
             return;
           }
@@ -437,7 +437,7 @@ namespace ConnectorGrasshopper.Ops
             catch (Exception e)
             {
               // TODO: Check this with team.
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
             }
           }
 
@@ -468,7 +468,7 @@ namespace ConnectorGrasshopper.Ops
             }
             catch (Exception e)
             {
-              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.InnerException?.Message ?? e.Message));
+              RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, e.ToFormattedString()));
               continue;
             }
 
@@ -509,7 +509,7 @@ namespace ConnectorGrasshopper.Ops
           // TODO: This message condition should be removed once the `link sharing` issue is resolved server-side.
           var msg = exception.Message.Contains("401")
             ? $"You don't have access to this transport , or it doesn't exist."
-            : exception.Message;
+            : exception.ToFormattedString();
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, $"{transportName}: {exception.ToFormattedString()}"));
           Done();
           var asyncParent = (GH_AsyncComponent)Parent;
@@ -615,7 +615,7 @@ namespace ConnectorGrasshopper.Ops
 
         // If we reach this, something happened that we weren't expecting...
         Log.CaptureException(e);
-        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.Message));
+        RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Something went terribly wrong... " + e.ToFormattedString()));
         //Parent.Message = "Error";
         //((SendComponent)Parent).CurrentComponentState = "expired";
         Done();

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObject.cs
@@ -16,6 +16,7 @@ using Grasshopper.Kernel.Special;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -383,7 +384,7 @@ namespace ConnectorGrasshopper
           }
           catch (Exception e)
           {
-            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
+            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
             return;
           }
         }
@@ -411,7 +412,7 @@ namespace ConnectorGrasshopper
       }
       catch (Exception e)
       {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
         return;
       }
 
@@ -434,7 +435,7 @@ namespace ConnectorGrasshopper
         }
         catch (Exception e)
         {
-          AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, e.Message);
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, e.ToFormattedString());
         }
       }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -14,6 +14,7 @@ using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Special;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 using Utilities = ConnectorGrasshopper.Extras.Utilities;
 
@@ -369,7 +370,7 @@ namespace ConnectorGrasshopper
           }
           catch (Exception e)
           {
-            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
+            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
             return;
           }
         }
@@ -399,7 +400,7 @@ namespace ConnectorGrasshopper
       catch (Exception e)
       {
 
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.InnerException?.Message ?? e.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.ToFormattedString());
         return;
       }
 
@@ -424,7 +425,7 @@ namespace ConnectorGrasshopper
         }
         catch (Exception e)
         {
-          AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, e.Message);
+          AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, e.ToFormattedString());
         }
       }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamCreateComponent.cs
@@ -9,6 +9,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 
 namespace ConnectorGrasshopper.Streams
@@ -126,7 +127,7 @@ namespace ConnectorGrasshopper.Streams
           Rhino.RhinoApp.InvokeOnUiThread((Action)delegate
           {
             ExpireSolution(false);
-            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"Could not create stream at {account.serverInfo.url}:\n{e.Message}");
+            AddRuntimeMessage(GH_RuntimeMessageLevel.Error, $"Could not create stream at {account.serverInfo.url}:\n{e.ToFormattedString()}");
           });
         }
       });

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamDetailsComponent.cs
@@ -9,6 +9,7 @@ using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 
 namespace ConnectorGrasshopper.Streams
@@ -54,7 +55,7 @@ namespace ConnectorGrasshopper.Streams
       if (error != null)
       {
         Message = null;
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.ToFormattedString());
         error = null;
         streams = null;
       }
@@ -112,7 +113,7 @@ namespace ConnectorGrasshopper.Streams
                 }
                 catch (Exception e)
                 {
-                  error = e.InnerException ?? e;
+                  error = e;
                   return;
                 }
                 

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamGetComponent.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Speckle.Core.Credentials;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 
 namespace ConnectorGrasshopper.Streams
@@ -71,7 +72,7 @@ namespace ConnectorGrasshopper.Streams
       if (error != null)
       {
         Message = null;
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.ToFormattedString());
         error = null;
         stream = null;
       }
@@ -101,7 +102,7 @@ namespace ConnectorGrasshopper.Streams
           catch (Exception e)
           {
             stream = null;
-            error = e.InnerException ?? e;
+            error = e;
           }
           finally
           {

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamListComponent.cs
@@ -8,6 +8,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 
 namespace ConnectorGrasshopper.Streams
@@ -45,7 +46,7 @@ namespace ConnectorGrasshopper.Streams
       if (error != null)
       {
         Message = null;
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.ToFormattedString());
         error = null;
         streams = null;
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/Streams/StreamUpdateComponent.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using ConnectorGrasshopper.Extras;
 using Grasshopper.Kernel;
 using Speckle.Core.Api;
+using Speckle.Core.Models.Extensions;
 using Logging = Speckle.Core.Logging;
 
 namespace ConnectorGrasshopper.Streams
@@ -57,7 +58,7 @@ namespace ConnectorGrasshopper.Streams
       if (error != null)
       {
         Message = null;
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.Message);
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, error.ToFormattedString());
         error = null;
       }
       else if (stream == null)
@@ -90,7 +91,7 @@ namespace ConnectorGrasshopper.Streams
           }
           catch (Exception e)
           {
-            error = e.InnerException ?? e;
+            error = e;
           }
           finally
           {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -10,6 +10,7 @@ using Rhino.Geometry;
 using Rhino.Geometry.Collections;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Arc = Objects.Geometry.Arc;
 using Box = Objects.Geometry.Box;
 using Brep = Objects.Geometry.Brep;
@@ -1022,7 +1023,7 @@ namespace Objects.Converter.RhinoGh
       }
       catch (Exception e)
       {
-        notes.Add(e.Message);
+        notes.Add(e.ToFormattedString());
         return null;
       }
     }


### PR DESCRIPTION
This PR fixes:

- Bug where a non existent `commit url` would not report an error to the user when plugged into the receive node (or attempting to receive).
- Adds `ToFormattedString` to all user facing instances where exception messages are shown (i.e. any AddRuntimeException() call. We were previously unwrapping the inner exception, but that doesn't print the entire error message in some cases.