### PR TITLE
hotfix(rhino): handles null app ids on update receive mode

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -480,6 +480,9 @@ namespace SpeckleRhino
     // gets objects by id directly or by applicaiton id user string
     private List<RhinoObject> GetObjectsByApplicationId(string applicationId)
     {
+      if (string.IsNullOrEmpty(applicationId))
+        return new List<RhinoObject>();
+
       // first try to find the object by app id user string
       var match = Doc.Objects.Where(o => o.Attributes.GetUserString(ApplicationIdKey) == applicationId)?.ToList() ?? new List<RhinoObject>();
       
@@ -552,7 +555,7 @@ namespace SpeckleRhino
         {
           appObj.Convertible = true;
           if (StoredObjects.ContainsKey(@base.id))
-            appObj.Update(logItem: $"Found another {speckleType} in this commit with the same id. Skipped other object");
+            appObj.Update(logItem: $"Found another {speckleType} in this commit with the same id {@base.id}. Skipped other object");
           else
             StoredObjects.Add(@base.id, @base);
           objects.Add(appObj);


### PR DESCRIPTION
## Description & motivation

The Rhino update mode was not properly handling objects with null `applicationId` and therefore removing all previously baked objects with no `applicationId` user string.

Fixes #1775

## Changes:

Rhino connector

## Screenshots:

![image](https://user-images.githubusercontent.com/16748799/197762787-235c5117-87ba-42a4-b275-6e42af17df41.png)

## Validation of changes:

Received https://speckle.xyz/streams/17b0b76d13/commits/c028853130?c=%5B283000.97965,5709543.66179,1602.16947,283676.88013,5709951.8115,543.55274,0,1%5D on update mode

