### PR TITLE
Fix(revit): scale analytical properties when sending to speckle

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
@@ -369,78 +369,81 @@ namespace Objects.Converter.Revit
 
       var speckleSection = new SectionProfile();
 
+      var scaleFactor = ScaleToSpeckle(1);
+      var scaleFactor2 = scaleFactor * scaleFactor;
+
       switch (revitSection)
       {
         case StructuralSectionGeneralI o: // General Double T shape
           var ISection = new ISection();
           ISection.shapeType = Structural.ShapeType.I;
-          ISection.depth = o.Height;
-          ISection.width = o.Width;
-          ISection.webThickness = o.WebThickness;
-          ISection.flangeThickness = o.FlangeThickness;
+          ISection.depth = o.Height * scaleFactor;
+          ISection.width = o.Width * scaleFactor;
+          ISection.webThickness = o.WebThickness * scaleFactor;
+          ISection.flangeThickness = o.FlangeThickness * scaleFactor;
          
           speckleSection = ISection;
           break;
         case StructuralSectionGeneralT o: // General Tee shape
           var teeSection = new Tee();
           teeSection.shapeType = Structural.ShapeType.Tee;
-          teeSection.depth = o.Height;
-          teeSection.width = o.Width;
-          teeSection.webThickness = o.WebThickness;
-          teeSection.flangeThickness = o.FlangeThickness;
+          teeSection.depth = o.Height * scaleFactor;
+          teeSection.width = o.Width * scaleFactor;
+          teeSection.webThickness = o.WebThickness * scaleFactor;
+          teeSection.flangeThickness = o.FlangeThickness * scaleFactor;
 
           speckleSection = teeSection;
           break;
         case StructuralSectionGeneralH o: // Rectangular Pipe structural sections
           var rectSection = new Rectangular();
           rectSection.shapeType = Structural.ShapeType.I;
-          rectSection.depth = o.Height;
-          rectSection.width = o.Width;
-          rectSection.webThickness = o.WallNominalThickness;
-          rectSection.flangeThickness = o.WallNominalThickness;
+          rectSection.depth = o.Height * scaleFactor;
+          rectSection.width = o.Width * scaleFactor;
+          rectSection.webThickness = o.WallNominalThickness * scaleFactor;
+          rectSection.flangeThickness = o.WallNominalThickness * scaleFactor;
 
           speckleSection = rectSection;
           break;
         case StructuralSectionGeneralR o: // Pipe structural sections
           var circSection = new Circular();
           circSection.shapeType = Structural.ShapeType.Circular;
-          circSection.radius = o.Diameter / 2;
-          circSection.wallThickness = o.WallNominalThickness;
+          circSection.radius = o.Diameter / 2 * scaleFactor;
+          circSection.wallThickness = o.WallNominalThickness * scaleFactor;
 
           speckleSection = circSection;
           break;
         case StructuralSectionGeneralF o: // Flat Bar structural sections
           var flatRectSection = new Rectangular();
           flatRectSection.shapeType = Structural.ShapeType.I;
-          flatRectSection.depth = o.Height;
-          flatRectSection.width = o.Width;
+          flatRectSection.depth = o.Height * scaleFactor;
+          flatRectSection.width = o.Width * scaleFactor;
 
           speckleSection = flatRectSection;
           break;
         case StructuralSectionGeneralS o: // Round Bar structural sections
           var flatCircSection = new Circular();
           flatCircSection.shapeType = Structural.ShapeType.Circular;
-          flatCircSection.radius = o.Diameter / 2;
+          flatCircSection.radius = o.Diameter / 2 * scaleFactor;
 
           speckleSection = flatCircSection;
           break;
         case StructuralSectionGeneralW o: // Angle structural sections
           var angleSection = new Angle();
           angleSection.shapeType = Structural.ShapeType.Angle;
-          angleSection.depth = o.Height;
-          angleSection.width = o.Width;
-          angleSection.webThickness = o.WebThickness;
-          angleSection.flangeThickness = o.FlangeThickness;
+          angleSection.depth = o.Height * scaleFactor;
+          angleSection.width = o.Width * scaleFactor;
+          angleSection.webThickness = o.WebThickness * scaleFactor;
+          angleSection.flangeThickness = o.FlangeThickness * scaleFactor;
 
           speckleSection = angleSection;
           break;
         case StructuralSectionGeneralU o: // Channel  structural sections
           var channelSection = new Channel();
           channelSection.shapeType = Structural.ShapeType.Channel;
-          channelSection.depth = o.Height;
-          channelSection.width = o.Width;
-          channelSection.webThickness = o.WebThickness;
-          channelSection.flangeThickness = o.FlangeThickness;
+          channelSection.depth = o.Height * scaleFactor;
+          channelSection.width = o.Width * scaleFactor;
+          channelSection.webThickness = o.WebThickness * scaleFactor;
+          channelSection.flangeThickness = o.FlangeThickness * scaleFactor;
 
           speckleSection = channelSection;
           break;
@@ -448,11 +451,11 @@ namespace Objects.Converter.Revit
 
       speckleSection.units = ModelUnits;
       speckleSection.name = familySymbol.Name;
-      speckleSection.area = revitSection.SectionArea;
-      speckleSection.weight = revitSection.NominalWeight;
-      speckleSection.Izz = revitSection.MomentOfInertiaWeakAxis;
-      speckleSection.Iyy = revitSection.MomentOfInertiaStrongAxis;
-      speckleSection.J = revitSection.TorsionalMomentOfInertia;
+      speckleSection.area = revitSection.SectionArea * scaleFactor2;
+      speckleSection.weight = revitSection.NominalWeight * scaleFactor;
+      speckleSection.Izz = revitSection.MomentOfInertiaWeakAxis * scaleFactor2;
+      speckleSection.Iyy = revitSection.MomentOfInertiaStrongAxis * scaleFactor2;
+      speckleSection.J = revitSection.TorsionalMomentOfInertia * scaleFactor2 * scaleFactor2;
 
       return speckleSection;
     }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Analytical section properties are being sent to speckle using Revit internal units (feet). Scale to speckle before assigning these values.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- compute scale factor and then multiply required values by scale factor. Previous experiences profiling with Jedd has shown that computing the scale factor once and then multiplying it to values is much more performant than calling scaleToNative every time.

<!---

- Item 1
- Item 2

-->

## Screenshots:

From Revit
![image](https://user-images.githubusercontent.com/43247197/222989054-dd061b20-7b9a-4660-b6ae-6de4ef73e56f.png)

Before this PR
![image](https://user-images.githubusercontent.com/43247197/222989072-a60cb7ac-1cbb-4fb2-ba95-7e37bf1a2a23.png)

After this PR
![image](https://user-images.githubusercontent.com/43247197/222989086-aa1cd5e1-ebc2-4c85-b43f-238fd19ea586.png)


<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

See above screenshots. The types now send the correct sizes to Speckle

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References
Issue reported on forum when receiving to ETABS https://speckle.community/t/etabs-20-3-and-revit-2022-interoperability-issue/5065/4

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
