### PR TITLE
fix(autocadcivil): polycurve handling and reporting

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -33,7 +33,6 @@ using Polyline = Objects.Geometry.Polyline;
 using Spiral = Objects.Geometry.Spiral;
 using Surface = Objects.Geometry.Surface;
 using Vector = Objects.Geometry.Vector;
-using Objects.Geometry;
 
 namespace Objects.Converter.AutocadCivil
 {
@@ -731,12 +730,6 @@ namespace Objects.Converter.AutocadCivil
       {
         appObj.Update(status: ApplicationObject.State.Failed, logItem: "No segments were successfully converted");
         return appObj;
-      }
-      else
-      {
-        appObj.Status = ReceiveMode == Speckle.Core.Kits.ReceiveMode.Update ? 
-          ApplicationObject.State.Updated : 
-          ApplicationObject.State.Created;
       }
 
       if (others.Count > 0)

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -302,8 +302,10 @@ namespace Objects.Converter.AutocadCivil
 
         case Polycurve o:
           bool convertAsSpline = (o.segments.Where(s => !(s is Line) && !(s is Arc)).Count() > 0) ? true : false;
-          if (!convertAsSpline) convertAsSpline = IsPolycurvePlanar(o) ? false : true;
-          acadObj = convertAsSpline ? PolycurveSplineToNativeDB(o) : PolycurveToNativeDB(o);
+          if (convertAsSpline || !IsPolycurvePlanar(o))
+            acadObj = PolycurveSplineToNativeDB(o);
+          else
+            acadObj = PolycurveToNativeDB(o);
           break;
 
         case Curve o:
@@ -362,8 +364,8 @@ namespace Objects.Converter.AutocadCivil
       switch (acadObj)
       {
         case ApplicationObject o: // some to native methods return an application object (if object is baked to doc during conv)
-          acadObj = o.Converted.Any() ? o.Converted.FirstOrDefault() : null;
-          if (reportObj != null) reportObj.Update(status: o.Status, createdIds: o.CreatedIds, container: o.Container, log: o.Log);
+          acadObj = o.Converted.Any() ? o.Converted : null;
+          if (reportObj != null) reportObj.Update(status: o.Status, createdIds: o.CreatedIds, converted: o.Converted, container: o.Container, log: o.Log);
           break;
         default:
           if (reportObj != null) reportObj.Update(log: notes);


### PR DESCRIPTION
## Description & motivation

When receiving, `Polycurve`s which need to be converted as individual segments are now reported correctly in DUI.
Reporting for receiving `Hatch`es has also been improved with error logging when individual hatch loops fail.

Part of #1906 

## Changes:

Hatch and Polycurve conversion to native in Autocad
This requires modifying the return type of these methods to `ApplicationObject`




