### PR TITLE
fix(tekla): Regenerated Tekla's `ManifestGenerator.xml` and re-added C tsep build step

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -152,6 +152,8 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build TSEP
                 command: speckle-sharp-ci-tools/TSEPBuilder/TeklaExtensionPackage.BatchBuilder.exe -I C:/Users/circleci/project/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ManifestGenerator.xml -O C:/Users/circleci/project/speckle-sharp-ci-tools/Installers/<<parameters.slug>>/<<parameters.dllname>>.tsep
+            - store_artifacts:
+                path: speckle-sharp-ci-tools/Installers/<<parameters.slug>>/
       - when:
           condition: << pipeline.git.tag >>
           steps:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -145,13 +145,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           shell: cmd.exe #does not work in powershell
           environment:
             SLUG: << parameters.slug >>
-      # - when:
-      #     condition:
-      #       equal: [teklastructures, << parameters.slug >>] # Tekla Structures has it's own "plugin packager", so we do this instead of the ISS step
-      #     steps:
-      #       - run:
-      #           name: Build TSEP
-      #           command: speckle-sharp-ci-tools/TSEPBuilder/TeklaExtensionPackage.BatchBuilder.exe -I C:/Users/circleci/project/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ManifestGenerator.xml -O C:/Users/circleci/project/speckle-sharp-ci-tools/Installers/<<parameters.slug>>/<<parameters.dllname>>.tsep
+      - when:
+          condition:
+            equal: [teklastructures, << parameters.slug >>] # Tekla Structures has it's own "plugin packager", so we do this instead of the ISS step
+          steps:
+            - run:
+                name: Build TSEP
+                command: speckle-sharp-ci-tools/TSEPBuilder/TeklaExtensionPackage.BatchBuilder.exe -I C:/Users/circleci/project/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ManifestGenerator.xml -O C:/Users/circleci/project/speckle-sharp-ci-tools/Installers/<<parameters.slug>>/<<parameters.dllname>>.tsep
       - when:
           condition: << pipeline.git.tag >>
           steps:

--- a/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ManifestGenerator.xml
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ManifestGenerator.xml
@@ -58,12 +58,15 @@
 		<File Id="Avalonia.X11.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Avalonia.X11.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="DesktopUI2.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\DesktopUI2.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="DynamicData.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\DynamicData.dll" Target="%BinariesTargetDirectory%"/>
+		<File Id="e_sqlite3.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\e_sqlite3.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="GraphQL.Client.Abstractions.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\GraphQL.Client.Abstractions.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="GraphQL.Client.Abstractions.Websocket.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\GraphQL.Client.Abstractions.Websocket.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="GraphQL.Client.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\GraphQL.Client.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="GraphQL.Primitives.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\GraphQL.Primitives.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="HarfBuzzSharp.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\HarfBuzzSharp.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="JetBrains.Annotations.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\JetBrains.Annotations.dll" Target="%BinariesTargetDirectory%"/>
+		<File Id="libHarfBuzzSharp.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\libHarfBuzzSharp.dll" Target="%BinariesTargetDirectory%"/>
+		<File Id="libSkiaSharp.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\libSkiaSharp.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Material.Avalonia.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Material.Avalonia.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Material.Colors.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Material.Colors.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Material.DataGrid.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Material.DataGrid.dll" Target="%BinariesTargetDirectory%"/>
@@ -79,6 +82,7 @@
 		<File Id="Microsoft.CodeAnalysis.CSharp.Scripting.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Microsoft.CodeAnalysis.CSharp.Scripting.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Microsoft.CodeAnalysis.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Microsoft.CodeAnalysis.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Microsoft.CodeAnalysis.Scripting.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Microsoft.CodeAnalysis.Scripting.dll" Target="%BinariesTargetDirectory%"/>
+		<File Id="Microsoft.Data.Sqlite.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Microsoft.Data.Sqlite.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Newtonsoft.Json.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Newtonsoft.Json.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Objects.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Objects.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="PolygonMesher.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\PolygonMesher.dll" Target="%BinariesTargetDirectory%"/>
@@ -89,12 +93,14 @@
 		<File Id="SpeckleConnectorTeklaStructures.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\SpeckleConnectorTeklaStructures.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="SpeckleCore2.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\SpeckleCore2.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Splat.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Splat.dll" Target="%BinariesTargetDirectory%"/>
+		<File Id="SQLitePCLRaw.batteries_v2.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\SQLitePCLRaw.batteries_v2.dll" Target="%BinariesTargetDirectory%"/>
+		<File Id="SQLitePCLRaw.core.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\SQLitePCLRaw.core.dll" Target="%BinariesTargetDirectory%"/>
+		<File Id="SQLitePCLRaw.provider.e_sqlite3.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\SQLitePCLRaw.provider.e_sqlite3.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="Stylet.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\Stylet.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="System.Buffers.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.Buffers.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="System.Collections.Immutable.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.Collections.Immutable.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="System.ComponentModel.Annotations.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.ComponentModel.Annotations.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="System.Data.Common.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.Data.Common.dll" Target="%BinariesTargetDirectory%"/>
-		<File Id="System.Data.SQLite.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.Data.SQLite.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="System.Diagnostics.StackTrace.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.Diagnostics.StackTrace.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="System.Diagnostics.Tracing.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.Diagnostics.Tracing.dll" Target="%BinariesTargetDirectory%"/>
 		<File Id="System.Drawing.Common.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\System.Drawing.Common.dll" Target="%BinariesTargetDirectory%"/>
@@ -175,10 +181,8 @@
 		<File Id="\tr\Microsoft.CodeAnalysis.Scripting.resources.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\tr\Microsoft.CodeAnalysis.Scripting.resources.dll" Target= "%BinariesTargetDirectory%\tr"/>
 		<File Id="\x64\libHarfBuzzSharp.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\x64\libHarfBuzzSharp.dll" Target= "%BinariesTargetDirectory%\x64"/>
 		<File Id="\x64\libSkiaSharp.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\x64\libSkiaSharp.dll" Target= "%BinariesTargetDirectory%\x64"/>
-		<File Id="\x64\SQLite.Interop.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\x64\SQLite.Interop.dll" Target= "%BinariesTargetDirectory%\x64"/>
 		<File Id="\x86\libHarfBuzzSharp.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\x86\libHarfBuzzSharp.dll" Target= "%BinariesTargetDirectory%\x86"/>
 		<File Id="\x86\libSkiaSharp.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\x86\libSkiaSharp.dll" Target= "%BinariesTargetDirectory%\x86"/>
-		<File Id="\x86\SQLite.Interop.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\x86\SQLite.Interop.dll" Target= "%BinariesTargetDirectory%\x86"/>
 		<File Id="\zh-Hans\Microsoft.CodeAnalysis.CSharp.resources.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\zh-Hans\Microsoft.CodeAnalysis.CSharp.resources.dll" Target= "%BinariesTargetDirectory%\zh-Hans"/>
 		<File Id="\zh-Hans\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\zh-Hans\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll" Target= "%BinariesTargetDirectory%\zh-Hans"/>
 		<File Id="\zh-Hans\Microsoft.CodeAnalysis.resources.dll" Source="C:\Users\circleci\project\ConnectorTeklaStructures\ConnectorTeklaStructures2021\bin\Release\zh-Hans\Microsoft.CodeAnalysis.resources.dll" Target= "%BinariesTargetDirectory%\zh-Hans"/>


### PR DESCRIPTION
Fixes #1630 

Tekla TSEP build step was removed last release because it was blocking our release while Rey was on vacation.

The issue with that step was that Tekla connector requries a `Manifest.xml` file that contains **all of the files the TSEP plugin should contain**.

This mainfest file is generated using a T4 template on the Tekla project, but it is not hooked up to be automatically updated on every build (to be fixed on issue #1749)
