### PR TITLE
Fix(Revit): Duplicated mesh when sending nested familyinstance

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -275,7 +275,7 @@ namespace Objects.Converter.Revit
       if (revitFi.Location is LocationPoint)
         speckleFi.rotation = ((LocationPoint)revitFi.Location).Rotation;
 
-      speckleFi.displayValue = GetElementMesh(revitFi, GetAllFamSubElements(revitFi));
+      speckleFi.displayValue = GetElementMesh(revitFi);
 
       var material = ConverterRevit.GetMEPSystemMaterial(revitFi);
 
@@ -312,8 +312,6 @@ namespace Objects.Converter.Revit
 
 #endregion
 
-      // TODO:
-      // revitFi.GetSubelements();
       return speckleFi;
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -10,7 +10,7 @@ namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
-    public List<Mesh> GetElementMesh(DB.Element element, List<DB.Element> subElements = null)
+    public List<Mesh> GetElementMesh(DB.Element element)
     {
       var allSolids = GetElementSolids(element, opt: new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = true });
       if (!allSolids.Any()) //it's a mesh!
@@ -19,12 +19,7 @@ namespace Objects.Converter.Revit
         return GetMeshes(geom, element.Document);
       }
 
-      if (subElements != null)
-        foreach (var sb in subElements)
-          allSolids.AddRange(GetElementSolids(sb));
-
       return GetMeshesFromSolids(allSolids, element.Document);
-
     }
 
     /// <summary>


### PR DESCRIPTION
## Description & motivation

The geometry of all sub elems was merged directly before implementing sub elems support. This part of the geometry should be removed after capturing the sub elems.

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

![before](https://user-images.githubusercontent.com/30818313/194742151-96c28a77-bcac-4578-9f95-6785ca0c938d.png)

![after](https://user-images.githubusercontent.com/30818313/194742187-3ccafba6-8dcd-4b2f-ace9-41680b30c4e1.png)


## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.