### PR TITLE
Fix(Revit): Structural objects not updating (creating duplicates)

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
@@ -28,6 +28,7 @@ namespace Objects.Converter.Revit
           //This only works for CSIC sections now for sure. Need to test on other sections
           revitBeam.type = speckleStick.property.name.Replace('X', 'x');
           revitBeam.baseLine = speckleStick.baseLine;
+          revitBeam.applicationId = speckleStick.applicationId;
           appObj = BeamToNative(revitBeam);
           DB.FamilyInstance nativeRevitBeam = (DB.FamilyInstance)appObj.Converted.FirstOrDefault();
           SetAnalyticalPros(nativeRevitBeam, speckleStick, offset1, offset2);
@@ -37,6 +38,7 @@ namespace Objects.Converter.Revit
           RevitBrace revitBrace = new RevitBrace();
           revitBrace.type = speckleStick.property.name.Replace('X', 'x');
           revitBrace.baseLine = speckleStick.baseLine;
+          revitBrace.applicationId = speckleStick.applicationId;
           appObj = BraceToNative(revitBrace);
           DB.FamilyInstance nativeRevitBrace = (DB.FamilyInstance)appObj.Converted.FirstOrDefault();
           SetAnalyticalPros(nativeRevitBrace, speckleStick, offset1, offset2);
@@ -46,6 +48,7 @@ namespace Objects.Converter.Revit
           revitColumn.type = speckleStick.property.name.Replace('X', 'x');
           revitColumn.baseLine = speckleStick.baseLine;
           revitColumn.units = speckleStick.units;
+          revitColumn.applicationId = speckleStick.applicationId;
           appObj = ColumnToNative(revitColumn);
           DB.FamilyInstance nativeRevitColumn = (DB.FamilyInstance)appObj.Converted.FirstOrDefault();
           SetAnalyticalPros(nativeRevitColumn, speckleStick, offset1, offset2);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBrace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBrace.cs
@@ -42,6 +42,7 @@ namespace Objects.Converter.Revit
 
       var myBrace = new RevitBrace()
       {
+        applicationId = myBeam.applicationId,
         type = myBeam.type,
         baseLine = myBeam.baseLine,
         level = myBeam.level,


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

AnalyticalStick and Brace elements are currently creating duplicate elements on receive when the receive mode is set to update.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- assign applicationId to analytical stick elements in AnalyticalStickToNative

<!---

- Item 1
- Item 2

-->

## Validation of changes:

- manual tests sending and receiving structural object commits and braces.
- duplicates are no longer created for Element1D elements when the receive mode is set to update.

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
