### PR TITLE
fix(rhino): successfully converts blocks on receive

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -402,7 +402,7 @@ namespace SpeckleRhino
               previewObj.Update(status: ApplicationObject.State.Failed, logItem: $"Couldn't retrieve stored object from bindings");
               continue;
             }
-            if (previewObj.Convertible && !storedObj.speckle_type.Contains("Block") && !storedObj.speckle_type.Contains("Block"))
+            if (previewObj.Convertible && !storedObj.speckle_type.Contains("Block") && !storedObj.speckle_type.Contains("View"))
               previewObj.Converted = ConvertObject(storedObj, converter);
             else
               foreach (var fallback in previewObj.Fallback)
@@ -411,7 +411,7 @@ namespace SpeckleRhino
                 previewObj.Log.AddRange(fallback.Log);
               }
 
-            if (previewObj.Converted == null || previewObj.Converted.Count == 0 && !storedObj.speckle_type.Contains("Block") && !storedObj.speckle_type.Contains("Block"))
+            if (previewObj.Converted == null || previewObj.Converted.Count == 0 && !storedObj.speckle_type.Contains("Block") && !storedObj.speckle_type.Contains("View"))
             {
               var convertedFallback = previewObj.Fallback.Where(o => o.Converted != null || o.Converted.Count > 0);
               if (convertedFallback != null && convertedFallback.Count() > 0)


### PR DESCRIPTION
## Description & motivation

Previously, blocks were being deleted prematurely in the connector receive logic because they were created during convert instead of on bake (this hypothetically applies to views too? need to check view update behavior)

Now, blocks and views are skipped during conversion and created on bake, since the converter methods for these two types add the objects to modelspace during conversion.

Fixes #1909

## Changes:

Rhino Connector
