### PR TITLE
fix(rhino): no longer using commit top layer in update receive mode

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -271,7 +271,7 @@ namespace SpeckleRhino
 
         int count = 0;
         var commitLayerName = DesktopUI2.Formatting.CommitInfo(state.CachedStream.name, state.BranchName, commit.id); // get commit layer name 
-        Preview = FlattenCommitObject(commitObject, converter, progress, commitLayerName, ref count);
+        Preview = FlattenCommitObject(commitObject, converter, progress, ref count);
         Doc.Notes += "%%%" + commitLayerName; // give converter a way to access commit layer info
 
         // Convert preview objects
@@ -394,7 +394,7 @@ namespace SpeckleRhino
         {
           // flatten the commit object to retrieve children objs
           int count = 0;
-          Preview = FlattenCommitObject(commitObject, converter, progress, commitLayerName, ref count);
+          Preview = FlattenCommitObject(commitObject, converter, progress, ref count);
 
           // convert
           foreach (var previewObj in Preview)
@@ -453,11 +453,10 @@ namespace SpeckleRhino
           {
             case ReceiveMode.Update: // existing objs will be removed if it exists in the received commit
               toRemove = GetObjectsByApplicationId(previewObj.applicationId);
-              if (toRemove.Any())
-                layer = Doc.Layers[toRemove.First().Attributes.LayerIndex].FullPath;
               toRemove.ForEach(o => Doc.Objects.Delete(o));
               break;
             default:
+              layer = $"{commitLayerName}{Layer.PathSeparator}{previewObj.Container}"; // use the commit as the top level layer in create mode
               break;
           }
           if (toRemove.Count() > 0) isUpdate = true;
@@ -567,7 +566,7 @@ namespace SpeckleRhino
     }
 
     // Recurses through the commit object and flattens it. Returns list of Preview objects
-    private List<ApplicationObject> FlattenCommitObject(object obj, ISpeckleConverter converter, ProgressViewModel progress, string layer, ref int count, bool foundConvertibleMember = false)
+    private List<ApplicationObject> FlattenCommitObject(object obj, ISpeckleConverter converter, ProgressViewModel progress, ref int count, string layer = null, bool foundConvertibleMember = false)
     {
       var objects = new List<ApplicationObject>();
 
@@ -593,7 +592,7 @@ namespace SpeckleRhino
           bool hasFallback = false;
           if (@base.GetMembers().ContainsKey("displayValue"))
           {
-            var fallbackObjects = FlattenCommitObject(@base["displayValue"], converter, progress, layer, ref count, foundConvertibleMember);
+            var fallbackObjects = FlattenCommitObject(@base["displayValue"], converter, progress, ref count, layer, foundConvertibleMember);
             if (fallbackObjects.Count > 0)
             {
               appObj.Fallback.AddRange(fallbackObjects);
@@ -621,9 +620,9 @@ namespace SpeckleRhino
 
             // get bake layer name
             string objLayerName = prop.StartsWith("@") ? prop.Remove(0, 1) : prop;
-            string rhLayerName = objLayerName.StartsWith($"{layer}{Layer.PathSeparator}") ? objLayerName : $"{layer}{Layer.PathSeparator}{objLayerName}";
+            string rhLayerName = layer == null || objLayerName.StartsWith($"{layer}{Layer.PathSeparator}") ? objLayerName : $"{layer}{Layer.PathSeparator}{objLayerName}";
 
-            var nestedObjects = FlattenCommitObject(@base[prop], converter, progress, rhLayerName, ref count, foundConvertibleMember);
+            var nestedObjects = FlattenCommitObject(@base[prop], converter, progress, ref count, rhLayerName, foundConvertibleMember);
             var validNestedObjects = nestedObjects.Where(o => o.Convertible == true || o.Fallback.Count > 0)?.ToList();
             if (validNestedObjects != null && validNestedObjects.Count > 0)
             {
@@ -646,7 +645,7 @@ namespace SpeckleRhino
       {
         count = 0;
         foreach (var listObj in list)
-          objects.AddRange(FlattenCommitObject(listObj, converter, progress, layer, ref count));
+          objects.AddRange(FlattenCommitObject(listObj, converter, progress, ref count, layer));
         return objects;
       }
 
@@ -654,7 +653,7 @@ namespace SpeckleRhino
       {
         count = 0;
         foreach (DictionaryEntry kvp in dict)
-          objects.AddRange(FlattenCommitObject(kvp.Value, converter, progress, layer, ref count));
+          objects.AddRange(FlattenCommitObject(kvp.Value, converter, progress, ref count, layer));
         return objects;
       }
 


### PR DESCRIPTION
## Description & motivation

Previously, receiving in Rhino always creates a top layer with the stream, branch, and commit info, except in update mode where the received object is placed in the same layer as the object it is replacing.

Now, the top commit layer will only be created in `Create` receive mode.
In `Update` mode, objects will be placed in the layer structure as determined by the commit traversal. This means any object that is replacing an existing object in the rhino file will no longer be placed in the existing object's layer.

Fixes #1836 

## Changes:

Rhino Connector

## Screenshots:

Before:
![image](https://user-images.githubusercontent.com/16748799/204840687-80721f8a-371d-40b9-ab4b-fb178b318dae.png)

After (update mode):
![image](https://user-images.githubusercontent.com/16748799/204840964-88c852b0-33a9-45fb-b9c1-fec904e2efec.png)

After (create mode):
![image](https://user-images.githubusercontent.com/16748799/204841157-6697cfb2-eaec-4c04-9b78-0fd6fc137d45.png)

## Checklist:

- [ ] I have updated or added relevant documentation.

