### PR TITLE
fix(rhino): stream edit view selection issues in rhino

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -21,7 +21,6 @@ namespace SpeckleRhino
     private static string SpeckleKey = "speckle2";
 
     public ConnectorBindingsRhino Bindings { get; private set; }
-    public MainViewModel ViewModel { get; private set; }
 
     internal bool _initialized;
 
@@ -39,7 +38,6 @@ namespace SpeckleRhino
 
         SpeckleCommand.InitAvalonia();
         Bindings = new ConnectorBindingsRhino();
-        ViewModel = new MainViewModel(Bindings);
 
         RhinoDoc.BeginOpenDocument += RhinoDoc_BeginOpenDocument;
         RhinoDoc.EndOpenDocument += RhinoDoc_EndOpenDocument;
@@ -82,9 +80,6 @@ namespace SpeckleRhino
 
     private void RhinoDoc_BeginOpenDocument(object sender, DocumentOpenEventArgs e)
     {
-      //new document => new view model (used by the panel only)
-      ViewModel = new MainViewModel(Bindings);
-
       if (e.Merge) // this is a paste or import event
       {
         // get existing streams in doc before a paste or import operation to use for cleanup

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/Panel.xaml.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/Panel.xaml.cs
@@ -17,8 +17,11 @@ namespace SpeckleRhino
       try
       {
         InitializeComponent();
-        //Set in the Plugin so that it's not disposed each time the panel is closed
-        this.DataContext = SpeckleRhinoConnectorPlugin.Instance.ViewModel;
+        //set here otherwise we get errors about re-used visual parents when closing and re-opening the panel
+        //there might be other solutions too. If changing this behaviour make sure to refresh the view model
+        //when opening a new file as well
+        var viewModel = new MainViewModel(SpeckleRhinoConnectorPlugin.Instance.Bindings);
+        this.DataContext = viewModel;
         AvaloniaHost.Content = new MainUserControl();
       }
       catch (Exception ex)
@@ -26,7 +29,7 @@ namespace SpeckleRhino
 
       }
 
-      
+
 
     }
 

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -33,7 +33,7 @@ namespace DesktopUI2.ViewModels
   {
 
     public StreamState StreamState { get; set; }
-    private IScreen HostScreen { get; set; }
+    public IScreen HostScreen { get; set; }
 
     private ConnectorBindings Bindings;
 
@@ -306,8 +306,8 @@ namespace DesktopUI2.ViewModels
         else
         {
           var filterItems = _reportSelectedFilterItems.Any() ? Report.Where(o => _reportSelectedFilterItems.Any(a => o.Status == a)).ToList() : Report;
-          return SearchQuery == "" ? 
-            filterItems : 
+          return SearchQuery == "" ?
+            filterItems :
             filterItems.Where(o => _searchQueryItems.All(a => o.SearchText.ToLower().Contains(a.ToLower()))).ToList();
         }
       }
@@ -320,13 +320,13 @@ namespace DesktopUI2.ViewModels
     {
       get
       {
-        string defaultMessage = string.IsNullOrEmpty(Progress.Report.ConversionLogString) ? 
+        string defaultMessage = string.IsNullOrEmpty(Progress.Report.ConversionLogString) ?
           "\nWelcome to the report! \n\nObjects you send or receive will appear here to help you understand how your document has changed." :
           Progress.Report.ConversionLogString;
 
         string reportInfo = $"\nOperation: {(PreviewOn ? "Preview " : "")}{(IsReceiver ? "Received at " : "Sent at ")}{DateTime.Now.ToLocalTime().ToString("dd/MM/yy HH:mm:ss")}";
         reportInfo += $"\nTotal: {Report.Count} objects";
-        reportInfo += Progress.Report.OperationErrors.Any() ? $"\n\nErrors: \n{Progress.Report.OperationErrorsString}":"";
+        reportInfo += Progress.Report.OperationErrors.Any() ? $"\n\nErrors: \n{Progress.Report.OperationErrorsString}" : "";
 
         return Report.Any() || Progress.Report.OperationErrors.Any() ? reportInfo : defaultMessage;
       }
@@ -477,8 +477,6 @@ namespace DesktopUI2.ViewModels
 
       }
     }
-
-    IScreen IRoutableViewModel.HostScreen => throw new NotImplementedException();
 
     public void UpdateVisualParentAndInit(IScreen hostScreen)
     {


### PR DESCRIPTION
**Description:**
Fixes 2 (unlogged) issues in DUI that were affecting the Rhino connector:
1. When the Speckle panel was closed and reopened and the user would click on a Stream, an exception was thrown about a visual parent being reused in Avalonia. This would also crash Rhino.
2. When copy-pasting across different Rhino documents (AND under some other unclear circumstances), the stream edit navigation would break. Nothing was happening when clicking on streams.

**Solution:**
1. A new view model is now generated each time the panel is initiated, instead of reusing one stored in the `SpeckleRhinoConnectorPlugin` class
   - note: now, if closing the panel and re-opening it, saved streams in DUI that have not been baked in the file will be lost, but this is probably a very rare use case
3. There was a duplicated `HostScreen` property in the `StreamViewModel` class! Deleting it seems to have solved the problem.

**Release:**
I've set to merge this in 2.9, but if required, we could cherry-pick the changes and backport them to 2.8 as well, I'll let @clairekuang decide 😊

