### PR TITLE
fix(acadcivil): commit prefix no longer used for layers on update receive mode

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -359,7 +359,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
           // flatten the commit object to retrieve children objs
           int count = 0;
-          var commitObjs = FlattenCommitObject(commitObject, converter, progress, commitPrefix, ref count);
+          var commitObjs = FlattenCommitObject(commitObject, converter, progress, ref count);
 
           // open model space block table record for write
           BlockTableRecord btr = (BlockTableRecord)tr.GetObject(Doc.Database.CurrentSpaceId, OpenMode.ForWrite);
@@ -449,12 +449,14 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
             // find existing doc objects if they exist
             var existingObjs = new List<ObjectId>();
+            var layer = commitObj.Container;
             switch (state.ReceiveMode)
             {
               case ReceiveMode.Update: // existing objs will be removed if it exists in the received commit
                 existingObjs = Doc.GetObjectsByApplicationId(tr, commitObj.applicationId);
                 break;
               default:
+                layer = $"{commitPrefix}${commitObj.Container}";
                 break;
             }
 
@@ -485,7 +487,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
       }
     }
     // Recurses through the commit object and flattens it. Returns list of Base objects with their bake layers
-    private List<ApplicationObject> FlattenCommitObject(object obj, ISpeckleConverter converter, ProgressViewModel progress, string layer, ref int count, bool foundConvertibleMember = false)
+    private List<ApplicationObject> FlattenCommitObject(object obj, ISpeckleConverter converter, ProgressViewModel progress, ref int count, string layer = null, bool foundConvertibleMember = false)
     {
       var objects = new List<ApplicationObject>();
 
@@ -511,7 +513,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
           bool hasFallback = false;
           if (@base.GetMembers().ContainsKey("displayValue"))
           {
-            var fallbackObjects = FlattenCommitObject(@base["displayValue"], converter, progress, layer, ref count, foundConvertibleMember);
+            var fallbackObjects = FlattenCommitObject(@base["displayValue"], converter, progress, ref count, layer, foundConvertibleMember);
             if (fallbackObjects.Count > 0)
             {
               appObj.Fallback.AddRange(fallbackObjects);
@@ -539,9 +541,9 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
             // get bake layer name
             string objLayerName = prop.StartsWith("@") ? prop.Remove(0, 1) : prop;
-            string acLayerName = $"{layer}${objLayerName}";
+            string acLayerName = layer == null ? $"{objLayerName}" : $"{layer}${objLayerName}";
 
-            var nestedObjects = FlattenCommitObject(@base[prop], converter, progress, acLayerName, ref count, foundConvertibleMember);
+            var nestedObjects = FlattenCommitObject(@base[prop], converter, progress, ref count, acLayerName, foundConvertibleMember);
             var validNestedObjects = nestedObjects.Where(o => o.Convertible == true || o.Fallback.Count > 0)?.ToList();
             if (validNestedObjects != null && validNestedObjects.Count > 0)
             {
@@ -564,7 +566,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
       {
         count = 0;
         foreach (var listObj in list)
-          objects.AddRange(FlattenCommitObject(listObj, converter, progress, layer, ref count));
+          objects.AddRange(FlattenCommitObject(listObj, converter, progress, ref count, layer));
         return objects;
       }
 
@@ -572,7 +574,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
       {
         count = 0;
         foreach (DictionaryEntry kvp in dict)
-          objects.AddRange(FlattenCommitObject(kvp.Value, converter, progress, layer, ref count));
+          objects.AddRange(FlattenCommitObject(kvp.Value, converter, progress, ref count, layer));
         return objects;
       }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -412,7 +412,9 @@ namespace Objects.Converter.AutocadCivil
     public ObjectId BlockDefinitionToNativeDB(BlockDefinition definition)
     {
       // get modified definition name with commit info
-      var blockName = RemoveInvalidAutocadChars($"{Doc.UserData["commit"]} - {definition.name}");
+      var blockName = ReceiveMode == ReceiveMode.Create ?
+        RemoveInvalidAutocadChars($"{Doc.UserData["commit"]} - {definition.name}") :
+        RemoveInvalidAutocadChars($"{definition.name}");
 
       ObjectId blockId = ObjectId.Null;
 


### PR DESCRIPTION
## Description & motivation
Aligning update receive behavior with Rhino, this pr removes the `stream branch commit` info as a prefix to received layers on update mode. This means that objects roundtripping in autocad on update mode should be placed in the same layers.

Receiving commits on create mode will still create new layers.

Also includes a minor fix for blocks that were being reported as updated instead of created

Fixes #1899

## Changes:

Autocad connector

## Screenshots:

Before on update mode:
![image](https://user-images.githubusercontent.com/16748799/204872621-dfb1ddea-7f32-4c8f-a584-3e4566d054ec.png)

After on update mode:
![image](https://user-images.githubusercontent.com/16748799/204874198-0f3be7a8-ac1d-43d4-98c1-f293fdf58f6c.png)


## Checklist:

- [ ] I have updated or added relevant documentation.
