### PR TITLE
fix(archicad): Mesh import

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
@@ -179,17 +179,19 @@ GSErrCode LibpartImportManager::CreateLibraryPart (const ModelInfo& modelInfo, A
 
 				bool smooth = false;
 				bool hidden = false;
-				switch (edges[edge]) {
-				case ModelInfo::HiddenEdge:
-					hidden = true;
-					break;
-				case ModelInfo::SmoothEdge:
-					smooth = true;
-					break;
-				case ModelInfo::VisibleEdge:
-					break;
-				default:
-					break;
+				if (edges.ContainsKey(edge)) {
+					switch (edges[edge]) {
+					case ModelInfo::HiddenEdge:
+						hidden = true;
+						break;
+					case ModelInfo::SmoothEdge:
+						smooth = true;
+						break;
+					case ModelInfo::VisibleEdge:
+						break;
+					default:
+						break;
+					}
 				}
 
 				sprintf (buffer, "EDGE %d, %d, -1, -1, %s\t!#%d%s", pointIds[start] + 1, pointIds[end] + 1, (smooth ? "smoothBodyEdge" : (hidden ? "hiddenBodyEdge" : "visibleBodyEdge")), edgeIndex + i, GS::EOL);

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
@@ -38,11 +38,16 @@ namespace Archicad.Converters
 
         // get the geometry
         List<Mesh> meshes = null;
-        var m = element["displayValue"] ?? element["@displayValue"];
-        if (m is List<Mesh>)
-          meshes = (List<Mesh>)m;
-        else if (m is List<object>)
-          meshes = ((List<object>)m).Cast<Mesh>().ToList();
+        if (element is Mesh mesh)
+          meshes = new List<Mesh>() { mesh };
+        else
+        {
+          var m = element["displayValue"] ?? element["@displayValue"];
+          if (m is List<Mesh>)
+            meshes = (List<Mesh>)m;
+          else if (m is List<object>)
+            meshes = ((List<object>)m).Cast<Mesh>().ToList();
+        }
 
         if (meshes == null)
           continue;


### PR DESCRIPTION
Simple mesh elements are not imported as Objects.
https://speckle.community/t/cant-receive-in-archicad/4906


## Description & motivation


## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
