### PR TITLE
Feat(Rhino): include standard views viewport in Project Info when sending

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
@@ -74,6 +74,35 @@ namespace SpeckleRhino
       }
       return layer;
     }
+
+    /// <summary>
+    /// Get the NamedViews in the specified doc.
+    /// </summary>
+    /// <param name="doc">A RhinoDoc.</param>
+    /// <returns>A string List of NamedViews name.</returns>
+    public static List<string> NamedViews(this RhinoDoc doc)
+    {
+      List<string> views = doc.NamedViews
+        .Select(v => v.Name)
+        .ToList();
+
+      return views;
+    }
+
+    /// <summary>
+    /// Get the StandardViews in the specified doc.
+    /// </summary>
+    /// <param name="doc">A RhinoDoc.</param>
+    /// <returns>A string List of ViewportID.</returns>
+    public static List<string> StandardViews(this RhinoDoc doc)
+    {
+      List<string> views = doc.Views
+        .GetStandardRhinoViews()
+        .Select(v => v.ActiveViewportID.ToString())
+        .ToList();
+
+      return views;
+    }
     #endregion
 
     #region internal methods


### PR DESCRIPTION
## Description & motivation

Allow Rhino standard views (viewport) to be included in the send operation.

This wasn’t possible before and a request was made on the community forum about it: https://speckle.community/t/send-the-views-from-reno-grasshopper-to-the-web-version/2109/6
The associated issue : https://github.com/specklesystems/speckle-sharp/issues/919
## Changes:

Rhino Connector

## To-do before merge:

Ensure the team is ok with this logic:

- [x] The Named View use their Name property as Id as they don’t have an associated guid. However the standard view viewport do have a guid and this was used as an Id to follow the rest of the object logic.

- [x] One should keep in my mind that when receiving standard views, they will be converted to Named Views in Rhino. Since the issue is only about sending, I only dealt with that. 

## Screenshots:
Standard appearing in the view tab and in their own "Standard views" container:
![image](https://user-images.githubusercontent.com/71726210/216986374-fc49bd17-7e06-4a19-955b-5032421062b4.png)
## Validation of changes:

Test have been manually done in Rhino 7 and Rhino 6. This public stream contains standard views for exemple :

https://speckle.xyz/streams/5827632392/commits/eb333113b8

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

