### PR TITLE
Fix(Revit): don't set view name parameter and fix null value error

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -388,7 +388,7 @@ namespace Objects.Converter.Revit
     /// </summary>
     /// <param name="revitElement"></param>
     /// <param name="speckleElement"></param>
-    public void SetInstanceParameters(Element revitElement, Base speckleElement)
+    public void SetInstanceParameters(Element revitElement, Base speckleElement, List<string> exclusions = null)
     {
       if (revitElement == null)
         return;
@@ -404,7 +404,11 @@ namespace Objects.Converter.Revit
       // NOTE: we are using the ParametersMap here and not Parameters, as it's a much smaller list of stuff and 
       // Parameters most likely contains extra (garbage) stuff that we don't need to set anyways
       // so it's a much faster conversion. If we find that's not the case, we might need to change it in the future
-      var revitParameters = revitElement.ParametersMap.Cast<DB.Parameter>().Where(x => x != null && !x.IsReadOnly && !problematicParameters.Contains(x.Id.IntegerValue));
+      IEnumerable<DB.Parameter> revitParameters = null;
+      if (exclusions == null)
+        revitParameters = revitElement.ParametersMap.Cast<DB.Parameter>().Where(x => x != null && !x.IsReadOnly);
+      else
+        revitParameters = revitElement.ParametersMap.Cast<DB.Parameter>().Where(x => x != null && !x.IsReadOnly && !exclusions.Contains(GetParamInternalName(x)));
 
       // Here we are creating two  dictionaries for faster lookup
       // one uses the BuiltInName / GUID the other the name as Key

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -379,11 +379,6 @@ namespace Objects.Converter.Revit
 
     #endregion
 
-    private List<int> problematicParameters = new List<int>()
-    { 
-      (int)BuiltInParameter.VIEW_NAME, // set this property using view.Name = "name"
-    };
-
     /// <summary>
     /// </summary>
     /// <param name="revitElement"></param>

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -379,6 +379,11 @@ namespace Objects.Converter.Revit
 
     #endregion
 
+    private List<int> problematicParameters = new List<int>()
+    { 
+      (int)BuiltInParameter.VIEW_NAME, // set this property using view.Name = "name"
+    };
+
     /// <summary>
     /// </summary>
     /// <param name="revitElement"></param>
@@ -399,7 +404,7 @@ namespace Objects.Converter.Revit
       // NOTE: we are using the ParametersMap here and not Parameters, as it's a much smaller list of stuff and 
       // Parameters most likely contains extra (garbage) stuff that we don't need to set anyways
       // so it's a much faster conversion. If we find that's not the case, we might need to change it in the future
-      var revitParameters = revitElement.ParametersMap.Cast<DB.Parameter>().Where(x => x != null && !x.IsReadOnly);
+      var revitParameters = revitElement.ParametersMap.Cast<DB.Parameter>().Where(x => x != null && !x.IsReadOnly && !problematicParameters.Contains(x.Id.IntegerValue));
 
       // Here we are creating two  dictionaries for faster lookup
       // one uses the BuiltInName / GUID the other the name as Key

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -123,6 +123,9 @@ namespace Objects.Converter.Revit
       List<Mesh> meshes = new List<Mesh>();
 
       var geom = element.get_Geometry(new Options());
+      if (geom == null)
+        return null;
+
       foreach (GeometryInstance instance in geom)
       {
         //Get instance geometry from fabrication part geometry

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
@@ -12,6 +12,10 @@ namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
+    private List<string> excludedParameters = new List<string>()
+    {
+      "VIEW_NAME", // param value is already stored in name prop of view and setting this param can cause errors 
+    };
     public View ViewToSpeckle(DB.View revitView)
     {
       switch (revitView.ViewType)
@@ -60,7 +64,7 @@ namespace Objects.Converter.Revit
         AttachViewParams(speckleView, rv3d);
       }
 
-      GetAllRevitParamsAndIds(speckleView, revitView);
+      GetAllRevitParamsAndIds(speckleView, revitView, excludedParameters);
       Report.Log($"Converted View {revitView.ViewType} {revitView.Id}");
       return speckleView;
     }
@@ -96,7 +100,7 @@ namespace Objects.Converter.Revit
       view.SaveOrientationAndLock();
 
       if (view.IsValidObject)
-        SetInstanceParameters(view, speckleView);
+        SetInstanceParameters(view, speckleView, excludedParameters);
       view = SetViewParams(view, speckleView);
 
       // set name last due to duplicate name errors

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
@@ -69,31 +69,57 @@ namespace Objects.Converter.Revit
       return speckleView;
     }
 
-    public DB.View ViewToNative(View3D speckleView)
+    public ApplicationObject ViewToNative(View3D speckleView)
     {
-      var editViewName = EditViewName(speckleView.name, "SpeckleView");
+      var appObj = new ApplicationObject(speckleView.id, speckleView.speckle_type) { applicationId = speckleView.applicationId };
 
-      // get view3d type
-      var viewType = new FilteredElementCollector(Doc)
-        .WhereElementIsElementType()
-        .OfClass(typeof(ViewFamilyType))
-        .ToElements()
-        .Cast<ViewFamilyType>()
-        .FirstOrDefault(o => o.ViewFamily == ViewFamily.ThreeDimensional);
+      DB.View3D view = null;
+      var viewNameSplit = speckleView.name.Split('-');
 
       // get orientation
       var up = new XYZ(speckleView.upDirection.x, speckleView.upDirection.y, speckleView.upDirection.z).Normalize(); //unit vector
       var forward = new XYZ(speckleView.forwardDirection.x, speckleView.forwardDirection.y, speckleView.forwardDirection.z).Normalize();
       if (Math.Round(up.DotProduct(forward), 3) != 0) // will throw error if vectors are not perpendicular
-        return null;
+      {
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: "The up and forward vectors for this view are not perpendicular.");
+        return appObj;
+      }
       var orientation = new ViewOrientation3D(PointToNative(speckleView.origin), up, forward);
 
-      // create view
-      DB.View3D view = null;
-      if (speckleView.isOrthogonal)
-        view = DB.View3D.CreateIsometric(Doc, viewType.Id);
+      var editViewName = EditViewName(speckleView.name, "SpeckleView");
+      // get the existing view with this name, if there is one
+      view = new FilteredElementCollector(Doc)
+          .WhereElementIsNotElementType()
+          .OfClass(typeof(DB.View3D))
+          .Cast<DB.View3D>()
+          .FirstOrDefault(o => o.Name == editViewName);
+
+      if (view == null)
+      {
+        // get view3d type
+        var viewType = new FilteredElementCollector(Doc)
+          .WhereElementIsElementType()
+          .OfClass(typeof(ViewFamilyType))
+          .ToElements()
+          .Cast<ViewFamilyType>()
+          .FirstOrDefault(o => o.ViewFamily == ViewFamily.ThreeDimensional);
+
+        // create view
+        if (speckleView.isOrthogonal)
+          view = DB.View3D.CreateIsometric(Doc, viewType.Id);
+        else
+          view = DB.View3D.CreatePerspective(Doc, viewType.Id);
+
+        view.Name = editViewName;
+        appObj.Update(status: ApplicationObject.State.Created);
+      }
+      else if (view.IsLocked)
+      {
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: $"View named {editViewName} is locked and cannot be modified.");
+        return appObj;
+      }
       else
-        view = DB.View3D.CreatePerspective(Doc, viewType.Id);
+        appObj.Update(status: ApplicationObject.State.Updated);
 
       // set props
       view.SetOrientation(orientation);
@@ -103,19 +129,8 @@ namespace Objects.Converter.Revit
         SetInstanceParameters(view, speckleView, excludedParameters);
       view = SetViewParams(view, speckleView);
 
-      // set name last due to duplicate name errors
-      try
-      {
-        view.Name = editViewName;
-        return view;
-      }
-      catch (Exception e)
-      {
-        Report.ConversionErrors.Add(new Exception($@"View {editViewName} already exists."));
-        view.Dispose();
-        view = null;
-        return null;
-      }
+      appObj.Update(createdId: view.UniqueId, convertedItem: view);
+      return appObj;
     }
 
     private void AttachViewParams(View speckleView, DB.View view)
@@ -160,6 +175,11 @@ namespace Objects.Converter.Revit
 
     private string EditViewName(string name, string prefix = null)
     {
+      var viewNameSplit = name.Split('-');
+      // if the name already starts with the prefix, don't add the prefix again
+      if (viewNameSplit.Length > 0 && viewNameSplit.First() == prefix)
+        return name;
+
       var newName = name;
       // append commit info as prefix
       if (prefix != null)


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Sometimes when receiving into revit, no error gets thrown yet the entire transaction will get rolled back during the transation. I found one specific case where this was being caused by trying to import a perspective 3D view and setting the "VIEW_NAME" property. The erroreater was throwing an error talking about a name already existing in the project.

It seems like the view name property for this view was temporarily changed to the same name as an existing view before being changed to a unique name. We've seen instances before where objects become invalid for a split second but then become valid again and the receive process continues without throwing an error until the commit operation causes the whole transaction to be rolled back (ref [this pr](https://github.com/specklesystems/speckle-sharp/pull/1580)). Therefore we don't want to set this parameter at all for views.

Also we have an issue with the views that we create. When we receive a view, it seems like we don't want to edit the user's existing views so we append SpeckleView to the front and then create a new view. The issue is that over time we end up creating views like this
![image](https://user-images.githubusercontent.com/43247197/203608242-07590f0e-4572-4692-b2bf-09597568bd6e.png)
This pr will make it so that the SpeckleView prefix is only added once.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- create exclusions list in ConvertView.cs
- allow exclusions list to be passed into SetInstanceParameters
- check if geom is null before looping through it
- change return type of ViewToNative to return an ApplicationObject
- check for view with existing name and try to edit instead of assigning name and catching error if it exists

<!---

- Item 1
- Item 2

-->

## Validation of changes:

- of course it was manual testing

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
