### PR TITLE
fix(rhino): assigns materials when receiving revit instances

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -9,14 +9,31 @@ using Grasshopper.Kernel.Types;
 
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
-using Objects.Geometry;
-using Objects.Primitive;
-using Objects.Other;
 
 namespace Objects.Converter.RhinoGh
 {
   public partial class ConverterRhinoGh
   {
+    /// <summary>
+    /// Retrieves the index of a render material in the document rendermaterialtable by name
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns>Index of the rendermaterial, or -1 if no matches are found</returns>
+    public int GetMaterialIndex(string name)
+    {
+      var index = -1;
+      if (string.IsNullOrEmpty(name)) return index;
+      for (int i = 0; i < Doc.Materials.Count; i++)
+      {
+        if (Doc.Materials[i].Name == name)
+        {
+          index = i;
+          break;
+        }
+      }
+      return index;
+    }
+
     private string GetSchema(RhinoObject obj, out string[] args)
     {
       args = null;


### PR DESCRIPTION
Fixes receiving revit instances with render materials in Rhino. 
Also improves revit instance definition naming, using the category/family/type information for Rhino block definition names.

## Changes:

Rhino converter

## Screenshots:

Before:
![image](https://user-images.githubusercontent.com/16748799/225069541-156e47b8-e4b5-4679-b892-8d6fcbf593f3.png)


After:
![image](https://user-images.githubusercontent.com/16748799/225069024-b342fc54-6f4c-42a5-aaaf-8b4d324dbf4d.png)


## Validation of changes:

Tested receiving a few different revit family instances
