### PR TITLE
fix(rhino): updating blocks and views

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -454,6 +454,12 @@ namespace SpeckleRhino
             case ReceiveMode.Update: // existing objs will be removed if it exists in the received commit
               toRemove = GetObjectsByApplicationId(previewObj.applicationId);
               toRemove.ForEach(o => Doc.Objects.Delete(o));
+              
+              if (!toRemove.Any()) // if no rhinoobjects were found, this could've been a view
+              {
+                var viewId = Doc.NamedViews.FindByName(previewObj.applicationId);
+                if (viewId != -1) Doc.NamedViews.Delete(viewId);
+              }
               break;
             default:
               layer = $"{commitLayerName}{Layer.PathSeparator}{previewObj.Container}"; // use the commit as the top level layer in create mode
@@ -771,11 +777,11 @@ namespace SpeckleRhino
               appObj.Update(status: ApplicationObject.State.Created, createdId: o.Id.ToString());
             bakedCount++;
             break;
-          case string o: // this was prbly a view, baked during conversion
+          case ViewInfo o: // this is a view, baked during conversion
             if (parent != null)
-              parent.Update(createdId: o);
+              parent.Update(createdId: o.Name);
             else
-              appObj.Update(status: ApplicationObject.State.Created, createdId: o);
+              appObj.Update(status: ApplicationObject.State.Created, createdId: o.Name);
             bakedCount++;
             break;
           default:

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -399,8 +399,10 @@ namespace SpeckleRhino
           // convert
           foreach (var previewObj in Preview)
           {
+            var isPreviewIgnore = false;
             if (previewObj.Convertible)
             {
+              converter.Report.Log(previewObj); // Log object so converter can access
               var storedObj = StoredObjects[previewObj.OriginalId];
               if (storedObj == null)
               {
@@ -408,8 +410,8 @@ namespace SpeckleRhino
                   logItem: $"Couldn't retrieve stored object from bindings");
                 continue;
               }
-
-              if (!IsPreviewIgnore(storedObj))
+              isPreviewIgnore = IsPreviewIgnore(storedObj);
+              if (!isPreviewIgnore)
               {
                 previewObj.Converted = ConvertObject(storedObj, converter);
               }
@@ -423,7 +425,7 @@ namespace SpeckleRhino
               }
             }
 
-            if (previewObj.Converted == null || previewObj.Converted.Count == 0)
+            if (!isPreviewIgnore && (previewObj.Converted == null || previewObj.Converted.Count == 0))
             {
               var convertedFallback = previewObj.Fallback.Where(o => o.Converted != null || o.Converted.Count > 0);
               if (convertedFallback != null && convertedFallback.Count() > 0)
@@ -494,6 +496,7 @@ namespace SpeckleRhino
           conversionProgressDict["Conversion"]++;
           progress.Update(conversionProgressDict);
         }
+        progress.Report.Merge(converter.Report);
 
         // undo notes edit
         var segments = Doc.Notes.Split(new string[] { "%%%" }, StringSplitOptions.None).ToList();

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -111,8 +111,7 @@ namespace Objects.Converter.RhinoGh
         else
         {
           var namedView = Doc.NamedViews[res];
-          var status = ReceiveMode == ReceiveMode.Update ? ApplicationObject.State.Updated : ApplicationObject.State.Created;
-          appObj.Update(status: status, createdId: bakedViewName, convertedItem: namedView);
+          appObj.Update(createdId: bakedViewName, convertedItem: namedView);
         }
       });
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -25,7 +25,6 @@ using Point = Objects.Geometry.Point;
 using View3D = Objects.BuiltElements.View3D;
 using RH = Rhino.Geometry;
 using RV = Objects.BuiltElements.Revit;
-using Grasshopper;
 
 namespace Objects.Converter.RhinoGh
 {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -1,3 +1,4 @@
+using GH_IO.Serialization;
 using Objects.Other;
 using Rhino.Display;
 using Rhino.DocObjects;
@@ -278,7 +279,8 @@ namespace Objects.Converter.RhinoGh
           {
             case BlockInstance o:
               var instanceNotes = new List<string>();
-              var instance = BlockInstanceToNative(o, out instanceNotes);
+              var instanceAppObj = BlockInstanceToNative(o, false);
+              var instance = instanceAppObj.Converted.FirstOrDefault() as InstanceObject;
               if (instance != null)
               {
                 converted.Add(instance.DuplicateGeometry());
@@ -366,14 +368,23 @@ namespace Objects.Converter.RhinoGh
       return _instance;
     }
 
-    public InstanceObject BlockInstanceToNative(BlockInstance instance, out List<string> notes)
+    public ApplicationObject BlockInstanceToNative(BlockInstance instance, bool AppendToModelSpace = true)
     {
+      var appObj = new ApplicationObject(instance.id, instance.speckle_type) { applicationId = instance.applicationId };
+
       // get the block definition
-      InstanceDefinition definition = BlockDefinitionToNative(instance.blockDefinition, out notes);
+      var def = instance.blockDefinition ?? instance["@blockDefinition"] as BlockDefinition; // some applications need to dynamically attach block defs (eg sketchup)
+      if (def == null)
+      {
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: "instance did not have a block definition");
+        return appObj;
+      }
+      InstanceDefinition definition = BlockDefinitionToNative(def, out List<string> notes);
+      notes.ForEach(o => appObj.Update(logItem: o));
       if (definition == null)
       {
-        notes.Add("Could not create block definition");
-        return null;
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not create block definition");
+        return appObj;
       }
 
       // get the transform
@@ -387,19 +398,28 @@ namespace Objects.Converter.RhinoGh
 
       if (instanceId == Guid.Empty)
       {
-        notes.Add("Could not add instance to doc");
-        return null;
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not add instance to doc");
+        return appObj;
       }
 
       var _instance = Doc.Objects.FindId(instanceId) as InstanceObject;
+
       // add application id
       try
       {
         _instance.Attributes.SetUserString(ApplicationIdKey, instance.applicationId);
       }
-      catch { }
+      catch (Exception e)
+      {
+        appObj.Update(logItem: $"Could not set application id user string: {e.Message}");
+      }
 
-      return _instance;
+      // update appobj
+      var status = ReceiveMode == ReceiveMode.Update ? ApplicationObject.State.Updated : ApplicationObject.State.Created;
+      appObj.Update(status: status, convertedItem: _instance);
+      if (AppendToModelSpace)
+        appObj.CreatedIds.Add(instanceId.ToString());
+      return appObj;
     }
 
     public DisplayMaterial RenderMaterialToDisplayMaterial(RenderMaterial material)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -1,4 +1,5 @@
 using GH_IO.Serialization;
+using Objects.BuiltElements.Revit;
 using Objects.Other;
 using Rhino.Display;
 using Rhino.DocObjects;
@@ -265,12 +266,23 @@ namespace Objects.Converter.RhinoGh
         return def;
 
       // base point
+      if (definition.basePoint == null)
+      {
+        notes.Add("definition had no basepoint");
+        return null;
+      }
       Point3d basePoint = PointToNative(definition.basePoint).Location;
 
       // geometry and attributes
       var geometry = new List<GeometryBase>();
       var attributes = new List<ObjectAttributes>();
-      foreach (var geo in definition.geometry)
+      var definitionGeo = definition.geometry ?? (definition["@geometry"] as List<object>).Cast<Base>().ToList();
+      if (definitionGeo == null)
+      {
+        notes.Add("Definition had no geometry");
+        return null;
+      }
+      foreach (var geo in definitionGeo)
       {
         if (CanConvertToNative(geo))
         {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -1,5 +1,3 @@
-using GH_IO.Serialization;
-using Objects.BuiltElements.Revit;
 using Objects.Other;
 using Rhino.Display;
 using Rhino.DocObjects;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -427,8 +427,7 @@ namespace Objects.Converter.RhinoGh
       }
 
       // update appobj
-      var status = ReceiveMode == ReceiveMode.Update ? ApplicationObject.State.Updated : ApplicationObject.State.Created;
-      appObj.Update(status: status, convertedItem: _instance);
+      appObj.Update(convertedItem: _instance);
       if (AppendToModelSpace)
         appObj.CreatedIds.Add(instanceId.ToString());
       return appObj;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -697,11 +697,6 @@ namespace Objects.Converter.RhinoGh
             break;
 
           case Alignment o:
-            if (o.curves is null) // TODO: remove after a few releases, this is for backwards compatibility
-            {
-              rhinoObj = CurveToNative(o.baseCurve);
-              break;
-            }
             rhinoObj = AlignmentToNative(o);
             break;
 
@@ -722,7 +717,7 @@ namespace Objects.Converter.RhinoGh
             break;
 
           case BlockInstance o:
-            rhinoObj = BlockInstanceToNative(o, out notes);
+            rhinoObj = BlockInstanceToNative(o);
             break;
 
           case Text o:
@@ -731,7 +726,6 @@ namespace Objects.Converter.RhinoGh
 
           case Dimension o:
             rhinoObj = isFromRhino ? RhinoDimensionToNative(o) : DimensionToNative(o);
-            Report.Log($"Created Dimension {o.id}");
             break;
 
           case Objects.Structural.Geometry.Element1D o:
@@ -766,12 +760,18 @@ namespace Objects.Converter.RhinoGh
         reportObj.Update(status: ApplicationObject.State.Failed, logItem: $"{@object.GetType()} unhandled converion error: {ex.Message}\n{ex.StackTrace}");
       }
 
-      if (reportObj != null)
+      switch (rhinoObj)
       {
-        reportObj.Update(log: notes);
-        Report.UpdateReportObject(reportObj);
+        case ApplicationObject o: // some to native methods return an application object (if object is baked to doc during conv)
+          rhinoObj = o.Converted.Any() ? o.Converted : null;
+          if (reportObj != null) reportObj.Update(status: o.Status, createdIds: o.CreatedIds, converted: o.Converted, container: o.Container, log: o.Log);
+          break;
+        default:
+          if (reportObj != null) reportObj.Update(log: notes);
+          break;
       }
 
+      if (reportObj != null) Report.UpdateReportObject(reportObj);
       return rhinoObj;
     }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -309,7 +309,6 @@ namespace Objects.Converter.RhinoGh
         Report.UpdateReportObject(reportObj);
       }
 
-
       return @base;
     }
 


### PR DESCRIPTION
## Description & motivation

Blocks and Views should now be correctly received in update mode, with correct reporting as well.
This also includes an improvement to the block to native methods to handle dynamically detached block properties (eg blocks sent from sketchup)

This fix may be relevant for #1905

## Changes:
 Rhino connector and converter
