### PR TITLE
fix(archicad): Added msbuild.assemblyinfo nuget for windows only (needed for Innosetup)

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/ConnectorArchicad.csproj
+++ b/ConnectorArchicad/ConnectorArchicad/ConnectorArchicad.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="Avalonia" Version="0.10.18" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
+    <PackageReference Include="MSBuild.AssemblyVersion" Version="1.3.0" Condition="$([MSBuild]::IsOSPlatform(Windows))">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
The `MSBuild.AssemblyInfo` was removed by @jozseflkiss because it was conflicting with his build process in Mac.

It is required for Innosetup to properly pick up the version when creating the installer.

Since Innosetup is windows only, i've also added a condition to prevent it from messing up with the mac build.

Tested on my computer and it works like a charm.