### PR TITLE
feat(gh): Prevents empty meshes from being sent

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
@@ -429,7 +429,7 @@ namespace ConnectorGrasshopper.Extras
       if (converter != null && converter.CanConvertToSpeckle(value))
       {
         var result = converter.ConvertToSpeckle(value);
-        result.applicationId = refId;
+        if(result != null) result.applicationId = refId;
         return result;
       }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
@@ -388,6 +388,7 @@ namespace ConnectorGrasshopper.Ops
             {
               ReportProgress("Conversion", Math.Round(convertedCount++ / (double)d.Value.DataCount / DataInputs.Count, 2));
             });
+            
             convertedCount++;
             var param = Parent.Params.Input.Find(p => p.Name == d.Key || p.NickName == d.Key);
             var key = d.Key;
@@ -407,6 +408,11 @@ namespace ConnectorGrasshopper.Ops
           }
         }
 
+        foreach (var error in sendComponent.Converter.Report.ConversionErrors)
+        {
+          RuntimeMessages.Add((GH_RuntimeMessageLevel.Warning, error.ToFormattedString()));
+        }
+        
         if (convertedCount == 0)
         {
           RuntimeMessages.Add((GH_RuntimeMessageLevel.Error, "Zero objects converted successfully. Send stopped."));

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -617,12 +617,18 @@ namespace Objects.Converter.RhinoGh
 
     public RH.Box BoxToNative(Box box)
     {
+      
       return new RH.Box(PlaneToNative(box.basePlane), IntervalToNative(box.xSize), IntervalToNative(box.ySize), IntervalToNative(box.zSize));
     }
 
     // Meshes
     public Mesh MeshToSpeckle(RH.Mesh mesh, string units = null)
     {
+      if (mesh.Vertices.Count == 0 || mesh.Faces.Count == 0)
+      {
+        Report.ConversionErrors.Add(new Exception("Cannot convert empty mesh (0 faces, 0 vertices)"));
+        return null;
+      }
       var u = units ?? ModelUnits;
       var verts = PointsToFlatList(mesh.Vertices.ToPoint3dArray());
 


### PR DESCRIPTION
Fixes #1324 

When encountering a mesh with no faces or vertices, we will now return `null` instead of sending a mesh that won't work anywhere.

This has been tested in Rhino and Grasshopper and does not interfere with the send operation.

<img width="732" alt="Screenshot 2022-11-11 at 21 25 10" src="https://user-images.githubusercontent.com/2316535/201426438-bdf287b6-d674-48b9-9322-aca885b759d9.png">

<img width="712" alt="Screenshot 2022-11-11 at 21 23 11" src="https://user-images.githubusercontent.com/2316535/201426462-44cdf876-7a8a-4f98-9390-d741ab270906.png">
