### PR TITLE
fix(objects): Removed non IDisplayMesh `displayMesh` properties

### DIFF
--- a/Objects/Objects/BuiltElements/TeklaStructures/Bolts.cs
+++ b/Objects/Objects/BuiltElements/TeklaStructures/Bolts.cs
@@ -28,16 +28,7 @@ namespace Objects.BuiltElements.TeklaStructures
     public double cutLength { get; set; }
     public List<Point> coordinates { get; set; }
     public List<string> boltedPartsIds { get; set; } = new List<string>(); // First guid is PartToBeBolted, second guid is PartToBoltTo, any others are OtherPartsToBolt
-
-
-    #region Obsolete Members
-    [JsonIgnore, Obsolete("Use " + nameof(displayValue) + " instead")]
-    public Mesh displayMesh
-    {
-      get => displayValue?.FirstOrDefault();
-      set => displayValue = new List<Mesh> { value };
-    }
-    #endregion
+    
     public Bolts() { }
 
   }

--- a/Objects/Objects/BuiltElements/TeklaStructures/TeklaContourPlate.cs
+++ b/Objects/Objects/BuiltElements/TeklaStructures/TeklaContourPlate.cs
@@ -25,24 +25,11 @@ namespace Objects.BuiltElements.TeklaStructures
     public string classNumber { get; set; }
     [DetachProperty]
     public TeklaPosition position { get; set; }
-    [DetachProperty]
-    public List<Mesh> displayValue { get; set; }
+
     [DetachProperty]
     public Base rebars { get; set; }
     public List<TeklaContourPoint> contour { get; set; } // Use for ToNative to Tekla. Other programs can use Area.outline.
-
-    public string units { get; set; }
-
-
-    #region Obsolete Members
-    [JsonIgnore, Obsolete("Use " + nameof(displayValue) + " instead")]
-    public Mesh displayMesh
-    {
-      get => displayValue?.FirstOrDefault();
-      set => displayValue = new List<Mesh> { value };
-    }
-    #endregion
-
+    
 
     [SchemaInfo("ContourPlate", "Creates a TeklaStructures contour plate.", "Tekla", "Structure")]
     public TeklaContourPlate(SectionProfile profile, Polyline outline, string finish, string classNumber, string units, StructuralMaterial material = null, TeklaPosition position = null, Base rebars = null)

--- a/Objects/Objects/BuiltElements/TeklaStructures/Welds.cs
+++ b/Objects/Objects/BuiltElements/TeklaStructures/Welds.cs
@@ -30,16 +30,7 @@ namespace Objects.BuiltElements.TeklaStructures
     public TeklaWeldType typeAbove { get; set; }
     public TeklaWeldType typeBelow { get; set; }
     public TeklaWeldIntermittentType intermittentType { get; set; }
-
-
-    #region Obsolete Members
-    [JsonIgnore, Obsolete("Use " + nameof(displayValue) + " instead")]
-    public Mesh displayMesh
-    {
-      get => displayValue?.FirstOrDefault();
-      set => displayValue = new List<Mesh> { value };
-    }
-    #endregion
+    
     public Welds() { }
 
   }


### PR DESCRIPTION
Removes `displayMesh` properties in non-IDisplayMesh elements:

- Bolts
- TeklaContourPlate
- Welds

