### PR TITLE
fix(Navisworks): Changes hidden self and ancestor logic. Fixes #2051

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
@@ -54,7 +54,7 @@ namespace Speckle.ConnectorNavisworks.Bindings
     private static bool IsElementVisible(ModelItem element)
     {
       // Hidden status is stored at the earliest node in the hierarchy
-      return element.AncestorsAndSelf.All(x => x.IsHidden != true);
+      return element.AncestorsAndSelf.Any(x => x.IsHidden != true);
     }
   }
 }


### PR DESCRIPTION
## Changes:

Previous logic was presuming that elements are hidden when all their ancestors in the tree are hidden. This was incorrect as Navisworks sets the hidden logic on the node closest to root that encompasses all children due to be hidden rather than propagating hidden status to all children.

Unhiding an element will clear the hidden status of ancestors and then the tree will reprocess to hide sibling nodes but leave children unaffected.

The change was a shift from `.All` to `.Any` in the `element.AncestorsAndSelf.Any(x => x.IsHidden != true);` check.