### PR TITLE
Fix(CSI): refresh objects list every time we send to Speckle

### DIFF
--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Selection.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Selection.cs
@@ -88,8 +88,7 @@ namespace Speckle.ConnectorCSI.UI
         case "manual":
           return GetSelectedObjects();
         case "all":
-          if (ConnectorCSIUtils.ObjectIDsTypesAndNames == null)
-            ConnectorCSIUtils.GetObjectIDsTypesAndNames(Model);
+          ConnectorCSIUtils.GetObjectIDsTypesAndNames(Model);
 
           selection.AddRange(ConnectorCSIUtils.ObjectIDsTypesAndNames
                       .Select(pair => pair.Key).ToList());
@@ -97,8 +96,7 @@ namespace Speckle.ConnectorCSI.UI
 
         case "type":
           var typeFilter = filter as ListSelectionFilter;
-          if (ConnectorCSIUtils.ObjectIDsTypesAndNames == null)
-            ConnectorCSIUtils.GetObjectIDsTypesAndNames(Model);
+          ConnectorCSIUtils.GetObjectIDsTypesAndNames(Model);
 
           foreach (var type in typeFilter.Selection)
           {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

When receiving a commit into Speckle and then trying to send it to Speckle again, my speckle commits were not showing any displayable objects in them. Upon further investigation I found that the master list of object IDs that the send operation then narrows down to your specified filter (Everything, Selection, Group, etc.) is only refreshed in the GetSelectionFilters() method which is only called when a user opens a stream view. Therefore between the actions of receiving and sending, the master list of elements is never refreshed (unless the user goes back to the main list of streams and re-opens the stream view) which makes the send operation show 0 visible elements.

It sounds reasonable to assume that we could maybe only call this method once when the user opens the stream view, as most likely not many people are going to be receiving and then immediately sending. However it could certainly happen by a new user just testing out Speckle. Also, if a user closes the plugin and then reopens it during the same session, the plugin will open up to the page that it was last on, which could be the stream page. That means that a user could receive a commit, close the plugin and make some additions to the model, and then try to send the model again, but Speckle would not recognize the new objects that were added. 

This change makes it so the master list is refreshed during the send operation before the list is needed. 

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- remove null constraint for refreshing the ObjectIDsTypesAndNames dictionary

<!---

- Item 1
- Item 2

-->

## Validation of changes:

- manual sending and receiving

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
