### PR TITLE
fix(Rhino): adds render material to brep display mesh

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -32,6 +32,7 @@ using Plane = Objects.Geometry.Plane;
 using Point = Objects.Geometry.Point;
 using Pointcloud = Objects.Geometry.Pointcloud;
 using Polyline = Objects.Geometry.Polyline;
+using RenderMaterial = Objects.Other.RenderMaterial;
 using Spiral = Objects.Geometry.Spiral;
 
 using RH = Rhino.Geometry;
@@ -816,7 +817,7 @@ namespace Objects.Converter.RhinoGh
     /// </summary>
     /// <param name="brep">BREP to be converted.</param>
     /// <returns></returns>
-    public Brep BrepToSpeckle(RH.Brep brep, string units = null, RH.Mesh previewMesh = null)
+    public Brep BrepToSpeckle(RH.Brep brep, string units = null, RH.Mesh previewMesh = null, RenderMaterial mat = null)
     {
       var tol = Doc.ModelAbsoluteTolerance;
       //tol = 0;
@@ -827,9 +828,14 @@ namespace Objects.Converter.RhinoGh
       //   f.RebuildEdges(tol, false, false);
       // }
       // Create complex
-      var displayMesh = previewMesh != null ? previewMesh : GetBrepDisplayMesh(brep);
 
-      var spcklBrep = new Brep(displayValue: MeshToSpeckle(displayMesh, u), provenance: RhinoAppName, units: u);
+      // get display mesh and attach render material to it if it exists
+      var displayMesh = previewMesh != null ? previewMesh : GetBrepDisplayMesh(brep);
+      var displayValue = MeshToSpeckle(displayMesh, u);
+      if (displayValue != null && mat != null)
+        displayValue["renderMaterial"] = mat;
+
+      var spcklBrep = new Brep(displayValue: displayValue, provenance: RhinoAppName, units: u);
 
       // Vertices, uv curves, 3d curves and surfaces
       spcklBrep.Vertices = brep.Vertices

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -145,7 +145,6 @@ namespace Objects.Converter.RhinoGh
           if (ro is BrepObject || ro is ExtrusionObject)
             displayMesh = GetRhinoRenderMesh(ro);
 
-
           //rhino BIM to be deprecated after the mapping tool is released
           if (ro.Attributes.GetUserString(SpeckleSchemaKey) != null) // schema check - this will change in the near future
             schema = ConvertToSpeckleBE(ro, reportObj, displayMesh) ?? ConvertToSpeckleStr(ro, reportObj);
@@ -243,16 +242,16 @@ namespace Objects.Converter.RhinoGh
 #if RHINO7
         case RH.SubD o:
           if (o.HasBrepForm)
-            @base = BrepToSpeckle(o.ToBrep(new SubDToBrepOptions()),null, displayMesh);
+            @base = BrepToSpeckle(o.ToBrep(new SubDToBrepOptions()),null, displayMesh, material);
           else
             @base = MeshToSpeckle(o);
           break;
 #endif
           case RH.Extrusion o:
-            @base = BrepToSpeckle(o.ToBrep(), null, displayMesh);
+            @base = BrepToSpeckle(o.ToBrep(), null, displayMesh, material);
             break;
           case RH.Brep o:
-            @base = BrepToSpeckle(o.DuplicateBrep(), null, displayMesh);
+            @base = BrepToSpeckle(o.DuplicateBrep(), null, displayMesh, material);
             break;
           case NurbsSurface o:
             @base = SurfaceToSpeckle(o);


### PR DESCRIPTION
## Description & motivation

Adds the render material to brep display meshes when sending to Speckle. This aligns the Rhino connector with the expected behavior for display value / render materials.

Fixes #1890

## Changes:

Rhino converter
