### PR TITLE
Update: Length for materialQuantities in RevitConverter

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMaterialQuantities.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMaterialQuantities.cs
@@ -25,16 +25,18 @@ namespace Objects.Converter.Revit
       //Get quantities
       double volume = element.GetMaterialVolume(material.Id);
       double area = element.GetMaterialArea(material.Id, false); //To-Do: Do we need Paint-Materials
-
+                                                                 //length
+      double length = 0;
+      if (LocationToSpeckle(element) is ICurve) length = (LocationToSpeckle(element) as ICurve).length;
       //Convert Feet to meters
       string units = Speckle.Core.Kits.Units.Meters;
       double factor = Speckle.Core.Kits.Units.GetConversionFactor(Speckle.Core.Kits.Units.Feet, units);
       volume *= factor * factor * factor;
       area *= factor * factor;
-
+      length *= factor;
       //Create and return materialquantity
       var speckleMaterial = ConvertAndCacheMaterial(material.Id, material.Document);
-      return new Objects.Other.MaterialQuantity(speckleMaterial, volume, area, units);
+      return new Objects.Other.MaterialQuantity(speckleMaterial, volume, area, length, units);
     }
 
     #endregion

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMaterialQuantities.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMaterialQuantities.cs
@@ -27,13 +27,13 @@ namespace Objects.Converter.Revit
       double area = element.GetMaterialArea(material.Id, false); //To-Do: Do we need Paint-Materials
                                                                  //length
       double length = 0;
-      if (LocationToSpeckle(element) is ICurve) length = (LocationToSpeckle(element) as ICurve).length;
+      if (LocationToSpeckle(element) is ICurve) length = (LocationToSpeckle(element) as ICurve).length/1000;  //LocationCurve default is mm (Speckle)
       //Convert Feet to meters
       string units = Speckle.Core.Kits.Units.Meters;
       double factor = Speckle.Core.Kits.Units.GetConversionFactor(Speckle.Core.Kits.Units.Feet, units);
       volume *= factor * factor * factor;
       area *= factor * factor;
-      length *= factor;
+  
       //Create and return materialquantity
       var speckleMaterial = ConvertAndCacheMaterial(material.Id, material.Document);
       return new Objects.Other.MaterialQuantity(speckleMaterial, volume, area, length, units);

--- a/Objects/Objects/Other/MaterialQuantity.cs
+++ b/Objects/Objects/Other/MaterialQuantity.cs
@@ -16,6 +16,10 @@ namespace Objects.Other
         /// Area of the material on a element
         /// </summary>
         public double area { get; set; }
+        /// <summary>
+        /// Length os the element; 0 if not line-based
+        /// </summary>
+        public double length { get; set; }
 
         /// <summary>
         /// UnitMeasure of the quantity,e.g meters implies aquaremeters for area and cubicmeters for the volume
@@ -26,12 +30,13 @@ namespace Objects.Other
         public MaterialQuantity() { }
         
         [Speckle.Core.Kits.SchemaInfo("MaterialQuantity", "Creates the quantity of a material")]
-        public MaterialQuantity(Objects.Other.Material m, double volume, double  area, string units)
+        public MaterialQuantity(Objects.Other.Material m, double volume, double  area, double length, string units)
         {
             material = m;
             this.volume = volume;   
             this.area = area;   
             this.units = units;
+            this.length = length;
         }
     }
 


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation


- Add length of elements to MaterialQuantities
- Allows for query of material quantities
- fixes issue #1944 


## Changes:


- ```Objects.Converter.Revit.ConverterRevit```
- ```Objects.Other.MaterialQuantity```


## Screenshots:
<img src="https://user-images.githubusercontent.com/86473259/205712715-985859a6-4cba-4003-9193-ef83fffcbede.png" width="250" height="400" /><img src="https://user-images.githubusercontent.com/86473259/205712640-6fe6278b-98d7-46ad-83db-34b139995870.png" width="250" height="400" />
Two differnet elements before(l.) and after(r.)

## Validation of changes:
I have testes it with Revit projects and different element categories.


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
