### PR TITLE
fix(CI): Remove old .yml file creation

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -135,8 +135,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             $semver = if($tag.Contains('/')) {$tag.Split("/")[0] } else { $tag }
             $ver = if($semver.Contains('-')) {$semver.Split("-")[0] } else { $semver }
             $version = "$($ver).$($env:WORKFLOW_NUM)"
-            msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:AssemblyVersionNumber=$version /p:AssemblyInformationalVersion=$semver /p:Version=$semver  
-            if(-Not [string]::IsNullOrEmpty($env:CIRCLE_TAG) -And -Not $semver.Contains('-')) { New-Item -Force "speckle-sharp-ci-tools/Installers/<< parameters.slug >>/latest.yml" -ItemType File -Value "version: $semver" }
+            msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:AssemblyVersionNumber=$version /p:AssemblyInformationalVersion=$semver /p:Version=$semver
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -231,7 +230,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false
             CHANNEL=$(if [[ "$VERSION" == *"-"* ]]; then echo $(cut -d "-" -f2 \<\<\< $VERSION); else echo latest; fi)
             mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
-            if [ "${CIRCLE_TAG}" ]; then echo "version: $SEMVER" > "speckle-sharp-ci-tools/Installers/<< parameters.slug >>/$CHANNEL.yml"; fi
           environment:
             WORKFLOW_NUM: << pipeline.number >>
 


### PR DESCRIPTION
An old part of our CI designed to work for the old deploy mechanism was creating the same `latest.yml` file in 2 different workspaces, causing CircleCI to freak out and fail all deploy jobs.

This is an urgent fix so it shall be merged directly.