### PR TITLE
GH: Fixes `ShallowCopy` issue with `displayValue` only containing 1 item

### DIFF
--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -215,7 +215,11 @@ namespace Speckle.Core.Models
       myDuplicate.id = id;
       myDuplicate.applicationId = applicationId;
 
-      foreach (var kvp in GetMembers(true,false))
+      foreach (var kvp in GetMembers(
+                 DynamicBaseMemberType.Instance 
+                 | DynamicBaseMemberType.Dynamic 
+                 | DynamicBaseMemberType.SchemaIgnored)
+               )
       {
         var p = GetType().GetProperty(kvp.Key);
         if (p != null && !p.CanWrite)

--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -215,9 +215,9 @@ namespace Speckle.Core.Models
       myDuplicate.id = id;
       myDuplicate.applicationId = applicationId;
 
-      foreach (var prop in GetDynamicMemberNames())
+      foreach (var kvp in GetMembers(true,false))
       {
-        var p = GetType().GetProperty(prop);
+        var p = GetType().GetProperty(kvp.Key);
         if (p != null && !p.CanWrite)
         {
           continue;
@@ -225,7 +225,7 @@ namespace Speckle.Core.Models
 
         try
         {
-          myDuplicate[prop] = this[prop];
+          myDuplicate[kvp.Key] = kvp.Value;
         }
         catch
         {

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -253,30 +253,6 @@ namespace Speckle.Core.Models
   }
 
   /// <summary>
-  /// Represents all different types of members that can be returned by <see cref="DynamicBase.GetMembers"/>
-  /// </summary>
-  [Flags]
-  public enum DynamicBaseMemberType
-  {
-    /// <summary>
-    /// The typed members of the DynamicBase object
-    /// </summary>
-    Instance = 1,
-    /// <summary>
-    /// The dynamically added members of the DynamicBase object
-    /// </summary>
-    Dynamic = 2,
-    /// <summary>
-    /// The typed members flagged with <see cref="ObsoleteAttribute"/> attribute.
-    /// </summary>
-    Obsolete = 4,
-    /// <summary>
-    /// The typed members flagged with <see cref="SchemaIgnored"/> attribute.
-    /// </summary>
-    SchemaIgnored = 8,
-  }
-  
-  /// <summary>
   /// This attribute is used internally to hide the this[key]{get; set;} property from inner reflection on members.
   /// For more info see this discussion: https://speckle.community/t/why-do-i-keep-forgetting-base-objects-cant-use-item-as-a-dynamic-member/3246/5
   /// </summary>

--- a/Core/Core/Models/DynamicBaseMemberType.cs
+++ b/Core/Core/Models/DynamicBaseMemberType.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Speckle.Core.Models
+{
+  /// <summary>
+  /// Represents all different types of members that can be returned by <see cref="DynamicBase.GetMembers"/>
+  /// </summary>
+  [Flags]
+  public enum DynamicBaseMemberType
+  {
+    /// <summary>
+    /// The typed members of the DynamicBase object
+    /// </summary>
+    Instance = 1,
+    /// <summary>
+    /// The dynamically added members of the DynamicBase object
+    /// </summary>
+    Dynamic = 2,
+    /// <summary>
+    /// The typed members flagged with <see cref="ObsoleteAttribute"/> attribute.
+    /// </summary>
+    Obsolete = 4,
+    /// <summary>
+    /// The typed members flagged with <see cref="SchemaIgnored"/> attribute.
+    /// </summary>
+    SchemaIgnored = 8,
+  }
+}

--- a/Core/Examples/ExampleApp.csproj
+++ b/Core/Examples/ExampleApp.csproj
@@ -5,7 +5,9 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests\TestsUnit.csproj" />
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/Core/IntegrationTests/TestsIntegration.csproj
+++ b/Core/IntegrationTests/TestsIntegration.csproj
@@ -5,7 +5,9 @@
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -102,7 +102,7 @@ namespace Tests
       @base["dynamicProp"] = 123;
       var names = @base.GetMemberNames();
       Assert.That(names, Has.No.Member("IgnoredSchemaProp"));
-      Assert.That(names, Has.No.Member("DeprecatedSchemaProp"));
+      Assert.That(names, Has.No.Member("ObsoleteSchemaProp"));
       Assert.That(names, Has.Member("dynamicProp"));
       Assert.That(names, Has.Member("attachedProp"));
     }
@@ -115,10 +115,54 @@ namespace Tests
 
       var names = @base.GetMembers().Keys;
       Assert.That(names, Has.No.Member("IgnoredSchemaProp"));
-      Assert.That(names, Has.No.Member("DeprecatedSchemaProp"));
+      Assert.That(names, Has.No.Member("ObsoleteSchemaProp"));
       Assert.That(names, Has.Member("dynamicProp"));
       Assert.That(names, Has.Member("attachedProp"));
     }
+    
+    [Test(Description = "Checks that only instance properties are returned, excluding obsolete and ignored.")]
+    public void CanGetMembers_OnlyInstance()
+    {
+      var @base = new SampleObject();
+      @base["dynamicProp"] = 123;
+
+      var names = @base.GetMembers(DynamicBaseMemberType.Instance).Keys;
+      Assert.That(names, Has.Member("attachedProp"));
+    }
+    
+    [Test(Description = "Checks that only dynamic properties are returned")]
+    public void CanGetMembers_OnlyDynamic()
+    {
+      var @base = new SampleObject();
+      @base["dynamicProp"] = 123;
+
+      var names = @base.GetMembers(DynamicBaseMemberType.Dynamic).Keys;
+      Assert.That(names, Has.Member("dynamicProp"));
+      Assert.That(names.Count, Is.EqualTo(1));
+    }
+    
+    [Test(Description = "Checks that all typed properties (including ignored ones) are returned")]
+    public void CanGetMembers_OnlyInstance_IncludeIgnored()
+    {
+      var @base = new SampleObject();
+      @base["dynamicProp"] = 123;
+
+      var names = @base.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.SchemaIgnored).Keys;
+      Assert.That(names, Has.Member("IgnoredSchemaProp"));
+      Assert.That(names, Has.Member("attachedProp"));
+    }
+        
+    [Test(Description = "Checks that all typed properties (including obsolete ones) are returned")]
+    public void CanGetMembers_OnlyInstance_IncludeObsolete()
+    {
+      var @base = new SampleObject();
+      @base["dynamicProp"] = 123;
+
+      var names = @base.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.Obsolete).Keys;
+      Assert.That(names, Has.Member("ObsoleteSchemaProp"));
+      Assert.That(names, Has.Member("attachedProp"));
+    }
+    
     
     [Test]
     public void CanGetDynamicMembers()

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -99,25 +99,27 @@ namespace Tests
     public void CanGetMemberNames()
     {
       var @base = new SampleObject();
-      @base["dynamicProp"] = 123;
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = 123;
       var names = @base.GetMemberNames();
-      Assert.That(names, Has.No.Member("IgnoredSchemaProp"));
-      Assert.That(names, Has.No.Member("ObsoleteSchemaProp"));
-      Assert.That(names, Has.Member("dynamicProp"));
-      Assert.That(names, Has.Member("attachedProp"));
+      Assert.That(names, Has.No.Member(nameof(@base.IgnoredSchemaProp)));
+      Assert.That(names, Has.No.Member(nameof(@base.ObsoleteSchemaProp)));
+      Assert.That(names, Has.Member(dynamicProp));
+      Assert.That(names, Has.Member(nameof(@base.attachedProp)));
     }
 
     [Test(Description = "Checks that no ignored or obsolete properties are returned")]
     public void CanGetMembers()
     {
       var @base = new SampleObject();
-      @base["dynamicProp"] = 123;
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = 123;
 
       var names = @base.GetMembers().Keys;
-      Assert.That(names, Has.No.Member("IgnoredSchemaProp"));
-      Assert.That(names, Has.No.Member("ObsoleteSchemaProp"));
-      Assert.That(names, Has.Member("dynamicProp"));
-      Assert.That(names, Has.Member("attachedProp"));
+      Assert.That(names, Has.No.Member(nameof(@base.IgnoredSchemaProp)));
+      Assert.That(names, Has.No.Member(nameof(@base.ObsoleteSchemaProp)));
+      Assert.That(names, Has.Member(dynamicProp));
+      Assert.That(names, Has.Member(nameof(@base.attachedProp)));
     }
     
     [Test(Description = "Checks that only instance properties are returned, excluding obsolete and ignored.")]
@@ -127,17 +129,18 @@ namespace Tests
       @base["dynamicProp"] = 123;
 
       var names = @base.GetMembers(DynamicBaseMemberType.Instance).Keys;
-      Assert.That(names, Has.Member("attachedProp"));
+      Assert.That(names, Has.Member(nameof(@base.attachedProp)));
     }
     
     [Test(Description = "Checks that only dynamic properties are returned")]
     public void CanGetMembers_OnlyDynamic()
     {
       var @base = new SampleObject();
-      @base["dynamicProp"] = 123;
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = 123;
 
       var names = @base.GetMembers(DynamicBaseMemberType.Dynamic).Keys;
-      Assert.That(names, Has.Member("dynamicProp"));
+      Assert.That(names, Has.Member(dynamicProp));
       Assert.That(names.Count, Is.EqualTo(1));
     }
     
@@ -148,8 +151,8 @@ namespace Tests
       @base["dynamicProp"] = 123;
 
       var names = @base.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.SchemaIgnored).Keys;
-      Assert.That(names, Has.Member("IgnoredSchemaProp"));
-      Assert.That(names, Has.Member("attachedProp"));
+      Assert.That(names, Has.Member(nameof(@base.IgnoredSchemaProp)));
+      Assert.That(names, Has.Member(nameof(@base.attachedProp)));
     }
         
     [Test(Description = "Checks that all typed properties (including obsolete ones) are returned")]
@@ -159,8 +162,8 @@ namespace Tests
       @base["dynamicProp"] = 123;
 
       var names = @base.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.Obsolete).Keys;
-      Assert.That(names, Has.Member("ObsoleteSchemaProp"));
-      Assert.That(names, Has.Member("attachedProp"));
+      Assert.That(names, Has.Member(nameof(@base.ObsoleteSchemaProp)));
+      Assert.That(names, Has.Member(nameof(@base.attachedProp)));
     }
     
     
@@ -168,11 +171,12 @@ namespace Tests
     public void CanGetDynamicMembers()
     {
       var @base = new SampleObject();
-      @base["dynamicProp"] = null;
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = null;
 
       var names = @base.GetDynamicMemberNames();
-      Assert.That(names, Has.Member("dynamicProp"));
-      Assert.Null(@base["dynamicProp"]);
+      Assert.That(names, Has.Member(dynamicProp));
+      Assert.Null(@base[dynamicProp]);
     }
 
     [Test]

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -198,7 +198,25 @@ namespace Tests
       @base[key] = null;
       Assert.IsNull(@base[key]);
     }
-    
+
+    [Test]
+    public void CanShallowCopy()
+    {
+      var sample = new SampleObject();
+      var copy = sample.ShallowCopy();
+
+      var selectedMembers = DynamicBaseMemberType.Dynamic
+                            | DynamicBaseMemberType.Instance
+                            | DynamicBaseMemberType.SchemaIgnored;
+      var sampleMembers = sample.GetMembers(selectedMembers);
+      var copyMembers = copy.GetMembers(selectedMembers);
+
+      foreach (var kvp in copyMembers)
+      {
+        Assert.Contains(kvp.Key,sampleMembers.Keys);
+        Assert.That(kvp.Value, Is.EqualTo(sample[kvp.Key]));
+      }
+    }
     
     public class SampleObject : Base
     {

--- a/Core/Tests/TestsUnit.csproj
+++ b/Core/Tests/TestsUnit.csproj
@@ -5,6 +5,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Objects/Tests/Utils/ShallowCopyTests.cs
+++ b/Objects/Tests/Utils/ShallowCopyTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Objects.BuiltElements;
+using Objects.Geometry;
+using Speckle.Core.Kits;
+
+namespace Tests.Utils
+{
+  [TestFixture]
+  public class ShallowCopyTests
+  {
+    [Test]
+    public void CanShallowCopy_Wall()
+    {
+      var wall = new Wall(
+        5, 
+        new Line(
+          new Point(0, 0), 
+          new Point(3, 0)
+          )
+        )
+      {
+        units = Units.Meters,
+        displayValue = new List<Mesh>
+        {
+          new Mesh(),
+          new Mesh()
+        }
+      };
+
+      var shallow = wall.ShallowCopy();
+
+      Assert.AreEqual(wall.displayValue.Count, ((IList)shallow["displayValue"]).Count);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #

When`Base.ShallowCopy` was called, it will use `GetMembers`, which was not coded to exclude Obsolete properties, which would cause:

- `displayValue` to be set, but also
- `displayMesh` to be set, which will override the `displayValue` list

To fix this, we had to change the signature of `GetMembers` in a non-breaking way. It now accepts a set of `Flags` that allow you to control which members are included in the output. By default, it works as it used to.

Updated tests to check for these new cases inside `GetMembers`, and changed all hard coded property name strings to use `nameof()` instead so errors will pop up if properties are renamed. Previous tests were checking for _non-inclusion_ of a property that had been renamed, so they would always pass.