### PR TITLE
Revert "chore(deps): bump System.Drawing.Common from 4.5.0 to 4.7.2 in /ConnectorCSI/ConnectorCSIBridge"

### DIFF
--- a/ConnectorCSI/ConnectorCSIBridge/packages.config
+++ b/ConnectorCSI/ConnectorCSIBridge/packages.config
@@ -19,7 +19,7 @@
   <package id="Splat" version="10.0.1" targetFramework="net48" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net48" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
-  <package id="System.Drawing.Common" version="4.7.2" targetFramework="net48" />
+  <package id="System.Drawing.Common" version="4.5.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.3" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />


### PR DESCRIPTION
Reverts specklesystems/speckle-sharp#1951

This conflicts with #1978