### PR TITLE
fix(rhino): fixed issue with everything filter

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -910,7 +910,7 @@ namespace SpeckleRhino
           viewIndex = Doc.NamedViews.FindByName(guid); // try get view
         }
         var descriptor = obj != null ? Formatting.ObjectDescriptor(obj) : "Named View";
-        var applicationId = obj.Attributes.GetUserString(ApplicationIdKey) ?? guid;
+        var applicationId = obj?.Attributes.GetUserString(ApplicationIdKey) ?? guid;
         ApplicationObject reportObj = new ApplicationObject(guid, descriptor) { applicationId = applicationId };
 
         if (obj != null)


### PR DESCRIPTION
Fixes issue 2.10 issue with sends getting stuck with "everything" filter

A small null check was all that's needed.