### PR TITLE
feat(ci): Allow external PRs to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run: # run a command
           name: Generate config
           command: |
-            python .circleci/scripts/config-generator.py -d ${CIRCLE_TAG:-none} -o .circleci/continuation-config.yml
+            python .circleci/scripts/config-generator.py -d ${CIRCLE_TAG:-none} -o .circleci/continuation-config.yml -e ${CIRCLE_PR_REPONAME}
       - continuation/continue:
           configuration_path: .circleci/continuation-config.yml # use newly generated config to continue
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run: # run a command
           name: Generate config
           command: |
-            python .circleci/scripts/config-generator.py -d ${CIRCLE_TAG:-none} -o .circleci/continuation-config.yml -e ${CIRCLE_PR_REPONAME}
+            python .circleci/scripts/config-generator.py -d ${CIRCLE_TAG:-none} -o .circleci/continuation-config.yml -e ${CIRCLE_PR_REPONAME:-none}
       - continuation/continue:
           configuration_path: .circleci/continuation-config.yml # use newly generated config to continue
 workflows:

--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -7,13 +7,15 @@ import getopt
 
 
 def runCommand(argv: List[str]):
-    deploy = False
-    output_filepath = ".circleci/continuation-config.yml"
+
+    deploy: bool = False
+    external_build: bool = False
+    output_filepath: str = ".circleci/continuation-config.yml"
     arg_help = "{0} -d <deploy?> -o <output>".format(argv[0])
 
     print(argv)
     try:
-        opts, _ = getopt.getopt(argv[1:], "hd:o:")
+        opts, _ = getopt.getopt(argv[1:], "hd:o:e:")
     except:
         print(arg_help)
         sys.exit(2)
@@ -33,8 +35,16 @@ def runCommand(argv: List[str]):
             print("deploy arg -- " + str(arg) + " -- " + str(deploy))
         elif opt in ("-o", "--output"):
             output_filepath = arg
-
-    createConfigFile(deploy, output_filepath)
+        elif opt in ("-e", "--external"):
+            external_build = arg is not None and arg not in [
+                "none",
+                "None",
+                "False",
+                "false",
+                "f",
+            ]
+            print("Building for external PR " + str(external_build))
+    createConfigFile(deploy, output_filepath, external_build)
 
 
 def setup():
@@ -58,12 +68,7 @@ def setup():
         common_jobs = yaml.safe_load(cf)
 
 
-def getTagRegexString(connector_names: List[str]):
-    # version_regex = "([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?"
-    # tags = connector_names + ["all"]
-    # tagExpression = "(" + "|".join(tags) + ")"
-    # return f"/^{version_regex}\\/{tagExpression}$/"
-
+def getTagRegexString(connector_names: List[str]) -> str:
     # Version format 'x.y.z' with optional suffix '-{SUFFIX_NAME}' and optional '/all' ending to force build all tags
     return "/^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?(\\/all)?$/"
 
@@ -75,10 +80,10 @@ def getTagFilter(connector_names: List[str]):
     }
 
 
-def createConfigFile(deploy: bool, outputPath: str):
+def createConfigFile(deploy: bool, outputPath: str, external_build: bool):
     print("---- Started creating config ----")
     print(
-        f"\n  -- Settings --\n  Deploy: {deploy}\n  Output path: {outputPath}\n  --\n"
+        f"\n  -- Settings --\n  Deploy: {deploy}\n  Output path: {outputPath}\n  External build: {external_build}\n  --\n"
     )
     setup()
 
@@ -176,11 +181,16 @@ def createConfigFile(deploy: bool, outputPath: str):
                 jobsToWait.append(job["deploy-connector-new"]["name"])
             main_workflow["jobs"] += [job]
         main_workflow["jobs"] += [
-            {"notify-deploy": {
-            "requires": jobsToWait, 
-            "context": "discord", "filters": getTagFilter(slugs_to_match)}}
+            {
+                "notify-deploy": {
+                    "requires": jobsToWait,
+                    "context": "discord",
+                    "filters": getTagFilter(slugs_to_match),
+                }
+            }
         ]
-
+    if external_build:
+        removeStepsThatUseSecrets(config)
     # Output continuation file
     with open(outputPath, "w") as file:
         yaml.dump(config, file, sort_keys=False)
@@ -188,9 +198,28 @@ def createConfigFile(deploy: bool, outputPath: str):
     print("---- Finished creating config ----")
 
 
+def removeStepsThatUseSecrets(config):
+    jobs: dict[str, dict[str, dict]] = config["workflows"]["build"]["jobs"]
+    filteredJobs: dict[str, Any] = {}
+
+    for jobItem in jobs:
+        key = next(iter(jobItem.keys()))
+        if key == "get-ci-tools":
+            continue
+        jobDict: dict = jobItem[key]
+        requires = jobDict["requires"]
+        if requires:
+            if "get-ci-tools" in requires:
+                requires.pop(requires.index("get-ci-tools"))
+        filteredJobs[key] = jobDict
+
+    config["workflows"]["build"]["jobs"] = filteredJobs
+    print("Cleaned up config for external build")
+
+
 def getNewDeployJob(jobName: str):
-    slug = jobName.split("-build")[0]
-    isMac = jobName.find("-mac") != -1
+    slug: str = jobName.split("-build")[0]
+    isMac: bool = jobName.find("-mac") != -1
     deployJob: Dict[str, Any] = {
         "slug": slug.split("-mac")[0] if isMac else slug,
         "name": slug + "-deploy-mac" if isMac else slug + "-deploy",

--- a/.circleci/scripts/config-generator.py
+++ b/.circleci/scripts/config-generator.py
@@ -200,7 +200,7 @@ def createConfigFile(deploy: bool, outputPath: str, external_build: bool):
 
 def removeStepsThatUseSecrets(config):
     jobs: dict[str, dict[str, dict]] = config["workflows"]["build"]["jobs"]
-    filteredJobs: dict[str, Any] = {}
+    filteredJobs = []
 
     for jobItem in jobs:
         key = next(iter(jobItem.keys()))
@@ -211,7 +211,7 @@ def removeStepsThatUseSecrets(config):
         if requires:
             if "get-ci-tools" in requires:
                 requires.pop(requires.index("get-ci-tools"))
-        filteredJobs[key] = jobDict
+        filteredJobs.append({f"{key}": jobDict})
 
     config["workflows"]["build"]["jobs"] = filteredJobs
     print("Cleaned up config for external build")

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -494,7 +494,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             cd ConnectorArchicad/AddOn
             mkdir Build.macOS.x64.<<parameters.archicadversion>>
-            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-0} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-0}
+            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-987654321} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-1234567890}
       - run:
           name: Build add-on
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -450,7 +450,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             cd ConnectorArchicad/AddOn
             mkdir Build.Win.x64.<<parameters.archicadversion>>
             export PATH=$PATH:"C:\Program Files\CMake\bin"
-            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-00000000000} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-111111111111}
+            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-00} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-00}
       - run:
           name: Build add-on
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -191,6 +191,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   WORKFLOW_NUM: << pipeline.number >>
       - run:
           name: Exit if External PR
+          shell: bash.exe
           command: if [ "$CIRCLE_PR_REPONAME" ]; then circleci-agent step halt; fi
       - run:
           name: Create Innosetup signing cert

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -450,7 +450,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             cd ConnectorArchicad/AddOn
             mkdir Build.Win.x64.<<parameters.archicadversion>>
             export PATH=$PATH:"C:\Program Files\CMake\bin"
-            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-fakegrahisoftdevid} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-fakegraphisoftaddonid}
+            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-00000000000} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-111111111111}
       - run:
           name: Build add-on
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -450,7 +450,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             cd ConnectorArchicad/AddOn
             mkdir Build.Win.x64.<<parameters.archicadversion>>
             export PATH=$PATH:"C:\Program Files\CMake\bin"
-            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=$GRAPHISOFT_DEV_ID -DAC_MDID_LOC=$GRAPHISOFT_ADDON_ID
+            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-fakegrahisoftdevid} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-fakegraphisoftaddonid}
       - run:
           name: Build add-on
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -494,7 +494,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             cd ConnectorArchicad/AddOn
             mkdir Build.macOS.x64.<<parameters.archicadversion>>
-            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=$GRAPHISOFT_DEV_ID -DAC_MDID_LOC=$GRAPHISOFT_ADDON_ID
+            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-00} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-00}
       - run:
           name: Build add-on
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -494,7 +494,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             cd ConnectorArchicad/AddOn
             mkdir Build.macOS.x64.<<parameters.archicadversion>>
-            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-00} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-00}
+            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-0} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-0}
       - run:
           name: Build add-on
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -450,7 +450,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             cd ConnectorArchicad/AddOn
             mkdir Build.Win.x64.<<parameters.archicadversion>>
             export PATH=$PATH:"C:\Program Files\CMake\bin"
-            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-00} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-00}
+            cmake -B "./Build.Win.x64.<<parameters.archicadversion>>/" -A "x64" -T "v142" -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKit" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-1} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-1}
       - run:
           name: Build add-on
           command: |
@@ -494,7 +494,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             cd ConnectorArchicad/AddOn
             mkdir Build.macOS.x64.<<parameters.archicadversion>>
-            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-987654321} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-1234567890}
+            cmake -B "./Build.macOS.x64.<<parameters.archicadversion>>/" -G 'Xcode' -DCMAKE_OSX_ARCHITECTURES=x86_64 -DAC_API_DEVKIT_DIR="../../Resources/Archicad<<parameters.archicadversion>>DevKitMac" -DAC_MDID_DEV=${GRAPHISOFT_DEV_ID:-1} -DAC_MDID_LOC=${GRAPHISOFT_ADDON_ID:-1}
       - run:
           name: Build add-on
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -190,6 +190,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
       - run:
+          name: Exit if External PR
+          command: if [ "$CIRCLE_PR_REPONAME" ]; then circleci-agent step halt; fi
+      - run:
           name: Create Innosetup signing cert
           command: |
             echo $env:PFX_B64 > "speckle-sharp-ci-tools\SignTool\AEC Systems Ltd.txt"
@@ -365,6 +368,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   mkdir -p speckle-sharp-ci-tools/Mac/<< parameters.installername >>/.installationFiles/
                   cp << parameters.slnname >>/<< parameters.slnname >>/bin/Release/net6.0/osx-x64/publish/<< parameters.slug >>-mac.zip speckle-sharp-ci-tools/Mac/<<parameters.installername>>/.installationFiles
       # Create installer
+      - run:
+          name: Exit if External PR
+          command: if [ "$CIRCLE_PR_REPONAME" ]; then circleci-agent step halt; fi
       - run:
           name: Build Mac installer
           command: ~/.dotnet/dotnet publish speckle-sharp-ci-tools/Mac/<<parameters.installername>>/<<parameters.installername>>.sln -r osx-x64 -c Release


### PR DESCRIPTION
This changes allow for 3rd party developers PRs to be built without leaking any secrets on our end.

Secrets were already securely stored, and not shared to external repo builds, but our pipeline was still relying on some steps that would fail if secrets were missing (`get-ci-tools` mainly, and any step using the `speckle-sharp-ci-tools/` path)

#2214 was the test PR I made and it seemed to work like a charm.