### PR TITLE
fix(csi): frames appear in wrong location & deleted frames not tracked

### DIFF
--- a/ConnectorCSI/ConnectorCSIShared/StreamStateManager/StreamStateManager.cs
+++ b/ConnectorCSI/ConnectorCSIShared/StreamStateManager/StreamStateManager.cs
@@ -4,6 +4,7 @@ using Speckle.Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace ConnectorCSI.Storage
@@ -117,5 +118,45 @@ namespace ConnectorCSI.Storage
       catch { return ""; }
     }
 
+    /// <summary>
+    /// Saves a backup file with the extension _speckleBackup1 (number ranges from 1-3)
+    /// if all three backups already exist, it will override the oldest one
+    /// </summary>
+    /// <param name="model"></param>
+    public static void SaveBackupFile(cSapModel model)
+    {
+      string CSIModelfilePath = model.GetModelFilename(true);
+      if (string.IsNullOrEmpty(CSIModelfilePath))
+        // CSI model is probably not saved, so speckle shouldn't do much
+        return;
+
+      string fileExtension = CSIModelfilePath.Split('.').Last();
+      string CSIFileName = Path.GetFileNameWithoutExtension(CSIModelfilePath);
+      string CSIModelFolder = Path.GetDirectoryName(CSIModelfilePath);
+      string speckleFolderPath = Path.Combine(CSIModelFolder, "speckle");
+
+      var backups = new List<(DateTime, string)>();
+      foreach (var fileName in Directory.GetFiles(speckleFolderPath)) 
+      { 
+        if (fileName.Contains($"{CSIFileName}_speckleBackup") && fileName.Split('.').Last().ToLower() == fileExtension.ToLower())
+        {
+          backups.Add((File.GetLastWriteTime(fileName), fileName));
+        }
+      }
+
+      if (backups.Count < 3)
+      {
+        model.File.Save(Path.Combine(speckleFolderPath, $"{CSIFileName}_speckleBackup{backups.Count + 1}.{fileExtension}"));
+      }
+      else
+      {
+        var oldestBackup = backups.Min(o => o.Item1);
+        var oldestFileName = backups.Where(o => o.Item1 == oldestBackup).First().Item2;
+        model.File.Save(oldestFileName);
+      }
+
+      // save back as the original file
+      model.File.Save(CSIModelfilePath);
+    }
   }
 }

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.ClientOperations.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.ClientOperations.cs
@@ -24,7 +24,6 @@ namespace Speckle.ConnectorCSI.UI
     {
       StreamStateManager.ClearStreamStateList(Model);
       StreamStateManager.WriteStreamStateList(Model, streams);
-      Model.File.Save();
     }
 
     public override List<StreamState> GetStreamsInFile()

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.ClientOperations.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.ClientOperations.cs
@@ -23,61 +23,19 @@ namespace Speckle.ConnectorCSI.UI
     public override void WriteStreamsToFile(List<StreamState> streams)
     {
       StreamStateManager.ClearStreamStateList(Model);
-      DocumentStreams = new List<StreamState>();
-
-      foreach (var s in streams)
-        DocumentStreams.Add(s);
-
-      WriteStateToFile();
+      StreamStateManager.WriteStreamStateList(Model, streams);
+      Model.File.Save();
     }
-
-    //public override void AddNewStream(StreamState state)
-    //{
-    //    Tracker.TrackPageview(Tracker.STREAM_CREATE);
-    //    var index = DocumentStreams.FindIndex(b => b.Stream.id == state.Stream.id);
-    //    if (index == -1)
-    //    {
-    //        DocumentStreams.Add(state);
-    //        WriteStateToFile();
-    //    }
-    //}
-    private void WriteStateToFile()
-    {
-      StreamStateManager.WriteStreamStateList(Model, DocumentStreams);
-    }
-
-    //public override void RemoveStreamFromFile(string streamId)
-    //{
-    //    var streamState = DocumentStreams.FirstOrDefault(s => s.Stream.id == streamId);
-    //    if (streamState != null)
-    //    {
-    //        DocumentStreams.Remove(streamState);
-    //        WriteStateToFile();
-    //    }
-    //}
 
     public override List<StreamState> GetStreamsInFile()
     {
-      if (Model != null)
-        DocumentStreams = StreamStateManager.ReadState(Model);
-
-      return DocumentStreams;
+      return Model == null ? new List<StreamState>() : StreamStateManager.ReadState(Model);
     }
 
     public override List<ISetting> GetSettings()
     {
       return new List<ISetting>();
     }
-
-    //public override void PersistAndUpdateStreamInFile(StreamState state)
-    //{
-    //    var index = DocumentStreams.FindIndex(b => b.Stream.id == state.Stream.id);
-    //    if (index != -1)
-    //    {
-    //        DocumentStreams[index] = state;
-    //        WriteStateToFile();
-    //    }
-    //}
 
     #endregion
   }

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
@@ -1,4 +1,5 @@
-﻿using DesktopUI2;
+﻿using ConnectorCSI.Storage;
+using DesktopUI2;
 using DesktopUI2.Models;
 using DesktopUI2.ViewModels;
 using Speckle.ConnectorCSI.Util;
@@ -112,9 +113,6 @@ namespace Speckle.ConnectorCSI.UI
       if (progress.Report.OperationErrorsCount != 0)
         return state;
 
-      if (progress.CancellationTokenSource.Token.IsCancellationRequested)
-        return null;
-
       Preview.Clear();
       StoredObjects.Clear();
 
@@ -135,6 +133,10 @@ namespace Speckle.ConnectorCSI.UI
       converter.ReceiveMode = state.ReceiveMode;
       // needs to be set for editing to work 
       converter.SetPreviousContextObjects(previouslyReceivedObjects);
+
+      if (progress.CancellationTokenSource.Token.IsCancellationRequested)
+        return null;
+      StreamStateManager.SaveBackupFile(Model);
 
       var newPlaceholderObjects = ConvertReceivedObjects(converter, progress);
 

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Recieve.cs
@@ -145,24 +145,20 @@ namespace Speckle.ConnectorCSI.UI
         return null;
       }
 
+      DeleteObjects(previouslyReceivedObjects, newPlaceholderObjects, progress);
+
+      // The following block of code is a hack to properly refresh the view
+      // I've only experienced this bug in ETABS so far
+#if ETABS
+      if (newPlaceholderObjects.Any(o => o.Status == ApplicationObject.State.Updated))
+        RefreshDatabaseTable("Beam Object Connectivity");
+#endif
+
       Model.View.RefreshWindow();
       Model.View.RefreshView();
 
       state.ReceivedObjects = newPlaceholderObjects;
 
-      try
-      {
-        //await state.RefreshStream();
-        WriteStateToFile();
-      }
-      catch (Exception e)
-      {
-        progress.Report.LogOperationError(e);
-        WriteStateToFile();
-        //state.Errors.Add(e);
-        //Globals.Notify($"Receiving done, but failed to update stream from server.\n{e.Message}");
-      }
-      progress.Report.Merge(converter.Report);
       return state;
     }
 
@@ -269,6 +265,64 @@ namespace Speckle.ConnectorCSI.UI
       }
 
       return objects;
+    }
+
+    private void RefreshDatabaseTable(string floorTableKey)
+    {
+      int tableVersion = 0;
+      int numberRecords = 0;
+      string[] fieldsKeysIncluded = null;
+      string[] tableData = null;
+      int numFatalErrors = 0;
+      int numWarnMsgs = 0;
+      int numInfoMsgs = 0;
+      int numErrorMsgs = 0;
+      string importLog = "";
+      Model.DatabaseTables.GetTableForEditingArray(floorTableKey, "ThisParamIsNotActiveYet", ref tableVersion, ref fieldsKeysIncluded, ref numberRecords, ref tableData);
+
+      double version = 0;
+      string versionString = null;
+      Model.GetVersion(ref versionString, ref version);
+      var programVersion = versionString;
+
+      // this is a workaround for a CSI bug. The applyEditedTables is looking for "Unique Name", not "UniqueName"
+      // this bug is patched in version 20.0.0
+      if (programVersion.CompareTo("20.0.0") < 0 && fieldsKeysIncluded[0] == "UniqueName")
+        fieldsKeysIncluded[0] = "Unique Name";
+
+      Model.DatabaseTables.SetTableForEditingArray(floorTableKey, ref tableVersion, ref fieldsKeysIncluded, numberRecords, ref tableData);
+      Model.DatabaseTables.ApplyEditedTables(false, ref numFatalErrors, ref numErrorMsgs, ref numWarnMsgs, ref numInfoMsgs, ref importLog);
+    }
+
+    // delete previously sent objects that are no longer in this stream
+    private void DeleteObjects(List<ApplicationObject> previouslyReceiveObjects, List<ApplicationObject> newPlaceholderObjects, ProgressViewModel progress)
+    {
+      foreach (var obj in previouslyReceiveObjects)
+      {
+        if (obj.Converted.Count == 0 || newPlaceholderObjects.Any(x => x.applicationId == obj.applicationId))
+          continue;
+
+        for (int i = 0; i < obj.Converted.Count; i++)
+        {
+          if (!(obj.Converted[i] is string s && s.Split(new[] { ConnectorCSIUtils.delimiter }, StringSplitOptions.None) is string[] typeAndName && typeAndName.Length == 2))
+            continue;
+
+          switch (typeAndName[0])
+          {
+            case "Frame":
+              Model.FrameObj.Delete(typeAndName[1]);
+              break;
+            case "Area":
+              Model.AreaObj.Delete(typeAndName[1]);
+              break;
+            default:
+              continue;
+          }
+
+          obj.Update(status: ApplicationObject.State.Removed);
+          progress.Report.Log(obj);
+        }
+      }
     }
   }
 }

--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.cs
@@ -16,7 +16,6 @@ namespace Speckle.ConnectorCSI.UI
   {
     public static cSapModel Model { get; set; }
     public List<Exception> Exceptions { get; set; } = new List<Exception>();
-    public List<StreamState> DocumentStreams { get; set; } = new List<StreamState>();
     public ConnectorBindingsCSI(cSapModel model)
     {
       Model = model;

--- a/ConnectorCSI/ConnectorCSIShared/Util/ConnectorCSIUtils.cs
+++ b/ConnectorCSI/ConnectorCSIShared/Util/ConnectorCSIUtils.cs
@@ -29,6 +29,9 @@ namespace Speckle.ConnectorCSI.Util
 
     public static List<SpeckleException> ConversionErrors { get; set; }
 
+    // warning: this delimter string needs to be the same as the delimter string in "converterCSIUtils"
+    public static string delimiter = "::";
+
     public static void GetObjectIDsTypesAndNames(cSapModel model)
     {
       ObjectIDsTypesAndNames = new Dictionary<string, (string, string)>();

--- a/ConnectorCSI/ConnectorETABS/ConnectorETABS.csproj
+++ b/ConnectorCSI/ConnectorETABS/ConnectorETABS.csproj
@@ -94,6 +94,11 @@
   </ItemGroup>
   <Import Project="..\ConnectorCSIShared\ConnectorCSIShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>if EXIST "$(LocalAppData)\Computers and Structures\ETABS\Speckle2ETABS" (
+xcopy "$(TargetDir)*.*" "$(LocalAppData)\Computers and Structures\ETABS\Speckle2ETABS" /Y /I /E
+)</PostBuildEvent>
+  </PropertyGroup>
   <!--<Target Name="CopySQLliteLib" AfterTargets="AfterBuild">
 		<Copy SourceFiles="$(SolutionDir)\..\Core\Core\bin\Debug\net4.8\runtimes\win-x64\native\e_sqlite3.dll" DestinationFolder="$(OutDir)" />
 	</Target>-->

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
@@ -10,6 +10,8 @@ namespace Objects.Converter.CSI
 {
   public partial class ConverterCSI
   {
+    // warning: this delimter string needs to be the same as the delimter string in "connectorCSIUtils"
+    public static string delimiter = "::";
     public string ModelUnits()
     {
       var units = Model.GetDatabaseUnits();

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertArea.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertArea.cs
@@ -130,7 +130,7 @@ namespace Objects.Converter.CSI
       {
         string guid = null;
         Model.AreaObj.GetGUID(name, ref guid);
-        appObj.Update(status: ApplicationObject.State.Updated, createdId: guid);
+        appObj.Update(status: ApplicationObject.State.Updated, createdId: guid, convertedItem: $"Area{delimiter}{name}");
         if (numErrorMsgs != 0)
           appObj.Update(log: new List<string>() { $"Area may not have updated successfully. Number of error messages for operation is {numErrorMsgs}", importLog });
       }
@@ -234,7 +234,7 @@ namespace Objects.Converter.CSI
       Model.AreaObj.GetGUID(name, ref guid);
 
       if (success == 0)
-        appObj.Update(status: ApplicationObject.State.Created, createdId: guid);
+        appObj.Update(status: ApplicationObject.State.Created, createdId: guid, convertedItem: $"Area{delimiter}{name}");
       else
         appObj.Update(status: ApplicationObject.State.Failed);
     }

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertFrame.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Geometry/ConvertFrame.cs
@@ -56,7 +56,7 @@ namespace Objects.Converter.CSI
       {
         string guid = null;
         Model.FrameObj.GetGUID(name, ref guid);
-        appObj.Update(status: ApplicationObject.State.Updated, createdId: guid);
+        appObj.Update(status: ApplicationObject.State.Updated, createdId: guid, convertedItem: $"Frame{delimiter}{name}");
       }
       else
         appObj.Update(status: ApplicationObject.State.Failed, logItem: "Failed to change frame connectivity");
@@ -138,7 +138,7 @@ namespace Objects.Converter.CSI
       Model.FrameObj.GetGUID(newFrame, ref guid);
 
       if (success == 0)
-        appObj.Update(status: ApplicationObject.State.Created, createdId: guid);
+        appObj.Update(status: ApplicationObject.State.Created, createdId: guid, convertedItem: $"Frame{delimiter}{newFrame}");
       else
         appObj.Update(status: ApplicationObject.State.Failed);
     }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation


<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- refresh the "Beam Object Connectivity" table as a workaround for a bug on CSI's end where frame elements that are moved via api calls will be moved in the database yet still appear in the previous location in the modelling space
- delete frame elements that were deleted from the stream to mimic the behavior of other connectors (namely Revit)
- cleanup the streamState saving process. Don't call it via the connector because it will be called later from DUI
- because the changes to the user's model cannot be undone (thanks CSI) save a backup in the Speckle folder before making any changes

<!---

- Item 1
- Item 2

-->

## Validation of changes:

Sending and receiving the same elements in different locations several times. Now experiencing a fairly smooth user experience)

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
