### PR TITLE
fix(gh): Logging in Async component could lead to stack overflow by recursively calling the parent SolveInstance.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleAsyncComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/GH_SpeckleAsyncComponent.cs
@@ -10,7 +10,7 @@ using Speckle.Core.Helpers;
 
 namespace ConnectorGrasshopper
 {
-  public abstract class GH_SpeckleAsyncComponent : GH_AsyncComponent, ISpeckleTrackingComponent
+  public abstract class GH_SpeckleAsyncComponent : GH_AsyncComponent, ISpeckleTrackingDocumentObject
   {
     public ComponentTracker Tracker { get; set; }
     public bool IsNew { get; set; } = true;
@@ -38,7 +38,7 @@ namespace ConnectorGrasshopper
       }
     }
     
-    protected sealed override void SolveInstance(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
       var guid = Guid.NewGuid();
       
@@ -53,9 +53,8 @@ namespace ConnectorGrasshopper
       using (LogContext.PushProperty("hostApplication", Utilities.GetVersionedAppName()))
       using (LogContext.PushProperty("grasshopperComponent", GetType().Name))
       using(LogContext.PushProperty("traceId", guid))
-        SolveInstanceWithLogContext(DA);
+        base.SolveInstance(DA);
     }
-
-    public abstract void SolveInstanceWithLogContext(IGH_DataAccess DA);
+    
   }
 }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/SelectKitAsyncComponentBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/SelectKitAsyncComponentBase.cs
@@ -138,7 +138,7 @@ namespace ConnectorGrasshopper.Objects
       base.BeforeSolveInstance();
     }
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
       //Ensure converter document is up to date
       if (Converter == null)
@@ -146,7 +146,6 @@ namespace ConnectorGrasshopper.Objects
         AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "No converter was provided. Conversions are disabled.");
 
       }
-
       base.SolveInstance(DA);
     }
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponent.cs
@@ -232,7 +232,7 @@ namespace ConnectorGrasshopper.Ops
           (s, e) => System.Diagnostics.Process.Start($"{StreamWrapper.ServerUrl}/streams/{StreamWrapper.StreamId}/commits/{ReceivedCommitId}"));
     }
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponent.cs
@@ -156,7 +156,7 @@ namespace ConnectorGrasshopper.Ops
       base.AppendAdditionalMenuItems(menu);
     }
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
 
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.VariableInputSendComponent.cs
@@ -160,7 +160,7 @@ namespace ConnectorGrasshopper.Ops
       base.AppendAdditionalMenuItems(menu);
     }
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
 
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.ReceiveLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.ReceiveLocalComponent.cs
@@ -98,7 +98,7 @@ namespace ConnectorGrasshopper.Ops
       }
     }
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
       if (!foundKit)
       {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SendLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SendLocalComponent.cs
@@ -40,7 +40,7 @@ namespace ConnectorGrasshopper.Ops
       pManager.AddGenericParameter("localDataId", "id", "ID of the local data sent.", GH_ParamAccess.item);
     }
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
       base.SolveInstance(DA);
       if(DA.Iteration == 0) Tracker.TrackNodeRun();

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -257,7 +257,7 @@ namespace ConnectorGrasshopper.Ops
           (s, e) => System.Diagnostics.Process.Start($"{StreamWrapper.ServerUrl}/streams/{StreamWrapper.StreamId}/commits/{ReceivedCommitId}"));
     }
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
       DA.DisableGapLogic();
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
@@ -165,7 +165,7 @@ namespace ConnectorGrasshopper.Ops
       .Select(p => p.NickName)
       .GroupBy(x => x).Count(group => group.Count() > 1) > 0;
 
-    public override void SolveInstanceWithLogContext(IGH_DataAccess DA)
+    protected override void SolveInstance(IGH_DataAccess DA)
     {
 
       // Set output data in a "first run" event. Note: we are not persisting the actual "sent" object as it can be very big.

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
@@ -42,7 +42,6 @@ namespace ConnectorGrasshopper.Streams
       {
         if (DA.Iteration == 0)
         {
-          hasInternetTask = Http.UserHasInternet();
           Tracker.TrackNodeRun();
         }
         
@@ -72,7 +71,7 @@ namespace ConnectorGrasshopper.Streams
           AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Max number of streams retrieved is 50. Limit has been capped.");
         }
         
-        TaskList.Add(ListStreams(account, limit));
+        TaskList.Add(Task.Run(()=> ListStreams(account, limit), CancelToken));
         return;
       }
 
@@ -82,20 +81,14 @@ namespace ConnectorGrasshopper.Streams
       DA.SetDataList(0, data.Select(item => new GH_SpeckleStream(item)));
     }
 
-    private Task<bool> hasInternetTask;
-    private async Task<List<StreamWrapper>> ListStreams(Account account, int limit)
+    private Task<List<StreamWrapper>> ListStreams(Account account, int limit)
     {
-      if (!hasInternetTask.Result)
-      {
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "You are not connected to the internet");
-        return null;
-      }
-      
       var client = new Client(account);
-      return Task.Run(() => client.StreamsGet(limit)
+      var res = client.StreamsGet(CancelToken ,limit)
         .Result
         .Select(stream => new StreamWrapper(stream.id, account.userInfo.id, account.serverInfo.url))
-        .ToList()).Result;
+        .ToList();
+      return Task.FromResult(res);
     }
   }
 }


### PR DESCRIPTION
Our latest fix for logging in #2274 broke our GH_AsyncComponent logic (on the components that inherited from it)

We did not take into account the convoluted solving logic of the Async component, and this lead to an infinite recursive call of `SolveInstance -> SolveInstanceWithLogContext -> SolveInstance`....
