### PR TITLE
Civil3d/converter fix

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2021/ConverterCivil2021.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Objects.Converter.Civil2021</AssemblyName>
+    <AssemblyName>Objects.Converter.Civil3D2021</AssemblyName>
     <RootNamespace>Objects.Converter.Civil</RootNamespace>
     <DefineConstants>$(DefineConstants);CIVIL2021</DefineConstants>
     <PackageId>Speckle.Objects.Converter.Civil2021</PackageId>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2022/ConverterCivil2022.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Objects.Converter.Civil2022</AssemblyName>
+    <AssemblyName>Objects.Converter.Civil3D2022</AssemblyName>
     <RootNamespace>Objects.Converter.Civil</RootNamespace>
     <DefineConstants>$(DefineConstants);CIVIL2022</DefineConstants>
     <PackageId>Speckle.Objects.Converter.Civil2022</PackageId>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2023/ConverterCivil2023.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2023/ConverterCivil2023.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Objects.Converter.Civil2023</AssemblyName>
+    <AssemblyName>Objects.Converter.Civil3D2023</AssemblyName>
     <RootNamespace>Objects.Converter.Civil</RootNamespace>
     <PackageId>Speckle.Objects.Converter.Civil2023</PackageId>
     <DefineConstants>$(DefineConstants);CIVIL2023</DefineConstants>
@@ -37,7 +37,7 @@
 
   <Import Project="..\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems" Label="Shared" />
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent"  Condition="'$(IsDesktopBuild)' == true">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsDesktopBuild)' == true">
     <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
   </Target>
 


### PR DESCRIPTION
Aligns the converter name for consistency and to make it work with the latest changes in `Applications.cs`

### Note
Goes hand in hand with this change in the installer: https://github.com/specklesystems/speckle-sharp-ci-tools/commit/8ac9091461238f5be18795d8da1e7c0daec55c06
We should not make new pre-releases for c3d on the 2.8 branch since the above has been merged already.