### PR TITLE
fix(ci): Adds `packandpublish-bash` for any bash jobs that require nuget pushing

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -98,7 +98,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             HOMEBREW_NO_AUTO_UPDATE=1 brew install mono mono-libgdiplus
       - run:
           name: Install dotnet
-          command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+          command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 3.1.0
       - run:
           name: Restore Objects
           command: ~/.dotnet/dotnet restore Objects/Objects.sln

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -32,7 +32,7 @@ commands:
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]+//')
             VERSION=$(echo "$SEMVER" | sed -e 's/[a-zA-Z]*\///')
-            dotnet build <<parameters.projectfilepath>> -p:Version="$VERSION" -p:Configuration=Release -p:WarningLevel=0 -p:IsDesktopBuild=false -t:pack
+            msbuild <<parameters.projectfilepath>> /p:Version="$VERSION" /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false -t:pack
             dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -88,11 +88,17 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       #- codecov/upload
 
   build-objects:
-    docker:
-      - image: "mcr.microsoft.com/dotnet/core/sdk" # dotnet core 3.1 sdk
-      - image: "mcr.microsoft.com/dotnet/core/sdk:2.1-focal" # dotnet core 2.1 sdk (for netstandard support on build)
+    macos:
+      xcode: 12.5.1
     steps:
       - checkout
+      - run:
+          name: Install mono
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install mono mono-libgdiplus
+      - run:
+          name: Install dotnet
+          command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
       - run:
           name: Restore Objects
           command: dotnet restore Objects/Objects.sln

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -98,7 +98,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             HOMEBREW_NO_AUTO_UPDATE=1 brew install mono mono-libgdiplus
       - run:
           name: Install dotnet
-          command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 3.1.0
+          command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1
       - run:
           name: Restore Objects
           command: ~/.dotnet/dotnet restore Objects/Objects.sln

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -33,7 +33,7 @@ commands:
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]+//')
             VERSION=$(echo "$SEMVER" | sed -e 's/[a-zA-Z]*\///')
             msbuild <<parameters.projectfilepath>> /p:Version="$VERSION" /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false -t:pack
-            dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
+            ~/.dotnet/dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
           environment:
             WORKFLOW_NUM: << pipeline.number >>
 jobs: # Each project will have individual jobs for each specific task it has to execute (build, release...)

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -101,13 +101,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
       - run:
           name: Restore Objects
-          command: dotnet restore Objects/Objects.sln
+          command: ~/.dotnet/dotnet restore Objects/Objects.sln
       - run:
           name: Build Objects
-          command: dotnet build --no-restore Objects/Objects/Objects.csproj -c Release /p:WarningLevel=0 /p:IsDesktopBuild=false
+          command: ~/.dotnet/dotnet build --no-restore Objects/Objects/Objects.csproj -c Release /p:WarningLevel=0 /p:IsDesktopBuild=false
       - run:
           name: Test Objects
-          command: dotnet test Objects/Tests/Tests.csproj --no-restore -c Release -v q --logger:"junit;LogFileName={assembly}.results.xml" --results-directory=TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+          command: ~/.dotnet/dotnet test Objects/Tests/Tests.csproj --no-restore -c Release -v q --logger:"junit;LogFileName={assembly}.results.xml" --results-directory=TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       - store_test_results:
           path: TestResults
       - store_artifacts:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -98,7 +98,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             HOMEBREW_NO_AUTO_UPDATE=1 brew install mono mono-libgdiplus
       - run:
           name: Install dotnet
-          command: curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1
+          command: |
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1
       - run:
           name: Restore Objects
           command: ~/.dotnet/dotnet restore Objects/Objects.sln

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -21,6 +21,21 @@ commands:
             dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
           environment:
             WORKFLOW_NUM: << pipeline.number >>
+  packandpublish-bash:
+    parameters:
+      projectfilepath:
+        type: string
+    steps:
+      - run:
+          name: Publish nuget package
+          command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]+//')
+            VERSION=$(echo "$SEMVER" | sed -e 's/[a-zA-Z]*\///')
+            dotnet build <<parameters.projectfilepath>> -p:Version="$VERSION" -p:Configuration=Release -p:WarningLevel=0 -p:IsDesktopBuild=false -t:pack
+            dotnet nuget push **/*.nupkg -s https://api.nuget.org/v3/index.json -k $env:NUGET_APIKEY -n true
+          environment:
+            WORKFLOW_NUM: << pipeline.number >>
 jobs: # Each project will have individual jobs for each specific task it has to execute (build, release...)
   build-core:
     executor: # Using a win executor since there are post-steps in the nuget workflow that use powershell
@@ -368,7 +383,7 @@ workflows:
             tags:
               only: /^(nuget-objects|nugets)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w{1,10})?$/
           post-steps:
-            - packandpublish:
+            - packandpublish-bash:
                 projectfilepath: Objects/Objects.sln
       - build-desktopui:
           name: nuget-deploy-desktopui

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterDxf.Tests.csproj
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterDxf.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -11,6 +10,7 @@
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.2.0" />
+        <PackageReference Include="Speckle.netDxf" Version="3.0.1" PrivateAssets="true" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterFixture.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterFixture.cs
@@ -1,20 +1,23 @@
 using System;
+using Objects.Converters.DxfConverter;
 using Speckle.Core.Models;
+using Speckle.netDxf.Units;
 using Xunit;
-using Dxf = netDxf;
-using Dxfe = netDxf.Entities;
+using Dxf = Speckle.netDxf;
+using Dxfe = Speckle.netDxf.Entities;
 
 namespace ConverterDxf.Tests
 {
     public class ConverterFixture: IDisposable
     {
         public SpeckleDxfConverter Converter;
-        public Dxf.DxfDocument Doc;
+        public readonly Dxf.DxfDocument Doc;
 
         public ConverterFixture()
         {
             Converter = new SpeckleDxfConverter();
             Doc = new Dxf.DxfDocument();
+            Doc.DrawingVariables.InsUnits = DrawingUnits.Meters;
             Converter.SetContextDocument(Doc);
         }
 

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterSetup.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/ConverterSetup.cs
@@ -12,10 +12,15 @@ namespace ConverterDxf.Tests
         public static IEnumerable<T> FetchAllObjectsOfType<T>(string streamUrl) where T: Base 
             => Speckle.Core.Api.Helpers.Receive(streamUrl)
                       .Result
-                      .Flatten(true, b => b is T).Cast<T>();
+                      .Flatten(b => b is T)
+                      .Where(b => b is T)
+                      .Cast<T>();
         
-        public static IEnumerable<object[]> GetTestMemberData<T>() where T: Base => 
-            FetchAllObjectsOfType<T>(TestStream).Select(v => new object[] { v });
+        public static IEnumerable<object[]> GetTestMemberData<T>() where T: Base
+        {
+            var d =FetchAllObjectsOfType<T>(TestStream).Select(v => new object[] { v });
+            return d;
+        }
 
     }
 }

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/BrepTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/BrepTests.cs
@@ -2,8 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Objects.Geometry;
 using Xunit;
-using Dxf = netDxf;
-using Dxfe = netDxf.Entities;
+using Dxf = Speckle.netDxf;
+using Dxfe = Speckle.netDxf.Entities;
 
 namespace ConverterDxf.Tests.Geometry
 {

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/CurveTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/CurveTests.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using Objects.Geometry;
 using Xunit;
-using Dxf = netDxf;
-using Dxfe = netDxf.Entities;
+using Dxf = Speckle.netDxf;
+using Dxfe = Speckle.netDxf.Entities;
 
 namespace ConverterDxf.Tests.Geometry
 {

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/MeshTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/MeshTests.cs
@@ -2,8 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Objects.Geometry;
 using Xunit;
-using Dxf = netDxf;
-using Dxfe = netDxf.Entities;
+using Dxf = Speckle.netDxf;
+using Dxfe = Speckle.netDxf.Entities;
 
 namespace ConverterDxf.Tests.Geometry
 {

--- a/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/VectorTests.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf.Tests/Geometry/VectorTests.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using Objects.Geometry;
 using Xunit;
-using Dxf = netDxf;
-using Dxfe = netDxf.Entities;
+using Dxf = Speckle.netDxf;
+using Dxfe = Speckle.netDxf.Entities;
 
 namespace ConverterDxf.Tests.Geometry
 {

--- a/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Objects.ConverterDxf</AssemblyName>
-        <LangVersion>9</LangVersion>
         <Nullable>disable</Nullable>
         <RootNamespace>Objects.Converters.DxfConverter</RootNamespace>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Document.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Speckle.Core.Models;
 using Speckle.netDxf;
@@ -16,6 +17,11 @@ namespace Objects.Converters.DxfConverter
                 case string str: // Load up an existing document
                     Doc = DxfDocument.Load(str);
                     break;
+                case DxfDocument d:
+                    Doc = d;
+                    break;
+                default:
+                    throw new Exception("Provided doc is not a string or a DXF doc");
             }
         }
 

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Geometry.cs
@@ -17,13 +17,13 @@ namespace Objects.Converters.DxfConverter
     public partial class SpeckleDxfConverter
     {
         public Dxf.Vector3 VectorToNative(Point pt) => VectorToNative(new Vector(pt) { units = pt.units });
-        public Dxf.Vector3 VectorToNative(Vector pt) => new(ScaleToNative(pt.x, pt.units), ScaleToNative(pt.y, pt.units), ScaleToNative(pt.z, pt.units));
-        public Dxf.Entities.Point PointToNative(Point pt) => new(VectorToNative(pt));
+        public Dxf.Vector3 VectorToNative(Vector pt) => new Dxf.Vector3(ScaleToNative(pt.x, pt.units), ScaleToNative(pt.y, pt.units), ScaleToNative(pt.z, pt.units));
+        public Dxf.Entities.Point PointToNative(Point pt) => new Dxf.Entities.Point(VectorToNative(pt));
 
         public Dxf.Entities.Line LineToNative(Line line) =>
-            new(VectorToNative(line.start), VectorToNative(line.end));
+            new Dxf.Entities.Line(VectorToNative(line.start), VectorToNative(line.end));
 
-        public Dxfe.Mesh MeshToNative(Mesh mesh) => new(
+        public Dxfe.Mesh MeshToNative(Mesh mesh) => new Dxfe.Mesh(
             mesh.GetPoints().Select(VectorToNative),
             mesh.GetFaceIndices()
         )

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Units.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.Units.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Core.Kits;
+﻿using System;
+using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.netDxf.Units;
 
@@ -8,37 +9,65 @@ namespace Objects.Converters.DxfConverter
   {
     public double ScaleToNative(double value, string units)
     {
+      Console.WriteLine(Doc);
+      Console.WriteLine(units);
+      if (units == null)
+      {
+        throw new Exception("null units");
+      }
+
+      if (Doc == null)
+        throw new Exception("null doc");
+      
       return value * Units.GetConversionFactor(units, DocUnitsToUnits(Doc.DrawingVariables.InsUnits));
     }
 
     public DrawingUnits UnitsToDocUnits(string units)
     {
-      return units switch
+      switch (units)
       {
-        Units.Centimeters => DrawingUnits.Centimeters,
-        Units.Meters => DrawingUnits.Meters,
-        Units.Kilometers => DrawingUnits.Kilometers,
-        Units.Inches => DrawingUnits.Inches,
-        Units.Feet => DrawingUnits.Feet,
-        Units.Yards => DrawingUnits.Yards,
-        Units.Miles => DrawingUnits.Miles,
-        _ => DrawingUnits.Meters
-      };
+        case Units.Centimeters:
+          return DrawingUnits.Centimeters;
+        case Units.Meters:
+          return DrawingUnits.Meters;
+        case Units.Kilometers:
+          return DrawingUnits.Kilometers;
+        case Units.Inches:
+          return DrawingUnits.Inches;
+        case Units.Feet:
+          return DrawingUnits.Feet;
+        case Units.Yards:
+          return DrawingUnits.Yards;
+        case Units.Miles:
+          return DrawingUnits.Miles;
+        default:
+          return DrawingUnits.Meters;
+      }
     }
 
     public string DocUnitsToUnits(DrawingUnits units)
     {
-      return units switch
+      switch (units)
       {
-        DrawingUnits.Centimeters => Units.Centimeters,
-        DrawingUnits.Meters => Units.Meters,
-        DrawingUnits.Kilometers => Units.Kilometers,
-        DrawingUnits.Inches => Units.Inches,
-        DrawingUnits.Feet => Units.Feet,
-        DrawingUnits.Yards => Units.Yards,
-        DrawingUnits.Miles => Units.Miles,
-        _ => throw new SpeckleException("Unknown document units!")
-      };
+        case DrawingUnits.Centimeters:
+          return Units.Centimeters;
+        case DrawingUnits.Meters:
+          return Units.Meters;
+        case DrawingUnits.Kilometers:
+          return Units.Kilometers;
+        case DrawingUnits.Inches:
+          return Units.Inches;
+        case DrawingUnits.Feet:
+          return Units.Feet;
+        case DrawingUnits.Yards:
+          return Units.Yards;
+        case DrawingUnits.Miles:
+          return Units.Miles;
+        case DrawingUnits.Unitless:
+          return Units.None;
+        default:
+          throw new SpeckleException($"Unknown document units: {units}");
+      }
     }
   }
 }

--- a/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/SpeckleDxfConverter.cs
@@ -19,8 +19,8 @@ namespace Objects.Converters.DxfConverter
     public string Author => "Speckle Systems";
     public string WebsiteOrEmail => "https://speckle.systems";
 
-    public ProgressReport Report { get; } = new();
-    public ConverterDxfSettings Settings = new();
+    public ProgressReport Report { get; } = new ProgressReport();
+    public ConverterDxfSettings Settings = new ConverterDxfSettings();
     public ReceiveMode ReceiveMode { get; set; } = ReceiveMode.Create;
 
     // TODO: Convert to Speckle is currently not supported.
@@ -60,7 +60,7 @@ namespace Objects.Converters.DxfConverter
         case Brep brep:
           return BrepToNative(brep);
         default:
-          return null!;
+          return null;
       }
     }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
@@ -27,7 +27,7 @@
 
     <ItemGroup>
         <PackageReference Include="Grasshopper" Version="7.4.21078.1001" />
-        <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0">
+        <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0" Condition="$([MSBuild]::IsOSPlatform(Windows))">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Fixes an issue introduced in #1621 inadvertently.

The PR modified the `Objects` job to run on bash instead of powershell. This seemed like the right choice at the time, since it simplified setup, reduced credit cost and actually ran faster.

I did not realise at the time that our `packandpublish` command was written in `powershell` so it would throw a syntax error on any jobs running on `bash`.

## Solution

This PR fixes the issue by creating a specific job to pack and publish when using `bash` that follows the same logic.

Had to downgrade `ConverterDxf` language version usage to the default, as it was using version `9` and it was causing issues when building. Required some updates on the DXF tests to get them to work again too.

