### PR TITLE
feat: forces the use of english names when grouping objects on send

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Autodesk.Revit.DB;
 using Speckle.Core.Kits;
@@ -54,6 +55,13 @@ namespace Speckle.ConnectorRevit
       }
 
       return _categories;
+    }
+
+    public static string GetEnglishCategoryName(Category category)
+    {
+      var builtInCategory = (BuiltInCategory)category.Id.IntegerValue;
+
+      return Regex.Replace(builtInCategory.ToString().Replace("OST_", ""), "([A-Z])", " $1", RegexOptions.Compiled).Trim();
     }
 
     #region extension methods
@@ -206,7 +214,7 @@ namespace Speckle.ConnectorRevit
       if (e.Category == null) return false;
       if (e.ViewSpecific) return false;
       // exclude specific unwanted categories
-      if (((BuiltInCategory) e.Category.Id.IntegerValue) == BuiltInCategory.OST_HVAC_Zones) return false;
+      if (((BuiltInCategory)e.Category.Id.IntegerValue) == BuiltInCategory.OST_HVAC_Zones) return false;
       return e.Category.CategoryType == CategoryType.Model && e.Category.CanAddSubcategory;
     }
 
@@ -215,7 +223,7 @@ namespace Speckle.ConnectorRevit
       if (e.Category == null) return false;
       if (e.ViewSpecific) return false;
 
-      if (SupportedBuiltInCategories.Contains((BuiltInCategory) e.Category.Id.IntegerValue))
+      if (SupportedBuiltInCategories.Contains((BuiltInCategory)e.Category.Id.IntegerValue))
         return true;
       return false;
     }
@@ -227,12 +235,12 @@ namespace Speckle.ConnectorRevit
     /// <returns></returns>
     public static string SimplifySpeckleType(string type)
     {
-      return type.Split(new char[] {':'}, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+      return type.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
     }
 
     public static string ObjectDescriptor(Element obj)
     {
-      var simpleType = obj.GetType().ToString().Split(new string[] {"DB."}, StringSplitOptions.RemoveEmptyEntries)
+      var simpleType = obj.GetType().ToString().Split(new string[] { "DB." }, StringSplitOptions.RemoveEmptyEntries)
         .LastOrDefault();
       return string.IsNullOrEmpty(obj.Name) ? $"{simpleType}" : $"{simpleType} {obj.Name}";
     }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -118,6 +118,9 @@ namespace Speckle.ConnectorRevit.UI
             // but the host doesn't know that it is a host
             if (conversionResult["speckleHost"] is Base host && host["category"] is string catName)
             {
+              //ensure we use english names for hosted elements too!
+              var cat = ConnectorRevitUtils.GetCategories(CurrentDoc.Document)[catName];
+              catName = ConnectorRevitUtils.GetEnglishCategoryName(cat);
               commitObject[$"@{catName}"] ??= new List<Base>();
               if (commitObject[$"@{catName}"] is List<Base> objs)
               {
@@ -147,7 +150,7 @@ namespace Speckle.ConnectorRevit.UI
             //is an element type, nest it under Types instead
             else if (typeof(ElementType).IsAssignableFrom(revitElement.GetType()))
             {
-              var category = $"@{revitElement.Category.Name}";
+              var category = $"@{ConnectorRevitUtils.GetEnglishCategoryName(revitElement.Category)}";
 
               if (commitObject["Types"] == null)
                 commitObject["Types"] = new Base();
@@ -161,14 +164,14 @@ namespace Speckle.ConnectorRevit.UI
             {
               var category = conversionResult.GetType().Name == "Network" ?
                 "@Networks" :
-                $"@{revitElement.Category.Name}";
+                $"@{ConnectorRevitUtils.GetEnglishCategoryName(revitElement.Category)}";
 
               commitObject[category] ??= new List<Base>();
 
               if (commitObject[category] is List<Base> objs)
               {
                 var hostIndex = objs.FindIndex(obj => obj.applicationId == conversionResult.applicationId);
-              
+
                 // here we are checking to see if we're converting a host that doesn't know it is a host
                 // and if dependent elements of that host have already been converted
                 if (hostIndex != -1 && objs[hostIndex]["elements"] is List<Base> elements)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -1,21 +1,21 @@
-﻿using Autodesk.Revit.DB;
-using Objects.BuiltElements;
-using Objects.BuiltElements.Revit;
-using Objects.Geometry;
-using Objects.Other;
-using Speckle.Core.Kits;
-using Speckle.Core.Models;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Autodesk.Revit.DB;
+using Objects.BuiltElements;
+using Objects.BuiltElements.Revit;
+using Objects.Geometry;
+using Objects.Other;
 using Speckle.Core.Helpers;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
 using DB = Autodesk.Revit.DB;
-using ElementType = Autodesk.Revit.DB.ElementType;
 using Duct = Objects.BuiltElements.Duct;
+using ElementType = Autodesk.Revit.DB.ElementType;
 using Floor = Objects.BuiltElements.Floor;
 using Level = Objects.BuiltElements.Level;
 using Line = Objects.Geometry.Line;
@@ -171,7 +171,7 @@ namespace Objects.Converter.Revit
     public ApplicationObject SetHostedElements(Base @base, Element host, ApplicationObject appObj)
     {
       if (@base == null) return appObj;
-      
+
       CurrentHostElement = host;
       foreach (var obj in GraphTraversal.TraverseMember(@base["elements"]))
       {
@@ -1336,7 +1336,7 @@ namespace Objects.Converter.Revit
         if (specifyOffset == 1)
         {
           // in this scenario, slope is returned as a percentage. Divide by 100 to get the unitless form
-          slope = GetParamValue<double>(l, BuiltInParameter.ROOF_SLOPE) / 100; 
+          slope = GetParamValue<double>(l, BuiltInParameter.ROOF_SLOPE) / 100;
           headOffset = tailOffset + lineLength * Math.Sin(Math.Atan(slope));
         }
         else if (specifyOffset == 0) // 0 corrospondes to the "height at tail" option


### PR DESCRIPTION
This PR aims to solve some of the issues reported in [this thread](https://speckle.community/t/mapping-tool-for-cad-bim-workflows/4086/24) in regard to the localization of categories used for grouping objects.

The idea is to derive an English name from the OST_BuiltInCategoryName name, note that there is not always an exact match here. For example, `Levels` in the UI corresponds to `OST_Levels`, but `Air Terminal Tags` to `OST_DuctTerminalTags`.

**NOTE: this PR will be breaking change for any code/app relying on a specific language for the category names.**

The category property on each element is kept as it is. 

Sample output, where `Soffitti` has been renamed to `Ceilings`:

![image](https://user-images.githubusercontent.com/2679513/223560954-36da5c24-243b-4cbf-b651-8741ca41e709.png)
