### PR TITLE
fix(gh): Schema Object no longer fails on first drop

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
@@ -114,9 +114,9 @@ namespace ConnectorGrasshopper
       if (SelectedConstructor != null)
       {
         base.AddedToDocument(document);
-        if (Grasshopper.Instances.ActiveCanvas.Document == null) return;
+        if (Grasshopper.Instances.ActiveCanvas?.Document == null) return;
         var otherSchemaBuilders =
-          Grasshopper.Instances.ActiveCanvas.Document.FindObjects(new List<string>() { Name }, 10000);
+          Grasshopper.Instances.ActiveCanvas?.Document.FindObjects(new List<string>() { Name }, 10000);
         foreach (var comp in otherSchemaBuilders)
         {
           if (!(comp is CreateSchemaObject scb)) continue;
@@ -125,8 +125,12 @@ namespace ConnectorGrasshopper
           break;
         }
         (Params.Output[0] as SpeckleBaseParam).UseSchemaTag = UseSchemaTag;
+#if RHINO7
+        if(!Grasshopper.Instances.RunningHeadless)
+          (Params.Output[0] as SpeckleBaseParam).ExpirePreview(true);
+#else
         (Params.Output[0] as SpeckleBaseParam).ExpirePreview(true);
-
+#endif
         return;
       }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -168,10 +168,11 @@ namespace ConnectorGrasshopper
       if (SelectedConstructor != null)
       {
         base.AddedToDocument(document);
-        if (Grasshopper.Instances.ActiveCanvas.Document != null)
+        if (Grasshopper.Instances.ActiveCanvas?.Document != null)
         {
           var otherSchemaBuilders =
-            Grasshopper.Instances.ActiveCanvas.Document.FindObjects(new List<string>() { Name }, 10000);
+            Grasshopper.Instances.ActiveCanvas?.Document?.FindObjects(new List<string>() { Name }, 10000);
+          
           foreach (var comp in otherSchemaBuilders)
           {
             if (comp is CreateSchemaObject scb)
@@ -198,7 +199,12 @@ namespace ConnectorGrasshopper
 
       if (Params.Input.Count == 0) SetupComponent(SelectedConstructor);
       ((SpeckleBaseParam)Params.Output[0]).UseSchemaTag = UseSchemaTag;
+#if RHINO7
+      if(!Grasshopper.Instances.RunningHeadless)
+        (Params.Output[0] as SpeckleBaseParam).ExpirePreview(true);
+#else
       (Params.Output[0] as SpeckleBaseParam).ExpirePreview(true);
+#endif
 
       Params.ParameterChanged += (sender, args) =>
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -169,7 +169,6 @@ namespace ConnectorGrasshopper
       {
         base.AddedToDocument(document);
         // We purposefully override the preprocess geometry setting since schema objects are mostly going to go to lesser powerful target apps regarding geometry processing.
-        Converter.SetConverterSettings(new Dictionary<string, object> { { "preprocessGeometry", true } });
 
         if (Grasshopper.Instances.ActiveCanvas?.Document != null)
         {
@@ -198,7 +197,6 @@ namespace ConnectorGrasshopper
             }
           }
         }
-        return;
       }
 
       if (Params.Input.Count == 0) SetupComponent(SelectedConstructor);
@@ -229,6 +227,7 @@ namespace ConnectorGrasshopper
       };
 
       base.AddedToDocument(document);
+      Converter?.SetConverterSettings(new Dictionary<string, object> { { "preprocessGeometry", true } });
     }
 
     public void SetupComponent(ConstructorInfo constructor)

--- a/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
+++ b/Objects/Converters/ConverterRhinoGh/ConverterGrasshopper7/ConverterGrasshopper7.csproj
@@ -72,7 +72,8 @@
         <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>
     </PropertyGroup>
     <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsDesktopBuild)' == true">
-        <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+      <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
+      <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).pdb&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;" />
         <!-- We assume Objects project has been built, and folder for the Kit already exists -->
         <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="cp '$(TargetDir)$(AssemblyName).dll' $HOME'/.config/Speckle/Kits/Objects/'" />
     </Target>

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -829,7 +829,7 @@ namespace Objects.Converter.RhinoGh
       brep.Repair(tol);
       
       if(PreprocessGeometry)
-        brep = BrepEncoder.ToRawBrep(brep);
+        brep = BrepEncoder.ToRawBrep(brep, 1.0, Doc.ModelAngleToleranceRadians, Doc.ModelRelativeTolerance);
 
       // get display mesh and attach render material to it if it exists
       var displayMesh = previewMesh ?? GetBrepDisplayMesh(brep);

--- a/Objects/Objects/Objects.csproj
+++ b/Objects/Objects/Objects.csproj
@@ -43,6 +43,7 @@
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(IsDesktopBuild)' == true">
     <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(AppData)\Speckle\Kits\$(ProjectName)\&quot;" />
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(TargetDir)$(AssemblyName).pdb&quot; &quot;$(AppData)\Speckle\Kits\$(ProjectName)\&quot;" />
     <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="mkdir -p $HOME'/.config/Speckle/Kits/$(ProjectName)'" />
     <Exec Condition="$([MSBuild]::IsOsPlatform('OSX'))" Command="cp '$(TargetDir)$(AssemblyName).dll' $HOME'/.config/Speckle/Kits/$(ProjectName)/'" />
   </Target>


### PR DESCRIPTION
Fixes an issue where Create Schema Object would fail to create it's input, leading to a non-usable component. Existing components were not affected by this.

Also fixes an issue reported on the forum where Schema Object nodes would not run on compute properly.