### PR TITLE
Fix(Revit): Allow conversion of Revit Spaces without a zone to Speckle

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -103,7 +103,7 @@ namespace Objects.Converter.Revit
       speckleSpace.area = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_AREA);
       speckleSpace.volume = GetParamValue<double>(revitSpace, BuiltInParameter.ROOM_VOLUME);
       speckleSpace.spaceType = revitSpace.SpaceType.ToString();
-      speckleSpace.zoneName = revitSpace.Zone.Name;
+      speckleSpace.zoneName = revitSpace.Zone?.Name;
 
       GetAllRevitParamsAndIds(speckleSpace, revitSpace);
 


### PR DESCRIPTION
## Description & motivation

Issue described here: https://github.com/specklesystems/speckle-sharp/issues/1956

In short, conversion of Revit Spaces without a zone to Speckle raised an error, as an attempt is made to get the `Zone.Name`, without a null check. This check is now implemented.

## Changes:

Only a null check added, literally one character.

## Screenshots:

![image](https://user-images.githubusercontent.com/43778345/206711342-8fc2e8ed-b996-4b60-aa8a-ec6db1c2fb92.png)

## Validation of changes:

Can now send a model including Spaces without Zones to Speckle. Receiving worked fine, and still does.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
