### PR TITLE
fix(revit): Fixed issue occurs when receiving object with an applicat…

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -716,10 +716,10 @@ namespace Objects.Converter.Revit
         //eg: user sends some objects, moves them, receives them 
         element = Doc.GetElement(applicationId);
       }
-      else
+      else if(@ref.CreatedIds.Any())
       {
         //return the cached object, if it's still in the model
-        element = Doc.GetElement(@ref.CreatedIds.FirstOrDefault());
+        element = Doc.GetElement(@ref.CreatedIds.First());
       }
 
       return element;


### PR DESCRIPTION
Small fix.
I notice a null reference exception is thrown sometimes when receiving elements in `Update` mode fails when receiving elements with an `ApplicationID` that doesn't match anything in the current document.

Seems like `Doc.GetElement(null)` throws (rather than returning null) as I think was expected.