### PR TITLE
feat(autocadcivil): interactive reports and update receive mode

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -369,6 +369,17 @@ namespace Speckle.ConnectorAutocadCivil
     }
 #endregion
 
+    public static List<ObjectId> GetObjectsByApplicationId(string appId) //TODO: USE XDATA FOR APPIDS
+    {
+      return new List<ObjectId>();
+    }
+    public static string ObjectDescriptor(DBObject obj)
+    {
+      if (obj == null) return String.Empty;
+      var simpleType = obj.GetType().ToString();
+      return $"{simpleType}";
+    }
+
     /// <summary>
     /// Retrieves the document's units.
     /// </summary>

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -375,8 +375,9 @@ namespace Speckle.ConnectorAutocadCivil
       var foundObjects = new List<ObjectId>();
 
       // first see if this appid is a handle (autocad appid)
-      if (doc.Database.TryGetObjectId(Utils.GetHandle(appId), out ObjectId id))
-        return new List<ObjectId>() { id };
+      if (Utils.GetHandle(appId, out Handle handle))
+        if (doc.Database.TryGetObjectId(handle, out ObjectId id))
+          return new List<ObjectId>() { id };
 
       // Create a TypedValue array to define the filter criteria
       TypedValue[] acTypValAr = new TypedValue[1];
@@ -393,12 +394,12 @@ namespace Speckle.ConnectorAutocadCivil
       foreach (var appIdObj in res.Value.GetObjectIds())
       {
         // get the db object from id
-        var obj = tr.GetObject(id, OpenMode.ForRead);
+        var obj = tr.GetObject(appIdObj, OpenMode.ForRead);
         if (obj != null)
           foreach (var entry in obj.XData)
             if (entry.Value as string == appId)
             {
-              foundObjects.Add(id);
+              foundObjects.Add(appIdObj);
               break;
             }
       }
@@ -444,9 +445,15 @@ namespace Speckle.ConnectorAutocadCivil
     /// </summary>
     /// <param name="str"></param>
     /// <returns></returns>
-    public static Handle GetHandle(string str)
+    public static bool GetHandle(string str, out Handle handle)
     {
-      return new Handle(Convert.ToInt64(str, 16));
+      handle = new Handle();
+      try
+      {
+        handle = new Handle(Convert.ToInt64(str, 16));
+      }
+      catch { return false; }
+      return true;
     }
 
     /// <summary>

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -955,7 +955,7 @@ namespace SpeckleRhino
         progress.Update(conversionProgressDict);
 
         // set application ids, also set for speckle schema base object if it exists
-        converted.applicationId = guid;
+        converted.applicationId = applicationId;
         if (converted["@SpeckleSchema"] != null)
         {
           var newSchemaBase = converted["@SpeckleSchema"] as Base;

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -769,12 +769,10 @@ namespace SpeckleRhino
           attributes.SetUserString(key, userStrings[key] as string);
 
       // set application id
+      var appId = parent != null ? parent.applicationId : obj.applicationId;
       try
       {
-        if (parent != null)
-          attributes.SetUserString(ApplicationIdKey, parent.applicationId);
-        else
-          attributes.SetUserString(ApplicationIdKey, obj.applicationId);
+        attributes.SetUserString(ApplicationIdKey, appId);
       }
       catch { }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -182,8 +182,10 @@ namespace Objects.Converter.AutocadCivil
 
       return _alignment;
     }
-    public CivilDB.Alignment AlignmentToNative(Alignment alignment)
+
+    public CivilDB.Alignment AlignmentToNative(Alignment alignment, out List<string> notes)
     {
+      notes = new List<string>();
       var name = string.IsNullOrEmpty(alignment.name) ? alignment.applicationId : alignment.name; // names need to be unique on creation (but not send i guess??)
       var layer = Doc.Database.LayerZero;
 
@@ -262,7 +264,7 @@ namespace Objects.Converter.AutocadCivil
       }
       catch (Exception e)
       {
-        Report.LogConversionError(e);
+        notes.Add(e.Message);
         return null; 
       }
     }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -84,10 +84,13 @@ namespace Objects.Converter.AutocadCivil
       Trans = Doc.TransactionManager.TopTransaction; // set the stream transaction here! make sure it is the top level transaction
     }
 
+    private string ApplicationIdKey = "applicationId";
+
     public Base ConvertToSpeckle(object @object)
     {
       Base @base = null;
       ApplicationObject reportObj = null;
+      DisplayStyle style = null;
       List<string> notes = new List<string>();
 
       switch (@object)
@@ -99,7 +102,10 @@ namespace Objects.Converter.AutocadCivil
           if (schema != null)
             return ObjectToSpeckleBuiltElement(o);
           */
-          reportObj = new ApplicationObject(obj.Id.ToString(), obj.GetType().ToString());
+          var appId = obj.ObjectId.ToString(); // TODO: UPDATE THIS WITH STORED APP ID IF IT EXISTS
+          reportObj = new ApplicationObject(obj.Id.ToString(), obj.GetType().ToString()) { applicationId = appId };
+          style = DisplayStyleToSpeckle(obj as Entity);
+          
           switch (obj)
           {
             case DBPoint o:
@@ -198,43 +204,42 @@ namespace Objects.Converter.AutocadCivil
               break;
 #endif
           }
-
-          DisplayStyle style = DisplayStyleToSpeckle(obj as Entity);
-          if (style != null)
-            @base["displayStyle"] = style;
           break;
-
         case Acad.Geometry.Point3d o:
           @base = PointToSpeckle(o);
           break;
-
         case Acad.Geometry.Vector3d o:
           @base = VectorToSpeckle(o);
           break;
-
         case Acad.Geometry.Line3d o:
           @base = LineToSpeckle(o);
           break;
-
         case Acad.Geometry.LineSegment3d o:
           @base = LineToSpeckle(o);
           break;
-
         case Acad.Geometry.CircularArc3d o:
           @base = ArcToSpeckle(o);
           break;
-
         case Acad.Geometry.Plane o:
           @base = PlaneToSpeckle(o);
           break;
-
         case Acad.Geometry.Curve3d o:
           @base = CurveToSpeckle(o) as Base;
           break;
-
         default:
-          throw new NotSupportedException();
+          if (reportObj != null)
+          {
+            reportObj.Update(status: ApplicationObject.State.Skipped, logItem: $"{@object.GetType()} type not supported");
+            Report.UpdateReportObject(reportObj);
+          }
+          return @base;
       }
+
+      if (@base is null) return @base;
+
+      if (style != null)
+        @base["displayStyle"] = style;
+
       if (reportObj != null)
       {
         reportObj.Update(log: notes);
@@ -331,7 +336,6 @@ namespace Objects.Converter.AutocadCivil
 
         case Text o:
           acadObj = isFromAutoCAD ? AcadTextToNative(o) : TextToNative(o);
-          Report.Log($"Created Text {o.id}");
           break;
 
         case Alignment o:
@@ -461,6 +465,5 @@ namespace Objects.Converter.AutocadCivil
           return false;
       }
     }
-
   }
 }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -340,7 +340,7 @@ namespace Objects.Converter.AutocadCivil
 
         case Alignment o:
 #if CIVIL2021 || CIVIL2022 || CIVIL2023
-          acadObj = AlignmentToNative(o);
+          acadObj = AlignmentToNative(o, out notes);
 #endif
           acadObj = PolylineToNativeDB(o.displayValue);
           break;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -386,9 +386,20 @@ namespace Objects.Converter.RhinoGh
       Guid instanceId = Doc.Objects.AddInstanceObject(definition.Index, transform);
 
       if (instanceId == Guid.Empty)
+      {
+        notes.Add("Could not add instance to doc");
         return null;
+      }
 
-      return Doc.Objects.FindId(instanceId) as InstanceObject;
+      var _instance = Doc.Objects.FindId(instanceId) as InstanceObject;
+      // add application id
+      try
+      {
+        _instance.Attributes.SetUserString(ApplicationIdKey, instance.applicationId)
+      }
+      catch { }
+
+      return _instance;
     }
 
     public DisplayMaterial RenderMaterialToDisplayMaterial(RenderMaterial material)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -395,7 +395,7 @@ namespace Objects.Converter.RhinoGh
       // add application id
       try
       {
-        _instance.Attributes.SetUserString(ApplicationIdKey, instance.applicationId)
+        _instance.Attributes.SetUserString(ApplicationIdKey, instance.applicationId);
       }
       catch { }
 


### PR DESCRIPTION
## Description & motivation

Adds two main features to the autocad and civil3d connectors: 
- Interactive reports for send and receive, aligning the autocad civil conenctors with functionality in rhino and revit
- Update receive mode that uses application ids of incoming objects to replace existing document objects if they share the same app id

Related to: https://speckle.community/t/speckle-should-be-able-to-update-existing-objects-in-the-dwg-file/3424/2
Part of: #1530

## Changes:

- Autocad Civil3d connector: adds implementation for `SelectClientObjs` binding as a prerequisite for interactive reports 

## Screenshots:

![ezgif com-gif-maker (32)](https://user-images.githubusercontent.com/16748799/192256414-32289480-d018-4b25-8473-fb38970f6b49.gif)

## Validation of changes:

manually tested sending/receiving in Autocad <> Autocad and Revit > Autocad

