### PR TITLE
fix(revit): uses bbox minimum plane for generating pointclouds

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -102,7 +102,9 @@ namespace Objects.Converter.Revit
       var u = units ?? ModelUnits;
       var boundingBox = pointcloud.get_BoundingBox(null);
       var transform = pointcloud.GetTransform();
-      var filter = PointCloudFilterFactory.CreateMultiPlaneFilter(new List<DB.Plane>() { DB.Plane.CreateByNormalAndOrigin(XYZ.BasisZ, transform.Origin) });
+
+      var minPlane = DB.Plane.CreateByNormalAndOrigin(XYZ.BasisZ, transform.OfPoint(boundingBox.Min));
+      var filter = PointCloudFilterFactory.CreateMultiPlaneFilter(new List<DB.Plane>() { minPlane });
       var points = pointcloud.GetPoints(filter, 0.0001, 999999); // max limit is 1 mil but 1000000 throws error
 
       var _pointcloud = new Pointcloud();


### PR DESCRIPTION
## Description & motivation
Previously, pointclouds in Revit were being generated with the transform origin, which was cutting off any part of the point cloud file that was below the origin xy plane. This has been fixed to use the pointcloud bounding box minimum plane, so the entire pointcloud should now be correctly captured on send.

Fixes #1816
## Changes:

Revit converter `PointcloudToSpeckle()`

## Screenshots:

Before:
![200213660-17d75492-4022-4bb1-88c0-fe8b3bc54ce0](https://user-images.githubusercontent.com/16748799/209343638-b78203bf-5f63-45ea-8ee3-0fa236c5842b.png)

After: 
![image](https://user-images.githubusercontent.com/16748799/209343161-eeb07254-6802-4e7f-b50e-5543de6f0217.png)


