### PR TITLE
feat(acadcivil): preview send

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -225,6 +225,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
     public override void ResetDocument()
     {
       Doc.Editor.SetImpliedSelection(new ObjectId[0]);
+      Autodesk.AutoCAD.Internal.Utils.FlushGraphics();
     }
 
     public override async Task<Dictionary<string, List<MappingValue>>> ImportFamilyCommand(Dictionary<string, List<MappingValue>> Mapping)
@@ -863,7 +864,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
             appObj.Update(status: ApplicationObject.State.Created);
           else
             appObj.Update(status: ApplicationObject.State.Failed, logItem: "Object type conversion to Speckle not supported");
-
+          progress.Report.Log(appObj);
           existingIds.Add(id);
         }
         tr.Commit();

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -224,7 +224,7 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
     public override void ResetDocument()
     {
-      // TODO!
+      Doc.Editor.SetImpliedSelection(new ObjectId[0]);
     }
 
     public override async Task<Dictionary<string, List<MappingValue>>> ImportFamilyCommand(Dictionary<string, List<MappingValue>> Mapping)
@@ -877,7 +877,6 @@ namespace Speckle.ConnectorAutocadCivil.UI
 
       Doc.Editor.SetImpliedSelection(new ObjectId[0]);
       SelectClientObjects(existingIds);
-      Doc.Editor.Regen();
     }
     public override async Task<string> SendStream(StreamState state, ProgressViewModel progress)
     {

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -223,7 +223,7 @@ namespace SpeckleRhino
       if (PreviewConduit != null)
         PreviewConduit.Enabled = false;
       else
-        Doc.Objects.UnselectAll(true);
+        Doc.Objects.UnselectAll(false);
 
       Doc.Views.Redraw();
     }
@@ -859,14 +859,13 @@ namespace SpeckleRhino
           continue;
         }
 
-        // get converter
         var appObj = new ApplicationObject(id, obj.ObjectType.ToString()) { Status = ApplicationObject.State.Unknown };
 
         if (converter.CanConvertToSpeckle(obj))
           appObj.Update(status: ApplicationObject.State.Created);
         else
           appObj.Update(status: ApplicationObject.State.Failed, logItem: "Object type conversion to Speckle not supported");
-
+        progress.Report.Log(appObj);
         existingIds.Add(id);
       }
 


### PR DESCRIPTION
## Description & motivation
Adds preview send feature to the autocad / civil3d connector. This feature selects objects that will be sent, and generates a report on the expected status of each object

This includes implementing the `ResetDocument()` and `PreviewSend()` bindings. 

Also includes a minor refactor of the rhino preview send feature, so that the converter isn't being set per object selected, and fixes a bug where objects weren't being logged to the report

## Changes:

Autocadcivil Connector
Rhino Connector

