### PR TITLE
refactor(objects): New SchemaComputed attribute and GetMembers implementation

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
+++ b/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
@@ -247,7 +247,7 @@
   <Target Name="AfterBuild">
     <!-- Icons stuff -->
     <!-- Get System.Drawing.dll -->
-    <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v4.7">
+    <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v4.8">
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
     </GetReferenceAssemblyPaths>
     <!-- Get assembly -->

--- a/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
@@ -128,7 +128,7 @@
   <Target Name="AfterBuild">
     <!-- Icons stuff -->
     <!-- Get System.Drawing.dll -->
-    <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v4.7">
+    <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v4.8">
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
     </GetReferenceAssemblyPaths>
     <!-- Get assembly -->

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/DeconstructSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/DeconstructSpeckleObjectTaskComponent.cs
@@ -301,7 +301,7 @@ namespace ConnectorGrasshopper.Objects
         }
         if (converted is Base b)
         {
-          b.GetMemberNames().ToList().ForEach(prop =>
+          b.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.Dynamic | DynamicBaseMemberType.SchemaComputed ).Keys.ToList().ForEach(prop =>
           {
             if (!fullProps.Contains(prop))
               fullProps.Add(prop);
@@ -336,7 +336,7 @@ namespace ConnectorGrasshopper.Objects
       // Assign all values to it's corresponding dictionary entry and branch path.
       var obj = @base;
       if (obj == null) return new Dictionary<string, object>();
-      foreach (var prop in obj.GetMembers())
+      foreach (var prop in obj.GetMembers(DynamicBaseMemberType.Instance | DynamicBaseMemberType.Dynamic | DynamicBaseMemberType.SchemaComputed))
       {
         // Convert and add to corresponding output structure
         var value = prop.Value;
@@ -381,14 +381,13 @@ namespace ConnectorGrasshopper.Objects
 
             break;
           default:
-            var temp = obj[prop.Key];
-            if (temp is Base tempB && Utilities.CanConvertToDataTree(tempB))
+            if (prop.Value is Base temp && Utilities.CanConvertToDataTree(temp))
             {
-              outputDict[prop.Key] = Utilities.DataTreeToNative(tempB, Converter);
+              outputDict[prop.Key] = Utilities.DataTreeToNative(temp, Converter);
             }
             else
             {
-              outputDict[prop.Key] = Utilities.TryConvertItemToNative(temp, Converter);
+              outputDict[prop.Key] = Utilities.TryConvertItemToNative(prop.Value, Converter);
             }
             break;
         }

--- a/Core/Core/Kits/Attributes.cs
+++ b/Core/Core/Kits/Attributes.cs
@@ -61,7 +61,7 @@ namespace Speckle.Core.Kits
   /// <summary>
   /// Used to indicate which is the main input parameter of the schema builder component. Schema info will be attached to this object.
   /// </summary>
-  [AttributeUsage(AttributeTargets.Parameter, Inherited = false, AllowMultiple = false)]
+  [AttributeUsage(AttributeTargets.Parameter)]
   public class SchemaMainParam : Attribute
   {
     public SchemaMainParam()
@@ -74,8 +74,18 @@ namespace Speckle.Core.Kits
   /// <summary>
   /// Used to ignore properties from expand objects etc
   /// </summary>
-  [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+  [AttributeUsage(AttributeTargets.Property)]
   public class SchemaIgnore : Attribute
   {
+  }
+  
+  [AttributeUsage(AttributeTargets.Method)]
+  public class SchemaComputedAttribute : Attribute
+  {
+    public virtual string Name { get; }
+    public SchemaComputedAttribute(string name)
+    {
+      Name = name;
+    }
   }
 }

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -152,8 +152,7 @@ namespace Speckle.Core.Models
 
     /// <summary>
     /// Gets all of the property names on this class, dynamic or not.
-    /// </summary>
-    /// <returns></returns>
+    /// </summary> <returns></returns>
     [Obsolete("Use `GetMembers(DynamicBaseMemberType.All).Keys` instead")]
     public override IEnumerable<string> GetDynamicMemberNames()
     {

--- a/Core/Core/Models/DynamicBaseMemberType.cs
+++ b/Core/Core/Models/DynamicBaseMemberType.cs
@@ -25,6 +25,10 @@ namespace Speckle.Core.Models
     /// </summary>
     SchemaIgnored = 8,
     /// <summary>
+    /// The typed methods flagged with TODO:
+    /// </summary>
+    SchemaComputed = 16,
+    /// <summary>
     /// All the typed members, including ones with <see cref="ObsoleteAttribute"/> or <see cref="Speckle.Core.Kits.SchemaIgnore"/> attributes.
     /// </summary>
     InstanceAll = Instance + Obsolete + SchemaIgnored,

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.Geometry.cs
@@ -910,12 +910,7 @@ namespace Objects.Converter.Dynamo
 
     public Dictionary<string, object> GetDynamicMembersFromBase(Base obj)
     {
-      var dict = new Dictionary<string, object>();
-      foreach (var prop in obj.GetDynamicMembers())
-      {
-        dict.Add(prop, obj[prop]);
-      }
-      return dict;
+      return obj.GetMembers(DynamicBaseMemberType.Dynamic);
     }
 
   }

--- a/Objects/Objects/Other/Instance.cs
+++ b/Objects/Objects/Other/Instance.cs
@@ -136,6 +136,7 @@ namespace Objects.Other.Revit
     public Base parameters { get; set; }
     public string elementId { get; set; }
     
+    [SchemaComputed("transformedGeometry")]
     public List<ITransformable> GetTransformedGeometry()
     {
       var allChildren = _definition.elements ?? new List<Base>();
@@ -186,6 +187,7 @@ namespace Objects.Other.Revit
     /// </summary>
     /// <remarks>This method will skip scaling. If you need scaling, we recommend using the transform instead.</remarks>
     /// <returns>A Plane on the insertion point of this Block Instance, with the correct 3-axis rotations.</returns>
+    [SchemaComputed("insertionPlane")]
     public Plane GetInsertionPlane()
     {
       // TODO: Check for Revit in GH/DYN

--- a/Objects/Objects/Other/Instance.cs
+++ b/Objects/Objects/Other/Instance.cs
@@ -86,7 +86,8 @@ namespace Objects.Other
       // whereas the instance transform assumes it contains the basePoint translation already.
       //this.transform = transform * blockDefinition.GetBasePointTransform();
     }
-
+    
+    [SchemaComputed("transformedGeometry")]
     public List<ITransformable> GetTransformedGeometry()
     {
       return _definition.geometry.SelectMany(b =>
@@ -114,6 +115,7 @@ namespace Objects.Other
     /// </summary>
     /// <remarks>This method will skip scaling. If you need scaling, we recommend using the transform instead.</remarks>
     /// <returns>A Plane on the insertion point of this Block Instance, with the correct 3-axis rotations.</returns>
+    [SchemaComputed("insertionPlane")]
     public Plane GetInsertionPlane()
     {
       // TODO: UPDATE!
@@ -121,14 +123,6 @@ namespace Objects.Other
       plane.TransformTo(transform, out Plane tPlane);
       return tPlane;
     }
-    
-    /// <inheritdoc cref="GetInsertionPlane"/>
-    [JsonIgnore]
-    public Plane insertionPlane => GetInsertionPlane();
-    
-    /// <inheritdoc cref="GetTransformedGeometry"/>
-    [JsonIgnore]
-    public List<ITransformable> transformedGeometry => GetTransformedGeometry();
   }
 }
 
@@ -200,14 +194,6 @@ namespace Objects.Other.Revit
       return tPlane;
     }
 
-    /// <inheritdoc cref="GetInsertionPlane"/>
-    [JsonIgnore]
-    public Plane insertionPlane => GetInsertionPlane();
-    
-    /// <inheritdoc cref="GetTransformedGeometry"/>
-    [JsonIgnore]
-    public List<ITransformable> transformedGeometry => GetTransformedGeometry();
-    
     public RevitInstance() { }
   }
 }

--- a/Objects/Tests/GenericTests.cs
+++ b/Objects/Tests/GenericTests.cs
@@ -19,16 +19,34 @@ namespace Tests
     {
       // Get all types in the Objects assembly that inherit from Base
       return Assembly.GetAssembly(typeof(ObjectsKit))
-        .GetTypes()
-        .Where(t => typeof(Base).IsAssignableFrom(t));
+                     .GetTypes()
+                     .Where(t => typeof(Base).IsAssignableFrom(t));
     }
-    
+
     [Test(Description = "Checks that all objects inside the Default Kit have empty constructors.")]
     [TestCaseSource(nameof(AvailableTypesInKit))]
     public void ObjectHasEmptyConstructor(Type t)
     {
       var constructor = t.GetConstructor(Type.EmptyTypes);
       Assert.That(constructor, Is.Not.Null);
+    }
+
+    [Test(Description =
+      "Checks that all methods with the 'SchemaComputed' attribute inside the Default Kit have no parameters.")]
+    [TestCaseSource(nameof(AvailableTypesInKit))]
+    public void SchemaComputedMethod_CanBeCalledWithNoParameters(Type t)
+    {
+      t.GetMethods()
+       .Where(m => m.IsDefined(typeof(SchemaComputedAttribute)))
+       .ToList()
+       .ForEach(m =>
+          {
+            // Check if all parameters are optional.
+            // This allows for other methods to be used as long as they can be called empty.
+            // But also covers the basic case of having no parameters in the first place.
+            Assert.True(m.GetParameters().All(p => p.IsOptional));
+          }
+        );
     }
   }
 }


### PR DESCRIPTION
This PR adds a new mechanism for `GetMembers` to fetch properties of an object, but also any computed values we may want to have included.

Any method that should be displayed in the output of `GetMembers` should be flagged with the `SchemaComputed` attribute, which requires a name.

GetMembers will use that name as the property name for  the output dictionary.


This PR also updates both Grasshopper and Dynamo nodes to reflect this change.