### PR TITLE
fix(rhino): disable Speckle when using Rhino.Inside.Revit, attempt #2

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -7,6 +7,7 @@ using DesktopUI2;
 using DesktopUI2.ViewModels;
 using Rhino;
 using Rhino.PlugIns;
+using Rhino.Runtime;
 using Speckle.Core.Api;
 
 namespace SpeckleRhino
@@ -96,11 +97,16 @@ namespace SpeckleRhino
     /// </summary>
     protected override LoadReturnCode OnLoad(ref string errorMessage)
     {
-      // The user is probably using Rhino Inside and Avalonia was already initialized there
-      if (App.Current != null)
+      string processName = "";
+      System.Version processVersion = null;
+      HostUtils.GetCurrentProcessInfo(out processName, out processVersion);
+
+      // The user is probably using Rhino Inside and Avalonia was already initialized there  or will be initialized later and will throw an error
+      // https://speckle.community/t/revit-command-failure-for-external-command/3489/27
+      if (!processName.Equals("rhino", StringComparison.InvariantCultureIgnoreCase))
       {
 
-        errorMessage = "Speckle cannot be loaded in multiple application at the same time.";
+        errorMessage = "Speckle does not currently support Rhino.Inside";
         RhinoApp.CommandLineOut.WriteLine(errorMessage);
         return LoadReturnCode.ErrorNoDialog;
       }


### PR DESCRIPTION
Uses [HostUtils.GetCurrentProcessInfo](https://developer.rhino3d.com/api/RhinoCommon/html/M_Rhino_Runtime_HostUtils_GetCurrentProcessInfo.htm) to check if Rhino is running inside something and then it stops loading the Speckle plugin.

This is because it seems Rhino might get loaded before the Revit connector at times?
See: https://speckle.community/t/revit-command-failure-for-external-command/3489/27