### PR TITLE
fix(rhino/gh): Do not weld Brep displayMeshes anymore

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -961,7 +961,6 @@ namespace Objects.Converter.RhinoGh
           break;
       }
       joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
-      joinedMesh.Weld(Math.PI);
       return joinedMesh;
     }
 


### PR DESCRIPTION
Fixes #1967

Removed the welding step on our displayMesh creation logic for all `Breps`

This will result in some duplicated vertices (i.e. minor increase in size) but has the benefit of rendering correctly on the viewer.