### PR TITLE
fix(core): ignore abstract types in `Base.speckle_type` serialization

### DIFF
--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -283,7 +283,10 @@ namespace Speckle.Core.Models
 
           while (myType.Name != nameof(Base))
           {
-            bases.Add(myType.FullName);
+            if (!myType.IsAbstract)
+            {
+              bases.Add(myType.FullName);
+            }
             myType = myType.BaseType;
           }
 


### PR DESCRIPTION
## Description & motivation
Removes abstract types from speckle type serialization in `Base`.
Closes #2249

## Changes:

Core/Models/Base

## Screenshots:
Before:
![image](https://user-images.githubusercontent.com/16748799/223457855-b73e1433-e453-4144-8162-4d2653dd4859.png)

After:
![image](https://user-images.githubusercontent.com/16748799/223458193-2e2cc1cb-b762-451d-aa6d-ce84b802fbfd.png)


## Validation of changes:

Sent and received block instances
