### PR TITLE
Objects: Adds tests to CI job

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -75,7 +75,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
   build-objects:
     docker:
       - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
-      - image: "mcr.microsoft.com/dotnet/sdk:6.0" # dotnet core 6.0 sdk for tests
       - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
     steps:
       - checkout

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -75,6 +75,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
   build-objects:
     docker:
       - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
+      - image: "mcr.microsoft.com/dotnet/core/sdk:6.0" # dotnet core 6.0 sdk for tests
       - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
     steps:
       - checkout

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -91,7 +91,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           path: TestResults
       - store_artifacts:
           path: TestResults
-      - codecov/upload
+      # Upload to codecov if necessary
+      # Currently disabled until we figure out a strategy to
+      # upload Core and Objects at once
+      # - codecov/upload
 
   build-desktopui:
     executor: # Using a win executor since there are post-steps in the nuget workflow that use powershell

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -75,7 +75,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
   build-objects:
     docker:
       - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
-      - image: "mcr.microsoft.com/dotnet/core/sdk:6.0" # dotnet core 6.0 sdk for tests
+      - image: "mcr.microsoft.com/dotnet/sdk:6.0" # dotnet core 6.0 sdk for tests
       - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
     steps:
       - checkout

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -74,7 +74,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 
   build-objects:
     docker:
-      - image: "mcr.microsoft.com/dotnet/core/sdk:5.0" # dotnet core 3.1 sdk
+      - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
       - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
     steps:
       - checkout

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -73,9 +73,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - codecov/upload
 
   build-objects:
-    executor:
-      name: win/default
-      shell: powershell.exe
+    docker:
+      - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
+      - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
     steps:
       - checkout
       - run:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -84,6 +84,14 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build Objects
           command: msbuild Objects/Objects.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false
+      - run:
+          name: Test Objects
+          command: dotnet test Objects/Tests/Tests.csproj -c Release -v q --logger:"junit;LogFileName={assembly}.results.xml" --results-directory=TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+      - store_test_results:
+          path: TestResults
+      - store_artifacts:
+          path: TestResults
+      - codecov/upload
 
   build-desktopui:
     executor: # Using a win executor since there are post-steps in the nuget workflow that use powershell

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -80,13 +80,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - checkout
       - run:
           name: Restore Objects
-          command: nuget restore Objects/Objects.sln
+          command: dotnet restore Objects/Objects.sln
       - run:
           name: Build Objects
-          command: msbuild Objects/Objects.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false
+          command: dotnet build --no-restore Objects/Objects.sln -c Release /p:WarningLevel=0 /p:IsDesktopBuild=false
       - run:
           name: Test Objects
-          command: dotnet test Objects/Tests/Tests.csproj -c Release -v q --logger:"junit;LogFileName={assembly}.results.xml" --results-directory=TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+          command: dotnet test Objects/Tests/Tests.csproj --no-restore -c Release -v q --logger:"junit;LogFileName={assembly}.results.xml" --results-directory=TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       - store_test_results:
           path: TestResults
       - store_artifacts:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -74,7 +74,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 
   build-objects:
     docker:
-      - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
+      - image: "mcr.microsoft.com/dotnet/core/sdk:5.0" # dotnet core 3.1 sdk
       - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
     steps:
       - checkout
@@ -83,7 +83,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: dotnet restore Objects/Objects.sln
       - run:
           name: Build Objects
-          command: dotnet build --no-restore Objects/Objects.sln -c Release /p:WarningLevel=0 /p:IsDesktopBuild=false
+          command: dotnet build --no-restore Objects/Objects/Objects.csproj -c Release /p:WarningLevel=0 /p:IsDesktopBuild=false
       - run:
           name: Test Objects
           command: dotnet test Objects/Tests/Tests.csproj --no-restore -c Release -v q --logger:"junit;LogFileName={assembly}.results.xml" --results-directory=TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover

--- a/Objects/Tests/GenericTests.cs
+++ b/Objects/Tests/GenericTests.cs
@@ -1,9 +1,14 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
+using Objects;
+using Objects.Geometry;
 using Speckle.Core.Kits;
+using Speckle.Core.Models;
 
 namespace Tests
 {
@@ -12,7 +17,10 @@ namespace Tests
   {
     public static IEnumerable AvailableTypesInKit()
     {
-      return KitManager.GetDefaultKit().Types;
+      // Get all types in the Objects assembly that inherit from Base
+      return Assembly.GetAssembly(typeof(ObjectsKit))
+        .GetTypes()
+        .Where(t => typeof(Base).IsAssignableFrom(t));
     }
     
     [Test(Description = "Checks that all objects inside the Default Kit have empty constructors.")]

--- a/Objects/Tests/GenericTests.cs
+++ b/Objects/Tests/GenericTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Speckle.Core.Kits;
+
+namespace Tests
+{
+  [TestFixture]
+  public class GenericTests
+  {
+    public static IEnumerable AvailableTypesInKit()
+    {
+      return KitManager.GetDefaultKit().Types;
+    }
+    
+    [Test(Description = "Checks that all objects inside the Default Kit have empty constructors.")]
+    [TestCaseSource(nameof(AvailableTypesInKit))]
+    public void ObjectHasEmptyConstructor(Type t)
+    {
+      var constructor = t.GetConstructor(Type.EmptyTypes);
+      Assert.That(constructor, Is.Not.Null);
+    }
+  }
+}

--- a/Objects/Tests/Tests.csproj
+++ b/Objects/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Objects/Tests/Tests.csproj
+++ b/Objects/Tests/Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Objects/Tests/Tests.csproj
+++ b/Objects/Tests/Tests.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="NUnit" Version="3.13.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
         <PackageReference Include="coverlet.collector" Version="3.0.2" />
+        <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Adds a step in `build-objects` to run the Objects unit tests (currently quite lacking).

Adds unit test to ensure **all objects in `ObjectsKit`** have an empty constructor implemented.


In order to not duplicate builds, `build-objects` will now only build:

- `Objects.csproj`
- `Tests.csproj`

All other projects correspond to `Converters` that are already being built on each of their respective `Connector` builds.

This also allowed to change the VM from windows to linux, which has less minute cost.
