### PR TITLE
hotfix(objects): incorrect application of `Transform` to vector

### DIFF
--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -181,11 +181,10 @@ namespace Objects.Other
     {
       var newPoint = new List<double>();
 
-      for (var i = 0; i < 16; i += 4)
+      for (var i = 0; i < 12; i += 4)
         newPoint.Add(vector[0] * value[i] + vector[1] * value[i + 1] + vector[2] * value[i + 2]);
 
-      return new List<double>(3)
-        { newPoint[ 0 ], newPoint[ 1 ], newPoint[ 2 ] };
+      return newPoint;
     }
 
     /// <summary>

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -179,11 +179,10 @@ namespace Objects.Other
     /// </summary>
     public List<double> ApplyToVector(List<double> vector)
     {
-      var newPoint = new List<double>(4) { vector[0], vector[1], vector[2], 1 };
+      var newPoint = new List<double>();
 
       for (var i = 0; i < 16; i += 4)
-        newPoint[i / 4] = newPoint[0] * value[i] + newPoint[1] * value[i + 1] +
-                            newPoint[2] * value[i + 2];
+        newPoint.Add(vector[0] * value[i] + vector[1] * value[i + 1] + vector[2] * value[i + 2]);
 
       return new List<double>(3)
         { newPoint[ 0 ], newPoint[ 1 ], newPoint[ 2 ] };


### PR DESCRIPTION
## Description & motivation
Fixes the iteration logic of `ApplyToVector` in our `Transform` class. This was causing `GetInsertionPlane` to return incorrect planes, resulting in failed receives in Dynamo.

Fixes #1949
Fixes #1683 

## Changes:

Objects

## To-do before merge:

- [x] Testing in Grasshopper and Dynamo by @AlanRynne 
