### PR TITLE
feature (DUI): TreeViewFilter to allow SelectionMode Binding

### DIFF
--- a/DesktopUI2/DesktopUI2/Models/Filters/TreeSelectionFilter.cs
+++ b/DesktopUI2/DesktopUI2/Models/Filters/TreeSelectionFilter.cs
@@ -1,4 +1,4 @@
-﻿using DesktopUI2.Views.Filters;
+using DesktopUI2.Views.Filters;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -6,6 +6,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using Speckle.Newtonsoft.Json;
+using System.Collections.Specialized;
 
 namespace DesktopUI2.Models.Filters
 {
@@ -62,11 +63,13 @@ namespace DesktopUI2.Models.Filters
       }
     }
 
+    public string SelectionMode { get; set; } = "Multiple, Toggle";
+
     private void Items_CollectionChanged(object sender,
-      System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+      NotifyCollectionChangedEventArgs e)
     {
       Selection.Clear();
-      Selection.AddRange(SelectedItems.Select(item => item.ToString()).ToList());
+      if (SelectedItems != null) Selection.AddRange(SelectedItems.Select(item => item.ToString()).ToList());
     }
   }
 

--- a/DesktopUI2/DesktopUI2/Views/Filters/TreeFilterView.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Filters/TreeFilterView.xaml
@@ -21,7 +21,7 @@
             Items="{Binding Filter.Values}"
             SelectedItems="{Binding Filter.SelectedItems}"
             SelectionChanged="TreeView_OnSelectionChanged"
-            SelectionMode="Multiple, Toggle">
+            SelectionMode="{Binding Filter.SelectionMode}">
             <TreeView.DataTemplates>
                 <TreeDataTemplate DataType="filters:TreeNode" ItemsSource="{Binding Elements}">
                     <TextBlock Text="{Binding DisplayName}" />

--- a/DesktopUI2/DesktopUI2/Views/Filters/TreeFilterView.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Filters/TreeFilterView.xaml.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Selection;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 using DesktopUI2.ViewModels;
@@ -22,16 +21,14 @@ namespace DesktopUI2.Views.Filters
 
     private void TreeView_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        try
-        {
-            (this.DataContext as FilterViewModel).RaisePropertyChanged("Summary");
-        }
-        catch
-        {
-            // ignore
-        }
+      try
+      {
+        (this.DataContext as FilterViewModel).RaisePropertyChanged("Summary");
+      }
+      catch
+      {
+        // ignore
+      }
     }
-
-   
   }
 }


### PR DESCRIPTION
The new Binding defaults to "Multiple + Toggle" modes. Overriding this with "Toggle" allows for restricting to the single selected item.

NB. An opinionated view that Multi-select should be the default.

Additional null checking prior to outputting to the Summary field.