### PR TITLE
feat(gh): Adds AdvanceSteel schema nodes

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
@@ -331,7 +331,9 @@ namespace ConnectorGrasshopper
         "Structural",
         "GSA",
         "Tekla",
-        "CSI"
+        "CSI",
+        "Archicad",
+        "Advance Steel"
       }.ForEach(s =>
       {
         var category = $"Speckle 2 {s}";

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/SchemaBuilderGen.cs
@@ -23,15 +23,78 @@ public class AdaptiveComponentSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("71420d27-62d1-f158-edab-a89e54604d76");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.AdaptiveComponent.ctor(System.String,System.String,System.Collections.Generic.List`1[Objects.Geometry.Point],System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.AdaptiveComponent");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class AdvanceSteelBeamSchemaComponent: CreateSchemaObjectBase {
+    static AdvanceSteelBeamSchemaComponent() {
+       SpeckleGHSettings.SettingsChanged += (_, args) =>
+          {
+            if (!args.Key.StartsWith("Speckle2:tabs.")) return;
+            var proxy = Grasshopper.Instances.ComponentServer.ObjectProxies.FirstOrDefault(p => p.Guid == internalGuid);
+            if (proxy == null) return;
+            proxy.Exposure = internalExposure;
+          };
+    }
+    public AdvanceSteelBeamSchemaComponent(): base("AdvanceSteelBeam", "AdvanceSteelBeam", "Creates a Advance Steel beam by curve.", "Speckle 2 Advance Steel", "Structure") { }
+    
+    internal static string internalCategory { get; }  = "Speckle 2 Advance Steel";
+
+    internal static Guid internalGuid => new Guid("bc7e258d-7e41-97cf-86d4-59bf3312ea52");
+
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
+    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
+      ? GH_Exposure.tertiary
+      : GH_Exposure.hidden;
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.AdvanceSteel.AdvanceSteelBeam.ctor(Objects.ICurve,Objects.Structural.Properties.Profiles.SectionProfile,Objects.Structural.Materials.StructuralMaterial)","Objects.BuiltElements.AdvanceSteel.AdvanceSteelBeam");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class AdvanceSteelPlateSchemaComponent: CreateSchemaObjectBase {
+    static AdvanceSteelPlateSchemaComponent() {
+       SpeckleGHSettings.SettingsChanged += (_, args) =>
+          {
+            if (!args.Key.StartsWith("Speckle2:tabs.")) return;
+            var proxy = Grasshopper.Instances.ComponentServer.ObjectProxies.FirstOrDefault(p => p.Guid == internalGuid);
+            if (proxy == null) return;
+            proxy.Exposure = internalExposure;
+          };
+    }
+    public AdvanceSteelPlateSchemaComponent(): base("AdvanceSteelPlate", "AdvanceSteelPlate", "Creates a Advance Steel plate.", "Speckle 2 Advance Steel", "Structure") { }
+    
+    internal static string internalCategory { get; }  = "Speckle 2 Advance Steel";
+
+    internal static Guid internalGuid => new Guid("6cf1d0a8-d647-1ccc-f5b5-51e2f185eaee");
+
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
+    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
+      ? GH_Exposure.tertiary
+      : GH_Exposure.hidden;
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.AdvanceSteel.AdvanceSteelPlate.ctor(Objects.Structural.Properties.Profiles.SectionProfile,Objects.Geometry.Polyline,System.String,Objects.Structural.Materials.StructuralMaterial)","Objects.BuiltElements.AdvanceSteel.AdvanceSteelPlate");
         base.AddedToDocument(document);
     }
 }
@@ -53,12 +116,13 @@ public class AngleSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("91df837b-3162-a0de-724d-ea182e77e68c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Angle.ctor(System.String,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.Profiles.Angle");
@@ -83,12 +147,13 @@ public class ArchicadBeamSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("73860182-c94b-d570-f568-1ab73eec8bfd");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Archicad.ArchicadBeam.ctor(Objects.Geometry.Point,Objects.Geometry.Point)","Objects.BuiltElements.Archicad.ArchicadBeam");
@@ -113,12 +178,13 @@ public class ArchicadColumnSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c69190c1-3311-5407-4a00-e58ea275fa89");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Archicad.ArchicadColumn.ctor(Objects.Geometry.Point,System.Double)","Objects.BuiltElements.Archicad.ArchicadColumn");
@@ -143,12 +209,13 @@ public class AreaSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b98bd134-1ebd-b805-821c-465f1a25fb4e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Area.ctor(System.String,System.String,Objects.BuiltElements.Level,Objects.Geometry.Point)","Objects.BuiltElements.Area");
@@ -173,12 +240,13 @@ public class AxisSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("38fdc896-0404-4961-120f-6e373d19edbc");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Axis.ctor(System.String,Objects.Structural.AxisType,Objects.Geometry.Plane)","Objects.Structural.Geometry.Axis");
@@ -203,12 +271,13 @@ public class BeamSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("5c0a392e-bc1c-cf28-0048-a99ee090ffa1");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Beam.ctor(Objects.ICurve)","Objects.BuiltElements.Beam");
@@ -233,12 +302,13 @@ public class BlockDefinitionSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("91f1164e-b519-d72f-d64b-e68bb14836e3");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.BlockDefinition.ctor(System.String,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Geometry.Point)","Objects.Other.BlockDefinition");
@@ -263,12 +333,13 @@ public class BlockInstanceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("28238ece-f2e0-fe7d-e25f-e8f8cb35e629");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.BlockInstance.ctor(Objects.Other.BlockDefinition,Objects.Other.Transform)","Objects.Other.BlockInstance");
@@ -293,12 +364,13 @@ public class BraceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("cf5f1dad-80cd-d499-2ef7-6ae1f8d34a5c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Brace.ctor(Objects.ICurve)","Objects.BuiltElements.Brace");
@@ -323,12 +395,13 @@ public class CatalogueSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7e0f97be-7297-64f8-fc85-f43623186129");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Catalogue.ctor(System.String)","Objects.Structural.Properties.Profiles.Catalogue");
@@ -353,12 +426,13 @@ public class Catalogue1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("1b5a50a5-4b3d-1018-8e3f-bb34ad0af7ff");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Catalogue.ctor(System.String,System.String,System.String,System.String)","Objects.Structural.Properties.Profiles.Catalogue");
@@ -383,12 +457,13 @@ public class CeilingSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("91b38d18-dd01-dfc7-f11d-e3d2c118ff0b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Ceiling.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.BuiltElements.Ceiling");
@@ -413,12 +488,13 @@ public class ChannelSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("40336db1-decb-2ad6-6680-01c457f0f31d");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Channel.ctor(System.String,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.Profiles.Channel");
@@ -443,12 +519,13 @@ public class CircularSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("fbf190e3-c085-dfc9-3b49-bcda58ab931f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Circular.ctor(System.String,System.Double,System.Double)","Objects.Structural.Properties.Profiles.Circular");
@@ -473,12 +550,13 @@ public class ColumnSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("d92fc447-81b6-e595-1905-6239ea13a49b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Column.ctor(Objects.ICurve)","Objects.BuiltElements.Column");
@@ -503,12 +581,13 @@ public class ConcreteSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("104f1e8d-a551-bb84-e671-3394bc6a4c2b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Materials.Concrete.ctor(System.String,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Boolean,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Materials.Concrete");
@@ -533,12 +612,13 @@ public class CSIAreaSpringSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f1b019ec-dac8-2669-a790-818aabd77c81");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIAreaSpring.ctor(System.String,System.Double,System.Double,System.Double,Objects.Structural.CSI.Properties.NonLinearOptions,System.String)","Objects.Structural.CSI.Properties.CSIAreaSpring");
@@ -563,12 +643,13 @@ public class CSIDiaphragmSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("97f96eaa-f4f3-ef29-0de3-63829f163dc1");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIDiaphragm.ctor(System.String,System.Boolean)","Objects.Structural.CSI.Properties.CSIDiaphragm");
@@ -593,12 +674,13 @@ public class CSIElement1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b19522f8-4264-ce56-3cc7-ec2132ece2e1");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Geometry.CSIElement1D.ctor(Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,System.String,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Geometry.Plane,Objects.Structural.CSI.Properties.CSILinearSpring,System.Double[],Objects.Structural.CSI.Properties.DesignProcedure)","Objects.Structural.CSI.Geometry.CSIElement1D");
@@ -623,12 +705,13 @@ public class CSIElement1D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("95254c64-1e71-0902-06a1-206b2f17b844");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Geometry.CSIElement1D.ctor(Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,System.String,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Structural.Geometry.Node,System.Double,Objects.Structural.CSI.Properties.CSILinearSpring,System.Double[],Objects.Structural.CSI.Properties.DesignProcedure)","Objects.Structural.CSI.Geometry.CSIElement1D");
@@ -653,12 +736,13 @@ public class CSIElement2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("33c58e3c-d8cb-86ca-b494-ee5c69ec7b14");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Geometry.CSIElement2D.ctor(System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Objects.Structural.Properties.Property2D,System.Double,System.Double,System.Double[],Objects.Structural.CSI.Properties.CSIAreaSpring,Objects.Structural.CSI.Properties.CSIDiaphragm)","Objects.Structural.CSI.Geometry.CSIElement2D");
@@ -683,12 +767,13 @@ public class CSILinearSpringSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a81ebbcb-78a6-9f21-5212-09701d89fa5d");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSILinearSpring.ctor(System.String,System.Double,System.Double,System.Double,System.Double,Objects.Structural.CSI.Properties.NonLinearOptions,Objects.Structural.CSI.Properties.NonLinearOptions,System.String)","Objects.Structural.CSI.Properties.CSILinearSpring");
@@ -713,12 +798,13 @@ public class CSILinkPropertySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("0d7960c0-ddc2-fa77-3b52-fd4d1587af32");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSILinkProperty.ctor(System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.CSI.Properties.CSILinkProperty");
@@ -743,12 +829,13 @@ public class CSINodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("2c39977e-f47f-3202-c778-ac46b8462fea");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Geometry.CSINode.ctor(Objects.Geometry.Point,System.String,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Axis,Objects.Structural.CSI.Properties.CSISpringProperty,Objects.Structural.Properties.PropertyMass,Objects.Structural.Properties.PropertyDamper,Objects.Structural.CSI.Properties.CSIDiaphragm,Objects.Structural.CSI.Properties.DiaphragmOption)","Objects.Structural.CSI.Geometry.CSINode");
@@ -773,12 +860,13 @@ public class CSIOpeningSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e6405aac-40ff-97c5-66d7-be3586eebbdd");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIOpening.ctor(System.Boolean)","Objects.Structural.CSI.Properties.CSIOpening");
@@ -803,12 +891,13 @@ public class CSISpringPropertySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("efa38436-affe-3ba9-2413-743fe26eb9f7");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSISpringProperty.ctor(System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.CSI.Properties.CSISpringProperty");
@@ -833,12 +922,13 @@ public class CSISpringProperty1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("9b2854b3-f8bc-b8e6-fd86-aa5c55051759");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSISpringProperty.ctor(System.String,System.String,System.String,System.Double)","Objects.Structural.CSI.Properties.CSISpringProperty");
@@ -863,12 +953,13 @@ public class DeckFilledSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("151a2166-f739-501f-d3bc-f1a24bdd4093");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIProperty2D+DeckFilled.ctor(System.String,Objects.Structural.CSI.Analysis.ShellType,Objects.Structural.Materials.StructuralMaterial,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.CSI.Properties.CSIProperty2D+DeckFilled");
@@ -893,12 +984,13 @@ public class DeckSlabSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b8102cde-4ea3-0583-9580-4a9530154440");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIProperty2D+DeckSlab.ctor(System.String,Objects.Structural.CSI.Analysis.ShellType,Objects.Structural.Materials.StructuralMaterial,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.CSI.Properties.CSIProperty2D+DeckSlab");
@@ -923,12 +1015,13 @@ public class DeckUnFilledSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("680e6f0c-d140-e8c4-27e1-28d353a87b8f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIProperty2D+DeckUnFilled.ctor(System.String,Objects.Structural.CSI.Analysis.ShellType,Objects.Structural.Materials.StructuralMaterial,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.CSI.Properties.CSIProperty2D+DeckUnFilled");
@@ -953,12 +1046,13 @@ public class DetailCurveSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("4752d321-22cc-2d9e-dc6d-e3cf8e70c612");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.DetailCurve.ctor(Objects.ICurve,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.DetailCurve");
@@ -983,12 +1077,13 @@ public class DirectShapeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("870d9670-cbf5-06d2-f371-e1e49212b063");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.DirectShape.ctor(System.String,Objects.BuiltElements.Revit.RevitCategory,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.DirectShape");
@@ -1013,13 +1108,12 @@ public class DuctSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("51d40791-43ea-a8e7-ef13-e9bfdf9cd893");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Duct.ctor(Objects.Geometry.Line,System.Double,System.Double,System.Double,System.Double)","Objects.BuiltElements.Duct");
@@ -1044,12 +1138,13 @@ public class Duct1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7e3a3fba-7d4f-d549-96c0-41693b512db0");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Duct.ctor(Objects.ICurve,System.Double,System.Double,System.Double,System.Double)","Objects.BuiltElements.Duct");
@@ -1074,12 +1169,13 @@ public class Element1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("9fffb53b-3465-7a5b-4839-91cfdcb86f63");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Element1D.ctor(Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,System.String,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Geometry.Plane)","Objects.Structural.Geometry.Element1D");
@@ -1104,12 +1200,13 @@ public class Element1D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6cb2d683-3116-0246-18b0-1bd35ed8fcc6");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Element1D.ctor(Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,System.String,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Structural.Geometry.Node,System.Double)","Objects.Structural.Geometry.Element1D");
@@ -1134,12 +1231,13 @@ public class Element2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("0927879c-d28c-1c35-0d3f-4ba8e324ec39");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Element2D.ctor(System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Objects.Structural.Properties.Property2D,System.Double,System.Double)","Objects.Structural.Geometry.Element2D");
@@ -1164,12 +1262,13 @@ public class Element3DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("54b79bd6-7a50-2107-afd5-f9b18346f8ea");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Element3D.ctor(Objects.Geometry.Mesh,Objects.Structural.Properties.Property3D,Objects.Structural.Geometry.ElementType3D,System.String,System.Double)","Objects.Structural.Geometry.Element3D");
@@ -1194,12 +1293,13 @@ public class ExplicitSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e15a7edd-4559-0bb6-3559-48b72c43da2e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Explicit.ctor(System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.Profiles.Explicit");
@@ -1224,12 +1324,13 @@ public class FamilyInstanceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("266c4d84-3f2a-9129-565b-0ddb1e5bdac4");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FamilyInstance.ctor(Objects.Geometry.Point,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FamilyInstance");
@@ -1254,12 +1355,13 @@ public class FloorSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("74c5b6bf-257e-8d4e-d9cb-7dc2c7ae3f22");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Floor.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.BuiltElements.Floor");
@@ -1284,12 +1386,13 @@ public class FreeformElementSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b24dc861-1c3c-a509-bc8b-560e9f7d503e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FreeformElement");
@@ -1314,13 +1417,12 @@ public class FreeformElement1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("d1bb3f50-6abc-9f34-acf3-297e82bbd8ac");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(Speckle.Core.Models.Base,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FreeformElement");
@@ -1345,13 +1447,12 @@ public class FreeformElement2SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("d1a2299d-b8b0-ce4a-6a52-8b8ad95acbfd");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.FreeformElement.ctor(System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.FreeformElement");
@@ -1376,13 +1477,12 @@ public class GridLineSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b2d4bd71-86a7-c142-7220-d9ed2ee7b02e");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.GridLine.ctor(Objects.ICurve)","Objects.BuiltElements.GridLine");
@@ -1407,12 +1507,13 @@ public class GridLine1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("436f3773-b3f9-1a35-684e-a75f25f6c3bd");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.GridLine.ctor(Objects.ICurve,System.String)","Objects.BuiltElements.GridLine");
@@ -1437,12 +1538,13 @@ public class GSAAlignmentSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("fc274806-efb5-c3b2-9c1d-bc9a6aba1a34");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Bridge.GSAAlignment.ctor(System.Int32,System.String,Objects.Structural.GSA.Geometry.GSAGridSurface,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double])","Objects.Structural.GSA.Bridge.GSAAlignment");
@@ -1467,12 +1569,13 @@ public class GSAAnalysisCaseSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("4bfc261f-98eb-7b2a-5da6-f2ef3505b9b7");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Analysis.GSAAnalysisCase.ctor(System.Int32,System.String,Objects.Structural.GSA.Analysis.GSATask,System.Collections.Generic.List`1[Objects.Structural.Loading.LoadCase],System.Collections.Generic.List`1[System.Double])","Objects.Structural.GSA.Analysis.GSAAnalysisCase");
@@ -1497,12 +1600,13 @@ public class GSAAssemblySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("9b2c7be3-5172-7660-659a-e39253688363");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAAssembly.ctor(System.Int32,System.String,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.GSA.Geometry.GSANode,Objects.Structural.GSA.Geometry.GSANode,Objects.Structural.GSA.Geometry.GSANode,System.Double,System.Double,System.String,System.Int32,System.String,System.Collections.Generic.List`1[System.Double])","Objects.Structural.GSA.Geometry.GSAAssembly");
@@ -1527,12 +1631,13 @@ public class GSAConcreteSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a86c1d31-6807-f465-c51c-24d5d7a5a728");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Materials.GSAConcrete.ctor(System.Int32,System.String,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Boolean,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.String)","Objects.Structural.GSA.Materials.GSAConcrete");
@@ -1557,12 +1662,13 @@ public class GSAElement1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("8b41c9e5-f24b-f0bc-7b62-169f839883ec");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAElement1D.ctor(System.Int32,Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Geometry.Plane)","Objects.Structural.GSA.Geometry.GSAElement1D");
@@ -1587,12 +1693,13 @@ public class GSAElement1D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("d3ff71ed-34b8-6f9b-7ebc-50ff8195d1b2");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAElement1D.ctor(System.Int32,Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Structural.Geometry.Node,System.Double)","Objects.Structural.GSA.Geometry.GSAElement1D");
@@ -1617,12 +1724,13 @@ public class GSAElement2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("9a1c5132-a785-c389-fe5f-441820f07446");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAElement2D.ctor(System.Int32,System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Objects.Structural.Properties.Property2D,Objects.Structural.Geometry.ElementType2D,System.String,System.Double,System.Double,System.Int32,System.String,System.Boolean)","Objects.Structural.GSA.Geometry.GSAElement2D");
@@ -1647,12 +1755,13 @@ public class GSAElement3DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3fb3f410-62f0-f972-de47-4e55d8aee0b6");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAElement3D.ctor(System.Int32,Objects.Geometry.Mesh,Objects.Structural.Properties.Property3D,Objects.Structural.Geometry.ElementType3D,System.String,System.Double,System.Int32,System.String,System.Boolean)","Objects.Structural.GSA.Geometry.GSAElement3D");
@@ -1677,12 +1786,13 @@ public class GSAGeneralisedRestraintSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e3b018a2-2196-d3aa-a66a-3248343143aa");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAGeneralisedRestraint.ctor(System.Int32,System.String,Objects.Structural.Geometry.Restraint,System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],System.Collections.Generic.List`1[Objects.Structural.GSA.Analysis.GSAStage])","Objects.Structural.GSA.Geometry.GSAGeneralisedRestraint");
@@ -1707,12 +1817,13 @@ public class GSAGridLineSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("1fdfd333-8214-4f28-1835-7609247412ac");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAGridLine.ctor(System.Int32,System.String,Objects.ICurve)","Objects.Structural.GSA.Geometry.GSAGridLine");
@@ -1737,12 +1848,13 @@ public class GSAGridPlaneSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f7db7fc7-c05e-c257-c11c-7d3a3e7ecdfc");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAGridPlane.ctor(System.Int32,System.String,Objects.Structural.Geometry.Axis,System.Double)","Objects.Structural.GSA.Geometry.GSAGridPlane");
@@ -1767,12 +1879,13 @@ public class GSAGridSurfaceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("868d0f73-da31-e362-f5c5-c2e5a98f0f46");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAGridSurface.ctor(System.String,System.Int32,Objects.Structural.GSA.Geometry.GSAGridPlane,System.Double,System.Double,Objects.Structural.GSA.Geometry.LoadExpansion,Objects.Structural.GSA.Geometry.GridSurfaceSpanType,System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.Structural.GSA.Geometry.GSAGridSurface");
@@ -1797,12 +1910,13 @@ public class GSAInfluenceBeamSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("8844e443-368c-0b7d-89d8-fc563aa7a56d");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Bridge.GSAInfluenceBeam.ctor(System.Int32,System.String,System.Double,Objects.Structural.GSA.Bridge.InfluenceType,Objects.Structural.Loading.LoadDirection,Objects.Structural.GSA.Geometry.GSAElement1D,System.Double)","Objects.Structural.GSA.Bridge.GSAInfluenceBeam");
@@ -1827,12 +1941,13 @@ public class GSAInfluenceNodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("61efde90-bb48-abf4-e69a-87376cab33bd");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Bridge.GSAInfluenceNode.ctor(System.Int32,System.String,System.Double,Objects.Structural.GSA.Bridge.InfluenceType,Objects.Structural.Loading.LoadDirection,Objects.Structural.Geometry.Node,Objects.Structural.Geometry.Axis)","Objects.Structural.GSA.Bridge.GSAInfluenceNode");
@@ -1857,12 +1972,13 @@ public class GSALoadBeamSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("eb5a5098-d189-58ab-d032-60dfdd6e5495");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadBeam.ctor(System.Int32,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.Loading.BeamLoadType,Objects.Structural.Loading.LoadDirection,Objects.Structural.LoadAxisType,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Boolean)","Objects.Structural.GSA.Loading.GSALoadBeam");
@@ -1887,12 +2003,13 @@ public class GSALoadBeam1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("29927efe-6612-a3f7-a0c7-49ef97bea3ae");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadBeam.ctor(System.Int32,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.Loading.BeamLoadType,Objects.Structural.Loading.LoadDirection,Objects.Structural.Geometry.Axis,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Boolean)","Objects.Structural.GSA.Loading.GSALoadBeam");
@@ -1917,12 +2034,13 @@ public class GSALoadCaseSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3d862f90-6804-d75c-a0e2-8e90c9b190db");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadCase.ctor(System.Int32,System.String,Objects.Structural.Loading.LoadType,Objects.Structural.Loading.LoadDirection2D,System.String,Objects.Structural.Loading.ActionType,System.String,System.String,System.Boolean)","Objects.Structural.GSA.Loading.GSALoadCase");
@@ -1947,12 +2065,13 @@ public class GSALoadCombinationSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a79c8825-221a-d44f-5faa-b257f3f6c98e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadCombination.ctor(System.Int32,System.String,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[System.Double])","Objects.Structural.GSA.Loading.GSALoadCombination");
@@ -1977,12 +2096,13 @@ public class GSALoadFaceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("abc889bd-7235-5b08-9f91-124a4dd94c7a");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadFace.ctor(System.Int32,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.Loading.FaceLoadType,Objects.Structural.Loading.LoadDirection2D,Objects.Structural.LoadAxisType,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Boolean)","Objects.Structural.GSA.Loading.GSALoadFace");
@@ -2007,12 +2127,13 @@ public class GSALoadGravitySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a49dd14b-f073-b628-f175-030c5cee8d3b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadGravity.ctor(System.Int32,System.String,Objects.Structural.Loading.LoadCase,Objects.Geometry.Vector)","Objects.Structural.GSA.Loading.GSALoadGravity");
@@ -2037,12 +2158,13 @@ public class GSALoadGravity1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6b27dc40-c384-1058-d7ab-eaf6bcd19587");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadGravity.ctor(System.Int32,System.String,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Geometry.Vector)","Objects.Structural.GSA.Loading.GSALoadGravity");
@@ -2067,12 +2189,13 @@ public class GSALoadGravity2SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("05096aa4-f73a-01d0-5613-1184349cb0ea");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadGravity.ctor(System.Int32,System.String,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Geometry.Vector,System.String)","Objects.Structural.GSA.Loading.GSALoadGravity");
@@ -2097,12 +2220,13 @@ public class GSALoadNodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("8a591a6c-207c-f42a-d2f4-596594a536a7");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadNode.ctor(System.Int32,System.String,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Objects.Structural.GSA.Geometry.GSANode],Objects.Structural.Loading.LoadDirection,System.Double)","Objects.Structural.GSA.Loading.GSALoadNode");
@@ -2127,12 +2251,13 @@ public class GSALoadNode1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("d641ad56-fa70-fd1f-7066-412a8e15970e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSALoadNode.ctor(System.Int32,System.String,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Objects.Structural.Geometry.Axis,Objects.Structural.Loading.LoadDirection,System.Double)","Objects.Structural.GSA.Loading.GSALoadNode");
@@ -2157,12 +2282,13 @@ public class GSAMaterialSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6e7d020a-4a4b-9f9a-f573-222476220b2c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Materials.GSAMaterial.ctor(System.Int32,System.String,Objects.Structural.MaterialType,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.String)","Objects.Structural.GSA.Materials.GSAMaterial");
@@ -2187,12 +2313,13 @@ public class GSAMember1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e86d92aa-cefd-5a09-138d-a1cd1fe36e7d");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAMember1D.ctor(System.Int32,Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Geometry.Plane)","Objects.Structural.GSA.Geometry.GSAMember1D");
@@ -2217,12 +2344,13 @@ public class GSAMember1D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7c4f3597-5d45-eb1e-c7e9-c3a4dfb9a240");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAMember1D.ctor(System.Int32,Objects.Geometry.Line,Objects.Structural.Properties.Property1D,Objects.Structural.Geometry.ElementType1D,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Restraint,Objects.Geometry.Vector,Objects.Geometry.Vector,Objects.Structural.GSA.Geometry.GSANode,System.Double)","Objects.Structural.GSA.Geometry.GSAMember1D");
@@ -2247,12 +2375,13 @@ public class GSAMember2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3b367574-1c20-77d0-c4e8-46979f8a3f42");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAMember2D.ctor(System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Objects.Structural.Properties.Property2D,Objects.Structural.Geometry.ElementType2D,System.Collections.Generic.List`1[System.Collections.Generic.List`1[Objects.Structural.Geometry.Node]],System.Double,System.Double)","Objects.Structural.GSA.Geometry.GSAMember2D");
@@ -2277,12 +2406,13 @@ public class GSANodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3b6c01e9-4d99-90a8-357e-def8c043faa0");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSANode.ctor(System.Int32,Objects.Geometry.Point,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Axis,Objects.Structural.Properties.PropertySpring,Objects.Structural.Properties.PropertyMass,Objects.Structural.Properties.PropertyDamper,System.Double,System.String)","Objects.Structural.GSA.Geometry.GSANode");
@@ -2307,12 +2437,13 @@ public class GSAPathSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f6c0f7f0-b742-f8ca-ebc4-0872bfd0517c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Bridge.GSAPath.ctor(System.Int32,System.String,Objects.Structural.GSA.Bridge.PathType,System.Int32,Objects.Structural.GSA.Bridge.GSAAlignment,System.Double,System.Double,System.Double,System.Int32)","Objects.Structural.GSA.Bridge.GSAPath");
@@ -2337,12 +2468,13 @@ public class GSAPolylineSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e1e8bcb7-7a12-79be-d15f-c2a2bc9ad6df");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Loading.GSAPolyline.ctor(System.String,System.Int32,System.Collections.Generic.IEnumerable`1[System.Double],System.String,Objects.Structural.GSA.Geometry.GSAGridPlane)","Objects.Structural.GSA.Loading.GSAPolyline");
@@ -2367,12 +2499,13 @@ public class GSAProperty1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("347df789-96b7-21f2-fc2f-5bfd26dfbe6f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Properties.GSAProperty1D.ctor(System.Int32,System.String,Objects.Structural.Materials.StructuralMaterial,Objects.Structural.Properties.Profiles.SectionProfile,System.Double,System.Double)","Objects.Structural.GSA.Properties.GSAProperty1D");
@@ -2397,12 +2530,13 @@ public class GSAProperty2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("562e2664-bdf3-8b98-6e09-cc6584cf2146");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Properties.GSAProperty2D.ctor(System.Int32,System.String,Objects.Structural.Materials.StructuralMaterial,System.Double)","Objects.Structural.GSA.Properties.GSAProperty2D");
@@ -2427,12 +2561,13 @@ public class GSARigidConstraintSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("fd5845ec-2b73-db4d-8c8f-01d9c7c7d0bb");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSARigidConstraint.ctor(System.String,System.Int32,Objects.Structural.Geometry.Node,System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Speckle.Core.Models.Base,System.Collections.Generic.List`1[Objects.Structural.GSA.Analysis.GSAStage],Objects.Structural.GSA.Geometry.LinkageType,System.Collections.Generic.Dictionary`2[Objects.Structural.GSA.Geometry.AxisDirection6,System.Collections.Generic.List`1[Objects.Structural.GSA.Geometry.AxisDirection6]])","Objects.Structural.GSA.Geometry.GSARigidConstraint");
@@ -2457,12 +2592,13 @@ public class GSAStageSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("0f7bf991-1225-1cea-5543-7dea926b1089");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Analysis.GSAStage.ctor(System.Int32,System.String,System.String,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Double,System.Int32,System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.Structural.GSA.Analysis.GSAStage");
@@ -2487,12 +2623,13 @@ public class GSASteelSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("073f9f26-2cfb-9f2d-fbcd-67ce9904872e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Materials.GSASteel.ctor(System.Int32,System.String,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.String)","Objects.Structural.GSA.Materials.GSASteel");
@@ -2517,12 +2654,13 @@ public class GSAStoreySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("24bd70e1-024d-538c-8132-d02c4c101e5d");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Geometry.GSAStorey.ctor(System.Int32,System.String,Objects.Structural.Geometry.Axis,System.Double,System.Double,System.Double)","Objects.Structural.GSA.Geometry.GSAStorey");
@@ -2547,12 +2685,13 @@ public class GSATaskSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("958d20e6-b44e-1dbc-4df3-6dee9b9e13bb");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Analysis.GSATask.ctor(System.Int32,System.String)","Objects.Structural.GSA.Analysis.GSATask");
@@ -2577,12 +2716,13 @@ public class GSAUserVehicleSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("891ecc6d-cf2a-a476-d94c-f31b51eff020");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.GSA.Bridge.GSAUserVehicle.ctor(System.Int32,System.String,System.Double,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double])","Objects.Structural.GSA.Bridge.GSAUserVehicle");
@@ -2607,12 +2747,13 @@ public class ISectionSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("321c4075-d631-8957-9daf-244e6374d73e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.ISection.ctor(System.String,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.Profiles.ISection");
@@ -2637,12 +2778,13 @@ public class LevelSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("04fca79a-ae5b-6ac4-581d-79438351a4e8");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Level.ctor(System.String,System.Double)","Objects.BuiltElements.Level");
@@ -2667,12 +2809,13 @@ public class LoadBeamSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("5aa7c096-d596-e901-49cd-94df21f0f4c9");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadBeam.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.Loading.BeamLoadType,Objects.Structural.Loading.LoadDirection,Objects.Structural.LoadAxisType,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Boolean,System.String)","Objects.Structural.Loading.LoadBeam");
@@ -2697,12 +2840,13 @@ public class LoadBeam1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a84bb64f-5fdc-13b4-bd37-99fa6ee8260a");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadBeam.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.Loading.BeamLoadType,Objects.Structural.Loading.LoadDirection,Objects.Structural.Geometry.Axis,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Boolean,System.String)","Objects.Structural.Loading.LoadBeam");
@@ -2727,12 +2871,13 @@ public class LoadCaseSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6436c6fd-e4e3-b78a-75f5-d967dc2550fc");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadCase.ctor(System.String,Objects.Structural.Loading.LoadType,System.String,Objects.Structural.Loading.ActionType,System.String)","Objects.Structural.Loading.LoadCase");
@@ -2757,12 +2902,13 @@ public class LoadCombinationSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("fdbef7a9-adba-eeed-cb4f-9d9799e16da7");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadCombination.ctor(System.String,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[System.Double],Objects.Structural.Loading.CombinationType)","Objects.Structural.Loading.LoadCombination");
@@ -2787,12 +2933,13 @@ public class LoadFaceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("9bc9c37f-a304-15dc-76ce-17fced07fa46");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadFace.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.Loading.FaceLoadType,Objects.Structural.Loading.LoadDirection2D,Objects.Structural.LoadAxisType,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Boolean,System.String)","Objects.Structural.Loading.LoadFace");
@@ -2817,12 +2964,13 @@ public class LoadFace1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("ad3f7cf4-8c06-10ce-39a2-895ab8a9a475");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadFace.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Structural.Loading.FaceLoadType,Objects.Structural.Loading.LoadDirection2D,Objects.Structural.Geometry.Axis,System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Double],System.Boolean,System.String)","Objects.Structural.Loading.LoadFace");
@@ -2847,12 +2995,13 @@ public class LoadGravitySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f29ce365-1d94-af6d-cf2d-455043fba7a4");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadGravity.ctor(Objects.Structural.Loading.LoadCase,Objects.Geometry.Vector,System.String)","Objects.Structural.Loading.LoadGravity");
@@ -2877,12 +3026,13 @@ public class LoadGravity1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a916973a-2052-a4b5-9184-2e76e0059e65");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadGravity.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Geometry.Vector,System.String)","Objects.Structural.Loading.LoadGravity");
@@ -2907,12 +3057,13 @@ public class LoadGravity2SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("0a4e16ba-52e5-38d9-dce6-630e15528828");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadGravity.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Speckle.Core.Models.Base],Objects.Geometry.Vector,System.String)","Objects.Structural.Loading.LoadGravity");
@@ -2937,12 +3088,13 @@ public class LoadNodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3d5a37ee-3ce8-8dc6-0efb-7c81bb9d4588");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadNode.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Objects.Structural.Loading.LoadDirection,System.Double,System.String)","Objects.Structural.Loading.LoadNode");
@@ -2967,12 +3119,13 @@ public class LoadNode1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("cbbfa332-f0f7-0470-a9f7-7a81813075ad");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Loading.LoadNode.ctor(Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[Objects.Structural.Geometry.Node],Objects.Structural.Geometry.Axis,Objects.Structural.Loading.LoadDirection,System.Double,System.String)","Objects.Structural.Loading.LoadNode");
@@ -2997,12 +3150,13 @@ public class MaterialSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a2ec94ca-c50c-01bf-3d12-0c8feb41004b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.Material.ctor(System.String)","Objects.Other.Material");
@@ -3027,12 +3181,13 @@ public class MaterialQuantitySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c94a9777-99bb-d501-281a-c10300309038");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.MaterialQuantity.ctor(Objects.Other.Material,System.Double,System.Double,System.String)","Objects.Other.MaterialQuantity");
@@ -3057,12 +3212,13 @@ public class ModelSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("af7f27db-7897-fcad-1839-3b5213188ef8");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Analysis.Model.ctor(Objects.Structural.Analysis.ModelInfo,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.Structural.Analysis.Model");
@@ -3087,12 +3243,13 @@ public class ModelCurveSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7aa6e073-6783-8e7b-eec2-7b7bb0420db2");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.ModelCurve.ctor(Objects.ICurve,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.ModelCurve");
@@ -3117,12 +3274,13 @@ public class ModelInfoSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f9da0acf-e2ee-8d25-662f-f5b9928ff8aa");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Analysis.ModelInfo.ctor(System.String,System.String,System.String,System.String,Objects.Structural.Analysis.ModelSettings,System.String,System.String)","Objects.Structural.Analysis.ModelInfo");
@@ -3147,12 +3305,13 @@ public class ModelSettingsSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("2f8c73cc-0692-3fd9-a825-7e0677164975");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Analysis.ModelSettings.ctor(Objects.Structural.Analysis.ModelUnits,System.String,System.String,System.Double)","Objects.Structural.Analysis.ModelSettings");
@@ -3177,12 +3336,13 @@ public class ModelUnitsSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6c3340f9-3493-5e35-7272-e6acd0eefa85");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Analysis.ModelUnits.ctor(Objects.Structural.Analysis.UnitsType)","Objects.Structural.Analysis.ModelUnits");
@@ -3207,12 +3367,13 @@ public class ModelUnits1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("162c2a99-e4c9-314f-1833-f0e4a5c7451d");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Analysis.ModelUnits.ctor(System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.String)","Objects.Structural.Analysis.ModelUnits");
@@ -3237,12 +3398,13 @@ public class NodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("dacc1582-c084-4685-981a-6f8f8d8663c8");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Node.ctor(Objects.Geometry.Point,System.String,Objects.Structural.Geometry.Restraint,Objects.Structural.Geometry.Axis,Objects.Structural.Properties.PropertySpring,Objects.Structural.Properties.PropertyMass,Objects.Structural.Properties.PropertyDamper)","Objects.Structural.Geometry.Node");
@@ -3267,12 +3429,13 @@ public class OpeningSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("087f847f-6f51-3cc9-5b7d-2cce478b46f4");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Opening.ctor(Objects.ICurve)","Objects.BuiltElements.Opening");
@@ -3297,12 +3460,13 @@ public class ParameterSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("706f3fe9-f499-b07f-b682-febedbe38c9c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Parameter.ctor(System.String,System.Object,System.String)","Objects.BuiltElements.Revit.Parameter");
@@ -3327,12 +3491,13 @@ public class ParameterUpdaterSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c4f5fc69-58e1-59f6-4dac-e31b738f7254");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.ParameterUpdater.ctor(System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.ParameterUpdater");
@@ -3357,12 +3522,13 @@ public class PerimeterSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("63b41dcc-8f2e-b900-be8a-82a661e56f19");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Perimeter.ctor(System.String,Objects.ICurve,System.Collections.Generic.List`1[Objects.ICurve])","Objects.Structural.Properties.Profiles.Perimeter");
@@ -3387,12 +3553,13 @@ public class PipeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6892cf99-6913-7004-27ab-2cfb8435a644");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Pipe.ctor(Objects.ICurve,System.Double,System.Double,System.Double,System.Double)","Objects.BuiltElements.Pipe");
@@ -3417,12 +3584,13 @@ public class PointcloudSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("2945c627-5f85-3119-d437-48a5426a12ae");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Geometry.Pointcloud.ctor(System.Collections.Generic.List`1[System.Double],System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.Double])","Objects.Geometry.Pointcloud");
@@ -3447,12 +3615,13 @@ public class PropertySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("8f7a7ef0-dbe1-4085-a1e8-f602612698a5");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Property.ctor(System.String)","Objects.Structural.Properties.Property");
@@ -3477,12 +3646,13 @@ public class Property1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("fa29bbb6-ab8f-a235-67da-c10fe9daa077");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Property1D.ctor(System.String)","Objects.Structural.Properties.Property1D");
@@ -3507,12 +3677,13 @@ public class Property1D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("301fb47d-9a12-ed72-4dbf-55d23ac5c432");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Property1D.ctor(System.String,Objects.Structural.Materials.StructuralMaterial,Objects.Structural.Properties.Profiles.SectionProfile)","Objects.Structural.Properties.Property1D");
@@ -3537,12 +3708,13 @@ public class Property2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b637985b-c4b8-0bbd-109b-7caf9fea829f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Property2D.ctor(System.String)","Objects.Structural.Properties.Property2D");
@@ -3567,12 +3739,13 @@ public class Property2D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a1f72576-5106-26da-625e-6c5dfe798b4f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Property2D.ctor(System.String,Objects.Structural.Materials.StructuralMaterial,Objects.Structural.PropertyType2D,System.Double)","Objects.Structural.Properties.Property2D");
@@ -3597,12 +3770,13 @@ public class Property3DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a1644434-1c43-113c-786e-c1942f56d205");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Property3D.ctor(System.String)","Objects.Structural.Properties.Property3D");
@@ -3627,12 +3801,13 @@ public class Property3D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("5cc8c1d0-c3a7-0c95-f2b6-f8f7b4afdc95");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Property3D.ctor(System.String,Objects.Structural.PropertyType3D,Objects.Structural.Materials.StructuralMaterial)","Objects.Structural.Properties.Property3D");
@@ -3657,12 +3832,13 @@ public class PropertyDamperSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3d966901-7bcc-b5d0-c5c9-060ae5a2caff");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.PropertyDamper.ctor(System.String)","Objects.Structural.Properties.PropertyDamper");
@@ -3687,12 +3863,13 @@ public class PropertyDamper1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("10534d96-587f-e36f-3a97-db6b3fae6b53");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.PropertyDamper.ctor(System.String,Objects.Structural.PropertyTypeDamper,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.PropertyDamper");
@@ -3717,12 +3894,13 @@ public class PropertyMassSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("2ab5d65b-d4d7-85fa-01bf-2384c5ce5666");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.PropertyMass.ctor(System.String)","Objects.Structural.Properties.PropertyMass");
@@ -3747,12 +3925,13 @@ public class PropertyMass1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("66fb8c7a-804c-06d2-a6e0-5da60241dc48");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.PropertyMass.ctor(System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Boolean,System.Double,System.Double,System.Double)","Objects.Structural.Properties.PropertyMass");
@@ -3777,12 +3956,13 @@ public class PropertySpringSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c83d3807-3ee9-9eb6-d6d3-ae472e5fce01");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.PropertySpring.ctor(System.String)","Objects.Structural.Properties.PropertySpring");
@@ -3807,12 +3987,13 @@ public class PropertySpring1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("03b67483-b251-b9f3-900a-e70c331314bb");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.PropertySpring.ctor(System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.PropertySpring");
@@ -3837,12 +4018,13 @@ public class PropertySpring2SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("761c5a65-bec6-b6fb-1df5-c49cc427631b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.PropertySpring.ctor(System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.PropertySpring");
@@ -3867,12 +4049,13 @@ public class RectangularSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("2f4dce06-42d9-fe1e-5096-24debfd2fd4b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Rectangular.ctor(System.String,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.Profiles.Rectangular");
@@ -3897,12 +4080,13 @@ public class RenderMaterialSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("03a49484-4eba-6e08-5e96-b3b78ed13f70");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.RenderMaterial.ctor(System.Double,System.Double,System.Double,System.Nullable`1[System.Drawing.Color],System.Nullable`1[System.Drawing.Color])","Objects.Other.RenderMaterial");
@@ -3927,12 +4111,13 @@ public class RestraintSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("4a117edf-50f0-9c11-6a80-e9692f15771b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Restraint.ctor(System.String)","Objects.Structural.Geometry.Restraint");
@@ -3957,12 +4142,13 @@ public class Restraint1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a57df1f7-6fbd-4c84-a9d6-bd2d84f73811");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Restraint.ctor(System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Geometry.Restraint");
@@ -3987,12 +4173,13 @@ public class Restraint2SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f85b9d32-e383-56a2-e6fa-1da0d28febe9");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Restraint.ctor(Objects.Structural.Geometry.RestraintType)","Objects.Structural.Geometry.Restraint");
@@ -4017,12 +4204,13 @@ public class Result1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("62b6e9c3-13b6-9dbd-b222-a0b6a978750e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.Result1D.ctor(Objects.Structural.Geometry.Element1D,Objects.Structural.Loading.LoadCase,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.Result1D");
@@ -4047,12 +4235,13 @@ public class Result1D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("1151871b-42cc-e3f5-5e08-454f9733ef08");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.Result1D.ctor(Objects.Structural.Geometry.Element1D,Objects.Structural.Loading.LoadCombination,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.Result1D");
@@ -4077,12 +4266,13 @@ public class Result2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("4d551fc5-fc7b-b2b8-5bba-63e48aeee645");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.Result2D.ctor(Objects.Structural.Geometry.Element2D,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[System.Double],System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.Result2D");
@@ -4107,12 +4297,13 @@ public class Result2D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("29194017-21da-96ee-56c4-273cc84ff951");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.Result2D.ctor(Objects.Structural.Geometry.Element2D,Objects.Structural.Loading.LoadCombination,System.Collections.Generic.List`1[System.Double],System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.Result2D");
@@ -4137,12 +4328,13 @@ public class Result3DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3a15c6fa-36cd-1da9-e410-928a62b940a8");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.Result3D.ctor(Objects.Structural.Geometry.Element3D,Objects.Structural.Loading.LoadCase,System.Collections.Generic.List`1[System.Double],System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.Result3D");
@@ -4167,12 +4359,13 @@ public class Result3D1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("1aa4dd1e-d845-7760-0e58-a3744255f0a1");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.Result3D.ctor(Objects.Structural.Geometry.Element3D,Objects.Structural.Loading.LoadCombination,System.Collections.Generic.List`1[System.Double],System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.Result3D");
@@ -4197,12 +4390,13 @@ public class ResultGlobalSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6e742681-a159-d811-8d7c-4ac42682872f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultGlobal.ctor(Objects.Structural.Loading.LoadCase,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.ResultGlobal");
@@ -4227,12 +4421,13 @@ public class ResultGlobal1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("cd0af8ae-e8d9-b1d9-fce1-63d137a8f69c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultGlobal.ctor(Objects.Structural.Loading.LoadCombination,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.ResultGlobal");
@@ -4257,12 +4452,13 @@ public class ResultNodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("5bf05a45-f397-00ae-0cf5-d89191042d21");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultNode.ctor(Objects.Structural.Loading.LoadCase,Objects.Structural.Geometry.Node,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.ResultNode");
@@ -4287,12 +4483,13 @@ public class ResultNode1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c219b902-4ffd-8d03-7de0-2264c8ad6030");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultNode.ctor(Objects.Structural.Loading.LoadCombination,Objects.Structural.Geometry.Node,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)","Objects.Structural.Results.ResultNode");
@@ -4317,12 +4514,13 @@ public class ResultSet1DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7928905d-5fad-53c8-8d44-0eec0c5478ba");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultSet1D.ctor(System.Collections.Generic.List`1[Objects.Structural.Results.Result1D])","Objects.Structural.Results.ResultSet1D");
@@ -4347,12 +4545,13 @@ public class ResultSet2DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("ff5bdc35-b72a-a0be-066f-5ad08fbb047d");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultSet2D.ctor(System.Collections.Generic.List`1[Objects.Structural.Results.Result2D])","Objects.Structural.Results.ResultSet2D");
@@ -4377,12 +4576,13 @@ public class ResultSet3DSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7cde5263-7dd0-a1f7-535b-e9856769bc39");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultSet3D.ctor(System.Collections.Generic.List`1[Objects.Structural.Results.Result3D])","Objects.Structural.Results.ResultSet3D");
@@ -4407,12 +4607,13 @@ public class ResultSetAllSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("440aefda-79ff-55f5-4571-1a7ef57239e8");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultSetAll.ctor(Objects.Structural.Results.ResultSet1D,Objects.Structural.Results.ResultSet2D,Objects.Structural.Results.ResultSet3D,Objects.Structural.Results.ResultGlobal,Objects.Structural.Results.ResultSetNode)","Objects.Structural.Results.ResultSetAll");
@@ -4437,12 +4638,13 @@ public class ResultSetNodeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("07d3aa5f-55e8-f0c6-96da-d9599a8da233");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Results.ResultSetNode.ctor(System.Collections.Generic.List`1[Objects.Structural.Results.ResultNode])","Objects.Structural.Results.ResultSetNode");
@@ -4467,12 +4669,13 @@ public class RevitBeamSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6aba19f5-1b1c-8e0c-f063-2a7c91816b1c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBeam.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitBeam");
@@ -4497,12 +4700,13 @@ public class RevitBraceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a3a689dc-2ca5-d5be-a225-99a144768e7e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitBrace.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitBrace");
@@ -4527,13 +4731,12 @@ public class RevitCeilingSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("93e6568e-0dc2-ebd2-64b0-e202eabe49cb");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitCeiling.ctor(Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,System.Double,Objects.Geometry.Line,System.Double,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.BuiltElements.Revit.RevitCeiling");
@@ -4558,12 +4761,13 @@ public class RevitCeiling1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6c7f6ee3-d520-3153-1ade-47ad953c9540");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitCeiling.ctor(Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,System.Double,Objects.Geometry.Line,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.BuiltElements.Revit.RevitCeiling");
@@ -4588,12 +4792,13 @@ public class RevitColumnSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c243fe91-0103-bea1-34b7-3e8b39c8d0ec");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitColumn");
@@ -4618,13 +4823,12 @@ public class RevitColumn1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("bd9936e6-c75f-c0de-feb0-b801eff0e0ea");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitColumn");
@@ -4649,12 +4853,13 @@ public class RevitColumn2SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("1600415c-b327-870c-7cd4-bb9c1b1a82fc");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitColumn.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitColumn");
@@ -4679,13 +4884,12 @@ public class RevitDuctSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("d7781536-e8a9-8aef-1b27-571584f8c4a3");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.Geometry.Line,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
@@ -4710,12 +4914,13 @@ public class RevitDuct1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7bb86598-9cd2-8d29-a1dc-7500c4b4ed4b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitDuct.ctor(System.String,System.String,Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitDuct");
@@ -4740,12 +4945,13 @@ public class RevitExtrusionRoofSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("707428ab-15b4-e7ec-a2cd-21154ff50c1b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof.ctor(System.String,System.String,System.Double,System.Double,Objects.Geometry.Line,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitRoof.RevitExtrusionRoof");
@@ -4770,12 +4976,13 @@ public class RevitFaceWallSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("fc3927a7-0877-8137-a34e-ecd19a6f688c");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFaceWall.ctor(System.String,System.String,Objects.Geometry.Brep,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.LocationLine,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFaceWall");
@@ -4800,12 +5007,13 @@ public class RevitFlexDuctSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f350f9a2-06ca-6118-a4e6-88e721bb7f52");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFlexDuct.ctor(System.String,System.String,Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,Objects.Geometry.Vector,Objects.Geometry.Vector,System.Double,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFlexDuct");
@@ -4830,12 +5038,13 @@ public class RevitFlexPipeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("219bfacc-9c41-441a-210c-c2cfb877929b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFlexPipe.ctor(System.String,System.String,Objects.ICurve,System.Double,Objects.BuiltElements.Level,Objects.Geometry.Vector,Objects.Geometry.Vector,System.String,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFlexPipe");
@@ -4860,12 +5069,13 @@ public class RevitFloorSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e6f17d4f-6c28-0d0f-2370-7b9c09a14fff");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitFloor.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Boolean,System.Double,Objects.Geometry.Line,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitFloor");
@@ -4890,12 +5100,13 @@ public class RevitFootprintRoofSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b2f55d9f-7242-ee7e-c44a-24e34d5f6e3e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof.ctor(Objects.ICurve,System.String,System.String,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.RevitLevel,System.Double,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitRoof.RevitFootprintRoof");
@@ -4920,12 +5131,13 @@ public class RevitLevelSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("5ef6e45c-00bd-f3b9-1cbf-6e9a902da7ab");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitLevel.ctor(System.String,System.Double,System.Boolean,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitLevel");
@@ -4950,12 +5162,13 @@ public class RevitLevel1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e075a88e-7867-3726-3bb7-15b73b2d17e6");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitLevel.ctor(System.String)","Objects.BuiltElements.Revit.RevitLevel");
@@ -4980,12 +5193,13 @@ public class RevitMaterialSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c291d027-7a6a-8950-a2aa-77e134675750");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Other.Revit.RevitMaterial.ctor(System.String,System.String,System.String,System.Int32,System.Int32,System.Int32,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.Other.Revit.RevitMaterial");
@@ -5010,12 +5224,13 @@ public class RevitPipeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("19700cd2-6310-c8b3-7ad5-954033702e52");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitPipe.ctor(System.String,System.String,Objects.ICurve,System.Double,Objects.BuiltElements.Level,System.String,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitPipe");
@@ -5040,12 +5255,13 @@ public class RevitProfileWallSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b3962fc0-69b0-e766-22b4-b08404650c8a");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitProfileWall.ctor(System.String,System.String,Objects.Geometry.Polycurve,Objects.BuiltElements.Level,Objects.BuiltElements.Revit.LocationLine,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitProfileWall");
@@ -5070,12 +5286,13 @@ public class RevitRailingSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a6c3be7a-9e6b-663b-2bc0-dd9fa2ee6552");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitRailing.ctor(System.String,Objects.Geometry.Polycurve,Objects.BuiltElements.Level,System.Boolean)","Objects.BuiltElements.Revit.RevitRailing");
@@ -5100,12 +5317,13 @@ public class RevitShaftSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("00cdb2fd-ef75-107e-822c-3490cd359380");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitShaft.ctor(Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitShaft");
@@ -5130,12 +5348,13 @@ public class RevitTopographySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f0840908-039e-b6d4-98de-8ed003dfd357");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitTopography.ctor(Objects.Geometry.Mesh,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitTopography");
@@ -5160,12 +5379,13 @@ public class RevitWallSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("fa1aef22-ddd5-01f4-887e-145ce21da247");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWall");
@@ -5190,12 +5410,13 @@ public class RevitWall1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("bd2a0bb1-14f7-cd0a-76c4-2429412a5128");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWall.ctor(System.String,System.String,Objects.ICurve,Objects.BuiltElements.Level,System.Double,System.Double,System.Double,System.Boolean,System.Boolean,System.Collections.Generic.List`1[Speckle.Core.Models.Base],System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWall");
@@ -5220,13 +5441,12 @@ public class RevitWallOpeningSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a1bd278d-fab5-0034-7aba-807b66122022");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWallOpening.ctor(Objects.ICurve,Objects.BuiltElements.Revit.RevitWall)","Objects.BuiltElements.Revit.RevitWallOpening");
@@ -5251,12 +5471,13 @@ public class RevitWallOpening1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("541bfed0-738d-e1bd-1130-de05ec4bbf9e");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWallOpening.ctor(Objects.Geometry.Polyline,Objects.BuiltElements.Revit.RevitWall)","Objects.BuiltElements.Revit.RevitWallOpening");
@@ -5281,12 +5502,13 @@ public class RevitWireSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("4045436b-0804-f0e1-a9f2-6217f4d8a45b");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.RevitWire.ctor(System.Collections.Generic.List`1[System.Double],System.String,System.String,Objects.BuiltElements.Level,System.String,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.RevitWire");
@@ -5311,12 +5533,13 @@ public class RibbedSlabSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("e5db5889-0924-136f-be6d-39c7de9a3649");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIProperty2D+RibbedSlab.ctor(System.String,Objects.Structural.CSI.Analysis.ShellType,Objects.Structural.Materials.StructuralMaterial,System.Double,System.Double,System.Double,System.Double,System.Double,System.Int32)","Objects.Structural.CSI.Properties.CSIProperty2D+RibbedSlab");
@@ -5341,13 +5564,12 @@ public class RoofSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c10c6dcd-e6a8-be88-32f3-45c935d0bae9");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Roof.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.ICurve],System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.BuiltElements.Roof");
@@ -5372,12 +5594,13 @@ public class RoomSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c62087b7-2a9d-743d-336d-e8ea2ab72a29");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Room.ctor(System.String,System.String,Objects.BuiltElements.Level,Objects.Geometry.Point)","Objects.BuiltElements.Room");
@@ -5402,12 +5625,13 @@ public class Room1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("9be891e2-aaf6-1d4e-3d6b-bd7ba1a06563");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Room.ctor(System.String,System.String,Objects.BuiltElements.Level,Objects.Geometry.Point,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Room");
@@ -5432,12 +5656,13 @@ public class RoomBoundaryLineSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("2edade8a-5139-09be-4273-551f3ac476e2");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.RoomBoundaryLine.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.RoomBoundaryLine");
@@ -5462,12 +5687,13 @@ public class SlabSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("27930f28-6811-7f66-f432-07dd5585f6e0");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIProperty2D+Slab.ctor(System.String,Objects.Structural.CSI.Analysis.ShellType,Objects.Structural.Materials.StructuralMaterial,System.Double)","Objects.Structural.CSI.Properties.CSIProperty2D+Slab");
@@ -5492,12 +5718,13 @@ public class SpaceSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c6907933-2792-eb6d-7c64-fb54835e9b44");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Space.ctor(System.String,System.String,Objects.Geometry.Point,Objects.BuiltElements.Level)","Objects.BuiltElements.Space");
@@ -5522,12 +5749,13 @@ public class Space1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("8f7b0323-3533-e7cd-ae43-0bdeb34f3570");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Space.ctor(System.String,System.String,Objects.Geometry.Point,Objects.BuiltElements.Level,Objects.BuiltElements.Level,System.Double,System.Double)","Objects.BuiltElements.Space");
@@ -5552,12 +5780,13 @@ public class SpaceSeparationLineSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("0bba13ce-5758-8513-42fd-9e0b3702a654");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Revit.Curve.SpaceSeparationLine.ctor(Objects.ICurve,System.Collections.Generic.List`1[Objects.BuiltElements.Revit.Parameter])","Objects.BuiltElements.Revit.Curve.SpaceSeparationLine");
@@ -5582,12 +5811,13 @@ public class SteelSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6756df31-1e5c-0c80-2047-f4b6557c2e3f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Materials.Steel.ctor(System.String,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Materials.Steel");
@@ -5612,12 +5842,13 @@ public class StoreySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("a3985ed4-fff8-47c1-bb0e-d63699e263e9");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Geometry.Storey.ctor(System.String,System.Double)","Objects.Structural.Geometry.Storey");
@@ -5642,12 +5873,13 @@ public class StructuralMaterialSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3e877a75-b3fb-0111-2128-1432ab15c4cf");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Materials.StructuralMaterial.ctor(System.String,Objects.Structural.MaterialType,System.String,System.String,System.String)","Objects.Structural.Materials.StructuralMaterial");
@@ -5672,12 +5904,13 @@ public class StructuralMaterial1SchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("ef78155b-0786-9846-38cd-41ce70911972");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Materials.StructuralMaterial.ctor(System.String,Objects.Structural.MaterialType,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Materials.StructuralMaterial");
@@ -5702,12 +5935,13 @@ public class TeeSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("7832cac3-92e9-9083-df97-0d4296b457c3");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Properties.Profiles.Tee.ctor(System.String,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Properties.Profiles.Tee");
@@ -5732,12 +5966,13 @@ public class TeklaBeamSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("5a4187bc-05d8-2447-7238-cdbc4b2fae45");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.TeklaStructures.TeklaBeam.ctor(Objects.ICurve,Objects.Structural.Properties.Profiles.SectionProfile,Objects.Structural.Materials.StructuralMaterial)","Objects.BuiltElements.TeklaStructures.TeklaBeam");
@@ -5762,12 +5997,13 @@ public class TeklaContourPlateSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("3b092935-3c2f-c084-eea5-077630507a49");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.TeklaStructures.TeklaContourPlate.ctor(Objects.Structural.Properties.Profiles.SectionProfile,Objects.Geometry.Polyline,System.String,System.String,System.String,Objects.Structural.Materials.StructuralMaterial,Objects.BuiltElements.TeklaStructures.TeklaPosition,Speckle.Core.Models.Base)","Objects.BuiltElements.TeklaStructures.TeklaContourPlate");
@@ -5792,12 +6028,13 @@ public class TimberSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("f11d278f-6a36-fd7c-409d-fb39f52c73f5");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.Materials.Timber.ctor(System.String,System.String,System.String,System.String,System.String,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.Materials.Timber");
@@ -5822,12 +6059,13 @@ public class TopographySchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b9207a45-eebc-72d6-a411-f496443d8b7f");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Topography.ctor(Objects.Geometry.Mesh)","Objects.BuiltElements.Topography");
@@ -5852,12 +6090,13 @@ public class WaffleSlabSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("b8956ee0-8372-db59-654a-c11c4af5e0f6");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.Structural.CSI.Properties.CSIProperty2D+WaffleSlab.ctor(System.String,Objects.Structural.CSI.Analysis.ShellType,Objects.Structural.Materials.StructuralMaterial,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)","Objects.Structural.CSI.Properties.CSIProperty2D+WaffleSlab");
@@ -5882,12 +6121,13 @@ public class WallSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("6878cc65-2628-d00d-e8c0-b130e828a6c7");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Wall.ctor(System.Double,Objects.ICurve,System.Collections.Generic.List`1[Speckle.Core.Models.Base])","Objects.BuiltElements.Wall");
@@ -5912,12 +6152,13 @@ public class WireSchemaComponent: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("c10c9c87-b93d-4e98-d2fb-942d182008dc");
 
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
     internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
       ? GH_Exposure.tertiary
       : GH_Exposure.hidden;
-
-    public override Guid ComponentGuid => internalGuid;
-    public override GH_Exposure Exposure => internalExposure;
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.Wire.ctor(System.Collections.Generic.List`1[Objects.ICurve])","Objects.BuiltElements.Wire");

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/SchemaBuilderGen.tt
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/SchemaBuilderGen.tt
@@ -75,20 +75,21 @@ public class <#= compName #>: CreateSchemaObjectBase {
 
     internal static Guid internalGuid => new Guid("<#= ToGuid("secretPhraseToKeepItRandom..." + compName) #>");
 
-    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
-      ? GH_Exposure.tertiary
-      : GH_Exposure.hidden;
+
+    public override GH_Exposure Exposure => internalExposure;
 
     public override Guid ComponentGuid => internalGuid;
 <#
     if (depr != null){
 #>
     public override bool Obsolete => true;
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
+    internal static GH_Exposure internalExposure => GH_Exposure.hidden;
 <#
         } else {
 #>
-    public override GH_Exposure Exposure => internalExposure;
+    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
+      ? GH_Exposure.tertiary
+      : GH_Exposure.hidden;
 <#
         }
 #>


### PR DESCRIPTION
Fixes #2253 

Adds a minor fix to obsolete schema nodes being shown in the toolbar instead of hidden