### PR TITLE
fix(ci): Prevents duplicate `get-ci-tools` job on deploy

### DIFF
--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -34,7 +34,7 @@ def runCommand(argv: List[str]):
         elif opt in ("-o", "--output"):
             output_filepath = arg
 
-    createConfigFile(True, output_filepath)
+    createConfigFile(deploy, output_filepath)
 
 
 def setup():

--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -34,7 +34,7 @@ def runCommand(argv: List[str]):
         elif opt in ("-o", "--output"):
             output_filepath = arg
 
-    createConfigFile(deploy, output_filepath)
+    createConfigFile(True, output_filepath)
 
 
 def setup():
@@ -152,10 +152,13 @@ def createConfigFile(deploy: bool, outputPath: str):
         main_workflow["jobs"] += [{"deploy-connectors": deploy_job}]
         print("Added deploy job: deployment")
 
-        if "get-ci-tools" in main_workflow["jobs"]:
-            main_workflow["jobs"].remove("get-ci-tools")
+        if main_workflow["jobs"][0]["get-ci-tools"] != None:
+            main_workflow["jobs"].pop(0)
 
-        ci_tools_job = {"filters": getTagFilter(slugs_to_match)}
+        ci_tools_job = {
+            "filters": getTagFilter(slugs_to_match),
+            "context": "github-dev-bot",
+        }
         main_workflow["jobs"] += [{"get-ci-tools": ci_tools_job}]
         print("Modified job for deploy: get-ci-tools")
 
@@ -180,7 +183,7 @@ def getNewDeployJob(jobName: str):
     isMac = jobName.find("-mac") != -1
     deployJob: Dict[str, Any] = {
         "slug": slug.split("-mac")[0] if isMac else slug,
-        "name": slug + "-deploy-mac" if isMac else slug + "-deploy" ,
+        "name": slug + "-deploy-mac" if isMac else slug + "-deploy",
         "os": "OSX" if isMac else "Win",
         "arch": "Any",
         "extension": "zip" if isMac else "exe",

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ What is Speckle? Check our ![YouTube Video Views](https://img.shields.io/youtube
 
 Give Speckle a try in no time by:
 
-- [![speckle XYZ](https://img.shields.io/badge/https://-speckle.xyz-0069ff?style=flat-square&logo=hackthebox&logoColor=white)](https://speckle.xyz) ⇒ creating an account at 
-- [![create a droplet](https://img.shields.io/badge/Create%20a%20Droplet-0069ff?style=flat-square&logo=digitalocean&logoColor=white)](https://marketplace.digitalocean.com/apps/speckle-server?refcode=947a2b5d7dc1) ⇒ deploying an instance in 1 click 
+- [![speckle XYZ](https://img.shields.io/badge/https://-speckle.xyz-0069ff?style=flat-square&logo=hackthebox&logoColor=white)](https://speckle.xyz) ⇒ creating an account at
+- [![create a droplet](https://img.shields.io/badge/Create%20a%20Droplet-0069ff?style=flat-square&logo=digitalocean&logoColor=white)](https://marketplace.digitalocean.com/apps/speckle-server?refcode=947a2b5d7dc1) ⇒ deploying an instance in 1 click
 
 ### Resources
 
@@ -52,7 +52,7 @@ This monorepo is the home to our Speckle 2.0 .NET projects:
 - Speckle Connectors
   - [`ConnectorAutocadCivil`](https://github.com/specklesystems/speckle-sharp/tree/main/ConnectorAutocadCivil): for Autodesk AutoCAD and Civil3D 2021+
   - [`ConnectorDynamo`](https://github.com/specklesystems/speckle-sharp/tree/main/ConnectorDynamo): for Autodesk Dynamo
-  - [`ConnectorGrasshopper`](https://github.com/specklesystems/speckle-sharp/tree/main/ConnectorGrasshopper): for McNeel Grasshopper 
+  - [`ConnectorGrasshopper`](https://github.com/specklesystems/speckle-sharp/tree/main/ConnectorGrasshopper): for McNeel Grasshopper
   - [`ConnectorRevit`](https://github.com/specklesystems/speckle-sharp/tree/main/ConnectorRevit): for Autodesk Revit 2019+
   - [`ConnectorRhino`](https://github.com/specklesystems/speckle-sharp/tree/main/ConnectorRhino): for McNeel Rhino 6+
 - [`DesktopUI`](https://github.com/specklesystems/speckle-sharp/tree/main/DesktopUI): reusable UI for all connectors (except visual programming)
@@ -71,11 +71,9 @@ Make sure to also check and ⭐️ these other Speckle repositories:
 - [`speckle-powerbi`](https://github.com/specklesystems/speckle-powerbi): PowerBi connector
 - and more [connectors & tooling](https://github.com/specklesystems/)!
 
-
-
 ## Developing and Debugging
 
-Clone this monorepo; **each section has its own readme**, so then just follow those instructions. 
+Clone this monorepo; **each section has its own readme**, so then just follow those instructions.
 
 Issues or questions? We encourage everyone interested to debug / hack / contribute / give feedback to this project.
 
@@ -88,9 +86,8 @@ Please make sure you read the [contribution guidelines](.github/CONTRIBUTING.md)
 
 ### Security
 
-For any security vulnerabilities or concerns, please contact us directly at security[at]speckle.systems. 
+For any security vulnerabilities or concerns, please contact us directly at security[at]speckle.systems.
 
 ### License
 
 Unless otherwise described, the code in this repository is licensed under the Apache-2.0 License. Please note that some modules, extensions or code herein might be otherwise licensed. This is indicated either in the root of the containing folder under a different license file, or in the respective file's header. If you have any questions, don't hesitate to get in touch with us via [email](mailto:hello@speckle.systems).
-

--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ For any security vulnerabilities or concerns, please contact us directly at secu
 ### License
 
 Unless otherwise described, the code in this repository is licensed under the Apache-2.0 License. Please note that some modules, extensions or code herein might be otherwise licensed. This is indicated either in the root of the containing folder under a different license file, or in the respective file's header. If you have any questions, don't hesitate to get in touch with us via [email](mailto:hello@speckle.systems).
+


### PR DESCRIPTION
Quick fix on the config generator script that was assuming `get-ci-tools` item was a string, but since last Friday it is now an object (as it now needs to have a `context` attached to it to work)