### PR TITLE
Fix dependency conflicts after update

### DIFF
--- a/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
+++ b/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
@@ -103,12 +103,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>3.20.1</Version>
-    </PackageReference>
-    <PackageReference Include="Speckle.Newtonsoft.Json">
-      <Version>12.0.3.1</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorCSIShared\ConnectorCSIShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ConnectorCSI/ConnectorETABS/ConnectorETABS.csproj
+++ b/ConnectorCSI/ConnectorETABS/ConnectorETABS.csproj
@@ -92,12 +92,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>3.20.1</Version>
-    </PackageReference>
-    <PackageReference Include="Speckle.Newtonsoft.Json">
-      <Version>12.0.3.1</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorCSIShared\ConnectorCSIShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ConnectorCSI/ConnectorSAFE/ConnectorSAFE.csproj
+++ b/ConnectorCSI/ConnectorSAFE/ConnectorSAFE.csproj
@@ -98,12 +98,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>3.20.1</Version>
-    </PackageReference>
-    <PackageReference Include="Speckle.Newtonsoft.Json">
-      <Version>12.0.3.1</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorCSIShared\ConnectorCSIShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
+++ b/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
@@ -90,12 +90,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>3.20.1</Version>
-    </PackageReference>
-    <PackageReference Include="Speckle.Newtonsoft.Json">
-      <Version>12.0.3.1</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorCSIShared\ConnectorCSIShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ConnectorCSI/DriverCSharp/DriverCSharp.csproj
+++ b/ConnectorCSI/DriverCSharp/DriverCSharp.csproj
@@ -88,12 +88,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>3.20.1</Version>
-    </PackageReference>
-    <PackageReference Include="Speckle.Newtonsoft.Json">
-      <Version>12.0.3.1</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="..\ConnectorCSIShared\ConnectorCSIShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ConnectorGrasshopper/ConnectorGrasshopper6/ConnectorGrasshopper6.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper6/ConnectorGrasshopper6.csproj
@@ -65,6 +65,11 @@
     <PackageReference Include="Grasshopper" Version="6.28.20199.17141" IncludeAssets="compile;build" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+
   <Target Name="GenerateT4" BeforeTargets="BeforeRebuild">
     <Message Text="Restoring T4 tool..." Importance="high" />
     <Exec Command="dotnet tool restore" />

--- a/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
+++ b/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
@@ -62,7 +62,7 @@
 
     <!-- We are building for win-x64 on mac too, so these deps are not automatically copied/loaded -->
   <ItemGroup Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">
-    <None Include="$(HOME)/.nuget/packages/sqlitepclraw.lib.e_sqlite3/2.0.6/runtimes/osx-x64/native/libe_sqlite3.dylib" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(HOME)/.nuget/packages/sqlitepclraw.lib.e_sqlite3/2.1.2/runtimes/osx-x64/native/libe_sqlite3.dylib" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">

--- a/ConnectorTeklaStructures/ConnectorTeklaStructures2020/ConnectorTeklaStructures2020.csproj
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructures2020/ConnectorTeklaStructures2020.csproj
@@ -111,12 +111,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>3.20.1</Version>
-    </PackageReference>
-    <PackageReference Include="Speckle.Newtonsoft.Json">
-      <Version>12.0.3.1</Version>
-    </PackageReference>
     <PackageReference Include="Stylet">
       <Version>1.3.6</Version>
     </PackageReference>

--- a/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ConnectorTeklaStructures2021.csproj
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructures2021/ConnectorTeklaStructures2021.csproj
@@ -103,12 +103,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>3.20.1</Version>
-    </PackageReference>
-    <PackageReference Include="Speckle.Newtonsoft.Json">
-      <Version>12.0.3.1</Version>
-    </PackageReference>
     <PackageReference Include="Stylet">
       <Version>1.3.6</Version>
     </PackageReference>


### PR DESCRIPTION
- removes direct depencencies of speckle newtonsoft and sentry from structural connectors
- adds system.forms and windowbase to gh6
- updates hardcoded version of sqlitepclraw.lib.e_sqlite3 in rhino7