### PR TITLE
Fix(Revit): add "spaces" as sendable category

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -265,6 +265,7 @@ namespace Speckle.ConnectorRevit
       BuiltInCategory.OST_MassFloor,
       BuiltInCategory.OST_Materials,
       BuiltInCategory.OST_MechanicalEquipment,
+      BuiltInCategory.OST_MEPSpaces,
       BuiltInCategory.OST_Parking,
       BuiltInCategory.OST_PipeCurves,
       BuiltInCategory.OST_PipingSystem,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -76,6 +76,7 @@ namespace Objects.Converter.Revit
       BuiltInCategory.OST_MassFloor,
       BuiltInCategory.OST_Materials,
       BuiltInCategory.OST_MechanicalEquipment,
+      BuiltInCategory.OST_MEPSpaces,
       BuiltInCategory.OST_Parking,
       BuiltInCategory.OST_PipeCurves,
       BuiltInCategory.OST_PipingSystem,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -97,7 +97,7 @@ namespace Objects.Converter.Revit
       speckleSpace.topLevel = ConvertAndCacheLevel(revitSpace.get_Parameter(BuiltInParameter.ROOM_UPPER_LEVEL).AsElementId(), revitSpace.Document);
       speckleSpace.baseOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_LOWER_OFFSET);
       speckleSpace.topOffset = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_UPPER_OFFSET);
-      speckleSpace.outline = profiles[0];
+      speckleSpace.outline = profiles.Count != 0 ? profiles[0] : null;
       if (profiles.Count > 1)
         speckleSpace.voids = profiles.Skip(1).ToList();
       speckleSpace.area = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_AREA);


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

MEP spaces are currenly not selectable as a category to send to speckle

Closes https://github.com/specklesystems/speckle-sharp/issues/1714

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- adds spaces as a supported built in category
- enable sending space will a null outline

<!---

- Item 1
- Item 2

-->

## References

Community request https://speckle.community/t/send-spaces-from-revit/3801

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
