### PR TITLE
Archciad/#1907 archicad connector receive does not work

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
@@ -248,7 +248,7 @@ namespace Archicad
 
         var subElements = currentObj["elements"] as List<Base>;
 
-        if (subElements.Count() > 0)
+        if (subElements != null && subElements.Count() > 0)
         {
           var convertedSubElements = await ConvertSubElementsToNative(subElements, token);
           result.AddRange(convertedSubElements);

--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -149,7 +149,7 @@ namespace Speckle.Core.Kits
     }
 
     // recursive search for referenced assemblies
-    public static List<Assembly> GetAssemblies()
+    public static List<Assembly> GetReferencedAssemblies()
     {
       var returnAssemblies = new List<Assembly>();
       var loadedAssemblies = new HashSet<string>();
@@ -182,7 +182,10 @@ namespace Speckle.Core.Kits
 
     private static void GetLoadedSpeckleReferencingAssemblies()
     {
-      foreach (var assembly in GetAssemblies())
+      Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+      assemblies.Concat (GetReferencedAssemblies());
+
+      foreach (var assembly in assemblies)
       {
         if (!assembly.IsDynamic && !assembly.ReflectionOnly)
         {

--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -182,8 +182,8 @@ namespace Speckle.Core.Kits
 
     private static void GetLoadedSpeckleReferencingAssemblies()
     {
-      Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-      assemblies.Concat (GetReferencedAssemblies());
+      List<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
+      assemblies.AddRange(GetReferencedAssemblies());
 
       foreach (var assembly in assemblies)
       {


### PR DESCRIPTION
We have two options to load kits dlls:
1. Searching and loading them from the execution processes' referenced assemblies (`GetLoadedSpeckleReferencingAssemblies` function) or
2. Loading them from the KIts folder ("C:\Users\...\AppData\Roaming\Speckle\Kits\Objects") via `LoadSpeckleReferencingAssemblies`

The supported way is No 2, because by design the connector plugin mustn't know about the Kit is used, Kit dlls should be dynamically loaded during the conversion process.

For the Archicad Connector we have a shortcut here (because we have no Converter dlls yet), we use No 1.
The problem was that the original AppDomain.CurrentDomain.GetAssemblies only returns the assemblies loaded into memory, and at that point no Objects.dll was loaded. Now a new enumeration was implemented which recursively determine the referenced assemblies, and for not to load huge amount of dll we skip and don't load systems assemblies.

Good document in this topic: https://dotnetcoretutorials.com/2020/07/03/getting-assemblies-is-harder-than-you-think-in-c/


