### PR TITLE
fix(rvt): Updates leftover `GenericModels` category references in Revit conversions.

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -95,7 +95,7 @@ namespace Objects.Converter.Revit
 
       BuiltInCategory bic;
       if ((int)speckleDs.category == -1)
-        speckleDs.category = RevitCategory.GenericModels;
+        speckleDs.category = RevitCategory.GenericModel;
       var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(speckleDs.category);
 
       BuiltInCategory.TryParse(bicName, out bic);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
@@ -181,7 +181,7 @@ namespace Objects.Converter.Revit
           {
             //by default free form elements are always generic models
             //otherwise we'd need to supply base files for each category..?
-            var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(BuiltElements.Revit.RevitCategory.GenericModels);
+            var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(BuiltElements.Revit.RevitCategory.GenericModel);
             BuiltInCategory.TryParse(bicName, out bic);
             cat = famDoc.Settings.Categories.get_Item(bic);
             if (cat.SubCategories.Contains(freeformElement.subcategory))


### PR DESCRIPTION
Fixes #2137 

Modifies both leftover references of `GenericModels` category in `FreeformElement` and `DirectShape` conversion.