### PR TITLE
fix(dui): dialog conflict

### DIFF
--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/DialogUserControl.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/DialogUserControl.cs
@@ -40,8 +40,8 @@ namespace DesktopUI2.Views.Windows.Dialogs
     public void Close(object dialogResult)
     {
       _dialogResult = dialogResult;
-      Closed?.Invoke(this, null);
       MainViewModel.Instance.DialogBody = null;
+      Closed?.Invoke(this, null);
     }
   }
 }


### PR DESCRIPTION
## Description & motivation

In some cases, such as exception dialog, they would not show up. 

The second dialog will show and close because the first dialog set `MainViewModel.Instance.DialogBody` to `null`. 

Like the example below I will not see a dialog indicating the reason for the failure.

https://github.com/specklesystems/speckle-sharp/blob/2cf08671f6ef70ce400a123bbf7237f9b8c46664/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs#L586-L618

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

Set `MainViewModel.Instance.DialogBody` to `null` before invoke `Closed` event.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.