### PR TITLE
Revert "Update `release/2.11` with changes in `main`"

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Events.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Events.cs
@@ -62,21 +62,19 @@ namespace Speckle.ConnectorRevit.UI
       RevitApp.Application.DocumentSynchronizingWithCentral += Application_DocumentSynchronizingWithCentral;
       RevitApp.Application.DocumentSynchronizedWithCentral += Application_DocumentSynchronizedWithCentral;
       RevitApp.Application.FileExported += Application_FileExported;
-      //RevitApp.Application.FileExporting += Application_FileExporting;
-      //RevitApp.Application.FileImporting += Application_FileImporting;
+      RevitApp.Application.FileExporting += Application_FileExporting;
+      RevitApp.Application.FileImporting += Application_FileImporting;
       //SelectionTimer = new Timer(1400) { AutoReset = true, Enabled = true };
       //SelectionTimer.Elapsed += SelectionTimer_Elapsed;
       // TODO: Find a way to handle when document is closed via middle mouse click
       // thus triggering the focus on a new project
     }
 
-    //DISABLED
     private void Application_FileExporting(object sender, FileExportingEventArgs e)
     {
       ShowImportExportAlert();
     }
 
-    //DISABLED
     private void Application_FileImporting(object sender, FileImportingEventArgs e)
     {
       ShowImportExportAlert();

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -155,9 +155,6 @@ namespace DesktopUI2.ViewModels
     {
       PreviewOn = false;
       Bindings.ResetDocument();
-      //if not a saved stream dispose client and subs
-      if (!HomeViewModel.Instance.SavedStreams.Any(x => x._guid == _guid))
-        Client.Dispose();
       MainViewModel.GoHome();
     }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -412,9 +412,7 @@ namespace Objects.Converter.AutocadCivil
     public ObjectId BlockDefinitionToNativeDB(BlockDefinition definition)
     {
       // get modified definition name with commit info
-      var blockName = ReceiveMode == ReceiveMode.Create ?
-        RemoveInvalidAutocadChars($"{Doc.UserData["commit"]} - {definition.name}") :
-        RemoveInvalidAutocadChars($"{definition.name}");
+      var blockName = RemoveInvalidAutocadChars($"{Doc.UserData["commit"]} - {definition.name}");
 
       ObjectId blockId = ObjectId.Null;
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -98,12 +98,12 @@ namespace Objects.Converter.RhinoGh
           viewport.ChangeToParallelProjection(true);
 
         var commitInfo = GetCommitInfo();
-        bakedViewName = ReceiveMode == ReceiveMode.Create ? $"{commitInfo} - {view.name}" : $"{view.name}";
+        bakedViewName = $"{commitInfo } - {view.name}";
 
-        var res = Doc.NamedViews.Add(bakedViewName, viewport.Id);
-        // if (res == -1) TODO: add reporting here and return application object
-
+        Doc.NamedViews.Add(bakedViewName, viewport.Id);
       });
+
+      //ConversionErrors.Add(sdfasdfaf);
 
       return bakedViewName;
     }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -961,6 +961,7 @@ namespace Objects.Converter.RhinoGh
           break;
       }
       joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
+      joinedMesh.Weld(Math.PI);
       return joinedMesh;
     }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -30,7 +30,6 @@ namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
-    // display and render
     public ObjectAttributes DisplayStyleToNative(DisplayStyle display)
     {
       var attributes = new ObjectAttributes();
@@ -99,10 +98,14 @@ namespace Objects.Converter.RhinoGh
     public Rhino.Render.RenderMaterial RenderMaterialToNative(RenderMaterial speckleMaterial)
     {
       var commitInfo = GetCommitInfo();
-      var speckleName = ReceiveMode == ReceiveMode.Create ? $"{commitInfo} - {speckleMaterial.name}" : $"{speckleMaterial.name}";
+      var speckleName = $"{commitInfo} - {speckleMaterial.name}";
 
       // check if the doc already has a material with speckle material name, or a previously created speckle material
-      var existing = Doc.RenderMaterials.FirstOrDefault(x => x.Name == speckleName);
+      var existing = Doc.RenderMaterials.FirstOrDefault(x => x.Name == speckleMaterial.name);
+      if (existing != null)
+        return existing;
+      else
+        existing = Doc.RenderMaterials.FirstOrDefault(x => x.Name == speckleName);
       if (existing != null)
         return existing;
 
@@ -136,7 +139,6 @@ namespace Objects.Converter.RhinoGh
 
       return rm;
     }
-
     public RenderMaterial RenderMaterialToSpeckle(RH.Material material)
     {
       var renderMaterial = new RenderMaterial();
@@ -174,7 +176,6 @@ namespace Objects.Converter.RhinoGh
       return renderMaterial;
     }
 
-    // hatch
     public Rhino.Geometry.Hatch[] HatchToNative(Hatch hatch)
     {
 
@@ -194,7 +195,6 @@ namespace Objects.Converter.RhinoGh
 
       return hatches;
     }
-
     public Hatch HatchToSpeckle(Rhino.Geometry.Hatch hatch)
     {
       var _hatch = new Hatch();
@@ -213,7 +213,6 @@ namespace Objects.Converter.RhinoGh
 
       return _hatch;
     }
-
     private HatchPattern FindDefaultPattern(string patternName)
     {
       var defaultPattern = typeof(HatchPattern.Defaults).GetProperties()?.Where(o => o.Name.Equals(patternName, StringComparison.OrdinalIgnoreCase))?.ToList().FirstOrDefault();
@@ -223,7 +222,6 @@ namespace Objects.Converter.RhinoGh
         return HatchPattern.Defaults.Solid;
     }
 
-    // blocks
     public BlockDefinition BlockDefinitionToSpeckle(InstanceDefinition definition)
     {
       var geometry = new List<Base>();
@@ -257,7 +255,7 @@ namespace Objects.Converter.RhinoGh
 
       // get modified definition name with commit info
       var commitInfo = GetCommitInfo();
-      var blockName = ReceiveMode == ReceiveMode.Create ? $"{commitInfo} - {definition.name}" : $"{definition.name}";
+      var blockName = $"{commitInfo} - {definition.name}";
 
       // see if block name already exists and return if so
       if (Doc.InstanceDefinitions.Find(blockName) is InstanceDefinition def)
@@ -306,8 +304,7 @@ namespace Objects.Converter.RhinoGh
           }
           if (converted.Count == 0)
             continue;
-          var geoLayer = ((string)geo["Layer"])?? $"block definition geometry";
-          var layerName = ReceiveMode == ReceiveMode.Create ? $"{commitInfo}{Layer.PathSeparator}{geoLayer}" : $"{geoLayer}";
+          var layerName = (geo["Layer"] != null) ? $"{commitInfo}{Layer.PathSeparator}{geo["Layer"] as string}" : $"{commitInfo}";
           int index = 1;
           if (layerName != null)
             GetLayer(Doc, layerName, out index, true);
@@ -414,6 +411,7 @@ namespace Objects.Converter.RhinoGh
       var displayMaterial = new DisplayMaterial(rhinoMaterial);
       return displayMaterial;
     }
+
 
     public RenderMaterial DisplayMaterialToSpeckle(DisplayMaterial material)
     {

--- a/Objects/Objects/Other/Transform.cs
+++ b/Objects/Objects/Other/Transform.cs
@@ -179,12 +179,14 @@ namespace Objects.Other
     /// </summary>
     public List<double> ApplyToVector(List<double> vector)
     {
-      var newPoint = new List<double>();
+      var newPoint = new List<double>(4) { vector[0], vector[1], vector[2], 1 };
 
-      for (var i = 0; i < 12; i += 4)
-        newPoint.Add(vector[0] * value[i] + vector[1] * value[i + 1] + vector[2] * value[i + 2]);
+      for (var i = 0; i < 16; i += 4)
+        newPoint[i / 4] = newPoint[0] * value[i] + newPoint[1] * value[i + 1] +
+                            newPoint[2] * value[i + 2];
 
-      return newPoint;
+      return new List<double>(3)
+        { newPoint[ 0 ], newPoint[ 1 ], newPoint[ 2 ] };
     }
 
     /// <summary>


### PR DESCRIPTION
Reverts specklesystems/speckle-sharp#1980

Updates between `release` and `main` branches should **always be done with merge commits**.

Reverting this PR bc it was **squashed merged** instead, which means we loose track of the history and can end up with super complex conflicts in the process