### PR TITLE
fix(Traversal): exclude analytical results from default and Revit traversal

### DIFF
--- a/Core/Core/Models/GraphTraversal/DefaultTraversal.cs
+++ b/Core/Core/Models/GraphTraversal/DefaultTraversal.cs
@@ -24,11 +24,15 @@ namespace Speckle.Core.Models.GraphTraversal
           displayValueAliases)
         );
 
+      var ignoreResultsRule = TraversalRule.NewTraversalRule()
+        .When(o => o.speckle_type.Contains("Objects.Structural.Results"))
+        .ContinueTraversing(None);
+
       var defaultRule = TraversalRule.NewTraversalRule()
         .When(_ => true)
         .ContinueTraversing(Members());
 
-      return new GraphTraversal(convertableRule, defaultRule);
+      return new GraphTraversal(convertableRule, ignoreResultsRule, defaultRule);
     }
     
     /// <summary>
@@ -49,11 +53,15 @@ namespace Speckle.Core.Models.GraphTraversal
           displayValueAliases)
         );
 
+      var ignoreResultsRule = TraversalRule.NewTraversalRule()
+        .When(o => o.speckle_type.Contains("Objects.Structural.Results"))
+        .ContinueTraversing(None);
+
       var defaultRule = TraversalRule.NewTraversalRule()
         .When(_ => true)
         .ContinueTraversing(Members());
 
-      return new GraphTraversal(convertableRule, displayValueRule, defaultRule);
+      return new GraphTraversal(convertableRule, displayValueRule, ignoreResultsRule, defaultRule);
     }
 
     


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Analytical results contain references to many objects which we don't want to traverse because they will either be duplicate objects or objects that were not in the user's send selection, so we just stop traversing when we encounter this type of object.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

<!---

- Item 1
- Item 2

-->

## Validation of changes:

Analytical results are no londer traversed in Revit

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
