### PR TITLE
Revit/jrm/direct shape fix

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -718,12 +718,12 @@ namespace Objects.Converter.Revit
 
     public List<DB.Element> GetExistingElementsByApplicationId(string applicationId)
     {
+      var elements = new List<Element>();
       if (applicationId == null || ReceiveMode == Speckle.Core.Kits.ReceiveMode.Create)
-        return null;
+        return elements;
 
       var @ref = PreviousContextObjects.FirstOrDefault(o => o.applicationId == applicationId);
 
-      var elements = new List<Element>();
       if (@ref == null)
       {
         //element was not cached in a PreviousContex but might exist in the model

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -198,7 +198,17 @@ namespace Objects.Converter.Revit
 
       var category = revitElement.Category;
       if (category != null)
-        speckleElement["category"] = category.Name;
+      {
+        if (speckleElement["category"] is RevitCategory)
+        {
+          speckleElement["category"] = Categories.GetSchemaBuilderCategoryFromBuiltIn(category.Name);
+        }
+        else
+        {
+          speckleElement["category"] = category.Name;
+        }
+      }
+        
     }
 
     //private List<string> alltimeExclusions = new List<string> { 


### PR DESCRIPTION
Fixed an issue with `DirectShapeToSpeckle` conversion.
`DirectShape`s, unlike other revit object models, expects the `Category` as a `RevitCategory` enum value. Not a string. 

Thus, this line causes the direct shape to fail conversion.
https://github.com/specklesystems/speckle-sharp/blob/bdf3a01220eebea4bba10109e54987824640fbbb/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs#L199-L202

Before:
https://latest.speckle.dev/streams/c1faab5c62/commits/d3e97603e2?c=%5B400.3724,21.57513,27.36468,247.89881,-66.22226,-59.07974,0,1%5D
![image](https://user-images.githubusercontent.com/45512892/195653168-4ace4a27-e4e8-4290-97db-5f409bd26deb.png)

After:
https://latest.speckle.dev/streams/c1faab5c62/commits/d9f212d6ab?c=%5B400.3724,21.57513,27.36468,247.89881,-66.22226,-59.07974,0,1%5D
![image](https://user-images.githubusercontent.com/45512892/195653131-0f4eb778-f81c-4843-ba2c-ccb41f1d06b7.png)

---


Q: Does this mean all direct shapes would have failed? in which case, this code seems like it has been broken for a while, are there any released issues logged?
