### PR TITLE
test(core): Serializer breaking changes tests

### DIFF
--- a/Core/Tests/SerializerNonBreakingChanges.cs
+++ b/Core/Tests/SerializerNonBreakingChanges.cs
@@ -1,0 +1,247 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using Speckle.Core.Api;
+using Speckle.Core.Models;
+
+namespace Tests.Models;
+
+/// <summary>
+/// Test fixture that documents what property typing changes maintain backwards/cross/forwards compatibility, and are "non-breaking" changes.
+/// This doesn't guarantee things work this way for SpecklePy
+/// Nor does it encompass other tricks (like deserialize callback, or computed json ignored properties)
+/// </summary>
+[TestFixture, Description("For certain types, changing property from one type to another should be implicitly backwards compatible")]
+public class SerializerNonBreakingChanges : PrimitiveTestFixture
+{
+  
+  [Test]
+  [TestCaseSource(nameof(Int8TestCases))]
+  [TestCaseSource(nameof(Int32TestCases))]
+  public void IntToColor(int argb)
+  {
+    var from = new IntValueMock { value = argb };
+
+    var res = from.SerializeAsTAndDeserialize<ColorValueMock>();
+    Assert.That(res.value.ToArgb(), Is.EqualTo(argb));
+  }
+  
+  [Test]
+  [TestCaseSource(nameof(Int8TestCases))]
+  [TestCaseSource(nameof(Int32TestCases))]
+  public void ColorToInt(int argb)
+  {
+    var from = new ColorValueMock { value = Color.FromArgb(argb) };
+
+    var res = from.SerializeAsTAndDeserialize<IntValueMock>();
+    Assert.That(res.value, Is.EqualTo(argb));
+  }
+
+  [Test]
+  [TestCaseSource(nameof(Int8TestCases))]
+  [TestCaseSource(nameof(Int32TestCases))]
+  [TestCaseSource(nameof(Int64TestCases))]
+  public void IntToDouble(long testCase)
+  {
+    var from = new IntValueMock { value = testCase };
+
+    var res = from.SerializeAsTAndDeserialize<DoubleValueMock>();
+    Assert.That(res.value, Is.EqualTo(testCase));
+  }
+  
+  [Test]
+  [TestCaseSource(nameof(Int8TestCases))]
+  [TestCaseSource(nameof(Int32TestCases))]
+  [TestCaseSource(nameof(Int64TestCases))]
+  public void IntToString(long testCase)
+  {
+    var from = new IntValueMock { value = testCase };
+
+    var res = from.SerializeAsTAndDeserialize<StringValueMock>();
+    Assert.That(res.value, Is.EqualTo(testCase.ToString()));
+  }
+
+  private static double[][] ArrayTestCases =
+  {
+    new double[] { },
+    new double[] { 0, 1, int.MaxValue, int.MinValue, },
+    new double[] { default, double.Epsilon, double.MaxValue, double.MinValue },
+  };
+
+  [Test]
+  [TestCaseSource(nameof(ArrayTestCases))]
+  public void ArrayToList(double[] testCase)
+  {
+    var from = new ArrayDoubleValueMock  { value = testCase };
+
+    var res = from.SerializeAsTAndDeserialize<ListDoubleValueMock>();
+    Assert.That(res.value, Is.EquivalentTo(testCase));
+  }
+  
+  [Test]
+  [TestCaseSource(nameof(ArrayTestCases))]
+  public void ListToArray(double[] testCase)
+  {
+    var from = new ListDoubleValueMock { value = testCase.ToList() };
+
+    var res = from.SerializeAsTAndDeserialize<ArrayDoubleValueMock>();
+    Assert.That(res.value, Is.EquivalentTo(testCase));
+  }
+  
+  [Test, TestCaseSource(nameof(MyEnums))]
+  public void EnumToInt(MyEnum testCase)
+  {
+    var from = new EnumValueMock{ value = testCase };
+
+    var res = from.SerializeAsTAndDeserialize<IntValueMock>();
+    Assert.That(res.value, Is.EqualTo((int)testCase));
+  }
+  
+  [Test, TestCaseSource(nameof(MyEnums))]
+  public void IntToEnum(MyEnum testCase)
+  {
+    var from = new IntValueMock { value = (int)testCase};
+
+    var res = from.SerializeAsTAndDeserialize<EnumValueMock>();
+    Assert.That(res.value, Is.EqualTo(testCase));
+  }
+  
+}
+
+/// <summary>
+/// Test fixture that documents what property typing changes break backwards/cross/forwards compatibility, and are "breaking" changes.
+/// This doesn't guarantee things work this way for SpecklePy
+/// Nor does it encompass other tricks (like deserialize callback, or computed json ignored properties)
+/// </summary>
+[TestFixture, Description("For certain types, changing property from one type to another is a breaking change, and not backwards/forwards compatible")]
+public class SerializerBreakingChanges : PrimitiveTestFixture
+{
+  [Test, Description("Deserialization of a JTokenType.Float to a .NET short/int/long should throw exception")]
+  [TestCaseSource(nameof(Float64TestCases))]
+  [TestCase(1e+30)]
+  public void DoubleToInt_ShouldThrow(double testCase)
+  {
+    var from = new DoubleValueMock { value = testCase };
+    Assert.Throws<Exception>(
+      () => from.SerializeAsTAndDeserialize<IntValueMock>()
+    );
+  }
+  
+  [Test]
+  public void StringToInt_ShouldThrow()
+  {
+    var from = new StringValueMock();
+    from.value = "testValue";
+    Assert.Throws<Exception>(
+      () => from.SerializeAsTAndDeserialize<IntValueMock>()
+    );
+  }
+  
+  [Test, TestCaseSource(nameof(MyEnums))]
+  public void StringToEnum_ShouldThrow(MyEnum testCase)
+  {
+    var from = new StringValueMock() { value = testCase.ToString() };
+
+    Assert.Throws<Exception>(() =>
+    {
+      var res = from.SerializeAsTAndDeserialize<EnumValueMock>();
+    });
+  }
+  
+
+}
+
+public class TValueMock<T> : SerializerMock
+{
+  public T value { get; set; }
+}
+
+public class ListDoubleValueMock : SerializerMock
+{
+  public List<double> value { get; set; }
+}
+
+public class ArrayDoubleValueMock : SerializerMock
+{
+  public double[] value { get; set; }
+}
+
+public class IntValueMock : SerializerMock
+{
+  public long value { get; set; }
+}
+
+public class StringValueMock : SerializerMock
+{
+  public string value { get; set; }
+}
+
+public class DoubleValueMock : SerializerMock
+{
+  public double value { get; set; }
+}
+
+public class ColorValueMock : SerializerMock
+{
+  public Color value { get; set; }
+}
+
+public class EnumValueMock : SerializerMock
+{
+  public MyEnum value { get; set; }
+}
+
+public enum MyEnum
+{
+  Zero, 
+  One, 
+  Two, 
+  Three,
+  Neg = -1,
+  Min = int.MinValue,
+  Max = int.MaxValue,
+}
+
+public abstract class SerializerMock : Base
+{
+  public string _speckle_type;
+
+  public SerializerMock()
+  {
+    _speckle_type = base.speckle_type;
+  }
+
+  public void SerializeAs<T>() where T : Base, new()
+  {
+    T target = new T();
+    _speckle_type = target.speckle_type;
+  }
+
+  public override string speckle_type => _speckle_type;
+
+  internal TTo SerializeAsTAndDeserialize<TTo>() where TTo : Base, new()
+  {
+    this.SerializeAs<TTo>();
+
+    var json = Operations.Serialize(this);
+
+    Base result = Operations.Deserialize(json);
+    Assert.NotNull(result);
+    Assert.That(result, Is.TypeOf<TTo>());
+    return (TTo)result;
+  }
+}
+
+public class PrimitiveTestFixture
+{
+  public static SByte[] Int8TestCases = { default, sbyte.MaxValue, sbyte.MinValue };
+  public static Int16[] Int16TestCases = { short.MaxValue, short.MinValue };
+  public static Int32[] Int32TestCases = { int.MinValue, int.MaxValue };
+  public static Int64[] Int64TestCases = { long.MaxValue, long.MinValue };
+  
+  public static Double[] Float64TestCases = { default, double.Epsilon, double.MaxValue, double.MinValue };
+  public static Single[] Float32TestCases = { default, float.Epsilon, float.MaxValue, float.MinValue };
+  public static Half[] Float16TestCases = { default, Half.Epsilon, Half.MaxValue, Half.MinValue };
+  public static Single[] FloatIntegralTestCases = { 0, 1, int.MaxValue, int.MinValue };
+  
+  public static MyEnum[] MyEnums => Enum.GetValues(typeof(MyEnum)).Cast<MyEnum>().ToArray();
+}


### PR DESCRIPTION
I've implemented a set of Tests that describe the behaviour of our serializer's when we make a changes to Object models.

I've documented which changes to a property's type breaks or maintains backwards compatibility with deserializing older commits. 
And answers the question of 
> If I change a prop from type `X` to type `T`, is that a breaking change?

These document the Current behaviour of our deserialize, not necessarily the behaviour we have designed/taken conscious decisions to maintain support for. And is focused SpeckleSharp and doesn't guarantee that things work the same in SpecklePy, Unreal, or Sketchup.

I've done some tricks to allow unit testing to emulate making changes to object models. This is achieved by re-writing the `SpeckleType` of an object such that it will deserialized as a different type. 

The results are as follows
![image](https://user-images.githubusercontent.com/45512892/222283159-72ac8716-2612-43a7-a081-5bdd7c0d6558.png)
