### PR TITLE
fix(rhino): Prevent Rhino from loading... again

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/ConnectorRhinoCommand.cs
@@ -62,12 +62,18 @@ namespace SpeckleRhino
       try
       {
 #if MAC
-        CreateOrFocusSpeckle();
+        var msg = "Speckle is temporarily disabled on Rhino due to a critical bug regarding Rhino's top-menu commands. Please use Grasshopper instead while we fix this.";
+        RhinoApp.CommandLineOut.WriteLine(msg);
+        Rhino.UI.Dialogs.ShowMessage(msg, "Speckle has been disabled", Rhino.UI.ShowMessageButton.OK, Rhino.UI.ShowMessageIcon.Exclamation);
+        return Result.Nothing;
+        //CreateOrFocusSpeckle();
+        //return Result.Success;
 #else
         Rhino.UI.Panels.OpenPanel(typeof(Panel).GUID);
-#endif
         return Result.Success;
-      } catch (Exception e)
+#endif
+      }
+      catch (Exception e)
       {
         RhinoApp.CommandLineOut.WriteLine($"Speckle Error - { e.ToFormattedString() }");
         return Result.Failure;


### PR DESCRIPTION
Adds Warning to not use Rhino for Mac (while we fix the issue with the top-menu (#1277).

It was accidentally removed when we fixed the SQLite build process for mac and windows.