### PR TITLE
fix(core): fixes issues using the new sqlite on network drives

### DIFF
--- a/Core/Core/Transports/SQLite.cs
+++ b/Core/Core/Transports/SQLite.cs
@@ -70,9 +70,7 @@ namespace Speckle.Core.Transports
 
 
       RootPath = Path.Combine(basePath, applicationName, $"{scope}.db");
-      //fix for network drives: https://stackoverflow.com/a/18506097/826060
-      var prefix = RootPath.StartsWith(@"\\") ? @"\\" : "";
-      ConnectionString = string.Format("Data Source={0};", prefix + RootPath);
+      ConnectionString = string.Format("Data Source={0};", RootPath);
 
       try
       {

--- a/Core/Core/Transports/SQLite.cs
+++ b/Core/Core/Transports/SQLite.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using Microsoft.Data.Sqlite;
-using Microsoft.Data.Sqlite;
 using Speckle.Core.Api;
 
 namespace Speckle.Core.Transports


### PR DESCRIPTION
The new `Microsoft.Data.Sqlite` handles network paths differently from the library we had before and this change is to address that.