### PR TITLE
Revert "fix:(navisworks): No longer require wgl."

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
@@ -79,7 +79,7 @@ namespace Speckle.ConnectorNavisworks.Entry
       app.UsePlatformDetect();
       app.With(new SkiaOptions { MaxGpuResourceSizeBytes = 8096000 });
       app.With(new Win32PlatformOptions
-        { AllowEglInitialization = true, EnableMultitouch = false, UseWgl = false });
+        { AllowEglInitialization = true, EnableMultitouch = false, UseWgl = true });
       app.LogToTrace();
       app.UseReactiveUI();
 


### PR DESCRIPTION
Reverts specklesystems/speckle-sharp#2191

Reverting this as it was merged in the wrong branch 🙇🏼‍♂️