### PR TITLE
feat(core): adds us survey feet support to units

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Reflection;
 
-using Speckle.Core.Kits;
-
 using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
 using Autodesk.AutoCAD.Colors;
+
+using Speckle.Core.Kits;
 using Speckle.Core.Models;
 
 #if CIVIL2021 || CIVIL2022 || CIVIL2023

--- a/Core/Core/Kits/Units.cs
+++ b/Core/Core/Kits/Units.cs
@@ -16,12 +16,12 @@ namespace Speckle.Core.Kits
     public const string Miles = "mi";
     public const string None = "none";
 
-    private static List<string> SupportedUnits = new List<string>() { Millimeters, Centimeters, Meters, Kilometers, Inches, Feet, Yards, Miles, None };
+    private static List<string> SupportedUnits = new List<string>() { Millimeters, Centimeters, Meters, Kilometers, Inches, Feet, USFeet, Yards, Miles, None };
 
     public static bool IsUnitSupported(string unit) => SupportedUnits.Contains(unit);
 
     // public const string USInches = "us_in"; the smelliest ones, can add later if people scream "USA #1"
-    // public const string USFeet = "us_ft"; the smelliest ones, can add later if people scream "USA #1"
+    public const string USFeet = "us_ft"; // it happened, absolutely gross
     // public const string USYards = "us_yd"; the smelliest ones, can add later if people scream "USA #1"
     // public const string USMiles = "us_mi"; the smelliest ones, can add later if people scream "USA #1"
 
@@ -46,6 +46,8 @@ namespace Speckle.Core.Kits
               return 0.0393701;
             case Units.Feet:
               return 0.00328084;
+            case Units.USFeet:
+              return 0.0032808333;
             case Units.Yards:
               return 0.00109361;
             case Units.Miles:
@@ -65,6 +67,8 @@ namespace Speckle.Core.Kits
               return 0.393701;
             case Units.Feet:
               return 0.0328084;
+            case Units.USFeet:
+              return 0.0328083333;
             case Units.Yards:
               return 0.0109361;
             case Units.Miles:
@@ -84,6 +88,8 @@ namespace Speckle.Core.Kits
               return 39.3701;
             case Units.Feet:
               return 3.28084;
+            case Units.USFeet:
+              return 3.28083333;
             case Units.Yards:
               return 1.09361;
             case Units.Miles:
@@ -103,6 +109,8 @@ namespace Speckle.Core.Kits
               return 39370.1;
             case Units.Feet:
               return 3280.84;
+            case Units.USFeet:
+              return 3280.83333;
             case Units.Yards:
               return 1093.61;
             case Units.Miles:
@@ -124,6 +132,8 @@ namespace Speckle.Core.Kits
               return 2.54e-5;
             case Units.Feet:
               return 0.0833333;
+            case Units.USFeet:
+              return 0.0833331667;
             case Units.Yards:
               return 0.027777694;
             case Units.Miles:
@@ -143,10 +153,54 @@ namespace Speckle.Core.Kits
               return 0.0003048;
             case Units.Inches:
               return 12;
+            case Units.USFeet:
+              return 0.999998;
             case Units.Yards:
               return 0.333332328;
             case Units.Miles:
               return 0.000189394;
+          }
+          break;
+        case Units.USFeet:
+          switch (to)
+          {
+            case Units.Millimeters:
+              return 120000d / 3937d;
+            case Units.Centimeters:
+              return 12000d / 3937d;
+            case Units.Meters:
+              return 1200d / 3937d;
+            case Units.Kilometers:
+              return 1.2 / 3937d;
+            case Units.Inches:
+              return 12.000024000000002;
+            case Units.Feet:
+              return 1.000002;
+            case Units.Yards:
+              return 1.000002 / 3d;
+            case Units.Miles:
+              return 1.000002 / 5280d;
+          }
+          break;
+        case Units.Yards:
+          switch (to)
+          {
+            case Units.Millimeters:
+              return 914.4;
+            case Units.Centimeters:
+              return 91.44;
+            case Units.Meters:
+              return 0.9144;
+            case Units.Kilometers:
+              return 0.0009144;
+            case Units.Inches:
+              return 36;
+            case Units.Feet:
+              return 3;
+            case Units.USFeet:
+              return 2.999994;
+            case Units.Miles:
+              return 1d / 1760d;
           }
           break;
         case Units.Miles:
@@ -164,6 +218,8 @@ namespace Speckle.Core.Kits
               return 63360;
             case Units.Feet:
               return 5280;
+            case Units.USFeet:
+              return 5279.98944002112;
             case Units.Yards:
               return 1759.99469184;
           }
@@ -205,6 +261,8 @@ namespace Speckle.Core.Kits
         case "foot":
         case "ft":
           return Units.Feet;
+        case "ussurveyfeet":
+          return Units.USFeet;
         case "yard":
         case "yards":
         case "yd":

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -6,11 +6,12 @@ using System.Drawing;
 using Autodesk.AutoCAD.Geometry;
 using AcadGeo = Autodesk.AutoCAD.Geometry;
 using Autodesk.AutoCAD.DatabaseServices;
-using Objects.Utils;
 using AcadBRep = Autodesk.AutoCAD.BoundaryRepresentation;
 using AcadDB = Autodesk.AutoCAD.DatabaseServices;
+
 using Speckle.Core.Models;
 
+using Objects.Utils;
 using Arc = Objects.Geometry.Arc;
 using Box = Objects.Geometry.Box;
 using Brep = Objects.Geometry.Brep;


### PR DESCRIPTION
## Description & motivation

Adds `USFeet` to units class, and all related unit conversions.
Also added `Yard` conversions because I noticed they were missing.
Closes #2207

## Changes:

Core

## Validation of changes:
Sent geo from Civil3d in us survey feet

