### PR TITLE
Fix(gh):  Handle `GH_Goo<Base>` objects in `ESO`

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectTaskComponent.cs
@@ -52,7 +52,10 @@ namespace ConnectorGrasshopper.Objects
         } else if(inputObj is IGH_Goo goo)
         {
           var value = goo.GetType().GetProperty("Value")?.GetValue(goo);
-          if(Converter.CanConvertToSpeckle(value))
+          if (value is Base baseObj) {
+            @base = baseObj;
+          }
+          else if(Converter.CanConvertToSpeckle(value))
           {
             @base = Converter.ConvertToSpeckle(value);
             AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Input object was not a Speckle object, but has been converted to one.");


### PR DESCRIPTION
Fixes #1829 

Aligns the `ESO` input verification with the `DSO` node, which already included a provision to test for `Base` as a value of any `IGH_Goo`.

This issue was not a problem within our own components, but a result of 3rd party nodes generating `GH_ObjectWrapper` classes containing base objects.