### PR TITLE
feat: Commit Bundle Object

### DIFF
--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -362,6 +362,8 @@ namespace Speckle.Core.Models
       this.objectIds = objectIds;
     }
 
+
+  }
   public class BundleReferenceArgs : EventArgs
   {
     public List<BundleItem> items { get; set; }

--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -209,6 +209,11 @@ namespace Speckle.Core.Models
     /// </summary>
     public List<string> ConversionLog { get; } = new List<string>();
 
+   /// <summary>
+    /// List of bundles to pull down
+    /// </summary>
+    public List<BundleReferenceArgs> BundleReferenceArgs { get; set; } = new List<BundleReferenceArgs>();
+   
     private readonly object ConversionLogLock = new object();
     public string ConversionLogString
     {
@@ -323,5 +328,46 @@ namespace Speckle.Core.Models
           }
       }
     }
+  }
+   /// <summary>
+  /// A simple object for keeping track of the information in a bundle
+  /// </summary>
+  public class BundleItem : Base
+  {
+    /// <summary>
+    /// stream id to reference
+    /// </summary>
+    public string streamId { get; set; }
+
+    /// <summary>
+    /// List of objects to pull from stream
+    /// </summary>
+    public List<string> objectIds { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public BundleItem()
+    {
+    }
+
+    /// <summary>
+    /// Simple way of building item
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <param name="objectIds"></param>
+    public BundleItem(string streamId, List<string> objectIds)
+    {
+      this.streamId = streamId;
+      this.objectIds = objectIds;
+    }
+
+  public class BundleReferenceArgs : EventArgs
+  {
+    public List<BundleItem> items { get; set; }
+
+    public string name { get; set; }
+
+    public string id { get; set; }
   }
 }

--- a/Objects/Objects/Organization/Bundle.cs
+++ b/Objects/Objects/Organization/Bundle.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using Speckle.Core.Models;
+
+namespace Objects.Organization
+{
+
+  /// <summary>
+  /// A simple organization object that links multiple speckle objects into one bundle.
+  /// All linked objects must be situated on the same server
+  /// </summary>
+  public class Bundle : Base
+  {
+    /// <summary>
+    /// Name of the bundle
+    /// </summary>
+    public string name { get; set; }
+
+    /// <summary>
+    /// A list of reference object Ids to link together
+    /// Collection key is the streamId associated with the list of objects to use 
+    /// </summary>
+    [DetachProperty] public List<BundleItem> items { get; set; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public Bundle()
+    {
+    }
+
+    /// <summary>
+    /// Basic constructor 
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="items"></param>
+    public Bundle(string name, List<BundleItem> items)
+    {
+      this.name = name;
+      this.items = items;
+    }
+
+
+
+    /// <summary>
+    /// Checks if <see cref="name"/> and <see cref="items"/> are similar
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
+    public bool Equals(Bundle obj)
+    {
+      // check if name are similar along with collection of objects
+      if (!name.Equals(obj.name) || obj.items?.Count != items?.Count)
+        return false;
+
+      foreach (var item in items)
+      {
+        BundleItem itemToFind = null;
+
+        foreach (var o in obj.items)
+        {
+          if (!o.streamId.Equals(item.streamId))
+            continue;
+
+          itemToFind = o;
+          break;
+        }
+
+        if (itemToFind == null || itemToFind.objectIds?.Count != item.objectIds?.Count)
+          return false;
+
+        // check all ids
+        for (var i = 0; i < item.objectIds.Count; i++)
+        {
+          // TODO: Might get reordered somehow
+          if (!item.objectIds[i].Equals(itemToFind.objectIds[i]))
+            return false;
+        }
+      }
+
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
## Description & motivation

A PR to build off of #1785 

The idea of the `Bundle` object is to replicate the _Commit Overlay_  feature used in the web viewer as a `Base` type object for designers + devs to utilize within their commits. The bundle object is similar to the `Model` or `Container`  but instead of grouping all the objects it holds a list of references that point to a stream and a reference object. 

A couple of use cases that sparked this idea:

- Custom tools / apps that are built on top of Speckle rely heavily on the standard `Object` converter but need to link different model objects together in order to compose a specialized model scenario. This would allow for developers to rely on a standard Speckle object rather than standing up their own kit and converter for grouping together sets of different objects.
- Designers tend to utilize Branches as a way to separate different focuses of modeling work, but there is a bump in the process when they try to layer in all the necessary commits or objects they need to visualize the model (sometimes I've seen this info written down on slack messages or gh panels 😱 ). The bundle could act as a simple object for designers to rely on when passing around settings for model compositions. 

## Changes:

- [`Bundle`](https://github.com/haitheredavid/speckle-sharp/blob/dm/commit-bundle/Objects/Objects/Organization/Bundle.cs) object added to `Objects`
- [`BundleItem`](https://github.com/haitheredavid/speckle-sharp/blob/b17d50720f04780dceef890418e5f66a028168dc/Core/Core/Models/Extras.cs#L70) object added to `Core`
- `ProgressReport` supports collecting bundle data with [`BundleReferenceArgs`](https://github.com/haitheredavid/speckle-sharp/blob/b17d50720f04780dceef890418e5f66a028168dc/Core/Core/Models/Extras.cs#L126)
- This logic would mainly impact the receive calls. I implemented a basic version of this in the [`ReceiveSyncComponent`](https://github.com/haitheredavid/speckle-sharp/blob/dm/commit-bundle/ConnectorGrasshopper/ConnectorGrasshopper/Ops/Operations.SyncReceiveComponent.cs) in GH, which shows that this would be a pretty big change for conversion logic across all connectors. 

## To-do before merge:

- [ ] Connectors would need to check the `ProgressReport` and converters would need to be adapted to support the new object type. 
- [ ] Review if this object should sit in the `Objects.Organization` namespace
 

## Screenshots:

![Bundle In GH](https://github.com/haitheredavid/speckle-sharp/blob/dm/commit-bundle/Objects/BundleTest/Bundle.jpg?raw=true)

## Validation of changes:

Here is a tested [prototype](https://github.com/haitheredavid/speckle-sharp/tree/dm/commit-bundle/Objects/BundleTest), working in C# and the GH connector

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

