### PR TITLE
fix(core): creates Speckle folders if they do not exist

### DIFF
--- a/Core/Core/Api/Helpers.cs
+++ b/Core/Core/Api/Helpers.cs
@@ -261,7 +261,7 @@ namespace Speckle.Core.Api
     public static string InstallApplicationDataPath =>
 
         Assembly.GetAssembly(typeof(Helpers)).Location.Contains("ProgramData")
-          ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
+          ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData, Environment.SpecialFolderOption.Create)
           : UserApplicationDataPath;
 
 
@@ -278,7 +278,7 @@ namespace Speckle.Core.Api
     public static string UserApplicationDataPath =>
       !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(_speckleUserDataEnvVar)) ?
       Environment.GetEnvironmentVariable(_speckleUserDataEnvVar) :
-      Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+      Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create);
 
 
 

--- a/Core/Core/Transports/SQLite.cs
+++ b/Core/Core/Transports/SQLite.cs
@@ -1,11 +1,11 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Microsoft.Data.Sqlite;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
+using Microsoft.Data.Sqlite;
 using Microsoft.Data.Sqlite;
 using Speckle.Core.Api;
 
@@ -58,7 +58,16 @@ namespace Speckle.Core.Transports
         scope = "Data";
       _Scope = scope;
 
-      Directory.CreateDirectory(Path.Combine(basePath, applicationName)); //ensure dir is there
+      var dir = Path.Combine(basePath, applicationName);
+      try
+      {
+        Directory.CreateDirectory(dir); //ensure dir is there
+      }
+      catch (Exception ex)
+      {
+        throw new Exception($"Cound not create {dir}", ex);
+      }
+
 
       RootPath = Path.Combine(basePath, applicationName, $"{scope}.db");
       //fix for network drives: https://stackoverflow.com/a/18506097/826060


### PR DESCRIPTION
- fixes: https://github.com/specklesystems/speckle-manager2/issues/16
Ensures the special folders used by Accounts and kits are created if missing, by default, if they do not exist, the path returned is empty.