### PR TITLE
Fix(Revit): invalid characters causing object conversion failure

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -1028,16 +1028,20 @@ namespace Objects.Converter.Revit
     {
       if (speckleMaterial == null) return ElementId.InvalidElementId;
 
+      string matName = null;
+      if (!string.IsNullOrEmpty(speckleMaterial.name))
+        matName = Regex.Replace(speckleMaterial.name, "[\\[\\]{}|;<>?`~]", "");
+
       // Try and find an existing material
       var existing = new FilteredElementCollector(Doc)
         .OfClass(typeof(DB.Material))
         .Cast<DB.Material>()
-        .FirstOrDefault(m => string.Equals(m.Name, speckleMaterial.name, StringComparison.CurrentCultureIgnoreCase));
+        .FirstOrDefault(m => string.Equals(m.Name, matName, StringComparison.CurrentCultureIgnoreCase));
 
       if (existing != null) return existing.Id;
 
       // Create new material
-      ElementId materialId = DB.Material.Create(Doc, speckleMaterial.name ?? Guid.NewGuid().ToString());
+      ElementId materialId = DB.Material.Create(Doc, matName ?? Guid.NewGuid().ToString());
       DB.Material mat = Doc.GetElement(materialId) as DB.Material;
 
       var sysColor = System.Drawing.Color.FromArgb(speckleMaterial.diffuse);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -1028,9 +1028,7 @@ namespace Objects.Converter.Revit
     {
       if (speckleMaterial == null) return ElementId.InvalidElementId;
 
-      string matName = null;
-      if (!string.IsNullOrEmpty(speckleMaterial.name))
-        matName = Regex.Replace(speckleMaterial.name, "[\\[\\]{}|;<>?`~]", "");
+      string matName = RemoveProhibitedCharacters(speckleMaterial.name);
 
       // Try and find an existing material
       var existing = new FilteredElementCollector(Doc)
@@ -1225,6 +1223,13 @@ namespace Objects.Converter.Revit
         Doc.Delete(docObj.Id);
 
       return null;
+    }
+
+    private string RemoveProhibitedCharacters(string s)
+    {
+      if (string.IsNullOrEmpty(s))
+        return s;
+      return Regex.Replace(s, "[\\[\\]{}|;<>?`~]", "");
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -147,7 +147,7 @@ namespace Objects.Converter.Revit
       try
       {
         group = Doc.Create.NewGroup(ids);
-        group.GroupType.Name = $"SpeckleBlock_{instance.blockDefinition.name}_{instance.applicationId ?? instance.id}";
+        group.GroupType.Name = $"SpeckleBlock_{RemoveProhibitedCharacters(instance.blockDefinition.name)}_{instance.applicationId ?? instance.id}";
         string skipped = $"{(skippedBreps > 0 ? $"{skippedBreps} breps " : "")}{(skippedMeshes > 0 ? $"{skippedMeshes} meshes " : "")}{(skippedCurves > 0 ? $"{skippedCurves} curves " : "")}{(skippedBlocks > 0 ? $"{skippedBlocks} blocks " : "")}";
         if (!string.IsNullOrEmpty(skipped)) appObj.Update(logItem: $"Skipped {skipped}");
         var state = isUpdate ? ApplicationObject.State.Updated : ApplicationObject.State.Created;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -25,6 +25,7 @@ using Surface = Objects.Geometry.Surface;
 using Transform = Objects.Other.Transform;
 using Units = Speckle.Core.Kits.Units;
 using Vector = Objects.Geometry.Vector;
+using System.Text.RegularExpressions;
 
 namespace Objects.Converter.Revit
 {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -25,7 +25,6 @@ using Surface = Objects.Geometry.Surface;
 using Transform = Objects.Other.Transform;
 using Units = Speckle.Core.Kits.Units;
 using Vector = Objects.Geometry.Vector;
-using System.Text.RegularExpressions;
 
 namespace Objects.Converter.Revit
 {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

[here](https://latest.speckle.dev/streams/85bc4f61c6/commits/52382fa1d8) is a stream that I sent from Rhino to Speckle. When receiving to Revit, every BREP and block instance was failing with a warning about invalid characters.

This is an example of one of the material names that it was trying to copy, "RhinoTestStream[ 1 standard/meters @ f093ffcc80 ] - default"

According to the [RevitApiDocs](https://www.revitapidocs.com/2023/5d8f8735-b814-5ac0-e8c5-114da8caa7bc.htm), there are several prohibited characters that cannot be used in a material name. This pr removes those prohibited characters.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

now deleting all prohibited characters from the material name and the group name before trying to create those elements 

<!---

- Item 1
- Item 2

-->

## Validation of changes:

Receiving the commit linked above now works

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
