### PR TITLE
fix(revit): various fixes to analytical elements in Revit

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -654,7 +654,7 @@ namespace Objects.Converter.Revit
 
       if (types.Count == 0)
       {
-        var name = string.IsNullOrEmpty(element["category"].ToString()) ? typeof(T).Name : element["category"].ToString();
+        var name = string.IsNullOrEmpty(element["category"] as string) ? typeof(T).Name : element["category"].ToString();
         appObj.Log.Add($"Could not find any family to use for category {name}.");
         value = default(T);
         return false;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -1,5 +1,6 @@
 ﻿using Autodesk.Revit.DB;
 using Objects.Organization;
+using Objects.Structural.Properties.Profiles;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
@@ -74,6 +75,8 @@ namespace Objects.Converter.Revit
     public Dictionary<string, BE.Level> Levels { get; private set; } = new Dictionary<string, BE.Level>();
 
     public Dictionary<string, Phase> Phases { get; private set; } = new Dictionary<string, Phase>();
+
+    public Dictionary<string, SectionProfile> SectionProfiles { get; private set; } = new Dictionary<string, SectionProfile>();
 
     public ReceiveMode ReceiveMode { get; set; }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
@@ -8,7 +8,9 @@ using Objects.Structural.Properties;
 using Objects.Structural.Properties.Profiles;
 using Speckle.Core.Models;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using DB = Autodesk.Revit.DB;
 
 namespace Objects.Converter.Revit
@@ -58,9 +60,15 @@ namespace Objects.Converter.Revit
       DB.FamilyInstance physicalMember = null;
 
       if (docObj != null && docObj is AnalyticalMember analyticalMember)
-      {      
+      {
         // update location
-        analyticalMember.SetCurve(baseLine);
+        var currentCurve = analyticalMember.GetCurve();
+        var p0 = currentCurve.GetEndPoint(0);
+
+        if (p0.DistanceTo(baseLine.GetEndPoint(0)) > p0.DistanceTo(baseLine.GetEndPoint(1)))
+          analyticalMember.SetCurve(baseLine.CreateReversed());
+        else
+          analyticalMember.SetCurve(baseLine);
 
         //update type
         analyticalMember.SectionTypeId = familySymbol.Id;
@@ -198,7 +206,7 @@ namespace Objects.Converter.Revit
       if (curves.Count > 1)
         speckleElement1D.baseLine = null;
       else
-        speckleElement1D.baseLine = (Objects.Geometry.Line)CurveToSpeckle(curves[0]);
+        speckleElement1D.baseLine = CurveToSpeckle(curves[0]) as Objects.Geometry.Line;
 
       var coordinateSystem = revitStick.GetLocalCoordinateSystem();
       if (coordinateSystem != null)
@@ -272,7 +280,7 @@ namespace Objects.Converter.Revit
           break;
       }
 
-      speckleElement1D.baseLine = (Objects.Geometry.Line)CurveToSpeckle(revitStick.GetCurve());
+      speckleElement1D.baseLine = CurveToSpeckle(revitStick.GetCurve()) as Objects.Geometry.Line;
 
       SetEndReleases(revitStick, ref speckleElement1D);
 
@@ -367,92 +375,89 @@ namespace Objects.Converter.Revit
       if (revitSection == null)
         return null;
 
+      // check section profile cache
+      if (SectionProfiles.Keys.Contains(familySymbol.Name))
+        return SectionProfiles[familySymbol.Name];
+
       var speckleSection = new SectionProfile();
 
+      // note to future self, the StructuralSectionGeneralShape prop is sometimes null so it isn't reliable to use
+      // therefore switch on the object itself instead
       switch (revitSection)
       {
-        case StructuralSectionGeneralI o: // General Double T shape
-          var ISection = new ISection();
-          ISection.shapeType = Structural.ShapeType.I;
-          ISection.depth = o.Height;
-          ISection.width = o.Width;
-          ISection.webThickness = o.WebThickness;
-          ISection.flangeThickness = o.FlangeThickness;
-         
-          speckleSection = ISection;
+        case StructuralSectionIWelded _: // Built up wide flange
+        case StructuralSectionIWideFlange _: // I shaped wide flange
+        case StructuralSectionGeneralI _: // General Double T shape
+          speckleSection = new ISection();
           break;
-        case StructuralSectionGeneralT o: // General Tee shape
-          var teeSection = new Tee();
-          teeSection.shapeType = Structural.ShapeType.Tee;
-          teeSection.depth = o.Height;
-          teeSection.width = o.Width;
-          teeSection.webThickness = o.WebThickness;
-          teeSection.flangeThickness = o.FlangeThickness;
+        case StructuralSectionGeneralT _: // General Tee shape
+          speckleSection = new Tee();
+          break;
+        case StructuralSectionGeneralH _: // Rectangular Pipe structural sections
+        case StructuralSectionGeneralF _: // Flat Bar structural sections
+          speckleSection = new Rectangular();
+          break;
+        case StructuralSectionGeneralR _: // Pipe structural sections
+        case StructuralSectionGeneralS _: // Round Bar structural sections
+          speckleSection = new Circular();
+          break;
+        case StructuralSectionGeneralW _: // Angle structural sections
+          speckleSection = new Angle();
+          break;
+        case StructuralSectionGeneralU _: // Channel structural sections
+          speckleSection = new Channel();
+          break;
 
-          speckleSection = teeSection;
-          break;
-        case StructuralSectionGeneralH o: // Rectangular Pipe structural sections
-          var rectSection = new Rectangular();
-          rectSection.shapeType = Structural.ShapeType.I;
-          rectSection.depth = o.Height;
-          rectSection.width = o.Width;
-          rectSection.webThickness = o.WallNominalThickness;
-          rectSection.flangeThickness = o.WallNominalThickness;
+        //case StructuralSectionGeneralLA o:
+        //case StructuralSectionColdFormed o:
+        //case StructuralSectionUserDefined o:
+        //case StructuralSectionGeneralLZ o:
 
-          speckleSection = rectSection;
+        // keep these two last. They are last resorts
+        case StructuralSectionRectangular _:
+          speckleSection = new Rectangular();
           break;
-        case StructuralSectionGeneralR o: // Pipe structural sections
-          var circSection = new Circular();
-          circSection.shapeType = Structural.ShapeType.Circular;
-          circSection.radius = o.Diameter / 2;
-          circSection.wallThickness = o.WallNominalThickness;
+        case StructuralSectionRound _:
+          speckleSection = new Circular();
+          break;
+      }
 
-          speckleSection = circSection;
-          break;
-        case StructuralSectionGeneralF o: // Flat Bar structural sections
-          var flatRectSection = new Rectangular();
-          flatRectSection.shapeType = Structural.ShapeType.I;
-          flatRectSection.depth = o.Height;
-          flatRectSection.width = o.Width;
+      var propNamesMap = new Dictionary<string, string>()
+      {
+        { "Height", "depth" },
+        { "SectionalArea", "area" },
+        { "NominalWeight", "weight" },
+        { "MomentOfInertiaStrongAxis", "Iyy" }, //TODO change this prop, Iyy can mean different things
+        { "MomentOfInertiaWeakAxis", "Izz" },
+        { "TorsionalMomentOfInertia", "J" },
+      };
+      foreach (var prop in revitSection.GetType().GetProperties())
+      {
+        var value = prop.GetValue(revitSection, null);
+        var type = value?.GetType();
 
-          speckleSection = flatRectSection;
-          break;
-        case StructuralSectionGeneralS o: // Round Bar structural sections
-          var flatCircSection = new Circular();
-          flatCircSection.shapeType = Structural.ShapeType.Circular;
-          flatCircSection.radius = o.Diameter / 2;
+        if (type == null || type.IsClass || type.IsEnum)
+          continue;
 
-          speckleSection = flatCircSection;
-          break;
-        case StructuralSectionGeneralW o: // Angle structural sections
-          var angleSection = new Angle();
-          angleSection.shapeType = Structural.ShapeType.Angle;
-          angleSection.depth = o.Height;
-          angleSection.width = o.Width;
-          angleSection.webThickness = o.WebThickness;
-          angleSection.flangeThickness = o.FlangeThickness;
+        var key = prop.Name;
 
-          speckleSection = angleSection;
-          break;
-        case StructuralSectionGeneralU o: // Channel  structural sections
-          var channelSection = new Channel();
-          channelSection.shapeType = Structural.ShapeType.Channel;
-          channelSection.depth = o.Height;
-          channelSection.width = o.Width;
-          channelSection.webThickness = o.WebThickness;
-          channelSection.flangeThickness = o.FlangeThickness;
+        if (propNamesMap.Keys.Contains(key))
+        {
+          key = propNamesMap[key];
+        }
+        // Revit classes are named with first letter capitalized but ours are not (why speckle??)
+        else if (!char.IsLower(key, 0))
+        {
+          key = char.ToLowerInvariant(key[0]) + key.Substring(1);
+        }
 
-          speckleSection = channelSection;
-          break;
+        speckleSection[key] = value;
       }
 
       speckleSection.units = ModelUnits;
       speckleSection.name = familySymbol.Name;
-      speckleSection.area = revitSection.SectionArea;
-      speckleSection.weight = revitSection.NominalWeight;
-      speckleSection.Izz = revitSection.MomentOfInertiaWeakAxis;
-      speckleSection.Iyy = revitSection.MomentOfInertiaStrongAxis;
-      speckleSection.J = revitSection.TorsionalMomentOfInertia;
+
+      SectionProfiles.Add(familySymbol.Name, speckleSection);
 
       return speckleSection;
     }

--- a/Objects/Objects/Structural/Enums/PropertyType.cs
+++ b/Objects/Objects/Structural/Enums/PropertyType.cs
@@ -80,7 +80,8 @@ namespace Objects.Structural
         Perimeter,
         Box,
         Catalogue,
-        Explicit
+        Explicit,
+        Undefined
     }
 
 }

--- a/Objects/Objects/Structural/Property/SectionProfile.cs
+++ b/Objects/Objects/Structural/Property/SectionProfile.cs
@@ -10,7 +10,7 @@ namespace Objects.Structural.Properties.Profiles
   public class SectionProfile : Base //section profile description
   {
     public string name { get; set; }
-    public ShapeType shapeType { get; set; }
+    public virtual ShapeType shapeType { get; set; }
     public double area { get; set; }
     //Moment of inertia about the Major axis
     public double Iyy { get; set; }
@@ -42,6 +42,7 @@ namespace Objects.Structural.Properties.Profiles
     public double width { get; set; }
     public double webThickness { get; set; } // tw 
     public double flangeThickness { get; set; } // tf
+    public override ShapeType shapeType { get; set; } = ShapeType.Rectangular;
 
     public Rectangular() { }
 
@@ -53,7 +54,6 @@ namespace Objects.Structural.Properties.Profiles
       this.width = width;
       this.webThickness = webThickness;
       this.flangeThickness = flangeThickness;
-      this.shapeType = ShapeType.Rectangular;
     }
   }
 
@@ -61,6 +61,7 @@ namespace Objects.Structural.Properties.Profiles
   {
     public double radius { get; set; }
     public double wallThickness { get; set; }
+    public override ShapeType shapeType { get; set; } = ShapeType.Circular;
 
     public Circular() { }
 
@@ -70,7 +71,6 @@ namespace Objects.Structural.Properties.Profiles
       this.name = name;
       this.radius = radius;
       this.wallThickness = wallThickness;
-      this.shapeType = ShapeType.Circular;
     }
   }
 
@@ -80,7 +80,8 @@ namespace Objects.Structural.Properties.Profiles
     public double width { get; set; }
     public double webThickness { get; set; }
     public double flangeThickness { get; set; }
-        
+    public override ShapeType shapeType { get; set; } = ShapeType.I;
+
     public ISection() { }
 
     [SchemaInfo("ISection", "Creates a Speckle structural I section profile", "Structural", "Section Profile")]
@@ -91,7 +92,6 @@ namespace Objects.Structural.Properties.Profiles
       this.width = width;
       this.webThickness = webThickness;
       this.flangeThickness = flangeThickness;
-      this.shapeType = ShapeType.I;
     }
   }
 
@@ -101,6 +101,7 @@ namespace Objects.Structural.Properties.Profiles
     public double width { get; set; }
     public double webThickness { get; set; }
     public double flangeThickness { get; set; }
+    public override ShapeType shapeType { get; set; } = ShapeType.Tee;
 
     public Tee() { }
 
@@ -112,7 +113,6 @@ namespace Objects.Structural.Properties.Profiles
       this.width = width;
       this.webThickness = webThickness;
       this.flangeThickness = flangeThickness;
-      this.shapeType = ShapeType.Tee;
     }
   }
 
@@ -122,6 +122,7 @@ namespace Objects.Structural.Properties.Profiles
     public double width { get; set; }
     public double webThickness { get; set; }
     public double flangeThickness { get; set; }
+    public override ShapeType shapeType { get; set; } = ShapeType.Angle;
 
     public Angle() { }
 
@@ -133,7 +134,6 @@ namespace Objects.Structural.Properties.Profiles
       this.width = width;
       this.webThickness = webThickness;
       this.flangeThickness = flangeThickness;
-      this.shapeType = ShapeType.Angle;
     }
   }
 
@@ -143,6 +143,7 @@ namespace Objects.Structural.Properties.Profiles
     public double width { get; set; }
     public double webThickness { get; set; }
     public double flangeThickness { get; set; }
+    public override ShapeType shapeType { get; set; } = ShapeType.Channel;
 
     public Channel() { }
 
@@ -154,7 +155,6 @@ namespace Objects.Structural.Properties.Profiles
       this.width = width;
       this.webThickness = webThickness;
       this.flangeThickness = flangeThickness;
-      this.shapeType = ShapeType.Channel;
     }
   }
   public class Perimeter : SectionProfile
@@ -199,6 +199,7 @@ namespace Objects.Structural.Properties.Profiles
 
   public class Explicit : SectionProfile
   {
+    public override ShapeType shapeType { get; set; } = ShapeType.Explicit;
     public Explicit() { }
 
     [SchemaInfo("Explicit", "Creates a Speckle structural section profile based on explicitly defining geometric properties", "Structural", "Section Profile")]
@@ -211,7 +212,6 @@ namespace Objects.Structural.Properties.Profiles
       this.J = J;
       this.Ky = Ky;
       this.Kz = Kz;
-      this.shapeType = ShapeType.Explicit;
     }
   }
 }

--- a/Objects/Objects/Structural/Property/SectionProfile.cs
+++ b/Objects/Objects/Structural/Property/SectionProfile.cs
@@ -10,7 +10,7 @@ namespace Objects.Structural.Properties.Profiles
   public class SectionProfile : Base //section profile description
   {
     public string name { get; set; }
-    public virtual ShapeType shapeType { get; set; }
+    public virtual ShapeType shapeType { get; set; } = ShapeType.Undefined;
     public double area { get; set; }
     //Moment of inertia about the Major axis
     public double Iyy { get; set; }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- simple change in conversionUtils because .toString was being called on null members and throwing errors
-  create cache for SectionProfiles so sections don't have to be created every time
- when updating, make sure not to flip the baseLine of elements (this partially fixes https://github.com/specklesystems/speckle-sharp/issues/2164 but not fully)
- don't hard cast curves to a baseLine because that will throw errors sometimes
- use reflection to get all the props of the structuralSection from Revit. There are so many structural section classes in Revit that this seemed like the cleanest solution to me
- change the ShapeType prop of Speckle StructualSections to a virual prop and then give each child prop a default value. It doesn't make sense to always have to tell an angle section that its type is an angle. It should know that

<!---

- Item 1
- Item 2

-->

## Validation of changes:

this is a commit made before this pr https://latest.speckle.dev/streams/85bc4f61c6/commits/471e9287f4. You can inspect each element and see the property -> profile. Nothing is wrong with it but there is missing information
this is a commit made from this branch https://latest.speckle.dev/streams/85bc4f61c6/commits/9ffb056eb2. It has much more info. Some of it is wrong, but that is Revits fault.

Also, the specific case with frames becoming twisted no longer happens in this issue https://github.com/specklesystems/speckle-sharp/issues/2164

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

https://speckle.community/t/analytical-stick-conversion-from-revit-to-speckle/4951 This is where one of the issues originated

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
