### PR TITLE
Fix(Revit): add backup calc if structuralMatType of family is undefined

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
@@ -492,6 +492,22 @@ namespace Objects.Converter.Revit
     {
       Structural.Materials.StructuralMaterial speckleMaterial = null;
 
+      if (materialType == StructuralMaterialType.Undefined)
+      {
+        switch (materialAsset.StructuralAssetClass)
+        {
+          case StructuralAssetClass.Metal:
+            materialType = StructuralMaterialType.Steel;
+            break;
+          case StructuralAssetClass.Concrete:
+            materialType = StructuralMaterialType.Concrete;
+            break;
+          case StructuralAssetClass.Wood:
+            materialType = StructuralMaterialType.Wood;
+            break;
+        }
+      }
+
       switch (materialType)
       {
         case StructuralMaterialType.Concrete:


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

currently to set the structural material of an analytical member from Revit, we rely on the structuralMaterialType property of the family instance. I've found that this is sometimes "undefined". So I've added a backup way to find the structural material using the structural asset class of the family instance's material.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

add second method of determining structuralMaterialType if the first method resulted in "undefined"

<!---

- Item 1
- Item 2

-->