### PR TITLE
feat(dui): adds support for hiding the receive tab

### DIFF
--- a/DesktopUI2/DesktopUI2/ConnectorBindings.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorBindings.cs
@@ -41,9 +41,6 @@ namespace DesktopUI2
     /// </summary>
     /// <returns></returns>
     public virtual bool CanReceive => true;
-    public virtual bool CanSelectObjects => false;
-
-    public virtual bool CanTogglePreview => false;
 
     /// <summary>
     /// Indicates if previewing send has been implemented

--- a/DesktopUI2/DesktopUI2/ConnectorBindings.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorBindings.cs
@@ -36,6 +36,11 @@ namespace DesktopUI2
     #endregion
 
     #region virtual methods & properties
+    /// <summary>
+    /// Indicates if the connector can Receive and if that function has been implemented
+    /// </summary>
+    /// <returns></returns>
+    public virtual bool CanReceive => true;
     public virtual bool CanSelectObjects => false;
 
     public virtual bool CanTogglePreview => false;

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -434,7 +434,7 @@ namespace DesktopUI2.ViewModels
         this.RaisePropertyChanged("HasSettings");
       }
     }
-    public bool HasSettings => true; //AvailableSettings != null && AvailableSettings.Any();
+
 
     public string _previewImageUrl = "";
     public string PreviewImageUrl
@@ -474,6 +474,7 @@ namespace DesktopUI2.ViewModels
 
     public bool CanOpenCommentsIn3DView { get; set; } = false;
     public bool CanReceive { get; set; }
+    public bool HasSettings { get; set; } = true;
     private bool _isAddingBranches = false;
 
     #endregion
@@ -648,6 +649,7 @@ namespace DesktopUI2.ViewModels
 
         //get available settings from our bindings
         Settings = Bindings.GetSettings();
+        HasSettings = Settings.Any();
 
         //get available filters from our bindings
         AvailableFilters = new List<FilterViewModel>(Bindings.GetSelectionFilters().Select(x => new FilterViewModel(x)));

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -636,10 +636,12 @@ namespace DesktopUI2.ViewModels
       {
         if (CanReceive)
         {
-          if (!ReceiveModes.Any())
-            throw new SpeckleException("No Receive Mode is available.");
           //receive modes
           ReceiveModes = Bindings.GetReceiveModes();
+
+          if (!ReceiveModes.Any())
+            throw new SpeckleException("No Receive Mode is available.");
+
           //by default the first available receive mode is selected
           SelectedReceiveMode = ReceiveModes.Contains(StreamState.ReceiveMode) ? StreamState.ReceiveMode : ReceiveModes[0];
         }

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -473,6 +473,7 @@ namespace DesktopUI2.ViewModels
     }
 
     public bool CanOpenCommentsIn3DView { get; set; } = false;
+    public bool CanReceive { get; set; }
     private bool _isAddingBranches = false;
 
     #endregion
@@ -537,6 +538,7 @@ namespace DesktopUI2.ViewModels
         //use dependency injection to get bindings
         Bindings = Locator.Current.GetService<ConnectorBindings>();
         CanOpenCommentsIn3DView = Bindings.CanOpen3DView;
+        CanReceive = Bindings.CanReceive;
 
         if (Client == null)
         {
@@ -632,10 +634,15 @@ namespace DesktopUI2.ViewModels
     {
       try
       {
-        //receive modes
-        ReceiveModes = Bindings.GetReceiveModes();
-        //by default the first available receive mode is selected
-        SelectedReceiveMode = ReceiveModes.Contains(StreamState.ReceiveMode) ? StreamState.ReceiveMode : ReceiveModes[0];
+        if (CanReceive)
+        {
+          if (!ReceiveModes.Any())
+            throw new SpeckleException("No Receive Mode is available.");
+          //receive modes
+          ReceiveModes = Bindings.GetReceiveModes();
+          //by default the first available receive mode is selected
+          SelectedReceiveMode = ReceiveModes.Contains(StreamState.ReceiveMode) ? StreamState.ReceiveMode : ReceiveModes[0];
+        }
 
         //get available settings from our bindings
         Settings = Bindings.GetSettings();

--- a/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Receive.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Receive.xaml
@@ -171,7 +171,8 @@
             assists:ShadowAssist.ShadowDepth="Depth0"
             Background="Transparent"
             Command="{Binding OpenSettingsCommand}"
-            Foreground="{DynamicResource PrimaryHueMidBrush}">
+            Foreground="{DynamicResource PrimaryHueMidBrush}"
+            IsVisible="{Binding HasSettings}">
             <Grid Margin="0" ColumnDefinitions="auto,*">
               <icons:MaterialIcon VerticalAlignment="Center" Kind="Settings" />
               <TextBlock

--- a/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Send.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Send.xaml
@@ -127,7 +127,8 @@
             assists:ShadowAssist.ShadowDepth="Depth0"
             Background="Transparent"
             Command="{Binding OpenSettingsCommand}"
-            Foreground="{DynamicResource PrimaryHueMidBrush}">
+            Foreground="{DynamicResource PrimaryHueMidBrush}"
+            IsVisible="{Binding HasSettings}">
             <Grid Margin="0" ColumnDefinitions="auto,*">
               <icons:MaterialIcon VerticalAlignment="Center" Kind="Settings" />
               <TextBlock

--- a/DesktopUI2/DesktopUI2/Views/Pages/StreamEditView.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/StreamEditView.xaml
@@ -153,7 +153,7 @@
             </TabItem>
 
             <!--  RECEIVE  -->
-            <TabItem ToolTip.Tip="Receive">
+            <TabItem IsVisible="{Binding CanReceive}" ToolTip.Tip="Receive">
               <TabItem.Header>
                 <StackPanel Orientation="Horizontal">
                   <icons:MaterialIcon


### PR DESCRIPTION
Some connectors cannot receive, eg Navisworks, this PR adds a virtual binding prop to specify if Receive should be enabled or not.
This PR also fixes the "advanced settings" button not being hidden when no settings were available for the connector.