### PR TITLE
CI: Adds use of contexts and pulling through ssh

### DIFF
--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -186,6 +186,7 @@ def getNewDeployJob(jobName: str):
         "extension": "zip" if isMac else "exe",
         "requires": ["deploy-connectors", jobName],
         "filters": getTagFilter([jobName]),
+        "context": "do-spaces-speckle-releases",
     }
     return {"deploy-connector-new": deployJob}
 

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -371,9 +371,12 @@ jobs: # Each project will have individual jobs for each specific task it has to 
     docker:
       - image: cimg/base:2021.01
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "62:b2:1a:86:b7:9f:83:91:9b:61:f8:52:66:38:78:64"
       - run: # Could not get ssh to work, so using a personal token
           name: Clone
-          command: git clone https://$GH_TOKEN@github.com/specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools
+          command: git clone git@github.com:specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -376,7 +376,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - "62:b2:1a:86:b7:9f:83:91:9b:61:f8:52:66:38:78:64"
       - run:
           name: I know Github as a host
-          command: ssh-keyscan github.com >> ~/.ssh/known_hosts
+          command: |
+            mkdir ~/.ssh
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: # Could not get ssh to work, so using a personal token
           name: Clone
           command: git clone git@github.com:specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -373,7 +373,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
     steps:
       - run: # Could not get ssh to work, so using a personal token
           name: Clone
-          command: git clone https://$GITHUB_TOKEN@github.com/specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools
+          command: git clone https://$GH_TOKEN@github.com/specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools
       - persist_to_workspace:
           root: ./
           paths:
@@ -492,7 +492,8 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 workflows:
   build:
     jobs:
-      - get-ci-tools
+      - get-ci-tools:
+          context: github-dev-bot
       - build-core:
           requires:
             - get-ci-tools

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -376,7 +376,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - "62:b2:1a:86:b7:9f:83:91:9b:61:f8:52:66:38:78:64"
       - run:
           name: I know Github as a host
-          run: ssh-keyscan github.com >> ~/.ssh/known_hosts
+          command: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: # Could not get ssh to work, so using a personal token
           name: Clone
           command: git clone git@github.com:specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -524,7 +524,7 @@ workflows:
           post-steps:
             - packandpublish:
                 projectfilepath: Core/Core.sln
-                context: nuget
+          context: nuget
       - build-objects:
           name: nuget-deploy-objects
           filters:
@@ -535,7 +535,7 @@ workflows:
           post-steps:
             - packandpublish-bash:
                 projectfilepath: Objects/Objects.sln
-                context: nuget
+          context: nuget
       - build-desktopui:
           name: nuget-deploy-desktopui
           filters:
@@ -546,5 +546,5 @@ workflows:
           post-steps:
             - packandpublish:
                 projectfilepath: DesktopUI2/DesktopUI2/DesktopUI2.csproj
-                context: nuget
+          context: nuget
 # VS Code Extension Version: 1.4.0

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -374,6 +374,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - add_ssh_keys:
           fingerprints:
             - "62:b2:1a:86:b7:9f:83:91:9b:61:f8:52:66:38:78:64"
+      - run:
+          name: I know Github as a host
+          run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: # Could not get ssh to work, so using a personal token
           name: Clone
           command: git clone git@github.com:specklesystems/speckle-sharp-ci-tools.git speckle-sharp-ci-tools

--- a/.circleci/scripts/connector-jobs.yml
+++ b/.circleci/scripts/connector-jobs.yml
@@ -10,12 +10,14 @@ rhino:
       slug: rhino
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorRhino
       dllname: SpeckleConnectorRhino.rhp
       slug: grasshopper
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector-mac:
       name: rhino-build-mac
       slnname: ConnectorRhino
@@ -54,6 +56,7 @@ dynamo:
       slnname: ConnectorDynamo
       dllname: SpeckleConnectorDynamo.dll
       slug: dynamo
+      context: innosetup
 
 revit:
   - build-connector:
@@ -62,6 +65,7 @@ revit:
       slug: revit
       requires:
         - build-desktopui
+      context: innosetup
 
 autocadcivil:
   - build-connector:
@@ -70,12 +74,14 @@ autocadcivil:
       slug: autocad
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorAutocadCivil
       dllname: SpeckleConnectorAutocad.dll
       slug: civil3d
       requires:
         - build-desktopui
+      context: innosetup
 
 microstation:
   - build-connector:
@@ -84,22 +90,26 @@ microstation:
       slug: microstation
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorMicroStation
       dllname: SpeckleConnectorOpenBuildings.dll
       slug: openbuildings
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorMicroStation
       dllname: SpeckleConnectorOpenRail.dll
       slug: openrail
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorMicroStation
       dllname: SpeckleConnectorOpenRoads.dll
       slug: openroads
+      context: innosetup
 
 teklastructures:
   - build-connector:
@@ -108,6 +118,7 @@ teklastructures:
       slug: teklastructures
       requires:
         - build-desktopui
+      context: innosetup
 csi:
   - build-connector:
       slnname: ConnectorCSI
@@ -115,24 +126,28 @@ csi:
       slug: etabs
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorCSI
       dllname: SpeckleConnectorCSI.dll
       slug: sap2000
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorCSI
       dllname: SpeckleConnectorCSI.dll
       slug: safe
       requires:
         - build-desktopui
+      context: innosetup
   - build-connector:
       slnname: ConnectorCSI
       dllname: SpeckleConnectorCSI.dll
       slug: csibridge
       requires:
         - build-desktopui
+      context: innosetup
 
 archicad:
   - build-archicad-add-on:
@@ -155,6 +170,7 @@ archicad:
       slnname: ConnectorArchicad
       dllname: ConnectorArchicad.dll
       slug: archicad
+      context: innosetup
   - build-archicad-add-on-mac:
       archicadversion: "25"
       requires:
@@ -188,3 +204,4 @@ navisworks:
       slug: navisworks
       requires:
         - build-desktopui
+      context: innosetup


### PR DESCRIPTION

## Description & motivation

Due to the recent CircleCI debacle, we've been forced to rotate all credentials. Since we were at it, we converted all repeated env vars into contexts and applied those on the ci jobs.

This is a better strategy than the one we were following previously.

We're also now fetching the `speckle-sharp-ci-tools` repo via `ssh` instead of via a github_token.
