### PR TITLE
feat(core): Added InvalidPropName exception to DynamicBase

### DIFF
--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -112,7 +112,7 @@ namespace Speckle.Core.Models
       }
       set
       {
-        if (!IsPropNameValid(key, out string reason)) throw new SpeckleException("Invalid prop name: " + reason);
+        if (!IsPropNameValid(key, out string reason)) throw new InvalidPropNameException(key, reason);
 
         if (properties.ContainsKey(key))
         {

--- a/Core/Core/Models/InvalidPropNameException.cs
+++ b/Core/Core/Models/InvalidPropNameException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Speckle.Core.Logging;
+
+namespace Speckle.Core.Models
+{
+  public class InvalidPropNameException : SpeckleException
+  {
+
+    public InvalidPropNameException(string propName, string reason) : base($"Property '{propName}' is invalid: {reason}")
+    {
+    }
+  }
+}


### PR DESCRIPTION
Added `InvalidPropNameException` in DynamicBase.

Used to distinguish between errors and users/devs doing silly things.