### PR TITLE
refactor(core): Flags DynamicBase misleadingly named methods as obsolete

### DIFF
--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -153,7 +153,7 @@ namespace Speckle.Core.Models
     /// Gets all of the property names on this class, dynamic or not.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use GetMembers().Keys instead")]
+    [Obsolete("Use `GetMembers(DynamicBaseMemberType.All).Keys` instead")]
     public override IEnumerable<string> GetDynamicMemberNames()
     {
       PopulatePropInfoCache(GetType());
@@ -170,7 +170,7 @@ namespace Speckle.Core.Models
     /// Gets the names of the defined class properties (typed).
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use GetMembers(DynamicBaseMemberType.Dynamic).Keys instead")]
+    [Obsolete("Use GetMembers(DynamicBaseMemberType.InstanceAll).Keys instead")]
     public IEnumerable<string> GetInstanceMembersNames() => GetInstanceMembersNames(GetType());
     
     public static IEnumerable<string> GetInstanceMembersNames(Type t)

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -94,7 +94,7 @@ namespace Speckle.Core.Models
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    [IgnoreTheItemAttribute]
+    [IgnoreTheItem]
     public object this[string key]
     {
       get
@@ -153,6 +153,7 @@ namespace Speckle.Core.Models
     /// Gets all of the property names on this class, dynamic or not.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use GetMembers().Keys instead")]
     public override IEnumerable<string> GetDynamicMemberNames()
     {
       PopulatePropInfoCache(GetType());
@@ -169,7 +170,9 @@ namespace Speckle.Core.Models
     /// Gets the names of the defined class properties (typed).
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use GetMembers(DynamicBaseMemberType.Dynamic).Keys instead")]
     public IEnumerable<string> GetInstanceMembersNames() => GetInstanceMembersNames(GetType());
+    
     public static IEnumerable<string> GetInstanceMembersNames(Type t)
     {
       PopulatePropInfoCache(t);
@@ -246,6 +249,7 @@ namespace Speckle.Core.Models
     /// Gets the dynamically added property names only.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use GetMembers(DynamicBaseMemberType.Dynamic).Keys instead")]
     public IEnumerable<string> GetDynamicMembers()
     {
       return properties.Keys;

--- a/Core/Core/Models/DynamicBaseMemberType.cs
+++ b/Core/Core/Models/DynamicBaseMemberType.cs
@@ -24,5 +24,13 @@ namespace Speckle.Core.Models
     /// The typed members flagged with <see cref="SchemaIgnored"/> attribute.
     /// </summary>
     SchemaIgnored = 8,
+    /// <summary>
+    /// All the typed members, including ones with <see cref="ObsoleteAttribute"/> or <see cref="SchemaIgnored"/> attributes.
+    /// </summary>
+    InstanceAll = Instance + Obsolete + SchemaIgnored,
+    /// <summary>
+    /// All the members, including dynamic and instance members flagged with <see cref="ObsoleteAttribute"/> or <see cref="SchemaIgnored"/> attributes
+    /// </summary>
+    All = InstanceAll + Dynamic
   }
 }

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -166,6 +166,65 @@ namespace Tests
       Assert.That(names, Has.Member(nameof(@base.attachedProp)));
     }
     
+    [Test]
+    public void CanGetMembers_IsEquivalentTo_GetMemberNames()
+    {
+      var @base = new SampleObject();
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = null;
+      
+      var expected = @base.GetMemberNames();
+      var actual = @base
+        .GetMembers()
+        .Keys;
+      
+      Assert.That(actual, Is.EquivalentTo(expected));
+    }
+    
+    [Test]
+    public void CanGetMembers_IsEquivalentTo_GetDynamicMemberNames()
+    {
+      var @base = new SampleObject();
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = null;
+      
+      var expected = @base.GetDynamicMemberNames();
+      var actual = @base
+        .GetMembers(DynamicBaseMemberType.All)
+        .Keys;
+      
+      Assert.That(actual, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void CanGetMembers_IsEquivalentTo_GetInstanceMembersNames()
+    {
+      var @base = new SampleObject();
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = null;
+      
+      var expected = @base.GetInstanceMembersNames();
+      var actual = @base
+        .GetMembers(DynamicBaseMemberType.InstanceAll)
+        .Keys;
+      
+      Assert.That(actual, Is.EquivalentTo(expected));
+    }
+    
+    [Test]
+    public void CanGetMembers_IsEquivalentTo_GetDynamicMembers()
+    {
+      var @base = new SampleObject();
+      var dynamicProp = "dynamicProp";
+      @base[dynamicProp] = null;
+      
+      var expected = @base.GetDynamicMembers();
+      var actual = @base
+        .GetMembers(DynamicBaseMemberType.Dynamic)
+        .Keys;
+      
+      Assert.That(actual, Is.EquivalentTo(expected));
+    }
     
     [Test]
     public void CanGetDynamicMembers()


### PR DESCRIPTION
Closes #1033 

This is the first step on removing the super misleading methods to retrieve the member names from a `DynamicBase` object. The affected methods in this PR all return a `List<string>` and already have an equivalent in the `GetMembers` method using the appropriate `DynamicBaseMemberType` flags

The following methods have been flagged as `Obsolete`, but **will not throw errors yet**:

- [x] `GetDynamicMembers`
- [x] `GetMemberNames`
- [x] `GetInstanceMemberNames`
- [x] `GetDynamicMemberNames`

`GetInstanceMembers` in both its static and non-static form remains as-is, as it has a different return type and it's used in different ways, I decided to leave it out of the scope of this

### Other changes

- Added some extra options in `DynamicBaseMemberType` to make it easier to find the equivalent of each obsolete method.
    - `InstanceAll` will return all instance members including schema ignored and obsolete.
    - `All` will return anything matching `InstanceAll` plus any dynamic members (i.e. absolutely everything) 
- Added proper obsolete method indicating which `GetMembers` input to use in each case
- Added UnitTests to ensure that the new suggestion will return exactly the same items as the original implementation.

### Next steps

- As soon as possible, all internal usage of these methods should be changed for the new `GetMembers`
- In release `2.11` we should force users to stop using these by throwing an exception.
- In release `2.12` we should completely remove these from our codebase.