### PR TITLE
Logging & avatar download fix

### DIFF
--- a/Core/Core/Helpers/Http.cs
+++ b/Core/Core/Helpers/Http.cs
@@ -2,20 +2,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
-using Serilog;
-using Speckle.Core.Credentials;
 using Polly.Extensions.Http;
 using Polly.Retry;
-using System.Diagnostics;
+using Serilog;
 using Serilog.Context;
-using System.Net.Sockets;
+using Speckle.Core.Credentials;
 
 namespace Speckle.Core.Helpers
 {
@@ -72,15 +72,15 @@ namespace Speckle.Core.Helpers
           delay ?? DefaultDelay(),
           onRetry: (ex, timeSpan, retryAttempt, context) =>
           {
-            context.Remove("retryCount");
-            context.Add("retryCount", retryAttempt);
-            Log.Information(
-              ex.Exception,
-              "The http request failed with {exceptionType} exception retrying after {cooldown} miliseconds. This is retry attempt {retryAttempt}",
-              ex.GetType().Name,
-              timeSpan.TotalSeconds * 1000,
-              retryAttempt
-            );
+            //context.Remove("retryCount");
+            //context.Add("retryCount", retryAttempt);
+            //Log.Information(
+            //  ex.Exception,
+            //  "The http request failed with {exceptionType} exception retrying after {cooldown} milliseconds. This is retry attempt {retryAttempt}",
+            //  ex.GetType().Name,
+            //  timeSpan.TotalSeconds * 1000,
+            //  retryAttempt
+            //);
           }
         );
 
@@ -122,13 +122,13 @@ namespace Speckle.Core.Helpers
           DefaultDelay(),
           (ex, timeSpan, retryAttempt, context) =>
           {
-            Log.Information(
-              ex,
-              "The http request failed with {exceptionType} exception retrying after {cooldown} miliseconds. This is retry attempt {retryAttempt}",
-              ex.GetType().Name,
-              timeSpan.TotalSeconds * 1000,
-              retryAttempt
-            );
+            //Log.Information(
+            //  ex,
+            //  "The http request failed with {exceptionType} exception retrying after {cooldown} milliseconds. This is retry attempt {retryAttempt}",
+            //  ex.GetType().Name,
+            //  timeSpan.TotalSeconds * 1000,
+            //  retryAttempt
+            //);
           }
         );
       var policyResult = await policy.ExecuteAndCaptureAsync(async () =>
@@ -236,7 +236,7 @@ namespace Speckle.Core.Helpers
         );
         if (policyResult.Outcome == OutcomeType.Successful)
           return policyResult.Result!;
-        
+
         // should we wrap this exception into something Speckle specific?
         throw policyResult.FinalException!;
       }

--- a/DesktopUI2/DesktopUI2/Utils.cs
+++ b/DesktopUI2/DesktopUI2/Utils.cs
@@ -6,6 +6,8 @@ using DesktopUI2.Views.Windows.Dialogs;
 using Material.Dialog;
 using Material.Dialog.Icons;
 using Material.Dialog.Interfaces;
+using Serilog;
+using SkiaSharp;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
@@ -17,7 +19,6 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Serilog;
 
 namespace DesktopUI2
 {
@@ -264,7 +265,7 @@ namespace DesktopUI2
             {
               Log.ForContext("dialogResult", result)
                 .Warning(ex, "Swallowing exception in {methodName} {exceptionMessage}", nameof(AddAccountCommand), nameof(AddAccountCommand), ex.Message);
-              
+
               //errors already handled in AddAccount
 
               MainUserControl.NotificationManager.Show(new PopUpNotificationViewModel()
@@ -283,8 +284,24 @@ namespace DesktopUI2
       }
       catch (Exception ex)
       {
-        Log.Fatal(ex, "Failed to add account {viewModel} {exceptionMessage}",ex.Message);
+        Log.Fatal(ex, "Failed to add account {viewModel} {exceptionMessage}", ex.Message);
       }
+    }
+
+
+    public static byte[] ResizeImage(byte[] fileContents, int maxWidth, int maxHeight, SKFilterQuality quality = SKFilterQuality.Medium)
+    {
+      using MemoryStream ms = new MemoryStream(fileContents);
+      using SKBitmap sourceBitmap = SKBitmap.Decode(ms);
+
+      int height = Math.Min(maxHeight, sourceBitmap.Height);
+      int width = Math.Min(maxWidth, sourceBitmap.Width);
+
+      using SKBitmap scaledBitmap = sourceBitmap.Resize(new SKImageInfo(width, height), quality);
+      using SKImage scaledImage = SKImage.FromBitmap(scaledBitmap);
+      using SKData data = scaledImage.Encode();
+
+      return data.ToArray();
     }
   }
 }

--- a/DesktopUI2/DesktopUI2/ViewModels/AccountViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/AccountViewModel.cs
@@ -1,11 +1,16 @@
 ﻿using ReactiveUI;
+using Serilog;
+using SkiaSharp;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
+using Speckle.Core.Helpers;
 using System;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net;
-using Serilog;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace DesktopUI2.ViewModels
 {
@@ -98,28 +103,42 @@ namespace DesktopUI2.ViewModels
 
 
 
-    public void DownloadImage(string url)
-    {
-      try
-      {
-        if (string.IsNullOrEmpty(url))
-          return;
 
-        using (WebClient client = new WebClient())
-        {
-          //client.Headers.Set("Authorization", "Bearer " + Client.ApiToken);
-          client.DownloadDataAsync(new Uri(url));
-          client.DownloadDataCompleted += DownloadComplete;
-        }
-      }
-      catch (Exception ex)
+    public async void DownloadImage(string url)
+    {
+      if (string.IsNullOrEmpty(url))
+        return;
+
+      _firstDownload = false;
+
+      using (var request = new HttpRequestMessage(HttpMethod.Get, new Uri(url)))
       {
-        Log.ForContext("imageUrl", url)
-          .Warning(ex, "Swallowing exception in {methodName}: {exceptionMessage}", nameof(DownloadImage), ex.Message);
+        HttpClient client = Http.GetHttpProxyClient();
+        //request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "Bearer " + Account.token);
+        var result = await client.SendAsync(request);
+
+        if (!result.IsSuccessStatusCode)
+        {
+          Log.ForContext("imageUrl", url).Warning("{methodName} failed with code: {exceptionMessage}", nameof(DownloadImage), result.StatusCode);
+          AvatarUrl = null; // Could not download...
+          return;
+        }
+
+        try
+        {
+          var bytes = await result.Content.ReadAsByteArrayAsync();
+          SetImage(bytes);
+        }
+        catch (Exception ex)
+        {
+          Log.ForContext("imageUrl", url)
+         .Warning(ex, "Swallowing exception in {methodName}: {exceptionMessage}", nameof(DownloadImage), ex.Message);
+          AvatarUrl = null; // Could not download...
+        }
       }
     }
 
-
+    private bool _firstDownload = true;
 
     public string _avatarUrl = "";
     public string AvatarUrl
@@ -142,7 +161,9 @@ namespace DesktopUI2.ViewModels
           }
         }
 
-        if (value == null && Id != null)
+        // only use robohas if it's the first attempt
+        // otherwise it'll end up in a loop
+        if (value == null && Id != null && _firstDownload)
         {
           this.RaiseAndSetIfChanged(ref _avatarUrl, $"https://robohash.org/{Id}.png?size=28x28");
         }
@@ -162,27 +183,14 @@ namespace DesktopUI2.ViewModels
       set => this.RaiseAndSetIfChanged(ref _avatarImage, value);
     }
 
-    private void DownloadComplete(object sender, DownloadDataCompletedEventArgs e)
-    {
-      try
-      {
-        byte[] bytes = e.Result;
-        SetImage(bytes);
-      }
-      catch (Exception ex)
-      {
-        Log.Warning(ex, "Swallowing exception in {methodName}: {exceptionMessage}", nameof(DownloadComplete),ex.Message);
-        System.Diagnostics.Debug.WriteLine(ex);
-        AvatarUrl = null; // Could not download...
-      }
-    }
+
 
     private void SetImage(byte[] bytes)
     {
-      System.IO.Stream stream = new MemoryStream(bytes);
+      var resizedBytes = Utils.ResizeImage(bytes, 28, 28);
+      System.IO.Stream stream = new MemoryStream(resizedBytes);
       AvatarImage = new Avalonia.Media.Imaging.Bitmap(stream);
       this.RaisePropertyChanged(nameof(AvatarImage));
-
     }
   }
 }


### PR DESCRIPTION
- excludes from the logging http retry attempts
- resizes avatar images that are too big (probably causing https://github.com/specklesystems/speckle-manager2/issues/44)
- fixes an avatar download loop triggered when the download fails