### PR TITLE
feat(Dyn): Send/Receive tolerate conversion errors and reports them as node warnings

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -299,7 +299,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
           }
           else
           {
-            Message = "";
+            Message = "Conversion error";
             _errors.Add(e);
           }
         }
@@ -311,7 +311,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
         {
           LastCommitId = ((Commit)data["commit"]).id;
           InMemoryCache.Set(LastCommitId, data);
-          //Message = "";
+          Message = "";
         }
       }
       catch (Exception e)
@@ -344,9 +344,13 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
     internal void LoadInputs(EngineController engine)
     {
       // Report any errors of the receive operation upon input load. This ensures they're not erased.
-      foreach (var error in _errors)
-        Warning(error.ToFormattedString());
-      _errors = new List<Exception>();
+      if (_errors.Count > 0)
+      {
+        foreach (var error in _errors)
+          Warning(error.ToFormattedString());
+        Message = "Conversion error";
+        _errors = new List<Exception>();
+      }
       
       // Load inputs
       var oldStream = Stream;

--- a/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
+++ b/ConnectorDynamo/ConnectorDynamo/SendNode/Send.cs
@@ -14,6 +14,7 @@ using Speckle.ConnectorDynamo.Functions;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 
 namespace Speckle.ConnectorDynamo.SendNode
@@ -239,6 +240,9 @@ namespace Speckle.ConnectorDynamo.SendNode
         long totalCount = 0;
         Base @base = null;
         var converter = new BatchConverter();
+        var errors = new List<Exception>();
+        converter.OnError += (sender, args) => errors.Add(args.Error);
+        
         try
         {
           @base = converter.ConvertRecursivelyToSpeckle(_data);
@@ -251,6 +255,13 @@ namespace Speckle.ConnectorDynamo.SendNode
           throw new SpeckleException("Conversion error", e);
         }
 
+        if (errors.Count > 0)
+        {
+          Message = "Conversion errors";
+          foreach (var error in errors)
+            Warning(error.ToFormattedString());
+        }
+        
         if (totalCount == 0)
           throw new SpeckleException("Zero objects converted successfully. Send stopped.");
 

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -199,15 +199,17 @@ namespace Speckle.ConnectorDynamo.Functions
       // case 2: it's a wrapper Base
       //       2a: if there's only one member unpack it
       //       2b: otherwise return dictionary of unpacked members
-      var members = @base.GetMemberNames();
+      var members = @base.GetMemberNames().ToList();
 
-      if (members.Count() == 1)
+      if (members.Count == 1)
       {
         var converted = RecurseTreeToNative(@base[members.ElementAt(0)]);
         return converted;
       }
 
-      return members.ToDictionary(x => x, x => RecurseTreeToNative(@base[x]));
+      var regex = new Regex("::");
+      var dict =  members.ToDictionary(x => regex.Replace(x, "//"), x => RecurseTreeToNative(@base[x]));
+      return dict;
     }
 
 

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -122,7 +122,9 @@ namespace Speckle.ConnectorDynamo.Functions
         }
         catch (Exception ex)
         {
-          throw new SpeckleException("Could not convert " + value.GetType() + " to Speckle:" + ex.Message, ex);
+          var spcklEx = new SpeckleException("Could not convert " + value.GetType() + " to Speckle:", ex, false);
+          OnError?.Invoke(this, new OnErrorEventArgs(spcklEx));
+          return null;
         }
       }
 

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Developer/Conversion.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Developer/Conversion.cs
@@ -16,6 +16,7 @@ namespace Speckle.ConnectorDynamo.Functions.Developer
     {
       Analytics.TrackEvent(Analytics.Events.NodeRun, new Dictionary<string, object>() { { "name", "Convert To Speckle" } });
       var converter = new BatchConverter();
+      converter.OnError += (sender, args) => throw args.Error;
       return converter.ConvertRecursivelyToSpeckle(data);
     }
 
@@ -28,6 +29,7 @@ namespace Speckle.ConnectorDynamo.Functions.Developer
     {
       Analytics.TrackEvent(Analytics.Events.NodeRun, new Dictionary<string, object>() { { "name", "Convert To Native" } });
       var converter = new BatchConverter();
+      converter.OnError += (sender, args) => throw args.Error;
       return converter.ConvertRecursivelyToNative(@base);
     }
   }

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Developer/Local.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Developer/Local.cs
@@ -18,6 +18,8 @@ namespace Speckle.ConnectorDynamo.Functions.Developer
       Analytics.TrackEvent(Analytics.Events.NodeRun, new Dictionary<string, object>() { { "name", "Send Local" } });
 
       var converter = new BatchConverter();
+      converter.OnError += (sender, args) => throw args.Error;
+      
       var @base = converter.ConvertRecursivelyToSpeckle(data);
       var objectId = Task.Run(async () => await Operations.Send(@base, disposeTransports: true)).Result;
 
@@ -36,6 +38,9 @@ namespace Speckle.ConnectorDynamo.Functions.Developer
 
       var @base = Task.Run(async () => await Operations.Receive(localDataId, disposeTransports: true)).Result;
       var converter = new BatchConverter();
+      // If a conversion error occurs, throw error.
+      converter.OnError += (sender, args) => throw args.Error;
+      
       var data = converter.ConvertRecursivelyToNative(@base);
       return data;
     }

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -182,10 +182,8 @@ namespace Speckle.ConnectorDynamo.Functions
         return null;
 
       var converter = new BatchConverter();
-      converter.OnError += (sender, args) =>
-      {
-        onErrorAction?.Invoke("C", args.Error);
-      };
+      converter.OnError += (sender, args) => onErrorAction?.Invoke("C", args.Error);
+      
       var data = converter.ConvertRecursivelyToNative(@base);
 
       Analytics.TrackEvent(client.Account, Analytics.Events.Receive);

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -182,6 +182,10 @@ namespace Speckle.ConnectorDynamo.Functions
         return null;
 
       var converter = new BatchConverter();
+      converter.OnError += (sender, args) =>
+      {
+        onErrorAction?.Invoke("C", args.Error);
+      };
       var data = converter.ConvertRecursivelyToNative(@base);
 
       Analytics.TrackEvent(client.Account, Analytics.Events.Receive);

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -273,7 +273,7 @@ namespace Speckle.Core.Credentials
     private async Task ValidateWithAccount(Account acc)
     {
       if (ServerUrl != acc.serverInfo.url)
-        throw new SpeckleException($"Account is not from server {ServerUrl}");
+        throw new SpeckleException($"Account is not from server {ServerUrl}", false);
       
       var client = new Client(acc);
       // First check if the stream exists
@@ -284,13 +284,13 @@ namespace Speckle.Core.Credentials
       catch
       {
         throw new SpeckleException(
-          $"You don't have access to stream {StreamId} on server {ServerUrl}, or the stream does not exist.");
+          $"You don't have access to stream {StreamId} on server {ServerUrl}, or the stream does not exist.", false);
       }
 
       // Check if the branch exists
       if (Type == StreamWrapperType.Branch && await client.BranchGet(StreamId, BranchName, 1) == null)
         throw new SpeckleException(
-          $"The branch with name '{BranchName}' doesn't exist in stream {StreamId} on server {ServerUrl}");
+          $"The branch with name '{BranchName}' doesn't exist in stream {StreamId} on server {ServerUrl}", false);
     }
 
     public override string ToString()

--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -87,7 +87,17 @@ namespace Speckle.Core.Models
       {
         var detachAttribute = prop.GetCustomAttribute<DetachProperty>(true);
         var chunkAttribute = prop.GetCustomAttribute<Chunkable>(true);
-
+        var obsoleteAttr = prop.GetCustomAttribute<ObsoleteAttribute>(true);
+        var jsonIgnoredAttr = prop.GetCustomAttribute<JsonIgnoreAttribute>(true);
+        
+        if (obsoleteAttr != null || jsonIgnoredAttr != null)
+        {
+          // Skip properties from the count that are:
+          // - Obsolete
+          // - Ignored by the serializer
+          continue;
+        }
+        
         object value = prop.GetValue(@base);
 
         if (detachAttribute != null && detachAttribute.Detachable && chunkAttribute == null)

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -134,7 +134,7 @@ namespace Speckle.Core.Models
         }
         catch (Exception ex)
         {
-          throw new SpeckleException(ex.Message, ex);
+          throw new SpeckleException($"Failed to set value for {GetType().Name}.{prop.Name}", ex);
         }
       }
     }

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -761,9 +761,12 @@ namespace Objects.Converter.Dynamo
 
     public DS.Mesh MeshToNative(Mesh mesh)
     {
+      // Triangulate the mesh's NGons, since they're not supported in Dynamo
+      mesh.TriangulateMesh(true);
+      
       var points = ArrayToPointList(mesh.vertices, mesh.units);
-      List<IndexGroup> faces = new List<IndexGroup>();
-      int i = 0;
+      var faces = new List<IndexGroup>();
+      var i = 0;
       var faceIndices = new List<int>(mesh.faces);
       while (i < faceIndices.Count)
       {
@@ -784,11 +787,9 @@ namespace Objects.Converter.Dynamo
         }
         else
         {
-          // Ngon!
-          var triangleFaces = MeshTriangulationHelper.TriangulateFace(i, mesh);
-          faceIndices.AddRange(triangleFaces);
+          var fcount = faceIndices[i];
+          i += fcount + 1;
         }
-
       }
 
       var dsMesh = DS.Mesh.ByPointsFaceIndices(points, faces);


### PR DESCRIPTION
Closes #1387

- [x] Adds a new `OnError` event to `BatchConverter` to report conversion errors while continuing with the conversion of other objects. The conversion will return `null`
- [x] Hook's up the new `BatchConverter` event to the `Receive` function.
- [x] Adds events to every place where `BatchConverter` is used. This includes:
    - Conversion nodes
    - Local transport nodes
    - Send nodee
    - Receive node
- [x] Improve error messages to include ID of the object that failed.
- [x] TEST, TEST, TEST!

<img width="273" alt="Screenshot 2022-09-28 at 08 23 22" src="https://user-images.githubusercontent.com/2316535/192703421-cdce960f-8c55-4f8f-b78a-48852aa47e65.png">

Bonus:

- Modified `MeshToNative` to use `TriangulateMesh` instead of `TriangulateFace` to remove duplication of code, since N-gons are not supported in Dynamo.