### PR TITLE
fix(objects): Missing plane assignment in arc constructor

### DIFF
--- a/Objects/Objects/Geometry/Arc.cs
+++ b/Objects/Objects/Geometry/Arc.cs
@@ -177,6 +177,8 @@ namespace Objects.Geometry
             else if (startPoint.x < circleCentre.x && startPoint.y > circleCentre.y) // Q2
                 startAngle = Math.PI - startAngle;
             endAngle = startAngle + angleRadians;
+            // Set the plane of this arc
+            this.plane = plane;
         }
         
         /// <summary>

--- a/Objects/Tests/Geometry/ArcTests.cs
+++ b/Objects/Tests/Geometry/ArcTests.cs
@@ -1,0 +1,36 @@
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Objects.Geometry;
+
+namespace Tests.Geometry
+{
+  [TestFixture, TestOf(typeof(Arc))]
+
+  public class ArcTests
+  {
+    public Plane TestPlane =>  new (
+    new Point(0,0),
+    new Vector(0,0,1),
+    new Vector(1,0,0),
+    new Vector(0,1,0)
+      );
+    
+    [Test]
+    public void CanCreateArc_HalfCircle()
+    {
+      var arc = new Arc(
+        TestPlane,
+        new Point(-5,5),
+        new Point(5,5),
+        Math.PI
+      );
+
+      Assert.AreEqual(arc.startAngle, 0);
+      Assert.AreEqual(arc.endAngle, Math.PI);
+      
+      Assert.True(Point.Distance(arc.midPoint, new Point(0,0)) <= 0.0001);
+      Assert.True(Point.Distance(arc.plane.origin, new Point(0,5)) <= 0.0001);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1419

While investigating the aforementioned issue, I discovered that the Arc constructor was missing the plane assignment, leading to it being `null`.

Also adds a test in the Objects test project to verify that #1419 is not an actual issue.