### PR TITLE
Fix(revit): MEP elements handle invalid shape

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Revit/ConnectionPair.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Revit/ConnectionPair.cs
@@ -18,7 +18,7 @@ namespace ConverterRevitShared.Revit
         Height = Connector.Shape != ConnectorProfileType.Round ? curve.Height : 0;
         Width = Connector.Shape != ConnectorProfileType.Round ? curve.Width : 0;
       }
-      else
+      else if (Connector.Shape != ConnectorProfileType.Invalid)
       {
         Diameter = Connector.Shape == ConnectorProfileType.Round ? Connector.Radius * 2 : 0;
         Height = Connector.Shape != ConnectorProfileType.Round ? Connector.Height : 0;
@@ -36,11 +36,11 @@ namespace ConverterRevitShared.Revit
       ? $"{Owner.Category.Name}: {Connector.Owner.Name} --> {RefConnector.Owner.Category.Name}: {RefConnector.Owner.Name}"
       : $"{Owner.Category.Name}: {Connector.Owner.Name} --> NULL";
 
-    public double Diameter { get; private set; }
+    public double Diameter { get; private set; } = 0;
 
-    public double Height { get; private set; }
+    public double Height { get; private set; } = 0;
 
-    public double Width { get; private set; }
+    public double Width { get; private set; } = 0;
 
     public bool IsConnected { get; private set; }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Revit/ConnectionPair.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Revit/ConnectionPair.cs
@@ -6,43 +6,44 @@ namespace ConverterRevitShared.Revit
 {
   public class ConnectionPair : IComparable<ConnectionPair>, IEquatable<ConnectionPair>
   {
-    private ConnectionPair(Element element, Connector connector, Connector refConnector = null)
-    {
-      Owner = element;
-      Connector = connector;
-      RefConnector = refConnector;
-      IsConnected = RefConnector != null;
-      if (element is MEPCurve curve)
-      {
-        Diameter = Connector.Shape == ConnectorProfileType.Round ? curve.Diameter : 0;
-        Height = Connector.Shape != ConnectorProfileType.Round ? curve.Height : 0;
-        Width = Connector.Shape != ConnectorProfileType.Round ? curve.Width : 0;
-      }
-      else if (Connector.Shape != ConnectorProfileType.Invalid)
-      {
-        Diameter = Connector.Shape == ConnectorProfileType.Round ? Connector.Radius * 2 : 0;
-        Height = Connector.Shape != ConnectorProfileType.Round ? Connector.Height : 0;
-        Width = Connector.Shape != ConnectorProfileType.Round ? Connector.Width : 0;
-      }
-    }
-
     public Element Owner { get; private set; }
 
     public Connector Connector { get; private set; }
 
     public Connector RefConnector { get; private set; }
 
+    public double Diameter { get; private set; }
+
+    public double Height { get; private set; }
+
+    public double Width { get; private set; }
+
+    public bool IsConnected { get; private set; }
+
     public string Name => RefConnector != null
       ? $"{Owner.Category.Name}: {Connector.Owner.Name} --> {RefConnector.Owner.Category.Name}: {RefConnector.Owner.Name}"
       : $"{Owner.Category.Name}: {Connector.Owner.Name} --> NULL";
 
-    public double Diameter { get; private set; } = 0;
-
-    public double Height { get; private set; } = 0;
-
-    public double Width { get; private set; } = 0;
-
-    public bool IsConnected { get; private set; }
+    private ConnectionPair(Element element, Connector connector, Connector refConnector = null)
+    {
+      Owner = element;
+      Connector = connector;
+      RefConnector = refConnector;
+      IsConnected = RefConnector != null;
+      var curve = element as MEPCurve;
+      switch (Connector.Shape)
+      {
+        case ConnectorProfileType.Invalid:
+          break;
+        case ConnectorProfileType.Round:
+          Diameter = curve != null ? curve.Diameter : Connector.Radius * 2;
+          break;
+        default:
+          Height = curve != null ? curve.Height : Connector.Height;
+          Width = curve != null ? curve.Width : Connector.Width;
+          break;
+      }
+    }
 
     public static ICollection<ConnectionPair> GetConnectionPairs(Element element)
     {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Fixes error that was stopping Revit elements from being sent to Speckle

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- add initial value of 0 to connection pair dimensions
- don't try to set dimensions if the connectorProfileType is invalid

<!---

- Item 1
- Item 2

-->

## Validation of changes:

- was getting an error that said "The shape of the connector is neither rectangular nor oval." but now we are not getting that error

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->
## References

this partially fixes this issue https://github.com/specklesystems/speckle-sharp/issues/1915

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
