### PR TITLE
feat(Rhino/GH): Adds BREP pre-processing logic to Rhino converter

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using ConnectorGrasshopper.Extras;
 using ConnectorGrasshopper.Objects;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Serilog;
@@ -121,6 +124,31 @@ namespace ConnectorGrasshopper.Conversion
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.ToFormattedString());
         return new GH_SpeckleBase();
       }
+    }
+
+    private bool preprocessGeometry = false;
+    
+    public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
+    {
+      base.AppendAdditionalMenuItems(menu);
+      var item = Menu_AppendItem(menu, "Pre-process geometry", (sender, args) =>
+      {
+        preprocessGeometry = !preprocessGeometry;
+        Converter.SetConverterSettings(new Dictionary<string, object> { { "preprocessGeometry", preprocessGeometry } });
+      },null, true, preprocessGeometry);
+      
+    }
+
+    public override bool Write(GH_IWriter writer)
+    {
+      writer.SetBoolean("preprocessGeometry", preprocessGeometry);
+      return base.Write(writer);
+    }
+
+    public override bool Read(GH_IReader reader)
+    {
+      reader.TryGetBoolean("preprocessGeometry", ref preprocessGeometry);
+      return base.Read(reader);
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
@@ -97,6 +97,7 @@ namespace ConnectorGrasshopper.Conversion
           DA.AbortComponentSolution();
           return null;
         }
+        Converter.SetConverterSettings(new Dictionary<string, object> { { "preprocessGeometry", preprocessGeometry } });
         var converted = Extras.Utilities.TryConvertItemToSpeckle(item, Converter, true);
 
         if (source.Token.IsCancellationRequested)
@@ -135,6 +136,7 @@ namespace ConnectorGrasshopper.Conversion
       {
         preprocessGeometry = !preprocessGeometry;
         Converter.SetConverterSettings(new Dictionary<string, object> { { "preprocessGeometry", preprocessGeometry } });
+        ExpireSolution(true);
       },null, true, preprocessGeometry);
       
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
@@ -143,6 +143,9 @@ namespace ConnectorGrasshopper
       if (dialog.HasResult)
       {
         base.AddedToDocument(document);
+        // We purposefully override the preprocess geometry setting since schema objects are mostly going to go to lesser powerful target apps regarding geometry processing.
+        Converter.SetConverterSettings(new Dictionary<string, object> { { "preprocessGeometry", true } });
+        
         SwitchConstructor(dialog.model.SelectedItem.Tag as ConstructorInfo);
         Params.ParameterChanged += (sender, args) =>
         {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -168,6 +168,9 @@ namespace ConnectorGrasshopper
       if (SelectedConstructor != null)
       {
         base.AddedToDocument(document);
+        // We purposefully override the preprocess geometry setting since schema objects are mostly going to go to lesser powerful target apps regarding geometry processing.
+        Converter.SetConverterSettings(new Dictionary<string, object> { { "preprocessGeometry", true } });
+
         if (Grasshopper.Instances.ActiveCanvas.Document != null)
         {
           var otherSchemaBuilders =
@@ -194,6 +197,7 @@ namespace ConnectorGrasshopper
             }
           }
         }
+        return;
       }
 
       if (Params.Input.Count == 0) SetupComponent(SelectedConstructor);

--- a/ConnectorGrasshopper/ConnectorGrasshopperUtils/ConnectorGrasshopperUtils.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopperUtils/ConnectorGrasshopperUtils.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <LangVersion>8</LangVersion>

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/UI/ConnectorBindingsTeklaStructures.cs
@@ -28,7 +28,7 @@ namespace Speckle.ConnectorTeklaStructures.UI
     public ConnectorBindingsTeklaStructures(Model model)
     {
       Model = model;
-
+      
 
 
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
@@ -32,7 +32,7 @@
     <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
   </PropertyGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsDesktopBuild)' == true">
     <Exec Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
     <Exec Command="xcopy /Y /S &quot;$(MSBuildProjectDirectory)\..\Templates&quot; &quot;$(AppData)\Speckle\Kits\Objects\Templates\Revit\&quot;" />
   </Target>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Rhino;
+using Rhino.Geometry;
+
+namespace Objects.Converter.RhinoGh
+{
+  /// <summary>
+  /// Converts a "complex" <see cref="Brep"/> to be transferred to a <see cref="ARDB.Solid"/>.
+  /// </summary>
+  static class BrepEncoder
+  {
+    #region Encode
+    public static Brep ToRawBrep(/*const*/ Brep brep, double scaleFactor)
+    {
+      brep = brep.DuplicateShallow() as Brep;
+      return EncodeRaw(ref brep, scaleFactor) ? brep : default;
+    }
+
+    internal static bool EncodeRaw(ref Brep brep, double scaleFactor)
+    {
+      if (scaleFactor != 1.0 && !brep.Scale(scaleFactor))
+        return default;
+
+      var bbox = brep.GetBoundingBox(false);
+      if (!bbox.IsValid || bbox.Diagonal.Length < RhinoDoc.ActiveDoc.ModelAngleToleranceRadians)
+        return default;
+
+      // Split and Shrink faces
+      {
+        brep.Faces.SplitKinkyFaces(RhinoDoc.ActiveDoc.ModelAngleToleranceRadians, true);
+        brep.Faces.SplitClosedFaces(0);
+        brep.Faces.ShrinkFaces();
+      }
+
+      var options = AuditBrep(brep);
+
+      return RebuildBrep(ref brep, options);
+    }
+
+    [Flags]
+    enum BrepIssues
+    {
+      Nothing                     = 0,
+      OutOfToleranceEdges         = 1,
+      OutOfToleranceSurfaceKnots  = 2,
+    }
+
+    static BrepIssues AuditBrep(Brep brep)
+    {
+      var options = default(BrepIssues);
+
+      // Edges
+      {
+        foreach (var edge in brep.Edges)
+        {
+          if (edge.Tolerance > RhinoDoc.ActiveDoc.ModelRelativeTolerance)
+          {
+            options |= BrepIssues.OutOfToleranceEdges;
+            //GeometryEncoder.Context.Peek.RuntimeMessage(10, $"Geometry contains out of tolerance edges, it will be rebuilt.", edge);
+          }
+        }
+      }
+
+      // Faces
+      {
+        foreach (var face in brep.Faces)
+        {
+          var deltaU = KnotListEncoder.MinDelta(face.GetSpanVector(0));
+          if (deltaU < 1e-5)
+          {
+            options |= BrepIssues.OutOfToleranceSurfaceKnots;
+            break;
+          }
+
+          var deltaV = KnotListEncoder.MinDelta(face.GetSpanVector(1));
+          if (deltaV < 1e-5)
+          {
+            options |= BrepIssues.OutOfToleranceSurfaceKnots;
+            break;
+          }
+        }
+      }
+
+      return options;
+    }
+
+    static bool RebuildBrep(ref Brep brep, BrepIssues options)
+    {
+      if(options != BrepIssues.Nothing)
+      {
+        var edgesToUnjoin = brep.Edges.Select(x => x.EdgeIndex);
+        var shells = brep.UnjoinEdges(edgesToUnjoin);
+        if (shells.Length == 0)
+          shells = new Brep[] { brep };
+
+        var kinkyEdges = 0;
+        var microEdges = 0;
+        var mergedEdges = 0;
+
+        foreach (var shell in shells)
+        {
+          // Edges
+          {
+            var edges = shell.Edges;
+
+            int edgeCount = edges.Count;
+            for (int ei = 0; ei < edgeCount; ++ei)
+              edges.SplitKinkyEdge(ei, RhinoDoc.ActiveDoc.ModelAngleToleranceRadians);
+
+            kinkyEdges += edges.Count - edgeCount;
+            microEdges += edges.RemoveNakedMicroEdges(RhinoDoc.ActiveDoc.ModelRelativeTolerance, cleanUp: true);
+            mergedEdges += edges.MergeAllEdges(RhinoDoc.ActiveDoc.ModelAngleToleranceRadians) - edgeCount;
+          }
+
+          // Faces
+          {
+            foreach (var face in shell.Faces)
+            {
+              if(options.HasFlag(BrepIssues.OutOfToleranceSurfaceKnots))
+              {
+                face.GetSurfaceSize(out var width, out var height);
+
+                face.SetDomain(0, new Interval(0.0, width));
+                var deltaU = KnotListEncoder.MinDelta(face.GetSpanVector(0));
+                if (deltaU < 1e-6)
+                  face.SetDomain(0, new Interval(0.0, width * (1e-6 / deltaU)));
+
+                face.SetDomain(1, new Interval(0.0, height));
+                var deltaV = KnotListEncoder.MinDelta(face.GetSpanVector(1));
+                if (deltaV < 1e-6)
+                  face.SetDomain(1, new Interval(0.0, height * (1e-6 / deltaV)));
+              }
+
+              face.RebuildEdges(1e-6, false, true);
+            }
+          }
+
+          // Flags
+          shell.SetTrimIsoFlags();
+        }
+        
+        var join = Brep.JoinBreps(shells, RhinoDoc.ActiveDoc.ModelRelativeTolerance);
+        if (join.Length == 1) brep = join[0];
+        else
+        {
+          var merge = new Brep();
+          foreach (var shell in join)
+            merge.Append(shell);
+
+          brep = merge;
+        }
+      }
+
+      return brep.IsValid;
+    }
+    #endregion
+    
+  }
+}

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
@@ -111,7 +111,9 @@ namespace Objects.Converter.RhinoGh
               edges.SplitKinkyEdge(ei, RhinoDoc.ActiveDoc.ModelAngleToleranceRadians);
 
             kinkyEdges += edges.Count - edgeCount;
+            #if RHINO7
             microEdges += edges.RemoveNakedMicroEdges(RhinoDoc.ActiveDoc.ModelRelativeTolerance, cleanUp: true);
+            #endif
             mergedEdges += edges.MergeAllEdges(RhinoDoc.ActiveDoc.ModelAngleToleranceRadians) - edgeCount;
           }
 

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
@@ -33,6 +33,7 @@ namespace Objects.Converter.RhinoGh
         brep.Faces.SplitKinkyFaces(RhinoDoc.ActiveDoc.ModelAngleToleranceRadians, true);
         brep.Faces.SplitClosedFaces(0);
         brep.Faces.ShrinkFaces();
+        
       }
 
       var options = AuditBrep(brep);
@@ -155,7 +156,14 @@ namespace Objects.Converter.RhinoGh
           brep = merge;
         }
       }
+      
+      var res = new List<Brep>();
+      for(int i = 0; i < brep.Faces.Count; i++){
+        res.Add(brep.Faces.ExtractFace(i));
+      }
 
+      brep = Brep.JoinBreps(res, 0.001)[0];
+      
       return brep.IsValid;
     }
     #endregion

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/BrepEncoder.cs
@@ -13,10 +13,10 @@ namespace Objects.Converter.RhinoGh
   static class BrepEncoder
   {
     #region Encode
-    public static Brep ToRawBrep(/*const*/ Brep brep, double scaleFactor)
+    public static Brep ToRawBrep(/*const*/ Brep brep, double scaleFactor = 1.0)
     {
-      brep = brep.DuplicateShallow() as Brep;
-      return EncodeRaw(ref brep, scaleFactor) ? brep : default;
+      var duplicate = brep.DuplicateShallow() as Brep;
+      return EncodeRaw(ref duplicate, scaleFactor) ? duplicate : brep;
     }
 
     internal static bool EncodeRaw(ref Brep brep, double scaleFactor)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -827,6 +827,7 @@ namespace Objects.Converter.RhinoGh
       //tol = 0;
       var u = units ?? ModelUnits;
       brep.Repair(tol);
+      BrepEncoder.ToRawBrep(brep, 1.0);
       // foreach (var f in brep.Faces)
       // {
       //   f.RebuildEdges(tol, false, false);

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -623,7 +623,7 @@ namespace Objects.Converter.RhinoGh
     {
       object rhinoObj = null;
       bool isFromRhino = @object[RhinoPropName] != null ? true : false;
-      var reportObj = Report.ReportObjects.ContainsKey(@object.id) ? new ApplicationObject(@object.id, @object.speckle_type) : null;
+      var reportObj = @object.id != null && Report.ReportObjects.ContainsKey(@object.id) ? new ApplicationObject(@object.id, @object.speckle_type) : null;
       List<string> notes = new List<string>();
       try
       {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGhShared.projitems
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGhShared.projitems
@@ -9,11 +9,13 @@
     <Import_RootNamespace>ConverterRhinoGhShared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)BrepEncoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterRhinoGh.BuiltElements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterRhinoGh.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterRhinoGh.Geometry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterRhinoGh.Other.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterRhinoGh.Structural.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterRhinoGh.Utils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)KnotListEncoder.cs" />
   </ItemGroup>
 </Project>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/KnotListEncoder.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/KnotListEncoder.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.Collections.Generic;
+using Rhino.Geometry.Collections;
+
+namespace Objects.Converter.RhinoGh
+{
+  static class KnotListEncoder
+  {
+    public const double KnotTolerance = 1e-9;
+
+    /// <summary>
+    /// Compares a curve knot <paramref name="value"/> with a <paramref name="successor"/> value,
+    /// in a monotonic nondecreasing sequence, for equality.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="successor"></param>
+    /// <param name="tolerance"></param>
+    /// <param name="strict">true in case <paramref name="value"/> and <paramref name="successor"/> are strictly equal, else false is returned.</param>
+    /// <returns>true if <paramref name="value"/> and <paramref name="successor"/> are equal within <paramref name="tolerance"/>.</returns>
+    public static bool CurveKnotEqualTo(double value, double successor, double tolerance, out bool strict)
+    {
+      var distance = successor - value;
+      if (distance <= tolerance)
+      {
+        strict = value == successor;
+        return true;
+      }
+
+      strict = false;
+      return distance <= Math.Max(Math.Abs(value), Math.Abs(successor)) * tolerance;
+    }
+
+    /// <summary>
+    /// Compares a surface knot <paramref name="value"/> with a <paramref name="successor"/> value,
+    /// in a monotonic nondecreasing sequence, for equality.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="successor"></param>
+    /// <param name="tolerance"></param>
+    /// <param name="strict">true in case <paramref name="value"/> and <paramref name="successor"/> are strictly equal, else false is returned.</param>
+    /// <returns>true if <paramref name="value"/> and <paramref name="successor"/> are equal within <paramref name="tolerance"/>.</returns>
+    public static bool SurfaceKnotEqualTo(double value, double successor, double tolerance, out bool strict)
+    {
+      var distance = successor - value;
+      if (distance <= tolerance)
+      {
+        strict = value == successor;
+        return true;
+      }
+
+      strict = false;
+
+      // DB.BRepBuilderSurfaceGeometry.CreateNURBSSurface do not check using relative tolerance
+      // return distance <= Math.Max(Math.Abs(value), Math.Abs(successor)) * tolerance;
+      return false;
+    }
+
+    /// <summary>
+    /// Get knot multiplicity.
+    /// </summary>
+    /// <param name="knots"></param>
+    /// <param name="index">Index of knot to query.</param>
+    /// <param name="tolerance"></param>
+    /// <param name="average"></param>
+    /// <param name="strict"></param>
+    /// <returns>The multiplicity (valence) of the knot.</returns>
+    public static int KnotMultiplicity(NurbsCurveKnotList knots, int index, double tolerance, out double average, out bool strict)
+    {
+      var i = index;
+      var value = knots[i++];
+      average = value;
+
+      strict = true;
+      while (i < knots.Count && CurveKnotEqualTo(value, knots[i], tolerance, out var s))
+      {
+        strict &= s;
+        average += knots[i];
+        i++;
+      }
+
+      var multiplicity = i - index;
+
+      if (strict) average = knots[index];
+      else average /= multiplicity;
+
+      return multiplicity;
+    }
+
+    /// <summary>
+    /// Get knot multiplicity.
+    /// </summary>
+    /// <param name="knots"></param>
+    /// <param name="index">Index of knot to query.</param>
+    /// <param name="tolerance"></param>
+    /// <param name="average"></param>
+    /// <param name="strict"></param>
+    /// <returns>The multiplicity (valence) of the knot.</returns>
+    public static int KnotMultiplicity(NurbsSurfaceKnotList knots, int index, double tolerance, out double average, out bool strict)
+    {
+      var i = index;
+      var value = knots[i++];
+      average = value;
+
+      strict = true;
+      while (i < knots.Count && SurfaceKnotEqualTo(value, knots[i], tolerance, out var s))
+      {
+        strict &= s;
+        average += knots[i];
+        i++;
+      }
+
+      var multiplicity = i - index;
+
+      if (strict) average = knots[index];
+      else average /= multiplicity;
+
+      return multiplicity;
+    }
+
+    /// <summary>
+    /// Returns the minimum delta in a monotonic nondecreasin sequence of System.Double values.
+    /// </summary>
+    /// <param name="knots"></param>
+    /// <returns>The minimum delta in the sequence.</returns>
+    public static double MinDelta(IEnumerable<double> knots)
+    {
+      var delta = double.PositiveInfinity;
+
+      using (var enumerator = knots.GetEnumerator())
+      {
+        if (enumerator.MoveNext())
+        {
+          var previous = enumerator.Current;
+
+          while (enumerator.MoveNext())
+          {
+            var current = enumerator.Current;
+            if (previous == current)
+              continue;
+
+            var d = current - previous;
+            if (d < delta) delta = d;
+
+            previous = current;
+          }
+        }
+      }
+
+      return delta;
+    }
+
+    /// <summary>
+    /// Splits <paramref name="curve"/> as a <see cref="Rhino.Geometry.PolyCurve"/> where knot multiplicity is > degree - 2.
+    /// </summary>
+    /// <remarks>
+    /// Collapses knots using <paramref name="knotTolerance"/>.
+    /// </remarks>
+    /// <param name="curve"></param>
+    /// <param name="polyCurve"></param>
+    /// <param name="knotTolerance"></param>
+    /// <returns>false if no new polycurve is created.</returns>
+    public static bool TryGetPolyCurveC2(this Rhino.Geometry.NurbsCurve curve, out Rhino.Geometry.PolyCurve polyCurve, double knotTolerance = KnotTolerance)
+    {
+      bool duplicate = false;
+      var spans = default(List<double>);
+      var degree = curve.Degree;
+      var knots = curve.Knots;
+
+      for (int k = degree; k < knots.Count - degree;)
+      {
+        var multiplicity = KnotMultiplicity(knots, k, knotTolerance, out var _, out var strict);
+
+        if (multiplicity > degree - 2)
+        {
+          if (spans is null) spans = new List<double>();
+          spans.Add(knots[k]);
+        }
+
+        if (!strict)
+        {
+          // We are going to modify curve so we need a duplicate here
+          if (!duplicate)
+          {
+            curve = curve.Duplicate() as Rhino.Geometry.NurbsCurve;
+            knots = curve.Knots;
+            duplicate = true;
+          }
+
+          var excess = multiplicity - knots.KnotMultiplicity(k);
+
+          // Correct multiplicity in case more than degree knots are snapped here
+          multiplicity = Math.Min(multiplicity, degree);
+
+          // Insert new knot multiplicity
+          knots.InsertKnot(knots[k], multiplicity);
+
+          // Remove old knots that do not overlap knots[k]
+          if (excess > 0)
+            knots.RemoveKnots(k + multiplicity, k + multiplicity + excess);
+        }
+
+        k += multiplicity;
+      }
+
+      if (spans is null)
+      {
+        polyCurve = default;
+        return false;
+      }
+
+      polyCurve = new Rhino.Geometry.PolyCurve();
+      foreach (var span in curve.Split(spans))
+        polyCurve.AppendSegment(span);
+
+      // Split may generate PolyCurves on seams.
+      if (curve.IsClosed)
+        polyCurve.RemoveNesting();
+
+      return true;
+    }
+
+    static bool ToKinkedSpans(NurbsSurfaceKnotList knots, int degree, out List<double> kinks, double knotTolerance = KnotTolerance)
+    {
+      kinks = default;
+
+      for (int k = degree; k < knots.Count - degree;)
+      {
+        var multiplicity = KnotMultiplicity(knots, k, knotTolerance, out var _, out var strict);
+
+        if (multiplicity > degree)
+        {
+          if (kinks is null) kinks = new List<double>();
+          kinks.Add(knots[k]);
+        }
+
+        if (!strict)
+        {
+          var excess = multiplicity - knots.KnotMultiplicity(k);
+
+          // Correct multiplicity in case more than degree knots are snapped here
+          multiplicity = Math.Min(multiplicity, degree);
+
+          // Insert new knot multiplicity
+          knots.InsertKnot(knots[k], multiplicity);
+
+          // Remove old knots that do not overlap knots[k]
+          if (excess > 0)
+            knots.RemoveKnots(k + multiplicity, k + multiplicity + excess);
+        }
+
+        k += multiplicity;
+      }
+
+      for (int k = degree; k < knots.Count - degree;)
+      {
+        var m = KnotMultiplicity(knots, k, knotTolerance, out var a, out var s);
+        global::System.Diagnostics.Debug.Assert(m <= degree);
+        k += m;
+      }
+
+      return !(kinks is null);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2145

Improves compatibility between Rhino and _lesser_ applications with crappy geometry kernels ( 👀 Revit ).

This introduces several changes in the way we convert BREPs that are inspired by the lovely peeps at McNeel, specifically their `BrepEncoder` class inside `Rhino.Inside Revit` (see https://github.com/mcneel/rhino.inside-revit/blob/1.x/src/RhinoInside.Revit/Convert/Geometry/BrepEncoder.cs)

**Preprocess Geometry**:

By pre-processing geometry, what we mean is actually just simplifying the BREP so that it does not include some non-supported features in other software. Namely:

- Knots with lower multiplicity than degree + 1 on edges
- Surfaces that are closed in U or V direction (or both)
- Tiny edges/faces that are too small to be drawn
- Surfaces with kinky seams (i.e. surface lies on the control point, creating a "ridge")

This step will automatically be applied:

- In Grasshopper: Whenever a `Schema node` is used, or using the new `ToNative` menu option.
- In Rhino: Whenever the converter encounters an object that has a `SpeckleSchema` added to it. This is done automatically using the Speckle BIM toolbar in Rhino.

In essence, whenever we find a BREP that is clearly destined for a BIM/Structural environment, we'll run the pre-process step. If we cannot tell where this is destined to, we'll send the BREPs as they were modelled (to prevent issues with Rhino -> Rhino workflows returning slightly different geometries)

**Preprocess Limitations**
It's important to note that pre-processing the geometry **does not guarantee** that all of this issues will be solved, as sometimes it is mathematically impossible to simplify some geometries.

For this, Revit will continue to fallback to it's Mesh representation.

Preprocess will only apply for BREPs now, but can be extended into Curve support too (with some minor differences, namely that conversion could be one to many)

**New converter setting**: `preprocessGeometry`

The new converter setting exclusive for Rhino/GH converter. It consists in a boolean value to indicate if the converter should perform some optimisations on the Breps to simpify their representation.

**Grasshopper `To Native` new preprocess option**

In order to expose this for testing (and for greater flexibility on GH) I've added a right-click menu option to enable pre-processing for any object converted with that node.

** Screenshots **

Kudos to @bimgeek for providing me with a bunch of extra test models that were super helpful!!

**Left (original), Right (pre-processed)**: Brep geometry after receiving it in Revit.

White parts are parts that failed to convert as Brep and we used the fallback mesh. Grey parts are successfully converted Solids

![Screenshot 2023-02-24 at 09 39 50](https://user-images.githubusercontent.com/2316535/221133299-1331630d-5bc1-46cd-9073-2e8645c0606e.png)
![Screenshot 2023-02-24 at 09 41 04](https://user-images.githubusercontent.com/2316535/221133304-40f09908-f3db-4eca-83e5-9e9001fb5105.png)
![Screenshot 2023-02-24 at 09 42 48](https://user-images.githubusercontent.com/2316535/221133306-2ac97e11-4b28-47c1-9f0a-dbb551298df7.png)
![Screenshot 2023-02-24 at 09 44 56](https://user-images.githubusercontent.com/2316535/221133312-f4f83aae-9055-4e03-838d-bcf4c2b98d87.png)
