### PR TITLE
fix(revit): recomputes familysymbol definitions when sending revit instances

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -448,7 +448,7 @@ namespace Objects.Converter.AutocadCivil
       var commitInfo = RemoveInvalidAutocadChars(Doc.UserData["commit"] as string);
       string definitionName =
         definition is BlockDefinition blockDef ? RemoveInvalidAutocadChars(blockDef.name) :
-        definition is RevitSymbolElementType revitDef ? RemoveInvalidAutocadChars($"{revitDef.type} - {definition.id}") :
+        definition is RevitSymbolElementType revitDef ? RemoveInvalidAutocadChars($"{revitDef.family} - {revitDef.type} - {definition.id}") :
         definition.id;
       if (ReceiveMode == ReceiveMode.Create) definitionName = $"{commitInfo} - " + definitionName;
       BlockTable blckTbl = Trans.GetObject(Doc.Database.BlockTableId, OpenMode.ForRead) as BlockTable;

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -26,6 +26,7 @@ using HatchLoopType = Objects.Other.HatchLoopType;
 using Line = Objects.Geometry.Line;
 using Point = Objects.Geometry.Point;
 using Text = Objects.Other.Text;
+using Objects.BuiltElements.Revit;
 
 namespace Objects.Converter.AutocadCivil
 {
@@ -445,7 +446,10 @@ namespace Objects.Converter.AutocadCivil
 
       // get the definition name
       var commitInfo = RemoveInvalidAutocadChars(Doc.UserData["commit"] as string);
-      string definitionName = definition is BlockDefinition blockDef ? RemoveInvalidAutocadChars(blockDef.name) : definition.id;
+      string definitionName =
+        definition is BlockDefinition blockDef ? RemoveInvalidAutocadChars(blockDef.name) :
+        definition is RevitSymbolElementType revitDef ? RemoveInvalidAutocadChars($"{revitDef.type} - {definition.id}") :
+        definition.id;
       if (ReceiveMode == ReceiveMode.Create) definitionName = $"{commitInfo} - " + definitionName;
       BlockTable blckTbl = Trans.GetObject(Doc.Database.BlockTableId, OpenMode.ForRead) as BlockTable;
       if (blckTbl.Has(definitionName))

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -638,7 +638,7 @@ namespace Objects.Converter.Revit
       var transform = TransformToSpeckle(localTransform, instance.Document, out bool isMirrored);
 
       // get the definition base of this instance
-      RevitSymbolElementType definition = ConvertAndCacheRevitInstanceDefinition(instance, Doc, out List<string> definitionNotes, instanceTransform);
+      RevitSymbolElementType definition = GetRevitInstanceDefinition(instance, out List<string> definitionNotes, instanceTransform);
       notes.AddRange(definitionNotes);
 
       var _instance = new RevitInstance();
@@ -660,18 +660,14 @@ namespace Objects.Converter.Revit
       return _instance;
     }
 
-    private RevitSymbolElementType ConvertAndCacheRevitInstanceDefinition(DB.FamilyInstance instance, Document doc, out List<string> notes, Transform parentTransform)
-    {
-      notes = new List<string>();
-      var _symbol = instance.Document.GetElement(instance.GetTypeId()) as DB.FamilySymbol;
-
-      if (_symbol == null) return null;
-      if (!Symbols.ContainsKey(_symbol.UniqueId))
-        Symbols[_symbol.UniqueId] = GetRevitInstanceDefinition(instance, out notes, parentTransform);
-
-      return Symbols[_symbol.UniqueId] as RevitSymbolElementType;
-    }
-
+    /// <summary>
+    /// Converts the familysymbol into a revitsymbolelementtype
+    /// </summary>
+    /// <param name="instance"></param>
+    /// <param name="notes"></param>
+    /// <param name="parentTransform"></param>
+    /// <returns></returns>
+    /// <remarks>TODO: could potentially optimize this for symbols with the same displayvalues by caching previously converted symbols</remarks>
     private RevitSymbolElementType GetRevitInstanceDefinition(DB.FamilyInstance instance, out List<string> notes, Transform parentTransform)
     {
       notes = new List<string>();

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -314,7 +314,7 @@ namespace Objects.Converter.RhinoGh
       var commitInfo = GetCommitInfo();
       string definitionName = 
         definition is BlockDefinition blockDef ? blockDef.name : 
-        definition is RevitSymbolElementType revitDef ? $"{revitDef.type} - {definition.id}" : 
+        definition is RevitSymbolElementType revitDef ? $"{revitDef.family} -{revitDef.type} - {definition.id}" : 
         definition.id;
       if (ReceiveMode == ReceiveMode.Create) definitionName = $"{commitInfo} - " + definitionName;
       if (Doc.InstanceDefinitions.Find(definitionName) is InstanceDefinition def)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -314,7 +314,7 @@ namespace Objects.Converter.RhinoGh
       var commitInfo = GetCommitInfo();
       string definitionName = 
         definition is BlockDefinition blockDef ? blockDef.name : 
-        definition is RevitSymbolElementType revitDef ? $"{revitDef.category} - {revitDef.family} - {revitDef.type}" : 
+        definition is RevitSymbolElementType revitDef ? $"{revitDef.type} - {definition.id}" : 
         definition.id;
       if (ReceiveMode == ReceiveMode.Create) definitionName = $"{commitInfo} - " + definitionName;
       if (Doc.InstanceDefinitions.Find(definitionName) is InstanceDefinition def)


### PR DESCRIPTION
## Description & motivation
When `RevitInstance` is sent, the corresponding `RevitSymbolElementType` definition is reconverted every time, since there is no quick way to determine whether the `displayValue` on the familysymbol has changed based on instance parameters.

Also includes updates to Rhino and Autocad on receiving revit instances, which now appends the revit definition id to the created block definition name (which differentiates between same familysymbols with different display values).

Fixes #2302 and also some other bugs discovered when sending revit instances.

## Changes:

Revit, rhino, and autocad converter

## Screenshots:

Before: see issue

After:
![image](https://user-images.githubusercontent.com/16748799/226382638-b7ca4e38-80f4-4bef-900f-b6b5bb417c49.png)


## Validation of changes:
also tested receiving in rhino: block defs are being created as expected


