### PR TITLE
fix(rhino): update receive mode checks for user string before guid match

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -480,16 +480,19 @@ namespace SpeckleRhino
     // gets objects by id directly or by applicaiton id user string
     private List<RhinoObject> GetObjectsByApplicationId(string applicationId)
     {
-      var match = new List<RhinoObject>();
-      RhinoObject obj = null;
-      try
+      // first try to find the object by app id user string
+      var match = Doc.Objects.Where(o => o.Attributes.GetUserString(ApplicationIdKey) == applicationId)?.ToList() ?? new List<RhinoObject>();
+      
+      // if nothing is found, look for the geom obj by its guid directly
+      if (!match.Any())
       {
-        obj = Doc.Objects.FindId(new Guid(applicationId)); // try get geom object from app id directly
-        match.Add(obj);
-      }
-      catch
-      {
-        match = Doc.Objects.Where(o => o.Attributes.GetUserString(ApplicationIdKey) == applicationId).ToList(); // try get geom obj from geom obj app id user string
+        try
+        {
+          RhinoObject obj = Doc.Objects.FindId(new Guid(applicationId));
+          if (obj != null)
+            match.Add(obj);
+        }
+        catch { }
       }
       return match;
     }
@@ -965,7 +968,7 @@ namespace SpeckleRhino
         if (converted["@SpeckleSchema"] != null)
         {
           var newSchemaBase = converted["@SpeckleSchema"] as Base;
-          newSchemaBase.applicationId = guid;
+          newSchemaBase.applicationId = applicationId;
           converted["@SpeckleSchema"] = newSchemaBase;
         }
 


### PR DESCRIPTION
## Description & motivation

Fixes behavior in the update receive mode to check for an object's `applicationId` user string for a match before checking for an object's guid.

This should align expected behavior when updating received objects in a new rhino file

Fixes #1727 

## Changes:

Rhino connector

## Validation of changes:

Recieved Rhino test file commit in new Rhino file, moved some recieved objects, received again in update mode (moved objects were moved back)

