### PR TITLE
Dynamo: Handle deserialisation errors on Receive

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -324,12 +324,12 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
       {
         if (!_cancellationToken.IsCancellationRequested)
         {
-          //_cancellationToken.Cancel();
+          _cancellationToken.Cancel();
           var msg = e.ToFormattedString();
           Message = msg.Contains("401") || msg.Contains("don't have access") ? "Not authorized" : "Error";
           Warning(msg);
           _errors.Add(e);
-          //throw;
+          throw;
         }
       }
       finally

--- a/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/BatchConverter.cs
@@ -19,6 +19,7 @@ namespace Speckle.ConnectorDynamo.Functions
       get;
       set;
     }
+    
     public EventHandler<OnErrorEventArgs> OnError;
     
     public BatchConverter()
@@ -329,17 +330,6 @@ namespace Speckle.ConnectorDynamo.Functions
 
       Type type = @object.GetType();
       return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>);
-    }
-  }
-  
-  [IsVisibleInDynamoLibrary(false)]
-  public class OnErrorEventArgs : EventArgs
-  {
-    public Exception Error;
-
-    public OnErrorEventArgs(Exception error)
-    {
-      Error = error;
     }
   }
 }

--- a/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -72,6 +72,7 @@
     <Compile Include="InMemoryCache.cs" />
     <Compile Include="Account.cs" />
     <Compile Include="Functions.cs" />
+    <Compile Include="OnErrorEventArgs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Stream.cs" />
     <Compile Include="BatchConverter.cs" />

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Autodesk.DesignScript.Runtime;
+using Sentry;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
@@ -159,11 +160,15 @@ namespace Speckle.ConnectorDynamo.Functions
         cancellationToken,
         remoteTransport: transport,
         onProgressAction: onProgressAction,
-        onErrorAction: onErrorAction,
+        onErrorAction: ((s, exception) => throw exception),
         onTotalChildrenCountKnown: onTotalChildrenCountKnown,
         disposeTransports: true
       ).Result;
 
+      if (@base == null)
+      {
+        throw new SpeckleException("Receive operation returned nothing", false);
+      }
       try
       {
         client.CommitReceived(new CommitReceivedInput

--- a/ConnectorDynamo/ConnectorDynamoFunctions/OnErrorEventArgs.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/OnErrorEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Autodesk.DesignScript.Runtime;
+
+namespace Speckle.ConnectorDynamo
+{
+  [IsVisibleInDynamoLibrary(false)]
+  public class OnErrorEventArgs
+  {
+    public Exception Error;
+
+    public OnErrorEventArgs(Exception error)
+    {
+      Error = error;
+    }
+  }
+}


### PR DESCRIPTION

- Fixes #1733 

Receive node would swallow any deserialisation errors reported when expiring the node.

These changes just ensure that if a deserialisation error occurs, we report it to the user straight away and stop any further action.

Bonus:

- Fixes #1729 by just removing `EventArgs` as the parent of `OnErrorEventArgs`