### PR TITLE
feat(csi): enable roundtripping

### DIFF
--- a/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
+++ b/ConnectorCSI/ConnectorCSIShared/UI/ConnectorBindingsCSI.Send.cs
@@ -39,6 +39,7 @@ namespace Speckle.ConnectorCSI.UI
       converter.SetConverterSettings(settings);
 
       converter.SetContextDocument(Model);
+      converter.SetPreviousContextObjects(state.ReceivedObjects);
       Exceptions.Clear();
 
       int objCount = 0;

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSI.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSI.cs
@@ -383,6 +383,9 @@ namespace Objects.Converter.CSI
           //    break;
       }
 
+      // send the object out with the same appId that it came in with for updating purposes
+      returnObject.applicationId = GetOriginalApplicationId(returnObject.applicationId);
+
       return returnObject;
     }
 

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
@@ -222,6 +222,16 @@ namespace Objects.Converter.CSI
       return false;
     }
 
+    public string GetOriginalApplicationId(string csiAppId)
+    {
+      if (string.IsNullOrEmpty(csiAppId))
+        return csiAppId;
+
+      var originalAppId = PreviousContextObjects.Where(o => o.CreatedIds.Contains(csiAppId)).FirstOrDefault()?.applicationId;
+
+      return originalAppId ?? csiAppId;
+    }
+
 
     public ShellType ConvertShellType(eShellType eShellType)
     {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

check context objects for an object with a created id equal to an element's GUID. This enables roundtrip workflows (but admittedly it is a bit fragile).

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- Set previous objects on send
- Check previous objects for an element that created the object being sent and change the appId if one is found

<!---

- Item 1
- Item 2

-->

## Validation of changes:

revit -> csi -> revit now works and updates all member sizes without creating duplicates

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
