### PR TITLE
feat: Adds `Any` and `Linux` to the manager feed api OS list 

### DIFF
--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -490,17 +490,27 @@ namespace Speckle.Core.Api
     }
   }
 
+  /// <summary>
+  /// OS
+  /// NOTE: do not edit order and only append new items as they are serialized to ints
+  /// </summary>
   public enum Os
   {
-    Win,
-    OSX
+    Win, //0
+    OSX, //1
+    Linux, //2
+    Any //3
   }
 
+  /// <summary>
+  /// Architecture
+  /// NOTE: do not edit order and only append new items as they are serialized to ints
+  /// </summary>
   public enum Architecture
   {
-    Any,
-    Arm,
-    Intel
+    Any, //0
+    Arm, //1
+    Intel //2
   }
 
 


### PR DESCRIPTION
Adds `Any` and `Linux` to the manager feed OS list so we can publish a blender installer for any supported OS.