### PR TITLE
feat(objects): adds network and mep classes

### DIFF
--- a/Objects/Objects/BuiltElements/Conduit.cs
+++ b/Objects/Objects/BuiltElements/Conduit.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Objects.Geometry;
+using Objects.Utils;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using Speckle.Newtonsoft.Json;
+
+namespace Objects.BuiltElements
+{
+  public class Conduit : Base, IDisplayValue<List<Mesh>>
+  {
+    public ICurve baseCurve { get; set; }
+    public double diameter { get; set; }
+    public double length { get; set; }
+
+    [DetachProperty]
+    public List<Mesh> displayValue { get; set; }
+
+    public string units { get; set; }
+
+    public Conduit() { }
+  }
+}
+
+namespace Objects.BuiltElements.Revit
+{
+  public class RevitConduit : Conduit
+  {
+    public string family { get; set; }
+
+    public string type { get; set; }
+
+    public Level level { get; set; }
+
+    public Base parameters { get; set; }
+
+    public string elementId { get; set; }
+
+    public RevitConduit() { }
+  }
+}

--- a/Objects/Objects/BuiltElements/Fitting.cs
+++ b/Objects/Objects/BuiltElements/Fitting.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Objects.Geometry;
+using Objects.Utils;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using Speckle.Newtonsoft.Json;
+
+namespace Objects.BuiltElements
+{
+  /// <summary>
+  /// A fitting for MEP elements
+  /// </summary>
+  public class Fitting : Base, IDisplayValue<List<Mesh>>
+  {
+    public FittingType type { get; set; }
+
+    [DetachProperty]
+    public List<Mesh> displayValue { get; set; }
+
+    public string units { get; set; }
+
+    public Fitting() { }
+  }
+
+  public enum FittingType
+  {
+    Cross,
+    Elbow,
+    Tap,
+    Tee,
+    Transition,
+    Union,
+    Unknown
+  }
+}

--- a/Objects/Objects/BuiltElements/Network.cs
+++ b/Objects/Objects/BuiltElements/Network.cs
@@ -82,12 +82,22 @@ namespace Objects.BuiltElements.Revit
 {
   public class RevitNetworkElement : NetworkElement
   {
-    public bool isConnectorBased { get; set; }
-    public bool isCurve { get; set; }
+    /// <summary>
+    /// Indicates if this element was constructed from an MEP curve
+    /// </summary>
+    public bool isCurveBased { get; set; }
+
+    /// <summary>
+    /// Indicates if this element needs temporary placeholder objects to be created first when receiving
+    /// </summary>
+    /// <remarks>
+    /// This is a utility property used to track network creation state on receive. Deprecate if possible. 
+    /// For example, some fittings cannot be created based on connectors, and so will be created similarly to mechanical equipment
+    /// </remarks>
+    [JsonIgnore] public bool needsPlaceholders { get; set; }
 
     public RevitNetworkElement() { }
   }
-
   public class RevitNetworkLink : NetworkLink
   {
     public double height { get; set; }

--- a/Objects/Objects/BuiltElements/Network.cs
+++ b/Objects/Objects/BuiltElements/Network.cs
@@ -82,8 +82,7 @@ namespace Objects.BuiltElements.Revit
 {
   public class RevitNetworkElement : NetworkElement
   {
-    public FittingType fittingType { get; set; }
-    public bool connectorBasedCreation { get; set; }
+    public bool isConnectorBased { get; set; }
     public bool isCurve { get; set; }
 
     public RevitNetworkElement() { }
@@ -105,15 +104,38 @@ namespace Objects.BuiltElements.Revit
     /// <summary>
     /// The shape of the <see cref="NetworkLink"/>
     /// </summary>
-    public RevitNetworkLinkShape shape { get; set; }
+    public NetworkLinkShape shape { get; set; }
 
     /// <summary>
-    /// The connector domain. Could be duct, piping, conduit, cabletray, or unknown 
+    /// The link domain
     /// </summary>
-    public string domain { get; set; }
-    public int connectionIndex { get; set; }
-    public bool connectedToCurve { get; set; }
-    public bool connected { get; set; }
+    public NetworkLinkDomain domain { get; set; }
+
+    /// <summary>
+    /// The index indicating the position of this link on the connected fitting element, if applicable
+    /// </summary>
+    /// <remarks>
+    /// Revit fitting links are 1-indexed. For example, "T" fittings will have ordered links from index 1-3.
+    /// </remarks>
+    public int fittingIndex { get; set; }
+
+    /// <summary>
+    /// Indicates if this link needs temporary placeholder objects to be created first when receiving
+    /// </summary>
+    /// <remarks>
+    /// This is a utility property used to track network creation state on receive. Deprecate if possible. 
+    /// Placeholder geometry are curves. 
+    /// For example, U-bend links need temporary pipes to be created first, if one or more linked pipes have not yet been created in the network.
+    /// </remarks>
+    [JsonIgnore] public bool needsPlaceholders { get; set; }
+
+    /// <summary>
+    /// Indicates if this link has been connected to its elements
+    /// </summary>
+    /// <remarks>
+    /// This is a utility property used to track network creation state on receive. Deprecate if possible.
+    /// </remarks>
+    [JsonIgnore] public bool isConnected { get; set; }
 
     public RevitNetworkLink() { }
   }
@@ -121,11 +143,20 @@ namespace Objects.BuiltElements.Revit
   /// <summary>
   /// Represents the shape of a <see cref="NetworkLink"/>.
   /// </summary>
-  public enum RevitNetworkLinkShape
+  public enum NetworkLinkShape
   {
-    Unknown,
+    Oval,
     Round,
     Rectangular,
-    Oval
+    Unknown,
+  }
+
+  public enum NetworkLinkDomain
+  {
+    Cabletray,
+    Conduit,
+    Duct,
+    Piping,
+    Unknown
   }
 }

--- a/Objects/Objects/BuiltElements/Network.cs
+++ b/Objects/Objects/BuiltElements/Network.cs
@@ -1,0 +1,131 @@
+﻿using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using Speckle.Newtonsoft.Json;
+using Objects.BuiltElements;
+
+namespace Objects.BuiltElements
+{
+  /// <summary>
+  /// Represents graph connections between built elements objects
+  /// </summary>
+  /// <remarks>
+  /// Network <see cref="elements"/> may need to be created first in native applications before they are linked.
+  /// </remarks>
+  public class Network : Base
+  {
+    public string name { get; set; }
+
+    /// <summary>
+    /// The elements contained in the network
+    /// </summary>
+    public List<NetworkElement> elements { get; set; }
+
+    /// <summary>
+    /// The connections between <see cref="elements"/>
+    /// </summary>
+    public List<NetworkLink> links { get; set; }
+
+    public Network() { }
+  }
+
+  public class NetworkElement : Base
+  {
+    public string name { get; set; }
+
+    /// <summary>
+    /// The Base object representing the element in the network (eg Pipe, Duct, etc)
+    /// </summary>
+    public Base element { get; set; }
+
+    /// <summary>
+    /// The index of the links in <see cref="network"/> that are connected to this element
+    /// </summary>
+    public List<int> linkIndices { get; set; }
+
+    [JsonIgnore] public Network network { get; set; }
+
+    public NetworkElement() { }
+
+    /// <summary>
+    /// Retrieves the links for this element
+    /// </summary>
+    [JsonIgnore] public List<NetworkLink> links => linkIndices.Select(i => network.links[i]).ToList();
+  }
+
+  public class NetworkLink : Base
+  {
+    public string name { get; set; }
+
+    /// <summary>
+    /// The index of the elements in <see cref="network"/> that are connected by this link
+    /// </summary>
+    public List<int> elementIndices { get; set; }
+
+    [JsonIgnore] public Network network { get; set; }
+
+    public NetworkLink() { }
+
+    /// <summary>
+    /// Retrieves the elements for this link
+    /// </summary>
+    [JsonIgnore] public List<NetworkElement> elements => elementIndices.Select(i => network.elements[i]).ToList();
+  }
+}
+
+namespace Objects.BuiltElements.Revit
+{
+  public class RevitNetworkElement : NetworkElement
+  {
+    public FittingType fittingType { get; set; }
+    public bool connectorBasedCreation { get; set; }
+    public bool isCurve { get; set; }
+
+    public RevitNetworkElement() { }
+  }
+
+  public class RevitNetworkLink : NetworkLink
+  {
+    public double height { get; set; }
+    public double width { get; set; }
+    public double diameter { get; set; }
+    public Point origin { get; set; }
+    public Vector direction { get; set; }
+    /// <summary>
+    /// The system category
+    /// </summary>
+    public string systemName { get; set; }
+    public string systemType { get; set; }
+
+    /// <summary>
+    /// The shape of the <see cref="NetworkLink"/>
+    /// </summary>
+    public RevitNetworkLinkShape shape { get; set; }
+
+    /// <summary>
+    /// The connector domain. Could be duct, piping, conduit, cabletray, or unknown 
+    /// </summary>
+    public string domain { get; set; }
+    public int connectionIndex { get; set; }
+    public bool connectedToCurve { get; set; }
+    public bool connected { get; set; }
+
+    public RevitNetworkLink() { }
+  }
+
+  /// <summary>
+  /// Represents the shape of a <see cref="NetworkLink"/>.
+  /// </summary>
+  public enum RevitNetworkLinkShape
+  {
+    Unknown,
+    Round,
+    Rectangular,
+    Oval
+  }
+}


### PR DESCRIPTION
## Description & motivation

Adds the following classes to Objects:

- `Network`: organizational class representing graph connections for built elements objects like ducts, pipes, etc
- `NetworkElement`: element in a network (graph nodes)
- `NetworkLink`: links in a network (graph edges)
- revit subclasses for network element and link
- `Fitting`: new mep class

This is a prerequisite for handling sending and receiving revit mep elements that are connected to eachother.
Closes #1427

## Changes:

- Objects

**NOTE** some properties on the revit classes may potentially be deprecated with the Revit mep network PR if their supported function can be moved to the Revit connector or converter.

## Validation of changes:

## Checklist:

- [ ] Merge 2.10 into revit/mep-networks once this is merged and resolve any conflicts