### PR TITLE
chore: Change `Material.Icons.Avalonia` for our own `Speckle.Material.Icons.Avalonia` package

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Communication/CommandRequest.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/CommandRequest.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/CommandResponse.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/CommandResponse.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateBeam.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateBeam.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateColumn.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateColumn.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateDirectShape.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateDirectShape.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateDoor.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateDoor.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateFloor.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateFloor.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateObject.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateObject.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateRoom.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateRoom.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateWall.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateWall.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
+using Speckle.Newtonsoft.Json;
+
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateWindow.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateWindow.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
+
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetBeamData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetBeamData.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetColumnData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetColumnData.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
+
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetDoorData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetDoorData.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementIds.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementIds.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using Speckle.Newtonsoft.Json;
+using Speckle.Newtonsoft.Json.Converters;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementType.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementType.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetFloorData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetFloorData.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetModelOfElements.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetModelOfElements.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetObjectData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetObjectData.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetProjectInfo.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetProjectInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetRoomData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetRoomData.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetSubelementInfo.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetSubelementInfo.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetWallData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetWallData.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetWindowData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetWindowData.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
 using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands
 {

--- a/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication
 {

--- a/ConnectorArchicad/ConnectorArchicad/Model/MeshModel.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Model/MeshModel.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Model
 {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/SchemaBuilderGen.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/SchemaBuilderGen.cs
@@ -69,6 +69,37 @@ public class AdvanceSteelBeamSchemaComponent: CreateSchemaObjectBase {
 }
 
 // This is generated code:
+public class AdvanceSteelCircularBoltSchemaComponent: CreateSchemaObjectBase {
+    static AdvanceSteelCircularBoltSchemaComponent() {
+       SpeckleGHSettings.SettingsChanged += (_, args) =>
+          {
+            if (!args.Key.StartsWith("Speckle2:tabs.")) return;
+            var proxy = Grasshopper.Instances.ComponentServer.ObjectProxies.FirstOrDefault(p => p.Guid == internalGuid);
+            if (proxy == null) return;
+            proxy.Exposure = internalExposure;
+          };
+    }
+    public AdvanceSteelCircularBoltSchemaComponent(): base("AdvanceSteelCircularBolt", "AdvanceSteelCircularBolt", "Creates a Advance Steel circular bolt.", "Speckle 2 Advance Steel", "Structure") { }
+    
+    internal static string internalCategory { get; }  = "Speckle 2 Advance Steel";
+
+    internal static Guid internalGuid => new Guid("2882d168-7e7c-5090-be24-e70091521c1f");
+
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
+    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
+      ? GH_Exposure.tertiary
+      : GH_Exposure.hidden;
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.AdvanceSteel.AdvanceSteelCircularBolt.ctor","Objects.BuiltElements.AdvanceSteel.AdvanceSteelCircularBolt");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
 public class AdvanceSteelPlateSchemaComponent: CreateSchemaObjectBase {
     static AdvanceSteelPlateSchemaComponent() {
        SpeckleGHSettings.SettingsChanged += (_, args) =>
@@ -95,6 +126,68 @@ public class AdvanceSteelPlateSchemaComponent: CreateSchemaObjectBase {
     
     public override void AddedToDocument(GH_Document document){
         SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.AdvanceSteel.AdvanceSteelPlate.ctor(Objects.Structural.Properties.Profiles.SectionProfile,Objects.Geometry.Polyline,System.String,Objects.Structural.Materials.StructuralMaterial)","Objects.BuiltElements.AdvanceSteel.AdvanceSteelPlate");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class AdvanceSteelRectangularBoltSchemaComponent: CreateSchemaObjectBase {
+    static AdvanceSteelRectangularBoltSchemaComponent() {
+       SpeckleGHSettings.SettingsChanged += (_, args) =>
+          {
+            if (!args.Key.StartsWith("Speckle2:tabs.")) return;
+            var proxy = Grasshopper.Instances.ComponentServer.ObjectProxies.FirstOrDefault(p => p.Guid == internalGuid);
+            if (proxy == null) return;
+            proxy.Exposure = internalExposure;
+          };
+    }
+    public AdvanceSteelRectangularBoltSchemaComponent(): base("AdvanceSteelRectangularBolt", "AdvanceSteelRectangularBolt", "Creates a Advance Steel rectangular bolt.", "Speckle 2 Advance Steel", "Structure") { }
+    
+    internal static string internalCategory { get; }  = "Speckle 2 Advance Steel";
+
+    internal static Guid internalGuid => new Guid("f6791563-253b-9232-f611-bf6249626a34");
+
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
+    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
+      ? GH_Exposure.tertiary
+      : GH_Exposure.hidden;
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.AdvanceSteel.AdvanceSteelRectangularBolt.ctor","Objects.BuiltElements.AdvanceSteel.AdvanceSteelRectangularBolt");
+        base.AddedToDocument(document);
+    }
+}
+
+// This is generated code:
+public class AdvanceSteelSpecialPartSchemaComponent: CreateSchemaObjectBase {
+    static AdvanceSteelSpecialPartSchemaComponent() {
+       SpeckleGHSettings.SettingsChanged += (_, args) =>
+          {
+            if (!args.Key.StartsWith("Speckle2:tabs.")) return;
+            var proxy = Grasshopper.Instances.ComponentServer.ObjectProxies.FirstOrDefault(p => p.Guid == internalGuid);
+            if (proxy == null) return;
+            proxy.Exposure = internalExposure;
+          };
+    }
+    public AdvanceSteelSpecialPartSchemaComponent(): base("AdvanceSteelSpecialPart", "AdvanceSteelSpecialPart", "Creates a Advance Steel special part.", "Speckle 2 Advance Steel", "Structure") { }
+    
+    internal static string internalCategory { get; }  = "Speckle 2 Advance Steel";
+
+    internal static Guid internalGuid => new Guid("c93ed779-6784-00a3-d834-951108a361af");
+
+
+    public override GH_Exposure Exposure => internalExposure;
+
+    public override Guid ComponentGuid => internalGuid;
+    internal static GH_Exposure internalExposure => SpeckleGHSettings.GetTabVisibility(internalCategory)
+      ? GH_Exposure.tertiary
+      : GH_Exposure.hidden;
+    
+    public override void AddedToDocument(GH_Document document){
+        SelectedConstructor = CSOUtils.FindConstructor("Objects.BuiltElements.AdvanceSteel.AdvanceSteelSpecialPart.ctor","Objects.BuiltElements.AdvanceSteel.AdvanceSteelSpecialPart");
         base.AddedToDocument(document);
     }
 }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Mappings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Mappings.cs
@@ -10,10 +10,10 @@ using DesktopUI2.Models;
 using DesktopUI2.Models.Settings;
 using DesktopUI2.ViewModels;
 using DesktopUI2.Views.Windows.Dialogs;
-using Newtonsoft.Json;
 using Revit.Async;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
 using static DesktopUI2.ViewModels.ImportFamiliesDialogViewModel;
 using static DesktopUI2.ViewModels.MappingViewModel;
 

--- a/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
+++ b/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
@@ -62,7 +62,7 @@
 
     <!-- We are building for win-x64 on mac too, so these deps are not automatically copied/loaded -->
   <ItemGroup Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">
-    <None Include="$(HOME)/.nuget/packages/sqlitepclraw.lib.e_sqlite3/2.1.2/runtimes/osx-x64/native/libe_sqlite3.dylib" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(HOME)/.nuget/packages/sqlitepclraw.lib.e_sqlite3/2.1.4/runtimes/osx-x64/native/libe_sqlite3.dylib" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">

--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -36,13 +36,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="GraphQL.Client" Version="5.1.0" />
+    <PackageReference Include="GraphQL.Client" Version="5.1.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="Sentry" Version="3.25.0" />
-    <PackageReference Include="Sentry.Serilog" Version="3.25.0" />
+    <PackageReference Include="Sentry" Version="3.29.0" />
+    <PackageReference Include="Sentry.Serilog" Version="3.29.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.2.0" />
     <PackageReference Include="Serilog.Enrichers.GlobalLogContext" Version="3.0.0" />
@@ -52,7 +52,7 @@
     <PackageReference Include="Speckle.Newtonsoft.Json" Version="13.0.2">
       <Aliases></Aliases>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Serialisation\" />

--- a/DesktopUI2/DesktopUI2/DesktopUI2.csproj
+++ b/DesktopUI2/DesktopUI2/DesktopUI2.csproj
@@ -273,7 +273,7 @@
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.18" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
     <PackageReference Include="Material.Avalonia" Version="3.0.0-rc0.98-nightly" />
-    <PackageReference Include="Material.Icons.Avalonia" Version="1.1.10" />
+    <PackageReference Include="Speckle.Material.Icons.Avalonia" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Native\" />

--- a/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
+++ b/Objects/Converters/ConverterDxf/ConverterDxf/ConverterDxf.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Speckle.netDxf" Version="3.0.1" PrivateAssets="true" />
+      <PackageReference Include="Speckle.netDxf" Version="3.0.2" PrivateAssets="true" />
     </ItemGroup>
     
     <PropertyGroup>


### PR DESCRIPTION
Updates some dependencies and introduces our fork of Material.Icons.Avalonia to fully remove a dependency on Newtonsoft.Json.
