### PR TITLE
fix(gh/logging): Append correct hostApplication to SolveInstance in all components

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.AccountDetailsV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.AccountDetailsV2.cs
@@ -42,7 +42,7 @@ namespace ConnectorGrasshopper.Streams
       pManager.AddTextParameter("User Email", "UE", "Email of this account's user", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       Account account = null;
       DA.GetData(0, ref account);

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.GetAccountToken.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.GetAccountToken.cs
@@ -44,7 +44,7 @@ namespace ConnectorGrasshopper.Accounts
       pManager.AddTextParameter("Auth Token", "T", "The auth token for this user that is stored in Manager", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       var userId = "";
       if (!DA.GetData(0, ref userId)) return;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
@@ -12,7 +12,7 @@ using Logging = Speckle.Core.Logging;
 
 namespace ConnectorGrasshopper.Accounts
 {
-  public class AccountListComponent : GH_ValueList, ISpeckleTrackingComponent
+  public class AccountListComponent : GH_ValueList, ISpeckleTrackingDocumentObject
   {
     public ComponentTracker Tracker { get; set; }
     public bool IsNew { get; set; } = true;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ServerAccount.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ServerAccount.cs
@@ -47,7 +47,7 @@ namespace ConnectorGrasshopper.Accounts
       pManager.AddParameter(new SpeckleAccountParam());    
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       if (DA.Iteration != 0)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ServerAccount.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ServerAccount.cs
@@ -47,7 +47,7 @@ namespace ConnectorGrasshopper.Accounts
       pManager.AddParameter(new SpeckleAccountParam());    
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       if (DA.Iteration != 0)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Obsolete/Accounts.AccountDetails.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Obsolete/Accounts.AccountDetails.cs
@@ -42,7 +42,7 @@ namespace ConnectorGrasshopper.Streams
       pManager.AddTextParameter("User Email", "UE", "Email of this account's user", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       string userId = null;
       if (!DA.GetData(0, ref userId)) return;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleAsyncComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleAsyncComponent.cs
@@ -1,6 +1,7 @@
 ﻿using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using GrasshopperAsyncComponent;
+using Serilog.Core;
 
 namespace ConnectorGrasshopper
 {
@@ -30,6 +31,11 @@ namespace ConnectorGrasshopper
         Tracker.TrackNodeCreation();
         IsNew = false; // Flag as false to prevent double reporting in some cases.
       }
+    }
+
+    protected override void BeforeSolveInstance()
+    {
+      base.BeforeSolveInstance();
     }
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleAsyncComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleAsyncComponent.cs
@@ -1,6 +1,7 @@
 ﻿using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using GrasshopperAsyncComponent;
+using Serilog.Context;
 using Serilog.Core;
 
 namespace ConnectorGrasshopper
@@ -33,9 +34,12 @@ namespace ConnectorGrasshopper
       }
     }
 
-    protected override void BeforeSolveInstance()
+    protected sealed override void SolveInstance(IGH_DataAccess DA)
     {
-      base.BeforeSolveInstance();
+      using (LogContext.PushProperty("hostApplication", "grasshopperGrasshopper7"))
+        SolveInstanceWithLogContext(DA);
     }
+
+    public abstract void SolveInstanceWithLogContext(IGH_DataAccess DA);
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleComponent.cs
@@ -2,6 +2,7 @@
 using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
+using Serilog.Context;
 
 namespace ConnectorGrasshopper
 {
@@ -36,5 +37,13 @@ namespace ConnectorGrasshopper
         IsNew = false;
       }
     }
+    
+    protected sealed override void SolveInstance(IGH_DataAccess DA)
+    {
+      using (LogContext.PushProperty("hostApplication", "grasshopperGrasshopper7"))
+        SolveInstanceWithLogContext(DA);
+    }
+
+    public abstract void SolveInstanceWithLogContext(IGH_DataAccess DA);
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleTaskCapableComponent.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using GH_IO.Serialization;
+﻿using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using Serilog.Context;
 
@@ -33,15 +32,12 @@ namespace ConnectorGrasshopper
       }
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected sealed override void SolveInstance(IGH_DataAccess DA)
     {
-      // Host app fake!
       using (LogContext.PushProperty("hostApplication", "grasshopperGrasshopper7"))
-      {
-        SolveInstancePrivate(DA);
-      }
+        SolveInstanceWithLogContext(DA);
     }
 
-    protected abstract void SolveInstancePrivate(IGH_DataAccess DA);
+    public abstract void SolveInstanceWithLogContext(IGH_DataAccess DA);
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleTaskCapableComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using GH_IO.Serialization;
 using Grasshopper.Kernel;
+using Serilog.Context;
 
 namespace ConnectorGrasshopper
 {
@@ -31,5 +32,16 @@ namespace ConnectorGrasshopper
         IsNew = false;
       }
     }
+
+    protected override void SolveInstance(IGH_DataAccess DA)
+    {
+      // Host app fake!
+      using (LogContext.PushProperty("hostApplication", "grasshopperGrasshopper7"))
+      {
+        SolveInstancePrivate(DA);
+      }
+    }
+
+    protected abstract void SolveInstancePrivate(IGH_DataAccess DA);
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/ISpeckleTrackingComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/ISpeckleTrackingComponent.cs
@@ -1,6 +1,8 @@
-﻿namespace ConnectorGrasshopper
+﻿using Grasshopper.Kernel;
+
+namespace ConnectorGrasshopper
 {
-  public interface ISpeckleTrackingComponent
+  public interface ISpeckleTrackingDocumentObject
   {
     /// <summary>
     /// Common implementation for all tracking events inside a component.
@@ -11,5 +13,16 @@
     /// Upon Adding to a document, we should track node creation only if IsNew = true.
     /// </summary>
     bool IsNew { get; set; }
+
+  }
+
+  public interface ISpeckleTrackingComponent
+  {
+    /// <summary>
+    /// This is where the logic of of SolveInstance should be implemented.
+    /// Solve Instance should call `SolveInstanceWithLogContext` wrapped in a using statement that provides all necessary metadata for that run.
+    /// </summary>
+    /// <param name="DA">The solve instance DA input</param>
+    void SolveInstanceWithLogContext(IGH_DataAccess DA);
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/SelectKitAsyncComponentBase.cs
@@ -138,7 +138,7 @@ namespace ConnectorGrasshopper.Objects
       base.BeforeSolveInstance();
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       //Ensure converter document is up to date
       if (Converter == null)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/SelectKitTaskCapableComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/SelectKitTaskCapableComponentBase.cs
@@ -17,7 +17,7 @@ using Speckle.Core.Models.Extensions;
 
 namespace ConnectorGrasshopper.Objects
 {
-  public class SelectKitTaskCapableComponentBase<T> : GH_SpeckleTaskCapableComponent<T>
+  public abstract class SelectKitTaskCapableComponentBase<T> : GH_SpeckleTaskCapableComponent<T>
   {
     public ISpeckleConverter Converter;
 
@@ -136,11 +136,6 @@ namespace ConnectorGrasshopper.Objects
     {
       throw new SpeckleException("Please inherit from this class, don't use SelectKitComponentBase directly",
         level: SentryLevel.Warning);
-    }
-
-    protected override void SolveInstance(IGH_DataAccess DA)
-    {
-      throw new NotImplementedException();
     }
 
     protected override void BeforeSolveInstance()

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/DeserialiseTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/DeserialiseTaskCapableComponent.cs
@@ -47,7 +47,7 @@ namespace ConnectorGrasshopper
       pManager.AddParameter(new SpeckleBaseParam("Base", "B", "Deserialized Speckle Base objects.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/DeserialiseTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/DeserialiseTaskCapableComponent.cs
@@ -47,7 +47,7 @@ namespace ConnectorGrasshopper
       pManager.AddParameter(new SpeckleBaseParam("Base", "B", "Deserialized Speckle Base objects.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/SerialiseTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/SerialiseTaskCapableComponent.cs
@@ -52,7 +52,7 @@ namespace ConnectorGrasshopper.Conversion
       pManager.AddTextParameter("Json", "J", "Serialized objects in JSON format.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/SerialiseTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/SerialiseTaskCapableComponent.cs
@@ -52,7 +52,7 @@ namespace ConnectorGrasshopper.Conversion
       pManager.AddTextParameter("Json", "J", "Serialized objects in JSON format.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToNativeTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToNativeTaskCapableComponent.cs
@@ -60,7 +60,7 @@ namespace ConnectorGrasshopper.Conversion
       pManager.AddGenericParameter("Data", "D", "Converted data in GH native format.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToNativeTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToNativeTaskCapableComponent.cs
@@ -60,7 +60,7 @@ namespace ConnectorGrasshopper.Conversion
       pManager.AddGenericParameter("Data", "D", "Converted data in GH native format.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
@@ -61,7 +61,7 @@ namespace ConnectorGrasshopper.Conversion
       //pManager.AddParameter(new SpeckleBaseParam("Base", "B", "Converted Base Speckle objects.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Conversion/ToSpeckleTaskCapableComponent.cs
@@ -61,7 +61,7 @@ namespace ConnectorGrasshopper.Conversion
       //pManager.AddParameter(new SpeckleBaseParam("Base", "B", "Converted Base Speckle objects.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectByKeyValueV2TaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectByKeyValueV2TaskComponent.cs
@@ -38,7 +38,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Object", "O", "Speckle object", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectByKeyValueV2TaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectByKeyValueV2TaskComponent.cs
@@ -38,7 +38,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Object", "O", "Speckle object", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectTaskComponent.cs
@@ -36,7 +36,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Speckle Object", "O", "Created speckle object", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/CreateSpeckleObjectTaskComponent.cs
@@ -36,7 +36,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Speckle Object", "O", "Created speckle object", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/DeconstructSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/DeconstructSpeckleObjectTaskComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Objects
       // INFO -> All output params are dynamically generated!
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       //DA.DisableGapLogic();
       if (InPreSolve)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/DeconstructSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/DeconstructSpeckleObjectTaskComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Objects
       // INFO -> All output params are dynamically generated!
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       //DA.DisableGapLogic();
       if (InPreSolve)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/CreateSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/CreateSpeckleObjectByKeyValueTaskComponent.cs
@@ -37,7 +37,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Object", "O", "Speckle object", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/CreateSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/CreateSpeckleObjectByKeyValueTaskComponent.cs
@@ -37,7 +37,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Object", "O", "Speckle object", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
@@ -80,7 +80,7 @@ namespace ConnectorGrasshopper.Objects
       // INFO -> All output params are dynamically generated!
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
 
       if (InPreSolve)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
@@ -80,7 +80,7 @@ namespace ConnectorGrasshopper.Objects
       // INFO -> All output params are dynamically generated!
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
 
       if (InPreSolve)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExtendSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExtendSpeckleObjectByKeyValueTaskComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Objects
         "The resulting extended Speckle object.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExtendSpeckleObjectByKeyValueTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExtendSpeckleObjectByKeyValueTaskComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Objects
         "The resulting extended Speckle object.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectByKeyValueV2TaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectByKeyValueV2TaskComponent.cs
@@ -41,7 +41,7 @@ namespace ConnectorGrasshopper.Objects
         "The resulting extended Speckle object.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectByKeyValueV2TaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectByKeyValueV2TaskComponent.cs
@@ -41,7 +41,7 @@ namespace ConnectorGrasshopper.Objects
         "The resulting extended Speckle object.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectTaskComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Extended Speckle Object", "EO", "Extended speckle object.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectTaskComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddParameter(new SpeckleBaseParam("Extended Speckle Object", "EO", "Extended speckle object.", GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectKeysComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectKeysComponent.cs
@@ -34,7 +34,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddTextParameter("Keys", "K", "The keys available on this speckle object", GH_ParamAccess.list);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (perObject)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectValueByKeyTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectValueByKeyTaskComponent.cs
@@ -37,7 +37,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddGenericParameter("Value", "V", "Speckle object", GH_ParamAccess.list);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectValueByKeyTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectValueByKeyTaskComponent.cs
@@ -37,7 +37,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddGenericParameter("Value", "V", "Speckle object", GH_ParamAccess.list);
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/SpeckleObjectGroup.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/SpeckleObjectGroup.cs
@@ -55,7 +55,7 @@ namespace ConnectorGrasshopper.Objects
       pManager.AddGenericParameter("Group", "G", "The group containing the input objects", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       var values = new List<object>();
       if (!DA.GetDataList(0, values)) return;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponent.cs
@@ -232,7 +232,7 @@ namespace ConnectorGrasshopper.Ops
           (s, e) => System.Diagnostics.Process.Start($"{StreamWrapper.ServerUrl}/streams/{StreamWrapper.StreamId}/commits/{ReceivedCommitId}"));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
@@ -243,7 +243,7 @@ namespace ConnectorGrasshopper.Ops.Deprecated
     /// This is the method that actually does the work.
     /// </summary>
     /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
 
       if (RunCount == 1)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
@@ -243,7 +243,7 @@ namespace ConnectorGrasshopper.Ops.Deprecated
     /// This is the method that actually does the work.
     /// </summary>
     /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
 
       if (RunCount == 1)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponent.cs
@@ -156,7 +156,7 @@ namespace ConnectorGrasshopper.Ops
       base.AppendAdditionalMenuItems(menu);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
 
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponentSync.cs
@@ -194,7 +194,7 @@ namespace ConnectorGrasshopper.Ops.Deprecated
     /// This is the method that actually does the work.
     /// </summary>
     /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponentSync.cs
@@ -194,7 +194,7 @@ namespace ConnectorGrasshopper.Ops.Deprecated
     /// This is the method that actually does the work.
     /// </summary>
     /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.VariableInputSendComponent.cs
@@ -160,7 +160,7 @@ namespace ConnectorGrasshopper.Ops
       base.AppendAdditionalMenuItems(menu);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
 
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.ReceiveLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.ReceiveLocalComponent.cs
@@ -98,7 +98,7 @@ namespace ConnectorGrasshopper.Ops
       }
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (!foundKit)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SendLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SendLocalComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Ops
       pManager.AddGenericParameter("localDataId", "id", "ID of the local data sent.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       base.SolveInstance(DA);
       if(DA.Iteration == 0) Tracker.TrackNodeRun();

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
@@ -163,7 +163,7 @@ namespace ConnectorGrasshopper.Ops
       pManager.AddTextParameter("Info", "I", "Commit information.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (RunCount == 1)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
@@ -163,7 +163,7 @@ namespace ConnectorGrasshopper.Ops
       pManager.AddTextParameter("Info", "I", "Commit information.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (RunCount == 1)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncSendComponent.cs
@@ -98,7 +98,7 @@ namespace ConnectorGrasshopper.Ops
       return base.Read(reader);
     }
     
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       if (RunCount == 1)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncSendComponent.cs
@@ -98,7 +98,7 @@ namespace ConnectorGrasshopper.Ops
       return base.Read(reader);
     }
     
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       if (RunCount == 1)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -257,7 +257,7 @@ namespace ConnectorGrasshopper.Ops
           (s, e) => System.Diagnostics.Process.Start($"{StreamWrapper.ServerUrl}/streams/{StreamWrapper.StreamId}/commits/{ReceivedCommitId}"));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
@@ -165,7 +165,7 @@ namespace ConnectorGrasshopper.Ops
       .Select(p => p.NickName)
       .GroupBy(x => x).Count(group => group.Count() > 1) > 0;
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
 
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
@@ -344,7 +344,7 @@ namespace ConnectorGrasshopper
         true));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (readFailed)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -333,7 +333,7 @@ namespace ConnectorGrasshopper
       return valueList;
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (readFailed)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamCreateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamCreateComponent.cs
@@ -64,7 +64,7 @@ namespace ConnectorGrasshopper.Streams
       return base.Write(writer);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (DA.Iteration != 0)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamDetailsComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamDetailsComponent.cs
@@ -51,7 +51,7 @@ namespace ConnectorGrasshopper.Streams
     private Exception error;
     private Dictionary<GH_Path, Stream> streams;
     private bool tooManyItems;
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (error != null)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamGetComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamGetComponent.cs
@@ -44,7 +44,7 @@ namespace ConnectorGrasshopper.Streams
     private StreamWrapper stream;
     private Exception error;
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       if (DA.Iteration != 0)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamListComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamListComponent.cs
@@ -43,7 +43,7 @@ namespace ConnectorGrasshopper.Streams
     private List<StreamWrapper> streams;
     private Exception error;
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (error != null)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamUpdateComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/Deprecated/StreamUpdateComponent.cs
@@ -42,7 +42,7 @@ namespace ConnectorGrasshopper.Streams
     private Stream stream;
     Exception error = null;
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       GH_SpeckleStream ghSpeckleStream = null;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamCreateComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamCreateComponentV2.cs
@@ -58,7 +58,7 @@ namespace ConnectorGrasshopper.Streams
       return base.Write(writer);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamCreateComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamCreateComponentV2.cs
@@ -58,7 +58,7 @@ namespace ConnectorGrasshopper.Streams
       return base.Write(writer);
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamDetailsComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamDetailsComponentV2.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Streams
       pManager.AddGenericParameter("Branches", "B", "List of branches for this stream", GH_ParamAccess.list);
     }
     
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamDetailsComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamDetailsComponentV2.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Streams
       pManager.AddGenericParameter("Branches", "B", "List of branches for this stream", GH_ParamAccess.list);
     }
     
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamGetComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamGetComponentV2.cs
@@ -32,7 +32,7 @@ namespace ConnectorGrasshopper.Streams
         GH_ParamAccess.item));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       if (DA.Iteration != 0)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamGetComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamGetComponentV2.cs
@@ -32,7 +32,7 @@ namespace ConnectorGrasshopper.Streams
         GH_ParamAccess.item));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
       if (DA.Iteration != 0)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
@@ -36,7 +36,7 @@ namespace ConnectorGrasshopper.Streams
         GH_ParamAccess.list));
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
@@ -36,7 +36,7 @@ namespace ConnectorGrasshopper.Streams
         GH_ParamAccess.list));
     }
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamUpdateComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamUpdateComponentV2.cs
@@ -39,7 +39,7 @@ namespace ConnectorGrasshopper.Streams
     }
 
 
-    protected override void SolveInstancePrivate(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamUpdateComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamUpdateComponentV2.cs
@@ -39,7 +39,7 @@ namespace ConnectorGrasshopper.Streams
     }
 
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstancePrivate(IGH_DataAccess DA)
     {
       if (InPreSolve)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/SendReceiveTransport.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/SendReceiveTransport.cs
@@ -52,7 +52,7 @@ namespace ConnectorGrasshopper.Transports
       pManager.AddTextParameter("id", "ID", "The sent object's id.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (DA.Iteration != 0)
       {
@@ -126,7 +126,7 @@ namespace ConnectorGrasshopper.Transports
       pManager.AddGenericParameter("objects", "O", "The objects you requested.", GH_ParamAccess.list);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (DA.Iteration != 0)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/Transports.Disk.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/Transports.Disk.cs
@@ -48,7 +48,7 @@ namespace ConnectorGrasshopper.Transports
       pManager.AddGenericParameter("disk transport", "T", "The Disk Transport you have created.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (DA.Iteration != 0)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/Transports.Memory.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/Transports.Memory.cs
@@ -48,7 +48,7 @@ namespace ConnectorGrasshopper.Transports
       pManager.AddGenericParameter("disk transport", "T", "The Memory Transport you have created.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (DA.Iteration != 0)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/Transports.Sqlite.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Transports/Transports.Sqlite.cs
@@ -46,7 +46,7 @@ namespace ConnectorGrasshopper.Transports
       pManager.AddGenericParameter("sqlite transport", "T", "The Sqlite transport you have created.", GH_ParamAccess.item);
     }
 
-    protected override void SolveInstance(IGH_DataAccess DA)
+    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
     {
       if (DA.Iteration != 0)
       {

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -113,6 +113,8 @@ namespace Speckle.Core.Logging
         .Information(
           "Initialized logger inside {hostApplication}/{productVersion}/{version} for user {id}. Path info {userApplicationDataPath} {installApplicationDataPath}."
         );
+      
+      _initialized = true;
     }
 
     /// <summary>


### PR DESCRIPTION
Discovered by me and @gjedlicska!

This does not fix #2258, but is related to our use of Serilog in the same way.

Since only one global context of serilog can exist, but we have 2 plugins for Rhino (the Rhino and Grasshopper ones), our logs will report the `HostApplication` to be the one of the last plugin that was initialised (be it Rhino or Grasshopper).

This PR addresses this issue by forcefully overrides the context `hostApp` for our Grasshopper components on each solution.

All of our components now use `SolveInstanceWithLogContext` instead of `SolveInstance`.
I have also sealed `SolveInstance` for any of our components so that we can't override it by accident.