### PR TITLE
fix(ci): All mac connectors and Archicad for windows deployment

### DIFF
--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -177,11 +177,12 @@ def createConfigFile(deploy: bool, outputPath: str):
 
 def getNewDeployJob(jobName: str):
     slug = jobName.split("-build")[0]
-    isMac = slug.find("-mac") != -1
+    isMac = jobName.find("-mac") != -1
     deployJob: Dict[str, Any] = {
         "slug": slug.split("-mac")[0] if isMac else slug,
-        "name": slug + "-deploy",
+        "name": slug + "-deploy-mac" if isMac else slug + "-deploy" ,
         "os": "OSX" if isMac else "Win",
+        "arch": "Any",
         "extension": "zip" if isMac else "exe",
         "requires": ["deploy-connectors", jobName],
         "filters": getTagFilter([jobName]),

--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -34,7 +34,7 @@ def runCommand(argv: List[str]):
         elif opt in ("-o", "--output"):
             output_filepath = arg
 
-    createConfigFile(deploy, output_filepath)
+    createConfigFile(True, output_filepath)
 
 
 def setup():

--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -34,7 +34,7 @@ def runCommand(argv: List[str]):
         elif opt in ("-o", "--output"):
             output_filepath = arg
 
-    createConfigFile(True, output_filepath)
+    createConfigFile(deploy, output_filepath)
 
 
 def setup():

--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -130,9 +130,11 @@ def createConfigFile(deploy: bool, outputPath: str):
                         jobAttrs["requires"] += ["test-core"]
                     # Add name to all jobs
                     name = f"{slug}-build"
-                    jobAttrs["name"] = name
-                    jobs_before_deploy.append(name)
-                    print(f"    Added connector job: {name}")
+                    if "name" not in jobAttrs.keys():
+                        jobAttrs["name"] = name
+                    n = jobAttrs["name"]
+                    jobs_before_deploy.append(n)
+                    print(f"    Added connector job: {n}")
                     # Add tags if marked for deployment
                     if deploy:
                         jobAttrs["installer"] = True

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -170,6 +170,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
         type: string
       extension:
         type: string
+      arch:
+        type: string
+        default: Any
     steps:
       - checkout
       - attach_workspace:
@@ -182,7 +185,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            /root/.dotnet/tools/Speckle.Manager.Feed deploy -s << parameters.slug >> -v ${SEMVER} -u https://releases.speckle.dev/installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >> -o << parameters.os >> -f speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >>
+            /root/.dotnet/tools/Speckle.Manager.Feed deploy -s << parameters.slug >> -v ${SEMVER} -u https://releases.speckle.dev/installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >> -o << parameters.os >> -a << parameters.arch >> -f speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >>
 
   build-connector-mac:
     macos:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -182,7 +182,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            /root/.dotnet/tools/Speckle.Manager.Feed deploy -s << parameters.slug >> -v ${SEMVER} -u https://releases.speckle.dev/installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.exe -o << parameters.os >> -f speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >>
+            /root/.dotnet/tools/Speckle.Manager.Feed deploy -s << parameters.slug >> -v ${SEMVER} -u https://releases.speckle.dev/installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >> -o << parameters.os >> -f speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >>
 
   build-connector-mac:
     macos:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -327,18 +327,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
     docker:
       - image: cimg/base:2021.01
     steps:
-      - attach_workspace:
-          at: ./
       - run:
-          name: List contents
-          command: ls -R speckle-sharp-ci-tools/Installers
-      - aws-s3/copy:
-          arguments: "--recursive --endpoint=https://$SPACES_REGION.digitaloceanspaces.com --acl public-read"
-          aws-access-key-id: SPACES_KEY
-          aws-region: SPACES_REGION
-          aws-secret-access-key: SPACES_SECRET
-          from: '"speckle-sharp-ci-tools/Installers/"'
-          to: s3://speckle-releases/installers/
+          name: Proceed to deploy
+          command: echo "This step is just here to wait for all build jobs before proceeding to deploy each of them individually. If a job fails, no connector will be deployed."
 
 # The main workflows for our monorepo pipeline.
 # There should be at least one workflow per project in the monorepo. Each workflow should be run only when a boolean parameter is passed that corresponds to the pattern 'run_{PROJECT_NAME}'.

--- a/.circleci/scripts/connector-jobs.yml
+++ b/.circleci/scripts/connector-jobs.yml
@@ -21,7 +21,7 @@ rhino:
       projname: ConnectorRhino7
       installername: SpeckleRhinoInstall
       build-config: Release Mac
-      slug: rhino-mac
+      slug: rhino
       requires:
         - build-desktopui
       converter-files: "
@@ -37,7 +37,7 @@ rhino:
       build-config: Release Mac
       installername: SpeckleGhInstall
       installer: true
-      slug: grasshopper-mac
+      slug: grasshopper
       requires:
         - build-desktopui
       converter-files: "

--- a/.circleci/scripts/connector-jobs.yml
+++ b/.circleci/scripts/connector-jobs.yml
@@ -17,6 +17,7 @@ rhino:
       requires:
         - build-desktopui
   - build-connector-mac:
+      name: rhino-build-mac
       slnname: ConnectorRhino
       projname: ConnectorRhino7
       installername: SpeckleRhinoInstall
@@ -32,6 +33,7 @@ rhino:
         Objects/Converters/ConverterRhinoGh/ConverterGrasshopper6/bin/Release/netstandard2.0/Objects.Converter.Grasshopper6.dll
         "
   - build-connector-mac:
+      name: grasshopper-build-mac
       slnname: ConnectorRhino
       projname: ConnectorRhino7
       build-config: Release Mac

--- a/ConnectorArchicad/ConnectorArchicad/ConnectorArchicad.csproj
+++ b/ConnectorArchicad/ConnectorArchicad/ConnectorArchicad.csproj
@@ -18,6 +18,12 @@
     <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
     <ProjectReference Include="..\..\Objects\Objects\Objects.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
   <PropertyGroup>
     <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
   </PropertyGroup>

--- a/ConnectorArchicad/ConnectorArchicad/ConnectorArchicad.csproj
+++ b/ConnectorArchicad/ConnectorArchicad/ConnectorArchicad.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Company>Speckle</Company>
     <Product>ArchiCAD Connector</Product>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/ConnectorArchicad/ConnectorArchicad/Properties/AssemblyInfo.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ConnectorArchicad")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConnectorArchicad")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6EB6DB03-9878-46E1-9278-0B2A73F7514B")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("2.0.0-beta")]
+[assembly: AssemblyFileVersion("2.0.0-beta")]
+[assembly: AssemblyInformationalVersion("2.0.0-beta")]

--- a/ConnectorArchicad/ConnectorArchicad/Properties/AssemblyInfo.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0-beta")]
-[assembly: AssemblyFileVersion("2.0.0-beta")]
-[assembly: AssemblyInformationalVersion("2.0.0-beta")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]


### PR DESCRIPTION
Fixes CI deploy jobs for mac, which were not uploading due to misconfiguration on the extension and expected file name.

**Mac deploys**:

- The output of our mac installer build would be called `rhino-mac.zip`, following the `slug`. The slug has now been changed to be universal (`i.e. `rhino` or `grasshopper`), and the deploy job uses the correct parameters for `os` and `arch`.
- Added `arch` parameter to the `deploy-connector-new` job
- Extension parameter was not being used in all necessary places.
- `deploy-connectors` job no longer uploads to the new manager. Instead, it's just used as a buffer step to wait for all `build` jobs to be completed before proceeding to deployment.
- Some changes were made on the `Speckle.Manager.Feed` CLI so that the job would fail if the upload is not successful.

**Python CircleCI config generator script**:

Since the slug no longer contains `-mac` suffix, we now use the `name` of the job if it exists to figure out if it's a mac build or not.

**Archicad windows installer**:

While fixing this we found out that the Archicad connector was not properly configured:

- Added `MSBuild` nuget to `ConnectorArchicad.csproj`
- Added `Properties/AssemblyInfo.cs`
- Added <GenerateAssemblyInfo> as `false`.