### PR TITLE
fix(autocadcivil): get from id collection should check for `CanRead` prop

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -137,18 +137,19 @@ namespace Objects.Converter.AutocadCivil
       return ids;
     }
 
-    public ObjectId GetFromObjectIdCollection(string name, ObjectIdCollection collection)
+    public ObjectId GetFromObjectIdCollection(string name, ObjectIdCollection collection, bool useFirstIfNull = false)
     {
       var id = ObjectId.Null;
-      if (string.IsNullOrEmpty(name)) return id;
+      if ((string.IsNullOrEmpty(name) && !useFirstIfNull) || (string.IsNullOrEmpty(name) && collection.Count == 0))
+        return id; 
 
       foreach (ObjectId collectionId in collection)
       {
         var entity = Trans.GetObject(collectionId, OpenMode.ForRead);
         if (entity != null)
         {
-          var props = entity.GetType().GetProperty("Name");
-          if (props != null)
+          var props = entity.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
+          if (props != null && props.CanRead)
           {
             var entityName = props.GetValue(entity) as string;
             if (entityName == name)
@@ -159,6 +160,10 @@ namespace Objects.Converter.AutocadCivil
           }
         }
       }
+
+      if (id == ObjectId.Null && useFirstIfNull && collection.Count > 0)
+        id = collection[0];
+
       return id;
     }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -230,13 +230,13 @@ namespace Objects.Converter.AutocadCivil
         var docStyles = new ObjectIdCollection();
         foreach (ObjectId styleId in civilDoc.Styles.AlignmentStyles) docStyles.Add(styleId);
         var style = civilAlignment != null ? 
-          GetFromObjectIdCollection(civilAlignment.style, docStyles) :  civilDoc.Styles.AlignmentStyles.First();
+          GetFromObjectIdCollection(civilAlignment.style, docStyles, true) :  civilDoc.Styles.AlignmentStyles.First();
 
         // label set style
         var labelStyles = new ObjectIdCollection();
         foreach (ObjectId styleId in civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles) labelStyles.Add(styleId);
         var label = civilAlignment != null ?
-          GetFromObjectIdCollection(civilAlignment["label"] as string, labelStyles) : civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles.First();
+          GetFromObjectIdCollection(civilAlignment["label"] as string, labelStyles, true) : civilDoc.Styles.LabelSetStyles.AlignmentLabelSetStyles.First();
 #endregion
 
         try


### PR DESCRIPTION
## Description & motivation

The `GetFromObjectIdCollection()` util method in the acadcivil converter wasn't previously checking whether or not an existing prop has a getter. This was breaking alignment to native conversions when trying to retrieve the alignment style.

Method has been updated to return a defualt value if null, and also to check for `CanRead` before accessing an object prop.

Fixes #1708 

## Changes:

AutocadCivil converter: Utils and AlignmentToNative conversion

## Validation of changes:

Alignments received in new docs are now created without error.

