### PR TITLE
feat(core): fallback to default Objects folder if no converter is found

### DIFF
--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,10 +22,10 @@ namespace Speckle.Core.Kits
     {
       get
       {
-        if (_kitsFolder != null)
-          return _kitsFolder;
+        if (_kitsFolder == null)
+          _kitsFolder = Path.Combine(Helpers.InstallSpeckleFolderPath, "Kits");
 
-        return Path.Combine(Helpers.InstallSpeckleFolderPath, "Kits");
+        return _kitsFolder;
       }
       set
       {


### PR DESCRIPTION
**🙌 this PR touches delicate parts of Speckle!**

The suggested changes were discussed with Dim and allow us to safely reference `Objects` in DUI for us to unlock some features in the Mapping tool ([see](https://www.notion.so/speckle/CAD-to-BIM-4bde12f16ab847c788b17bce9b55fa25#79ec640a6d27482dbcfa21cffb4d8bff)).

What this does:
- if Objects.dll is already loaded in the AppDomain, currently, the Kit only looks for converters in the same directory
- if Objects.dll is also referenced by DUI (or any other plugin used by the host app) there will not be any converters in the same folder (because it will be in the connector folder instead)
- these changes allow falling back to the default Kits/Objects folder in the above scenario

NOTE: while DUI will reference Objects for use in the Mapping tool, we'll take measures not to ship it with DUI to avoid even further versions misalignments etc.