### PR TITLE
fix(core): null check for GetReferencedAssemblies

### DIFF
--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -161,6 +161,9 @@ namespace Speckle.Core.Kits
       {
         var assemblyToCheck = assembliesToCheck.Dequeue();
 
+        if (assemblyToCheck == null)
+          continue;
+
         foreach (var reference in assemblyToCheck.GetReferencedAssemblies())
         {
           // filtering out system dlls


### PR DESCRIPTION
Seems like the new logic added in [#1924](https://github.com/specklesystems/speckle-sharp/pull/1924) was not working well in Revit, as some of the loaded assemblies were null.

This nul check seems to do the job.