### PR TITLE
fix(acadcivil): application id handling fixed on send

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -947,9 +947,11 @@ namespace Speckle.ConnectorAutocadCivil.UI
           // get the db object from id
           DBObject obj = null;
           string layer = null;
+          string applicationId = null;
           if (Utils.GetHandle(autocadObjectHandle, out Handle hn))
           {
-            obj = hn.GetObject(tr, out string type, out layer);
+            obj = hn.GetObject(tr, out string type, out layer, out applicationId);
+            if (applicationId == null) { applicationId = autocadObjectHandle; }
           }
           else
           {
@@ -960,8 +962,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
           // create applicationobject for reporting
           Base converted = null;
           var descriptor = Utils.ObjectDescriptor(obj);
-          var applicationId = autocadObjectHandle; // TODO: ADD TEST FOR XDATA APPID
-          ApplicationObject reportObj = new ApplicationObject(autocadObjectHandle, descriptor) { applicationId = applicationId };
+          ApplicationObject reportObj = new ApplicationObject(autocadObjectHandle, descriptor) { applicationId = autocadObjectHandle };
 
           if (!converter.CanConvertToSpeckle(obj))
           {

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -393,14 +393,15 @@ namespace Speckle.ConnectorAutocadCivil
     /// </summary>
     /// <param name="appId">Id of the application that originally created the element, in AutocadCivil it's the handle</param>
     /// <returns>The element, if found, otherwise null</returns>
+    /// <remarks>
+    /// Updating is super buggy because of limitations to how object handles are generated. 
+    /// See: https://forums.autodesk.com/t5/net/is-the-quot-objectid-quot-unique-in-a-drawing-file/m-p/6527799#M49953
+    /// </remarks>
     public static List<ObjectId> GetObjectsByApplicationId(this Document doc, Transaction tr, string appId)
     {
       var foundObjects = new List<ObjectId>();
 
-      // first see if this appid is a handle (autocad appid)
-      if (Utils.GetHandle(appId, out Handle handle))
-        if (doc.Database.TryGetObjectId(handle, out ObjectId id))
-           return id.IsErased ? foundObjects : new List<ObjectId>() { id };
+      // first check for xustom xdata application ids, because object handles tend to be duplicated
 
       // Create a TypedValue array to define the filter criteria
       TypedValue[] acTypValAr = new TypedValue[1];
@@ -410,23 +411,30 @@ namespace Speckle.ConnectorAutocadCivil
       SelectionFilter acSelFtr = new SelectionFilter(acTypValAr);
       var editor = Application.DocumentManager.MdiActiveDocument.Editor;
       var res = editor.SelectAll(acSelFtr);
-      if (res.Status == PromptStatus.None || res.Status == PromptStatus.Error)
-        return foundObjects;
 
-      // loop through all obj with an appId 
-      foreach (var appIdObj in res.Value.GetObjectIds())
+      if (res.Status != PromptStatus.None && res.Status != PromptStatus.Error)
       {
-        // get the db object from id
-        var obj = tr.GetObject(appIdObj, OpenMode.ForRead);
-        if (obj != null)
-          foreach (var entry in obj.XData)
-            if (entry.Value as string == appId)
-            {
-              foundObjects.Add(appIdObj);
-              break;
-            }
+        // loop through all obj with an appId 
+        foreach (var appIdObj in res.Value.GetObjectIds())
+        {
+          // get the db object from id
+          var obj = tr.GetObject(appIdObj, OpenMode.ForRead);
+          if (obj != null)
+            foreach (var entry in obj.XData)
+              if (entry.Value as string == appId)
+              {
+                foundObjects.Add(appIdObj);
+                break;
+              }
+        }
       }
+      if (foundObjects.Any()) return foundObjects;
 
+      // if no matching xdata appids were found, loop through handles instead
+      if (Utils.GetHandle(appId, out Handle handle))
+        if (doc.Database.TryGetObjectId(handle, out ObjectId id))
+          return id.IsErased ? foundObjects : new List<ObjectId>() { id };
+     
       return foundObjects;
     }
 

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -420,12 +420,16 @@ namespace Speckle.ConnectorAutocadCivil
           // get the db object from id
           var obj = tr.GetObject(appIdObj, OpenMode.ForRead);
           if (obj != null)
+          {
             foreach (var entry in obj.XData)
+            {
               if (entry.Value as string == appId)
               {
                 foundObjects.Add(appIdObj);
                 break;
               }
+            }
+          }
         }
       }
       if (foundObjects.Any()) return foundObjects;

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -161,12 +161,16 @@ namespace Speckle.ConnectorAutocadCivil
           // application id is stored in xdata
           ResultBuffer rb = objEntity.GetXDataForApplication(ApplicationIdKey);
           if (rb != null)
+          {
             foreach (var entry in rb)
+            {
               if (entry.TypeCode == 1000)
               {
                 applicationId = entry.Value as string;
                 break;
               }
+            }
+          }
         }
       }
       return obj;
@@ -401,7 +405,7 @@ namespace Speckle.ConnectorAutocadCivil
     {
       var foundObjects = new List<ObjectId>();
 
-      // first check for xustom xdata application ids, because object handles tend to be duplicated
+      // first check for custom xdata application ids, because object handles tend to be duplicated
 
       // Create a TypedValue array to define the filter criteria
       TypedValue[] acTypValAr = new TypedValue[1];


### PR DESCRIPTION
## Description & motivation
- adds check for erased ids to not be included as objects to remove
- assigns the correct application id from xdata on send, if present

Fixes #1889

*NOTE* this does not fix the incorrect update behavior when receiving elements from autocad in a new autocad file - this is due to a limitation in how Autocad generates its persistent ids (`handle`s), which are very short and always generated from the same seed. Ref [this forum post](https://forums.autodesk.com/t5/net/is-the-quot-objectid-quot-unique-in-a-drawing-file/m-p/6527799#M49953) explaining the difference and why handle duplication is unavoidable

## Changes:

- connector bindings
- connector utils

