### PR TITLE
Fix(Revit): Don't remove context object unless it converts successfully

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -75,14 +75,13 @@ namespace Objects.Converter.Revit
           continue;
         }
 
-        ContextObjects.RemoveAt(isSelectedInContextObjects);
-
         ApplicationObject reportObj = Report.GetReportObject(element.UniqueId, out int index) ? Report.ReportObjects[index] : new ApplicationObject(element.UniqueId, element.GetType().ToString());
         if (CanConvertToSpeckle(element))
         {
           var obj = ConvertToSpeckle(element);
           if (obj != null)
           {
+            ContextObjects.RemoveAt(isSelectedInContextObjects);
             reportObj.Update(status: ApplicationObject.State.Created, logItem: $"Attached as hosted element to {host.UniqueId}");
             convertedHostedElements.Add(obj);
             ConvertedObjectsList.Add(obj.applicationId);


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- found an edge case where two objects can return the same hosted elements when the `host.FindInserts(true, false, false, false)` is called. To reproduce, receive [this commit](https://latest.speckle.dev/streams/f8991bf79d/commits/0281d670e1) into Revit and then try to send it back to speckle.

- When this happens, the first host tries to convert the objects and removes them from the contextObjects, but the conversion fails because the elements are hosted and the other host is still in the context objects. Therefore the conversion returns null assuming that the other host element will convert these objects. However, this doesn't happen because the objects have already been removed from the ContextObjects list (aka they are assumed to have already been converted) 
<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- Don't remove hosted objects from the ContextObjects unless they are converted successfully

<!---

- Item 1
- Item 2

-->

## Validation of changes:

Before this PR, sending this Revit model to speckle results in the windows being gone. 
![image](https://user-images.githubusercontent.com/43247197/196223388-73a107e0-40cd-4bff-9750-1572a5c44a69.png)

After this PR, the windows will be successfully sent
![image](https://user-images.githubusercontent.com/43247197/196223820-757cfd1c-b17c-4734-8002-80527ac8b06d.png)


<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
