### PR TITLE
Fix(Revit): null value error for GetExistingElementsByApplicationId

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -718,12 +718,12 @@ namespace Objects.Converter.Revit
 
     public List<DB.Element> GetExistingElementsByApplicationId(string applicationId)
     {
+      var elements = new List<Element>();
       if (applicationId == null || ReceiveMode == Speckle.Core.Kits.ReceiveMode.Create)
-        return null;
+        return elements;
 
       var @ref = PreviousContextObjects.FirstOrDefault(o => o.applicationId == applicationId);
 
-      var elements = new List<Element>();
       if (@ref == null)
       {
         //element was not cached in a PreviousContex but might exist in the model


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

error was being thrown when the "GetExistingElementsByApplicationId" function was returning null and then we were trying to call the .firstordefault() function on a null value.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

GetExistingElementsByApplicationId now returns an empty list so the .firstordefault function won't throw an error

<!---

- Item 1
- Item 2

-->
