### PR TITLE
Fix(Navisworks): Complete send of saved viewpoint commits: Fixes #2231

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Filters.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Filters.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Navisworks.Api;
 using Autodesk.Navisworks.Api.Clash;
@@ -20,7 +20,7 @@ namespace Speckle.ConnectorNavisworks.Bindings
 
       var selectSetsRootItem = Doc.SelectionSets.RootItem;
 
-      var savedSelectionSets = selectSetsRootItem.Children.Select(GetSets)?.OfType<TreeNode>().ToList();
+      var savedSelectionSets = selectSetsRootItem.Children.Select(GetSets).ToList();
 
       if (savedSelectionSets.Count > 0)
       {
@@ -35,14 +35,16 @@ namespace Speckle.ConnectorNavisworks.Bindings
 
       var savedViewsRootItem = Doc.SavedViewpoints.RootItem;
 
-      var savedViews = savedViewsRootItem.Children.Select(GetViews).ToList();
+      var savedViews = savedViewsRootItem.Children.Select(GetViews).Select(RemoveNullNodes).Where(x => x != null)
+        .ToList();
 
       if (savedViews.Count > 0)
       {
         var savedViewsFilter = new TreeSelectionFilter
         {
           Slug = "views", Name = "Saved Viewpoints", Icon = "FileTree",
-          Description = "Select a saved viewpoint and send its visible items in the commit.",
+          Description =
+            "Select a saved viewpoint and send its visible items in the commit. Only views with Hide/Require attribute checked are listed.",
           Values = savedViews,
           SelectionMode = "Toggle"
         };
@@ -92,17 +94,31 @@ namespace Speckle.ConnectorNavisworks.Bindings
 
     private static TreeNode GetViews(SavedItem savedItem)
     {
-
       var reference = Doc.SavedViewpoints.CreateReference(savedItem);
+
       var treeNode = new TreeNode
       {
         DisplayName = savedItem.DisplayName,
         Guid = savedItem.Guid,
         IndexWith = nameof(TreeNode.Reference),
-        Reference = reference.SavedItemId
+
+        // Rather than version check Navisworks host application we feature check
+        // to see if Guid is set correctly on viewpoints.
+        Reference = savedItem.Guid.ToString() == new Guid().ToString()
+          ? reference.SavedItemId
+          : savedItem.Guid.ToString()
       };
 
-      if (!savedItem.IsGroup) return treeNode;
+      switch (savedItem.IsGroup)
+      {
+        // TODO: This is a defensive measure to prevent sending millions of objects that are hidden in the
+        // current view but not hidden explicitly in the saved view. Optionally if this is not the case we could send visible items in the
+        // current view with the viewpoint as it is saved.
+        case false when !((SavedViewpoint)savedItem).ContainsVisibilityOverrides:
+          return null;
+        case false:
+          return treeNode;
+      }
 
       foreach (var childItem in ((GroupItem)savedItem).Children)
       {
@@ -113,6 +129,23 @@ namespace Speckle.ConnectorNavisworks.Bindings
       return treeNode.Elements.Count > 0
         ? treeNode
         : null;
+    }
+
+    public static TreeNode RemoveNullNodes(TreeNode node)
+    {
+      if (node == null) return null;
+
+      if (!node.Elements.Any()) return node;
+
+      var elements = node.Elements
+        .Select(RemoveNullNodes)
+        .Where(childNode => childNode != null)
+        .ToList();
+
+      if (!elements.Any()) return null;
+      
+      node.Elements = elements;
+      return node;
     }
 
     private static TreeNode GetClashTestResults(SavedItem savedItem)

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Objects.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Objects.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -46,25 +46,60 @@ namespace Speckle.ConnectorNavisworks.Bindings
 
     private static IEnumerable<string> GetObjectsFromSavedViewpoint(ISelectionFilter filter)
     {
-      var reference = filter.Selection[0].Split(new[] { ":" }, StringSplitOptions.None);
-      var savedViewpoint = (SavedViewpoint)Doc.ResolveReference(new SavedItemReference(reference[0], reference[1]));
+      var selection = filter.Selection.FirstOrDefault();
+      if (string.IsNullOrEmpty(selection))
+      {
+        return Enumerable.Empty<string>();
+      }
 
-      // TODO: Handle an amended viewpoint hierarchy.
-      // Possibly by adding a GUID to the selected viewpoint if none is set at the
-      // point of selection comparison can then be made by the GUID if the name and
-      // path don't align. This would be better as both order and name could be
-      // changed after a stream state is saved.
-      if (savedViewpoint == null || !savedViewpoint.ContainsVisibilityOverrides) return Enumerable.Empty<string>();
+      var savedViewpoint = ResolveSavedViewpoint(selection);
+      if (savedViewpoint == null || !savedViewpoint.ContainsVisibilityOverrides)
+      {
+        return Enumerable.Empty<string>();
+      }
 
       var items = savedViewpoint.GetVisibilityOverrides().Hidden;
       items.Invert(Doc);
 
-      // TODO: Where the SavedViews Filter is amended to accept multiple views
-      // for conversion, the logic for returning Object ids will have to change
-      // for processing i.e. Handle lists or id lists instead of a singular list,
-      // and in turn handle only converting member objects once.
-      return items.DescendantsAndSelf.Select(GetPseudoId).ToList();
+      return items.DescendantsAndSelf.Select(GetPseudoId);
     }
+
+    private static SavedViewpoint ResolveSavedViewpoint(string savedViewReference)
+    {
+      var flattenedViewpointList = Doc.SavedViewpoints.RootItem.Children
+        .Select(GetViews)
+        .Where(x => x != null)
+        .SelectMany(node => node.Flatten())
+        .Select(node => new { Reference = node?.Reference?.Split(':'), node?.Guid })
+        .ToList();
+
+      var viewpointMatch = flattenedViewpointList
+        .FirstOrDefault(node =>
+          node.Guid.ToString() == savedViewReference ||
+          node.Reference?.Length == 2 && node.Reference[1] == savedViewReference);
+
+      return viewpointMatch == null
+        ? null
+        // Resolve the SavedViewpoint
+        : ResolveSavedViewpoint(viewpointMatch, savedViewReference);
+    }
+
+    private static SavedViewpoint ResolveSavedViewpoint(dynamic viewpointMatch, string savedViewReference)
+    {
+      if (Guid.TryParse(savedViewReference, out var guid))
+      {
+        // Even though we may have already got a match, that could be to a generic Guid from earlier versions of Navisworks
+        if (savedViewReference != new Guid().ToString()) return (SavedViewpoint)Doc.SavedViewpoints.ResolveGuid(guid);
+      }
+
+      if (!(viewpointMatch?.Reference is string[] reference) || reference.Length != 2)
+      {
+        return null;
+      }
+
+      return (SavedViewpoint)Doc.ResolveReference(new SavedItemReference(reference[0], reference[1]));
+    }
+
 
     private static IEnumerable<string> GetObjectsFromSelection(ISelectionFilter filter)
     {

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -239,8 +239,11 @@ namespace Speckle.ConnectorNavisworks.Bindings
       {
         progressBar.Cancel();
         Application.EndProgress();
+
+
         progress.Report.LogOperationError(
           new SpeckleException("Zero objects converted successfully. Send stopped.", false));
+
         return null;
       }
 
@@ -251,7 +254,7 @@ namespace Speckle.ConnectorNavisworks.Bindings
       NavisworksConverter.SetConverterSettings(new Dictionary<string, string> { { "_Mode", "views" } });
       if (state.Filter?.Slug == "views")
       {
-        var selectedViews = state.Filter.Selection.Select(Convert).Where(c => c != null);
+        var selectedViews = state.Filter.Selection.Select(Convert).Where(c => c != null).ToList();
         views.AddRange(selectedViews);
       }
       else if (CurrentSettings.Find(x => x.Slug == "current-view") is CheckBoxSetting checkBox && checkBox.IsChecked)

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -257,7 +257,8 @@ namespace Speckle.ConnectorNavisworks.Bindings
         var selectedViews = state.Filter.Selection.Select(Convert).Where(c => c != null).ToList();
         views.AddRange(selectedViews);
       }
-      else if (CurrentSettings.Find(x => x.Slug == "current-view") is CheckBoxSetting checkBox && checkBox.IsChecked)
+
+      if (CurrentSettings.Find(x => x.Slug == "current-view") is CheckBoxSetting checkBox && checkBox.IsChecked)
       {
         views.Add(Convert(Doc.CurrentViewpoint.ToViewpoint()));
       }

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.cs
@@ -13,7 +13,7 @@ namespace Speckle.ConnectorNavisworks.Bindings
   {
     // Much of the interaction in Navisworks is through the ActiveDocument API
     public static Document Doc;
-    public Control Control;
+    public static Control Control;
     public ISpeckleKit DefaultKit;
     public ISpeckleConverter NavisworksConverter;
 

--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToSpeckle.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToSpeckle.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Navisworks.Api;
@@ -57,8 +57,8 @@ namespace Objects.Converter.Navisworks
         {
           switch (@object)
           {
-            case string reference:
-              @base = ViewpointToBase(ReferenceToSavedViewpoint(reference));
+            case string referenceOrGuid:
+              @base = ViewpointToBase(ReferenceOrGuidToSavedViewpoint(referenceOrGuid));
               break;
             case Viewpoint item:
               @base = ViewpointToBase(item);
@@ -94,15 +94,23 @@ namespace Objects.Converter.Navisworks
       return CanConvertToSpeckle(item);
     }
 
-    private SavedViewpoint ReferenceToSavedViewpoint(string referenceId)
+    private static SavedViewpoint ReferenceOrGuidToSavedViewpoint(string referenceOrGuid)
     {
-      var reference = referenceId.Split(':');
+      SavedViewpoint savedViewpoint;
 
-      var savedItemReference = Doc.ResolveReference(new SavedItemReference(reference[0], reference[1]));
+      if (Guid.TryParse(referenceOrGuid, out var guid))
+      {
+        savedViewpoint = (SavedViewpoint)Doc.SavedViewpoints.ResolveGuid(guid);
+      }
+      else
+      {
+        var parts = referenceOrGuid.Split(':');
+        savedViewpoint = (parts.Length != 2)
+          ? null
+          : (SavedViewpoint)Doc.ResolveReference(new SavedItemReference(parts[0], parts[1]));
+      }
 
-      if (savedItemReference != null) return (SavedViewpoint)savedItemReference;
-
-      return null;
+      return savedViewpoint;
     }
 
     public static Point ToPoint(InwLPos3f v)

--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Autodesk.Navisworks.Api;


### PR DESCRIPTION
## Description & motivation

This fixes #2231. The error was caused by differing implementations of the SavedItem class with different versions of Navisworks.

The original code assumed that the reference object was always sent as a string where the context of the reference and the member were separated with a ':'.

The reconstruction of the selected objects was failing when it was assumed this would always be the case. Instead the `string.Split` would return a single item array instead of the two parts. 

This fix also includes an alternative of resolving the selected Saved Viewpoint by Guid. This also has different implementations across versions. Prior to Navisworks 2022, a GUID was produced when saving a Viewpoint, but it was always the default Guid i.e. `00000-00000-00000-00000`, as such rendering it useless as a lookup.

## Changes:

The changes to defensively handle the differences between versions made this a bigger fix than anticipated.

ConnectorNavisworksBindings.Filters:
- feature detection on the host application will use a Guid as the reference if it is not a default Guid. This is the ideal as Guids persist even when the ordering or naming changes.
- The fallback to the View Name is resilient to order changes but will break if the naming changes. This will be used as a reference if no good Guid is present.
- The optional fallback of the path index in the tree of saved viewpoints is rejected as, unlike the ModelItems, where this is used as a pseudoId, and the ordering is static, Viewpoints can be reorganised much more frequently

ConnectorNavisworksBindings.Objects:
- An extensive rewrite of the GetObjectsFromSavedViewpoint method, which now handles the validity of save reference before handing to ResolveSavedViewpoint, which uses feature testing rather than version testing as branching code.
- Includes more robust handling of nulls resulting from the conversions of references to viewpoints
- No changes to retrieval of objects from the saved viewpoint

ConnectorNavisworksBindings.Send:
- Now sends the commit view alongside the saved view if the advanced setting option is checked.

ConverterNavisworks.ToSpeckle:
- Handles the two ways a viewpoint is referenced when converting the Viewpoint object itself.

## To-do before merge:

- [x] Ensure PR #XX change to DUI is merged

## Screenshots:



## Validation of changes:

Manual testing with multiple versions.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.