### PR TITLE
fix(dui): close notification button crashes the app

### DIFF
--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -924,13 +924,11 @@ namespace DesktopUI2.ViewModels
       Analytics.TrackEvent(Analytics.Events.DUIAction, new Dictionary<string, object>() { { "name", "Share Open" } });
     }
 
-    public void CloseNotificationCommand(bool track = true)
+    public void CloseNotificationCommand()
     {
       Notification = "";
       NotificationUrl = "";
 
-      if (track)
-        Analytics.TrackEvent(StreamState.Client.Account, Analytics.Events.DUIAction, new Dictionary<string, object>() { { "name", "Notification Dismiss" } });
     }
 
     public void LaunchNotificationCommand()
@@ -940,7 +938,7 @@ namespace DesktopUI2.ViewModels
       if (!string.IsNullOrEmpty(NotificationUrl))
         Process.Start(new ProcessStartInfo(NotificationUrl) { UseShellExecute = true });
 
-      CloseNotificationCommand(false);
+      CloseNotificationCommand();
     }
 
     public void EditSavedStreamCommand()


### PR DESCRIPTION
An optional parameter on the close notification command binding was making Avalonia crash.