### PR TITLE
feat(rhino): open comments in 3D view

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Events.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit2/ConnectorBindingsRevit2.Events.cs
@@ -318,7 +318,10 @@ namespace Speckle.ConnectorRevit.UI
             if (views.Any())
             {
               var viewPhase = views.First().get_Parameter(BuiltInParameter.VIEW_PHASE);
-              perspView.get_Parameter(BuiltInParameter.VIEW_PHASE).Set(viewPhase.AsElementId());
+              if (viewPhase != null)
+              {
+                perspView.get_Parameter(BuiltInParameter.VIEW_PHASE).Set(viewPhase.AsElementId());
+              }
             }
 
             t.Commit();

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -1159,9 +1159,12 @@ namespace SpeckleRhino
       Point3d target = new Point3d(viewCoordinates[3], viewCoordinates[4], viewCoordinates[5]);
       Vector3d direction = target - cameraLocation;
 
-      // Get bounds from active view
-      Rectangle bounds = Doc.Views.ActiveView.ActiveViewport.Bounds;
-      Doc.Views.Add("SpeckleCommentView", DefinedViewportProjection.Perspective, bounds, false);
+      if (!Doc.Views.Any(v => v.ActiveViewport.Name == "SpeckleCommentView"))
+      {
+        // Get bounds from active view
+        Rectangle bounds = Doc.Views.ActiveView.ScreenRectangle;
+        Doc.Views.Add("SpeckleCommentView", DefinedViewportProjection.Perspective, bounds, false);
+      }
 
       await Task.Run(() =>
       {
@@ -1171,7 +1174,12 @@ namespace SpeckleRhino
           RhinoView speckleCommentView = views.First();
           speckleCommentView.ActiveViewport.SetCameraDirection(direction, false);
           speckleCommentView.ActiveViewport.SetCameraLocation(cameraLocation, true);
-          Doc.Views.ActiveView = speckleCommentView;
+          speckleCommentView.Maximized = true;
+          
+          if (Doc.Views.ActiveView.ActiveViewport.Name != "SpeckleCommentView")
+          {
+            Doc.Views.ActiveView = speckleCommentView;
+          }
         }
 
         Doc.Views.Redraw();

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -1150,5 +1150,32 @@ namespace SpeckleRhino
 
     #endregion
 
+    public override bool CanOpen3DView => true;
+
+    public override async Task Open3DView(List<double> viewCoordinates, string viewName = "")
+    {
+      // Create positional objects for camera
+      Point3d cameraLocation = new Point3d(viewCoordinates[0], viewCoordinates[1], viewCoordinates[2]);
+      Point3d target = new Point3d(viewCoordinates[3], viewCoordinates[4], viewCoordinates[5]);
+      Vector3d direction = target - cameraLocation;
+
+      // Get bounds from active view
+      Rectangle bounds = Doc.Views.ActiveView.ActiveViewport.Bounds;
+      Doc.Views.Add("SpeckleCommentView", DefinedViewportProjection.Perspective, bounds, false);
+
+      await Task.Run(() =>
+      {
+        IEnumerable<RhinoView> views = Doc.Views.Where(v => v.ActiveViewport.Name == "SpeckleCommentView");
+        if (views.Any())
+        {
+          RhinoView speckleCommentView = views.First();
+          speckleCommentView.ActiveViewport.SetCameraDirection(direction, false);
+          speckleCommentView.ActiveViewport.SetCameraLocation(cameraLocation, true);
+          Doc.Views.ActiveView = speckleCommentView;
+        }
+
+        Doc.Views.Redraw();
+      });
+    }
   }
 }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

I added new view to rhino named view `SpeckleCommentView` when user want to see it by clicking

![image](https://user-images.githubusercontent.com/45078678/201679216-a86166e6-6e01-4b64-8287-a9a67182d71b.png)


<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

`CanOpen3DView`and `Open3DView` binding methods are overriden in `ConnectorBindingsRhino` file.
According to upcoming coordinates camera position and target constructed as `Point3d` and `Vector3d` to assign them into `RhinoView`.

<!---

- Item 1
- Item 2

-->

## To-do before merge:

- Create a comment from speckle.xyz
- Receive it by Rhino
- Navigate to comments tab
- Click Open View 📷 

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

![image](https://user-images.githubusercontent.com/45078678/201679465-4d36e3d9-1cf9-41e0-bded-3f28cfcb61b3.png)

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
