### PR TITLE
feat(civil3d): update alignments on receive

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -376,14 +376,17 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
             // convert base (or base fallback values) and store in appobj converted prop
             if (commitObj.Convertible)
+            {
+              converter.Report.Log(commitObj); // Log object so converter can access
               try
               {
                 commitObj.Converted = ConvertObject(commitObj, converter);
               }
-              catch(Exception e)
+              catch (Exception e)
               {
                 commitObj.Log.Add($"Failed conversion: {e.Message}");
               }
+            }
             else
               foreach (var fallback in commitObj.Fallback)
               {
@@ -439,26 +442,11 @@ namespace Speckle.ConnectorAutocadCivil.UI
               return;
 
             // check receive mode & if objects need to be removed from the document after bake (or received objs need to be moved layers)
-            var isUpdate = false;
             var toRemove = new List<ObjectId>();
             switch (state.ReceiveMode)
             {
               case ReceiveMode.Update: // existing objs will be removed if it exists in the received commit
                 toRemove = Doc.GetObjectsByApplicationId(tr, commitObj.applicationId);
-                if (toRemove.Count > 0)
-                {
-                  isUpdate = true;
-                  foreach (var objId in toRemove)
-                  {
-                    try
-                    {
-                      DBObject obj = tr.GetObject(objId, OpenMode.ForWrite);
-                      obj.Erase();
-                    }
-                    catch(Exception e)
-                    { }
-                  }
-                }
                 break;
               default:
                 break;
@@ -466,13 +454,13 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
             // bake
             if (commitObj.Convertible)
-              BakeObject(commitObj, converter, tr, isUpdate);
+              BakeObject(commitObj, converter, tr, toRemove);
             else
             {
               foreach (var fallback in commitObj.Fallback)
-                BakeObject(fallback, converter, tr, isUpdate, commitObj);
+                BakeObject(fallback, converter, tr, toRemove, commitObj);
               commitObj.Status = commitObj.Fallback.Where(o => o.Status == ApplicationObject.State.Failed).Count() == commitObj.Fallback.Count ?
-                ApplicationObject.State.Failed : isUpdate ?
+                ApplicationObject.State.Failed : toRemove.Count > 0 ?
                 ApplicationObject.State.Updated : ApplicationObject.State.Created;
             }
             Autodesk.AutoCAD.Internal.Utils.FlushGraphics();
@@ -609,7 +597,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
       return convertedList;
     }
 
-    private void BakeObject(ApplicationObject appObj, ISpeckleConverter converter, Transaction tr, bool isUpdate, ApplicationObject parent = null)
+    private void BakeObject(ApplicationObject appObj, ISpeckleConverter converter, Transaction tr, List<ObjectId> toRemove, ApplicationObject parent = null)
     {
       var obj = StoredObjects[appObj.OriginalId];
       int bakedCount = 0;
@@ -708,7 +696,26 @@ namespace Speckle.ConnectorAutocadCivil.UI
           appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not bake object");
       }
       else
-        appObj.Status = isUpdate ? ApplicationObject.State.Updated : ApplicationObject.State.Created;
+      {
+        // remove existing objects if they exist
+        foreach (var objId in toRemove)
+        {
+          try
+          {
+            DBObject objToRemove = tr.GetObject(objId, OpenMode.ForWrite);
+            objToRemove.Erase();
+          }
+          catch (Exception e)
+          {
+            if (parent != null)
+              parent.Log.Add(e.Message);
+            else
+              appObj.Log.Add(e.Message);
+          }
+        }
+
+        appObj.Status = toRemove.Count > 0 ? ApplicationObject.State.Updated : ApplicationObject.State.Created;
+      }
     }
 
     private void DeleteBlocksWithPrefix(string prefix, Transaction tr)

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -601,7 +601,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
     {
       var obj = StoredObjects[appObj.OriginalId];
       int bakedCount = 0;
-      bool remove = true;
+      bool remove = appObj.Status == ApplicationObject.State.Created || appObj.Status == ApplicationObject.State.Updated ? false : true;
 
       foreach (var convertedItem in appObj.Converted)
       {

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -368,9 +368,15 @@ namespace Speckle.ConnectorAutocadCivil
       }
       return objs;
     }
-#endregion
+    #endregion
 
-    public static List<ObjectId> GetObjectsByApplicationId(this Document doc, Transaction tr, string appId) //TODO: USE XDATA FOR APPIDS
+    /// <summary>
+    /// Returns, if found, the corresponding doc element.
+    /// The doc object can be null if the user deleted it. 
+    /// </summary>
+    /// <param name="appId">Id of the application that originally created the element, in AutocadCivil it's the handle</param>
+    /// <returns>The element, if found, otherwise null</returns>
+    public static List<ObjectId> GetObjectsByApplicationId(this Document doc, Transaction tr, string appId)
     {
       var foundObjects = new List<ObjectId>();
 

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -627,9 +627,9 @@ namespace SpeckleRhino
     }
 
     // conversion and bake
-    private List<object> ConvertObject(ApplicationObject previewObj, ISpeckleConverter converter)
+    private List<object> ConvertObject(ApplicationObject appObj, ISpeckleConverter converter)
     {
-      var obj = StoredObjects[previewObj.OriginalId];
+      var obj = StoredObjects[appObj.OriginalId];
       var convertedList = new List<object>();
 
       var converted = converter.ConvertToNative(obj);
@@ -649,28 +649,28 @@ namespace SpeckleRhino
 
       return convertedList;
     }
-    private void BakeObject(ApplicationObject previewObj, ISpeckleConverter converter, ApplicationObject parent = null)
+    private void BakeObject(ApplicationObject appObj, ISpeckleConverter converter, ApplicationObject parent = null)
     {
-      var obj = StoredObjects[previewObj.OriginalId];
+      var obj = StoredObjects[appObj.OriginalId];
       int bakedCount = 0;
       // check if this is a view or block - convert instead of bake if so (since these are "baked" during conversion)
-      if (!previewObj.Converted.Any() && (obj.speckle_type.Contains("Block") || obj.speckle_type.Contains("View")))
+      if (!appObj.Converted.Any() && (obj.speckle_type.Contains("Block") || obj.speckle_type.Contains("View")))
       {
-        previewObj.Converted = ConvertObject(previewObj, converter);
+        appObj.Converted = ConvertObject(appObj, converter);
       }
-      foreach (var convertedItem in previewObj.Converted)
+      foreach (var convertedItem in appObj.Converted)
       {
         switch (convertedItem)
         {
           case GeometryBase o:
-            string layerPath = previewObj.Container;
+            string layerPath = appObj.Container;
             if (!o.IsValidWithLog(out string log))
             {
               var invalidMessage = $"{log.Replace("\n", "").Replace("\r", "")}";
               if (parent != null)
-                parent.Update(logItem: $"fallback {previewObj.id}: {invalidMessage}");
+                parent.Update(logItem: $"fallback {appObj.id}: {invalidMessage}");
               else
-                previewObj.Update(logItem: invalidMessage);
+                appObj.Update(logItem: invalidMessage);
               continue;
             }
             Layer bakeLayer = Doc.GetLayer(layerPath, true);
@@ -678,9 +678,9 @@ namespace SpeckleRhino
             {
               var layerMessage = $"Could not create layer {layerPath}.";
               if (parent != null)
-                parent.Update(logItem: $"fallback {previewObj.id}: {layerMessage}");
+                parent.Update(logItem: $"fallback {appObj.id}: {layerMessage}");
               else
-                previewObj.Update(logItem: layerMessage);
+                appObj.Update(logItem: layerMessage);
               continue;
             }
             var attributes = new ObjectAttributes();
@@ -707,16 +707,16 @@ namespace SpeckleRhino
             {
               var bakeMessage = $"Could not bake to document.";
               if (parent != null)
-                parent.Update(logItem: $"fallback {previewObj.id}: {bakeMessage}");
+                parent.Update(logItem: $"fallback {appObj.id}: {bakeMessage}");
               else
-                previewObj.Update(logItem: bakeMessage);
+                appObj.Update(logItem: bakeMessage);
               continue;
             }
 
             if (parent != null)
               parent.Update(createdId: id.ToString());
             else
-              previewObj.Update(createdId: id.ToString());
+              appObj.Update(createdId: id.ToString());
 
             bakedCount++;
 
@@ -736,14 +736,14 @@ namespace SpeckleRhino
             if (parent != null)
               parent.Update(createdId: o.Id.ToString());
             else
-              previewObj.Update(status: ApplicationObject.State.Created, createdId: o.Id.ToString());
+              appObj.Update(status: ApplicationObject.State.Created, createdId: o.Id.ToString());
             bakedCount++;
             break;
           case string o: // this was prbly a view, baked during conversion
             if (parent != null)
               parent.Update(createdId: o);
             else
-              previewObj.Update(status: ApplicationObject.State.Created, createdId: o);
+              appObj.Update(status: ApplicationObject.State.Created, createdId: o);
             bakedCount++;
             break;
           default:
@@ -754,12 +754,12 @@ namespace SpeckleRhino
       if (bakedCount == 0)
       {
         if (parent != null)
-          parent.Update(logItem: $"fallback {previewObj.id}: could not bake object");
+          parent.Update(logItem: $"fallback {appObj.id}: could not bake object");
         else
-          previewObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not bake object");
+          appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not bake object");
       }
       else
-        previewObj.Update(status: ApplicationObject.State.Created);
+        appObj.Update(status: ApplicationObject.State.Created);
     }
 
     private void SetUserInfo(Base obj, ObjectAttributes attributes, ApplicationObject parent = null)

--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -159,7 +159,7 @@ namespace Speckle.Core.Models
       Status = State.Unknown;
     }
 
-    public void Update(string createdId = null, List<string> createdIds = null, State? status = null, List<string> log = null, string logItem = null, List<object> converted = null, object convertedItem = null)
+    public void Update(string createdId = null, List<string> createdIds = null, State? status = null, string container = null, List<string> log = null, string logItem = null, List<object> converted = null, object convertedItem = null)
     {
       if (createdIds != null) createdIds.Where(o => !string.IsNullOrEmpty(o) && !CreatedIds.Contains(o))?.ToList().ForEach(o => CreatedIds.Add(o));
       if (createdId != null && !CreatedIds.Contains(createdId)) CreatedIds.Add(createdId);
@@ -168,6 +168,7 @@ namespace Speckle.Core.Models
       if (!string.IsNullOrEmpty(logItem) && !Log.Contains(logItem)) Log.Add(logItem);
       if (convertedItem != null && !Converted.Contains(convertedItem)) Converted.Add(convertedItem);
       if (converted != null) converted.Where(o => o != null && !Converted.Contains(o))?.ToList().ForEach(o => Converted.Add(o));
+      if (!string.IsNullOrEmpty(container)) Container = container;
     }
   }
 
@@ -187,7 +188,7 @@ namespace Speckle.Core.Models
     {
       if (GetReportObject(obj.OriginalId, out int index))
       {
-        ReportObjects[index].Update(createdIds: obj.CreatedIds, converted: obj.Converted, log: obj.Log);
+        ReportObjects[index].Update(createdIds: obj.CreatedIds, container: obj.Container, converted: obj.Converted, log: obj.Log);
         if (obj.Status != ApplicationObject.State.Unknown)
           ReportObjects[index].Update(status: obj.Status);
         return ReportObjects[index];

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -248,17 +248,29 @@ namespace Objects.Converter.AutocadCivil
       }
 #endregion
 
+      // if this is in update mode, edit the alignment instead
+      if (ReceiveMode == Speckle.Core.Kits.ReceiveMode.Update)
+      {
+        ObjectId existingAlignment = ObjectId.Null;
+
+      }
+
       // create alignment entity curves
       try
       {
-        var id = CivilDB.Alignment.Create(civilDoc, name, site, layer, style, label); // ⚠ this will throw if name is not unique!!
+        var id = CivilDB.Alignment.Create(civilDoc, CivilDB.Alignment.GetNextUniqueName(name), site, layer, style, label); // ⚠ this will throw if name is not unique!!
 
         if (id == ObjectId.Null)
           return null;
         var _alignment = Trans.GetObject(id, OpenMode.ForWrite) as CivilDB.Alignment;
         var entities = _alignment.Entities;
+
         foreach (var curve in alignment.curves)
           AddAlignmentEntity(curve, ref entities);
+
+        // set start station
+        if (alignment.startStation != null)
+          _alignment.ReferencePointStation = alignment.startStation;
 
         return _alignment;
       }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -13,6 +13,7 @@ using Autodesk.AutoCAD.Geometry;
 using Acad = Autodesk.AutoCAD.Geometry;
 using AcadDB = Autodesk.AutoCAD.DatabaseServices;
 
+using Objects.BuiltElements.Civil;
 using Alignment = Objects.BuiltElements.Alignment;
 using Arc = Objects.Geometry.Arc;
 using Interval = Objects.Primitive.Interval;
@@ -85,9 +86,21 @@ namespace Objects.Converter.AutocadCivil
           return Civil.SpiralType.Clothoid;
       }
     }
-    public Alignment AlignmentToSpeckle(CivilDB.Alignment alignment)
+    public CivilAlignment AlignmentToSpeckle(CivilDB.Alignment alignment)
     {
-      var _alignment = new Alignment();
+      var _alignment = new CivilAlignment();
+
+      // get alignment props
+      _alignment.type = alignment.AlignmentType.ToString();
+      _alignment.offset = alignment.IsOffsetAlignment ? alignment.OffsetAlignmentInfo.NominalOffset : 0;
+      if (alignment.SiteName != null)
+        _alignment.site = alignment.SiteName;
+      if (alignment.StyleName != null)
+        _alignment.style = alignment.StyleName;
+      if (alignment.Description != null)
+        _alignment["description"] = alignment.Description;
+      if (alignment.Name != null)
+        _alignment.name = alignment.Name;
 
       // get alignment stations
       _alignment.startStation = alignment.StartingStation;
@@ -95,6 +108,18 @@ namespace Objects.Converter.AutocadCivil
       var stations = alignment.GetStationSet(CivilDB.StationTypes.All).ToList();
       List<Station> _stations = stations.Select(o => StationToSpeckle(o)).ToList();
       if (_stations.Count > 0) _alignment["@stations"] = _stations;
+
+      // handle station equations
+      var equations = new List<double>();
+      var directions = new List<bool>();
+      foreach (var stationEquation in alignment.StationEquations)
+      {
+        equations.AddRange(new List<double> { stationEquation.RawStationBack, stationEquation.StationBack, stationEquation.StationAhead });
+        bool equationIncreasing = (stationEquation.EquationType.Equals(CivilDB.StationEquationType.Increasing)) ? true : false;
+        directions.Add(equationIncreasing);
+      }
+      _alignment.stationEquations = equations;
+      _alignment.stationEquationDirections = directions;
 
       // get the alignment subentity curves
       List<ICurve> curves = new List<ICurve>();
@@ -144,141 +169,148 @@ namespace Objects.Converter.AutocadCivil
           curves.Add(polycurve);
         }
       }
-
-      /* this isn't very accurate, basecurve is usually a polycurve with lines and arcs
-      // get display poly
-      var poly = alignment.BaseCurve as Autodesk.AutoCAD.DatabaseServices.Polyline;
-      using (Polyline2d poly2d = poly.ConvertTo(false))
-      {
-        _alignment.displayValue = CurveToSpeckle(poly) as Polyline;
-      }
-      */
-
       _alignment.curves = curves;
-      if (alignment.Name != null)
-        _alignment.name = alignment.Name;
 
-      // handle station equations
-      var equations = new List<double>();
-      var directions = new List<bool>();
-      foreach (var stationEquation in alignment.StationEquations)
+
+      // if offset alignment, also set parent and offset side
+      if (alignment.IsOffsetAlignment)
       {
-        equations.AddRange(new List<double> { stationEquation.RawStationBack, stationEquation.StationBack, stationEquation.StationAhead });
-        bool equationIncreasing = (stationEquation.EquationType.Equals(CivilDB.StationEquationType.Increasing)) ? true : false;
-        directions.Add(equationIncreasing);
+        _alignment["offsetSide"] = alignment.OffsetAlignmentInfo.Side.ToString();
+        try
+        {
+          var parent = Trans.GetObject(alignment.OffsetAlignmentInfo.ParentAlignmentId, OpenMode.ForRead) as CivilDB.Alignment;
+          if (parent != null && parent.Name != null)
+            _alignment.parent = parent.Name;
+        }
+        catch { }
       }
-      _alignment.stationEquations = equations;
-      _alignment.stationEquationDirections = directions;
-
-      _alignment.units = ModelUnits;
-
-      // add civil3d props if they exist
-      if (alignment.SiteName != null)
-        _alignment["site"] = alignment.SiteName;
-      if (alignment.StyleName != null)
-        _alignment["style"] = alignment.StyleName;
-      if (alignment.Description != null)
-        _alignment["description"] = alignment.Description;
 
       return _alignment;
     }
 
-    public CivilDB.Alignment AlignmentToNative(Alignment alignment, out List<string> notes)
+    public ApplicationObject AlignmentToNative(Alignment alignment)
     {
-      notes = new List<string>();
-      var name = string.IsNullOrEmpty(alignment.name) ? alignment.applicationId : alignment.name; // names need to be unique on creation (but not send i guess??)
-      var layer = Doc.Database.LayerZero;
+      var appObj = new ApplicationObject(alignment.id, alignment.speckle_type) { applicationId = alignment.applicationId };
+      var existingObjs = GetExistingElementsByApplicationId(alignment.applicationId);
+      var civilAlignment = alignment as CivilAlignment;
 
+      // get civil doc
       BlockTableRecord modelSpaceRecord = Doc.Database.GetModelSpace();
       var civilDoc = CivilApplication.ActiveDocument;
       if (civilDoc == null)
-        return null;
+      {
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not retrieve civil3d document");
+        return appObj;
+      }
 
+      // create or retrieve alignment, and parent if it exists
+      CivilDB.Alignment _alignment = existingObjs.Any() ? Trans.GetObject(existingObjs.FirstOrDefault(), OpenMode.ForWrite) as CivilDB.Alignment : null;
+      var parent = civilAlignment != null ? GetFromObjectIdCollection(civilAlignment.parent, civilDoc.GetAlignmentIds()) : ObjectId.Null;
+      bool isUpdate = true;
+      if (_alignment == null || ReceiveMode == Speckle.Core.Kits.ReceiveMode.Create) // just create a new alignment
+      {
+        isUpdate = false;
+
+        // get civil props for creation
 #region properties
-      var site = ObjectId.Null;
-      var style = civilDoc.Styles.AlignmentStyles.First();
-      var label = civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles.First();
+        var name = string.IsNullOrEmpty(alignment.name) ? alignment.applicationId : alignment.name; // names need to be unique on creation (but not send i guess??)
+        var layer = Doc.Database.LayerZero;
 
-      // get site
-      if (alignment["site"] != null)
-      {
-        var _site = alignment["site"] as string;
-        if (_site != string.Empty)
-        {
-          foreach (ObjectId docSite in civilDoc.GetSiteIds())
-          {
-            var siteEntity = Trans.GetObject(docSite, OpenMode.ForRead) as CivilDB.Site;
-            if (siteEntity.Name.Equals(_site))
-            {
-              site = docSite;
-              break;
-            }
-          }
-        }
-      }
+        // type
+        var type = CivilDB.AlignmentType.Centerline;
+        if (civilAlignment != null)
+          if (Enum.TryParse(civilAlignment.type, out CivilDB.AlignmentType civilType))
+            type = civilType;
 
-      // get style
-      if (alignment["style"] != null)
-      {
-        var _style = alignment["style"] as string;
-        foreach (var docStyle in civilDoc.Styles.AlignmentStyles)
-        {
-          var styleEntity = Trans.GetObject(docStyle, OpenMode.ForRead) as CivilDB.Styles.AlignmentStyle;
-          if (styleEntity.Name.Equals(_style))
-          {
-            style = docStyle;
-            break;
-          }
-        }
-      }
+        // site
+        var site = civilAlignment != null ? 
+          GetFromObjectIdCollection(civilAlignment.site, civilDoc.GetSiteIds()) : ObjectId.Null;
 
-      // get labelset
-      if (alignment["label"] != null)
-      {
-        var _label = alignment["label"] as string;
-        foreach (var docLabelSet in civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles)
-        {
-          var labelEntity = Trans.GetObject(docLabelSet, OpenMode.ForRead) as CivilDB.Styles.AlignmentLabelSetStyle;
-          if (labelEntity.Name.Equals(_label))
-          {
-            label = docLabelSet;
-            break;
-          }
-        }
-      }
+        // style
+        var docStyles = new ObjectIdCollection();
+        foreach (ObjectId styleId in civilDoc.Styles.AlignmentStyles) docStyles.Add(styleId);
+        var style = civilAlignment != null ? 
+          GetFromObjectIdCollection(civilAlignment.style, docStyles) :  civilDoc.Styles.AlignmentStyles.First();
+
+        // label set style
+        var labelStyles = new ObjectIdCollection();
+        foreach (ObjectId styleId in civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles) labelStyles.Add(styleId);
+        var label = civilAlignment != null ?
+          GetFromObjectIdCollection(civilAlignment["label"] as string, labelStyles) : civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles.First();
 #endregion
 
-      // if this is in update mode, edit the alignment instead
-      if (ReceiveMode == Speckle.Core.Kits.ReceiveMode.Update)
-      {
-        ObjectId existingAlignment = ObjectId.Null;
-
+        try
+        {
+          // add new alignment to doc
+          // ⚠ this will throw if name is not unique!!
+          var id = ObjectId.Null;
+          switch (type)
+          {
+            case CivilDB.AlignmentType.Offset:
+              // create only if parent exists in doc
+              if (parent == ObjectId.Null) goto default;
+              try
+              {
+                id = CivilDB.Alignment.CreateOffsetAlignment(name, parent, civilAlignment.offset, style);
+              }
+              catch
+              {
+                id = CivilDB.Alignment.CreateOffsetAlignment(CivilDB.Alignment.GetNextUniqueName(name), parent, civilAlignment.offset, style);
+              }
+              break;
+            default:
+              try
+              {
+                id = CivilDB.Alignment.Create(civilDoc, name, site, layer, style, label);
+              }
+              catch
+              {
+                id = CivilDB.Alignment.Create(civilDoc, CivilDB.Alignment.GetNextUniqueName(name), site, layer, style, label);
+              }
+              break;
+          }
+          if (!id.IsValid)
+          {
+            appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Create method returned null");
+            return appObj;
+          }
+          _alignment = Trans.GetObject(id, OpenMode.ForWrite) as CivilDB.Alignment;
+        }
+        catch (Exception e)
+        {
+          appObj.Update(status: ApplicationObject.State.Failed, logItem: $"{e.Message}");
+          return appObj;
+        }
       }
 
-      // create alignment entity curves
-      try
+      if (_alignment == null)
       {
-        var id = CivilDB.Alignment.Create(civilDoc, CivilDB.Alignment.GetNextUniqueName(name), site, layer, style, label); // ⚠ this will throw if name is not unique!!
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: $"returned null after bake");
+        return appObj;
+      }
 
-        if (id == ObjectId.Null)
-          return null;
-        var _alignment = Trans.GetObject(id, OpenMode.ForWrite) as CivilDB.Alignment;
+      if (isUpdate) appObj.Container = _alignment.Layer; // set the appobj container to be the same layer as the existing alignment
+
+      if (parent != ObjectId.Null)
+      {
+        _alignment.OffsetAlignmentInfo.NominalOffset = civilAlignment.offset; // just update the offset
+      }
+      else
+      {
+        // create alignment entity curves
         var entities = _alignment.Entities;
-
+        if (isUpdate) _alignment.Entities.Clear(); // remove existing curves
         foreach (var curve in alignment.curves)
           AddAlignmentEntity(curve, ref entities);
-
-        // set start station
-        if (alignment.startStation != null)
-          _alignment.ReferencePointStation = alignment.startStation;
-
-        return _alignment;
       }
-      catch (Exception e)
-      {
-        notes.Add(e.Message);
-        return null; 
-      }
+
+      // set start station
+      _alignment.ReferencePointStation = alignment.startStation;
+
+      // update appobj
+      var status = isUpdate ? ApplicationObject.State.Updated : ApplicationObject.State.Created;
+      appObj.Update(status: status, createdId: _alignment.Handle.ToString(), convertedItem: _alignment);
+      return appObj;
     }
 
 #region helper methods

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -338,12 +338,11 @@ namespace Objects.Converter.AutocadCivil
           acadObj = isFromAutoCAD ? AcadTextToNative(o) : TextToNative(o);
           break;
 
-        case Alignment o:
 #if CIVIL2021 || CIVIL2022 || CIVIL2023
+        case Alignment o:
           acadObj = AlignmentToNative(o, out notes);
-#endif
-          acadObj = PolylineToNativeDB(o.displayValue);
           break;
+#endif
 
         case ModelCurve o:
           acadObj = CurveToNativeDB(o.baseCurve);

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -340,7 +340,7 @@ namespace Objects.Converter.AutocadCivil
 
 #if CIVIL2021 || CIVIL2022 || CIVIL2023
         case Alignment o:
-          acadObj = AlignmentToNative(o, out notes);
+          acadObj = AlignmentToNative(o);
           break;
 #endif
 
@@ -357,12 +357,17 @@ namespace Objects.Converter.AutocadCivil
           throw new NotSupportedException();
       }
 
-      if (reportObj != null)
+      switch (acadObj)
       {
-        reportObj.Update(log: notes);
-        Report.UpdateReportObject(reportObj);
+        case ApplicationObject o: // some to native methods return an application object (if object is baked to doc during conv)
+          acadObj = o.Converted.Any() ? o.Converted.FirstOrDefault() : null;
+          if (reportObj != null) reportObj.Update(status: o.Status, createdIds: o.CreatedIds, container: o.Container, log: o.Log);
+          break;
+        default:
+          if (reportObj != null) reportObj.Update(log: notes);
+          break;
       }
-
+      if (reportObj != null) Report.UpdateReportObject(reportObj);
       return acadObj;
     }
 

--- a/Objects/Objects/BuiltElements/Alignment.cs
+++ b/Objects/Objects/BuiltElements/Alignment.cs
@@ -10,6 +10,9 @@ namespace Objects.BuiltElements
 {
   public class Alignment : Base, IDisplayValue<Polyline>
   {
+    [JsonIgnore, Obsolete("Use curves property")]
+    public ICurve baseCurve { get; set; }
+
     public List<ICurve> curves { get; set; }
 
     public string name { get; set; }

--- a/Objects/Objects/BuiltElements/Alignment.cs
+++ b/Objects/Objects/BuiltElements/Alignment.cs
@@ -10,9 +10,6 @@ namespace Objects.BuiltElements
 {
   public class Alignment : Base, IDisplayValue<Polyline>
   {
-    [JsonIgnore, Obsolete("Use curves property")]
-    public ICurve baseCurve { get; set; }
-
     public List<ICurve> curves { get; set; }
 
     public string name { get; set; }
@@ -38,5 +35,26 @@ namespace Objects.BuiltElements
 
     public Alignment() { }
 
+  }
+}
+
+namespace Objects.BuiltElements.Civil
+{
+  public class CivilAlignment : Alignment
+  {
+    public string type { get; set; }
+
+    public string site { get; set; }
+
+    public string style { get; set; }
+
+    public double offset { get; set; }
+
+    /// <summary>
+    /// Name of parent alignment if this is an offset alignment
+    /// </summary>
+    public string parent { get; set; }
+
+    public CivilAlignment() { }
   }
 }


### PR DESCRIPTION
## Description & motivation
This pr improves receiving alignments:
- Reference station point is now being set on receive
- In update mode, alignments are updated in place with a new reference station, and new segments or a new offset (for offset alignments). Layer will remain unchanged. This allows for featurlines referencing the alignment to remain intact on receive!
- Improves sending and receiving offset alignments: previously these were always being created as regular alignments. Now on receive, if the parent exists in the doc they will properly be linked to the parent as an offset
- also fixes a naming bug where the ToNative() method throws on creation if a duplicate name exists. 

Closes #1626

## Changes:

- Autocadcivil connector
- Autocadcivil converter
- small core change in updating Applicationobject to include container update
- ⚠ change in alignment class in objects: adding a `CivilAlignment` subclass to formalize civil3d props ⚠ should not be breaking

## Screenshots:

Before:
![ezgif com-gif-maker (34)](https://user-images.githubusercontent.com/16748799/193033989-74b42523-57fe-4db1-9192-d0a1baa619ec.gif)


After:
![ezgif com-gif-maker (33)](https://user-images.githubusercontent.com/16748799/193033282-49d0514f-d996-4851-ba3b-337c3b78aeff.gif)


## Validation of changes:

sent and received community contributed test file for civil alignments and corridors

## Checklist:

- [ ] todo: create issue for properly nesting offset alignments on send and receive, and an open issue to check application id assignment on repeated update receives
