### PR TITLE
Added phaseDemolished parameter in RevitConverter

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -251,6 +251,10 @@ namespace Objects.Converter.Revit
       if (phaseCreated != null)
         speckleElement["phaseCreated"] = phaseCreated.Name;
 
+      Phase phaseDemolished = Doc.GetElement(revitElement.DemolishedPhaseId) as Phase;
+      if (phaseDemolished != null)
+        speckleElement["phaseDemolished"] = phaseDemolished.Name;
+
       var category = revitElement.Category;
       if (category != null)
       {
@@ -411,6 +415,9 @@ namespace Objects.Converter.Revit
       // Set the phaseCreated parameter
       if (speckleElement["phaseCreated"] is string phaseCreated && !string.IsNullOrEmpty(phaseCreated))
         TrySetParam(revitElement, BuiltInParameter.PHASE_CREATED, GetRevitPhase(revitElement.Document, phaseCreated));
+      //Set the phaseDemolished parameter
+      if (speckleElement["phaseDemolished"] is string phaseDemolished && !string.IsNullOrEmpty(phaseDemolished))
+        TrySetParam(revitElement, BuiltInParameter.PHASE_DEMOLISHED, GetRevitPhase(revitElement.Document, phaseDemolished));
 
       // NOTE: we are using the ParametersMap here and not Parameters, as it's a much smaller list of stuff and 
       // Parameters most likely contains extra (garbage) stuff that we don't need to set anyways


### PR DESCRIPTION
## Description & motivation



- Added phaseDemolished parameter 
- Identical implementation to previous issue #1390
- Fixed Issue : #2215 



## Changes:

- speckle-sharp\Objects\Converters\ConverterRevit\ConverterRevitShared\ConversionUtils.cs


## To-do before merge:

- Parameter can be null and is not included if the value is null (should this be changed?)



## Screenshots:

![image](https://user-images.githubusercontent.com/10882959/222145911-d09a6ad0-c5db-4c47-9c5f-d53b4cfa372c.png)

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

- [X ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [X] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [X] My commits are related to the pull request and do not amend unrelated code or documentation.
- [X] My code follows a similar style to existing code.
- [X] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

