### PR TITLE
fix(Rhino): handle invalid userstrings

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -56,18 +56,35 @@ namespace Objects.Converter.RhinoGh
     /// <param name="obj">The converted Base object to attach info to</param>
     /// <param name="nativeObj">The Rhino object containing info</param>
     /// <returns></returns>
-    public void GetUserInfo(Base obj, ObjectAttributes attributes)
+    public void GetUserInfo(Base obj, ObjectAttributes attributes, out List<string> notes)
     {
-      var userStringsBase = new Base();
-      var userDictionaryBase = new Base();
+      notes = new List<string>();
 
+      // user strings
       var userStrings = attributes.GetUserStrings();
-      userStrings.AllKeys.ToList().ForEach(k => userStringsBase[k] = userStrings[k]);
-      ParseArchivableToDictionary(userDictionaryBase, attributes.UserDictionary);
+      if (userStrings.Count > 0)
+      {
+        var userStringsBase = new Base();
+        foreach (var key in userStrings.AllKeys)
+        {
+          try
+          {
+            userStringsBase[key] = userStrings[key];
+          }
+          catch (Exception e)
+          {
+            notes.Add($"Could not attach user string: {e.Message}");
+          }
+        }
+        obj[UserStrings] = userStringsBase;
+      }
 
-      obj[UserStrings] = userStringsBase;
+      // user dictionary
+      var userDictionaryBase = new Base();
+      ParseArchivableToDictionary(userDictionaryBase, attributes.UserDictionary);
       obj[UserDictionary] = userDictionaryBase;
 
+      // obj name
       if (!string.IsNullOrEmpty(attributes.Name)) obj["name"] = attributes.Name;
     }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -280,7 +280,10 @@ namespace Objects.Converter.RhinoGh
       if (@base is null) return @base;
 
       if (attributes != null)
-        GetUserInfo(@base, attributes);
+      {
+        GetUserInfo(@base, attributes, out List<string> attributeNotes);
+        notes.AddRange(attributeNotes);
+      }
       if (material != null)
         @base["renderMaterial"] = material;
       if (style != null)


### PR DESCRIPTION
## Description & motivation

Rhino hangs when sending objects with invalid user strings, since the connector is attaching user strings as `Base` where each user string key is a prop name and therefore can't contain `./`. 

This fix no longer attaches the user string with invalid chars, and instead reports the missing user string when sending the object.

Fixes #1993 

## Changes:

Rhino connector

## Screenshots:

![image](https://user-images.githubusercontent.com/16748799/206768014-397dde7a-a908-4d19-8bdd-71785585c281.png)
