### PR TITLE
Fix: Adds <PlatformTarget> property to all connector csproj files

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
@@ -19,6 +19,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +29,6 @@
     <DefineConstants>TRACE;DEBUG;AUTOCAD2021</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
@@ -19,6 +19,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +29,6 @@
     <DefineConstants>TRACE;DEBUG;AUTOCAD2022</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/ConnectorAutocadCivil/ConnectorAutocad2023/ConnectorAutocad2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2023/ConnectorAutocad2023.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
@@ -22,6 +22,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,7 +32,6 @@
     <DefineConstants>TRACE;DEBUG;CIVIL2021</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
@@ -22,6 +22,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,7 +32,6 @@
     <DefineConstants>TRACE;DEBUG;CIVIL2022</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/ConnectorAutocadCivil/ConnectorCivil2023/ConnectorCivil2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2023/ConnectorCivil2023.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +22,6 @@
     <DefineConstants>TRACE;DEBUG;CIVIL2023</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
+++ b/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
@@ -18,6 +18,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ConnectorCSI/ConnectorSAFE/ConnectorSAFE.csproj
+++ b/ConnectorCSI/ConnectorSAFE/ConnectorSAFE.csproj
@@ -17,6 +17,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
+++ b/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
@@ -17,6 +17,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
+++ b/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
@@ -19,6 +19,8 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
+
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,7 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\SpeckleConnectorDynamo.xml</DocumentationFile>
-    <PlatformTarget>x64</PlatformTarget>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Core\2.7\DynamoSandbox.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper/ConnectorGrasshopper.csproj
@@ -14,6 +14,7 @@
     <TargetExt>.gha</TargetExt>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TransformOnBuild>false</TransformOnBuild>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj" />

--- a/ConnectorMicroStation/ConnectorMicroStation/ConnectorMicroStation.csproj
+++ b/ConnectorMicroStation/ConnectorMicroStation/ConnectorMicroStation.csproj
@@ -18,6 +18,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/ConnectorMicroStation/ConnectorOpenBuildings/ConnectorOpenBuildings.csproj
+++ b/ConnectorMicroStation/ConnectorOpenBuildings/ConnectorOpenBuildings.csproj
@@ -18,6 +18,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ConnectorMicroStation/ConnectorOpenRail/ConnectorOpenRail.csproj
+++ b/ConnectorMicroStation/ConnectorOpenRail/ConnectorOpenRail.csproj
@@ -14,6 +14,8 @@
     <Deterministic>true</Deterministic>
     <StartAction>Program</StartAction>
     <StartProgram>$(ProgramW6432)\Bentley\OpenRail Designer CONNECT Edition\OpenRailDesigner\OpenRailDesigner.exe</StartProgram>
+    <PlatformTarget>x64</PlatformTarget>
+
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ConnectorMicroStation/ConnectorOpenRoads/ConnectorOpenRoads.csproj
+++ b/ConnectorMicroStation/ConnectorOpenRoads/ConnectorOpenRoads.csproj
@@ -18,6 +18,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ConnectorTeklaStructures/ConnectorTeklaStructures2020/ConnectorTeklaStructures2020.csproj
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructures2020/ConnectorTeklaStructures2020.csproj
@@ -18,6 +18,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ConnectorTeklaStructures2021.csproj
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ConnectorTeklaStructures2021.csproj
@@ -18,6 +18,7 @@
     <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+    <PlatformTarget>x64</PlatformTarget>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Adds <PlatformTarget> to all connector projets that were missing it.

Moved it to a global position in all connectors that only had it on `debug`