### PR TITLE
Fix(dyn): Fixes the Converter loading issues with Dynamo

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -328,6 +328,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
           var msg = e.ToFormattedString();
           Message = msg.Contains("401") || msg.Contains("don't have access") ? "Not authorized" : "Error";
           Warning(msg);
+          _errors.Add(e);
           //throw;
         }
       }

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Utils.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Utils.cs
@@ -25,13 +25,13 @@ namespace Speckle.ConnectorDynamo.Functions
           var version = (string)type2.GetProperty("VersionNumber").GetValue(app, null);
 
           if (version.Contains("2024"))
-            return HostApplications.Dynamo.GetVersion(HostAppVersion.v2024);
+            return HostApplications.Dynamo.GetVersion(HostAppVersion.vRevit2024);
           if (version.Contains("2023"))
-            return HostApplications.Dynamo.GetVersion(HostAppVersion.v2023);
+            return HostApplications.Dynamo.GetVersion(HostAppVersion.vRevit2023);
           if (version.Contains("2022"))
-            return HostApplications.Dynamo.GetVersion(HostAppVersion.v2022);
+            return HostApplications.Dynamo.GetVersion(HostAppVersion.vRevit2022);
           if (version.Contains("2021"))
-            return HostApplications.Dynamo.GetVersion(HostAppVersion.v2021);
+            return HostApplications.Dynamo.GetVersion(HostAppVersion.vRevit2021);
           else
             return HostApplications.Dynamo.GetVersion(HostAppVersion.vRevit);
 


### PR DESCRIPTION
Dynamo was unable to find it's own Revit converter's due to a mismatch in the versions it was looking for.

Versions in connector and converter are now aligned.

Part of #1733 