### PR TITLE
Matteo/notifications hotfix

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Events.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Events.cs
@@ -62,19 +62,21 @@ namespace Speckle.ConnectorRevit.UI
       RevitApp.Application.DocumentSynchronizingWithCentral += Application_DocumentSynchronizingWithCentral;
       RevitApp.Application.DocumentSynchronizedWithCentral += Application_DocumentSynchronizedWithCentral;
       RevitApp.Application.FileExported += Application_FileExported;
-      RevitApp.Application.FileExporting += Application_FileExporting;
-      RevitApp.Application.FileImporting += Application_FileImporting;
+      //RevitApp.Application.FileExporting += Application_FileExporting;
+      //RevitApp.Application.FileImporting += Application_FileImporting;
       //SelectionTimer = new Timer(1400) { AutoReset = true, Enabled = true };
       //SelectionTimer.Elapsed += SelectionTimer_Elapsed;
       // TODO: Find a way to handle when document is closed via middle mouse click
       // thus triggering the focus on a new project
     }
 
+    //DISABLED
     private void Application_FileExporting(object sender, FileExportingEventArgs e)
     {
       ShowImportExportAlert();
     }
 
+    //DISABLED
     private void Application_FileImporting(object sender, FileImportingEventArgs e)
     {
       ShowImportExportAlert();

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -155,6 +155,9 @@ namespace DesktopUI2.ViewModels
     {
       PreviewOn = false;
       Bindings.ResetDocument();
+      //if not a saved stream dispose client and subs
+      if (!HomeViewModel.Instance.SavedStreams.Any(x => x._guid == _guid))
+        Client.Dispose();
       MainViewModel.GoHome();
     }
 


### PR DESCRIPTION
- subscriptions not correctly disposed when a stream is not saved and the user simply clicks on the back button
- disables the file import/export alert in Revit