### PR TITLE
fix(rh/gh): scale intervals in BoxToNative conversion

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -117,9 +117,11 @@ namespace Objects.Converter.RhinoGh
       return speckleInterval;
     }
 
-    public RH.Interval IntervalToNative(Interval interval)
+    public RH.Interval IntervalToNative(Interval interval, string units = Units.None)
     {
-      return new RH.Interval((double)interval.start, (double)interval.end);
+      return new RH.Interval(
+        ScaleToNative((double)interval.start, units), 
+        ScaleToNative((double)interval.end, units));
     }
 
     // Interval2d
@@ -619,7 +621,7 @@ namespace Objects.Converter.RhinoGh
     public RH.Box BoxToNative(Box box)
     {
       
-      return new RH.Box(PlaneToNative(box.basePlane), IntervalToNative(box.xSize), IntervalToNative(box.ySize), IntervalToNative(box.zSize));
+      return new RH.Box(PlaneToNative(box.basePlane), IntervalToNative(box.xSize, box.units), IntervalToNative(box.ySize, box.units), IntervalToNative(box.zSize, box.units));
     }
 
     // Meshes


### PR DESCRIPTION
Fixes #2064  issue with Box size intervals not being scaled to other dimensions.

The box position would be corrected, but it's intervals would not.

Added an optional input to `IntervalToNative` to pass in the parent object units, since Intervals are unit-less.