### PR TITLE
fix(core logging): make sure core logger uses our own SpeckleLog logger, not the global serilog instance

### DIFF
--- a/Core/Core/Api/GraphQL/Client.cs
+++ b/Core/Core/Api/GraphQL/Client.cs
@@ -144,7 +144,7 @@ namespace Speckle.Core.Api
           onRetry: (ex, timeout, context) =>
           {
             var graphqlEx = ex as SpeckleGraphQLException<T>;
-            Log.ForContext("graphqlExtensions", graphqlEx.Extensions)
+            SpeckleLog.Logger.ForContext("graphqlExtensions", graphqlEx.Extensions)
               .ForContext("graphqlErrorMessages", graphqlEx.ErrorMessages)
               .Warning(
                 ex,
@@ -166,7 +166,7 @@ namespace Speckle.Core.Api
     {
       using (LogContext.Push(_createEnrichers<T>(request)))
       {
-        Log.Debug("Starting execution of graphql request to get {resultType}", typeof(T).Name);
+        SpeckleLog.Logger.Debug("Starting execution of graphql request to get {resultType}", typeof(T).Name);
         var timer = new Stopwatch();
         var success = false;
         timer.Start();
@@ -196,7 +196,7 @@ namespace Speckle.Core.Api
         // anything else related to graphql gets logged
         catch (SpeckleGraphQLException<T> gqlException)
         {
-          Log.ForContext("graphqlResponse", gqlException.Response)
+          SpeckleLog.Logger.ForContext("graphqlResponse", gqlException.Response)
             .ForContext("graphqlExtensions", gqlException.Extensions)
             .ForContext("graphqlErrorMessages", gqlException.ErrorMessages.ToList())
             .Warning(
@@ -212,7 +212,7 @@ namespace Speckle.Core.Api
         // this makes sure, that any graphql operation only throws SpeckleGraphQLExceptions
         catch (Exception ex)
         {
-          Log.Warning(
+          SpeckleLog.Logger.Warning(
             ex,
             "Execution of the graphql request to get {resultType} failed without a graphql response. Cause {exceptionMessage}",
             typeof(T).Name,
@@ -232,7 +232,7 @@ namespace Speckle.Core.Api
           // the same performance log
           timer.Stop();
           var status = success ? "succeeded" : "failed";
-          Log.Information(
+          SpeckleLog.Logger.Information(
             "Execution of graphql request to get {resultType} {resultStatus} after {elapsed} seconds",
             typeof(T).Name,
             status,
@@ -339,7 +339,7 @@ namespace Speckle.Core.Api
                 }
                 else
                 {
-                  Log.ForContext("graphqlResponse", response)
+                  SpeckleLog.Logger.ForContext("graphqlResponse", response)
                     .Error(
                       "Cannot execute graphql callback for {resultType}, the response has no data.",
                       typeof(T).Name
@@ -354,7 +354,7 @@ namespace Speckle.Core.Api
               // anything else related to graphql gets logged
               catch (SpeckleGraphQLException<T> gqlException)
               {
-                Log.ForContext("graphqlResponse", gqlException.Response)
+                SpeckleLog.Logger.ForContext("graphqlResponse", gqlException.Response)
                   .ForContext("graphqlExtensions", gqlException.Extensions)
                   .ForContext("graphqlErrorMessages", gqlException.ErrorMessages.ToList())
                   .Warning(
@@ -375,7 +375,7 @@ namespace Speckle.Core.Api
             {
               // we're logging this as an error for now, to keep track of failures
               // so far we've swallowed these errors
-              Log.Error(
+              SpeckleLog.Logger.Error(
                 ex,
                 "Subscription request for {resultType} failed with {exceptionMessage}",
                 typeof(T).Name,
@@ -388,7 +388,7 @@ namespace Speckle.Core.Api
         }
         catch (Exception ex)
         {
-          Log.Warning(
+          SpeckleLog.Logger.Warning(
             ex,
             "Subscribing to graphql {resultType} failed without a graphql response. Cause {exceptionMessage}",
             typeof(T).Name,

--- a/Core/Core/Api/Operations/Operations.Receive.cs
+++ b/Core/Core/Api/Operations/Operations.Receive.cs
@@ -89,7 +89,7 @@ namespace Speckle.Core.Api
       using (LogContext.PushProperty("objectId", objectId))
       {
         var timer = Stopwatch.StartNew();
-        Log.Information(
+        SpeckleLog.Logger.Information(
           "Starting receive {objectId} from transports {localTransport} / {remoteTransport}",
           objectId,
           localTransport.TransportName,
@@ -158,7 +158,7 @@ namespace Speckle.Core.Api
             dispRemote.Dispose();
 
           timer.Stop();
-          Log.ForContext("deserializerElapsed", serializerV2?.Elapsed)
+          SpeckleLog.Logger.ForContext("deserializerElapsed", serializerV2?.Elapsed)
             .ForContext(
               "transportElapsedBreakdown",
               new ITransport?[] { localTransport, remoteTransport }
@@ -179,7 +179,7 @@ namespace Speckle.Core.Api
             $"Could not find specified object using the local transport {localTransport.TransportName}, and you didn't provide a fallback remote from which to pull it."
           );
 
-          Log.Error(
+          SpeckleLog.Logger.Error(
             ex,
             "Cannot receive object from the given transports {exceptionMessage}",
             ex.Message
@@ -193,7 +193,7 @@ namespace Speckle.Core.Api
         remoteTransport.OnProgressAction = internalProgressAction;
         remoteTransport.CancellationToken = cancellationToken;
 
-        Log.Debug(
+        SpeckleLog.Logger.Debug(
           "Cannot find object {objectId} in the local transport, hitting remote {transportName}.",
           remoteTransport.TransportName
         );
@@ -216,7 +216,7 @@ namespace Speckle.Core.Api
         if (disposeTransports && remoteTransport is IDisposable dr)
           dr.Dispose();
 
-        Log.ForContext("deserializerElapsed", serializerV2.Elapsed)
+        SpeckleLog.Logger.ForContext("deserializerElapsed", serializerV2.Elapsed)
           .ForContext(
             "transportElapsedBreakdown",
             new ITransport?[] { localTransport, remoteTransport }
@@ -259,7 +259,7 @@ namespace Speckle.Core.Api
         }
         catch (Exception ex)
         {
-          Log.Error(ex, "A deserialization error has occurred {exceptionMessage}", ex.Message);
+          SpeckleLog.Logger.Error(ex, "A deserialization error has occurred {exceptionMessage}", ex.Message);
           if (serializerV2.OnErrorAction == null)
             throw;
           serializerV2.OnErrorAction.Invoke(

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -91,7 +91,7 @@ namespace Speckle.Core.Api
       using (LogContext.PushProperty("correlationId", Guid.NewGuid().ToString()))
       {
         var sendTimer = Stopwatch.StartNew();
-        Log.Information("Starting send operation");
+        SpeckleLog.Logger.Information("Starting send operation");
 
         BaseObjectSerializer? serializer = null;
         JsonSerializerSettings? settings = null;
@@ -148,7 +148,7 @@ namespace Speckle.Core.Api
 
         if (cancellationToken.IsCancellationRequested)
         {
-          Log.Information(
+          SpeckleLog.Logger.Information(
             "Send operation cancelled after {elapsed} seconds",
             sendTimer.Elapsed.TotalSeconds
           );
@@ -171,7 +171,7 @@ namespace Speckle.Core.Api
 
         if (cancellationToken.IsCancellationRequested)
         {
-          Log.Information(
+          SpeckleLog.Logger.Information(
             "Send operation cancelled after {elapsed}",
             sendTimer.Elapsed.TotalSeconds
           );
@@ -183,7 +183,7 @@ namespace Speckle.Core.Api
         var hash = idToken.ToString();
 
         sendTimer.Stop();
-        Log.ForContext(
+        SpeckleLog.Logger.ForContext(
             "transportElapsedBreakdown",
             transports.ToDictionary(t => t.TransportName, t => t.Elapsed)
           )

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -176,7 +176,7 @@ namespace Speckle.Core.Credentials
       {
         var firstAccount = GetAccounts().FirstOrDefault();
         if (firstAccount == null)
-          Log.Information("No Speckle accounts found. Visit the Speckle web app to create one.");
+          SpeckleLog.Logger.Information("No Speckle accounts found. Visit the Speckle web app to create one.");
         return firstAccount;
       }
       return defaultAccount;
@@ -337,7 +337,7 @@ namespace Speckle.Core.Credentials
       if (string.IsNullOrEmpty(localUrl))
       {
         localUrl = GetDefaultServerUrl();
-        Log.Debug(
+        SpeckleLog.Logger.Debug(
           "The provided server url was null or empty. Changed to the default url {serverUrl}",
           localUrl
         );
@@ -349,7 +349,7 @@ namespace Speckle.Core.Credentials
     {
       if (!HttpListener.IsSupported)
       {
-        Log.Error("HttpListener not supported");
+        SpeckleLog.Logger.Error("HttpListener not supported");
         throw new Exception("Your operating system is not supported");
       }
     }
@@ -362,7 +362,7 @@ namespace Speckle.Core.Credentials
     {
       _ensureGetAccessCodeFlowIsSupported();
 
-      Log.Debug(
+      SpeckleLog.Logger.Debug(
         "Starting auth process for {server}/authn/verify/sca/{challenge}",
         server,
         challenge
@@ -381,14 +381,14 @@ namespace Speckle.Core.Credentials
         var localUrl = "http://localhost:29363/";
         listener.Prefixes.Add(localUrl);
         listener.Start();
-        Log.Debug("Listening for auth redirects on {localUrl}", localUrl);
+        SpeckleLog.Logger.Debug("Listening for auth redirects on {localUrl}", localUrl);
         // Note: The GetContext method blocks while waiting for a request.
         HttpListenerContext context = listener.GetContext();
         HttpListenerRequest request = context.Request;
         HttpListenerResponse response = context.Response;
 
         accessCode = request.QueryString["access_code"];
-        Log.Debug("Got access code {accessCode}", accessCode);
+        SpeckleLog.Logger.Debug("Got access code {accessCode}", accessCode);
         var message = "";
         if (accessCode != null)
           message =
@@ -403,7 +403,7 @@ namespace Speckle.Core.Credentials
         System.IO.Stream output = response.OutputStream;
         output.Write(buffer, 0, buffer.Length);
         output.Close();
-        Log.Debug("Processed finished processing the access code.");
+        SpeckleLog.Logger.Debug("Processed finished processing the access code.");
         listener.Stop();
         listener.Close();
       });
@@ -417,7 +417,7 @@ namespace Speckle.Core.Credentials
       // this is means the task timed out
       if (completedTask != task)
       {
-        Log.Warning(
+        SpeckleLog.Logger.Warning(
           "Local auth flow failed to complete within the timeout window. Access code is {accessCode}",
           accessCode
         );
@@ -426,7 +426,7 @@ namespace Speckle.Core.Credentials
 
       if (task.IsFaulted)
       {
-        Log.Error(
+        SpeckleLog.Logger.Error(
           task.Exception,
           "Getting access code flow failed with {exceptionMessage}",
           task.Exception.Message
@@ -435,7 +435,7 @@ namespace Speckle.Core.Credentials
       }
 
       // task completed within timeout
-      Log.Information(
+      SpeckleLog.Logger.Information(
         "Local auth flow completed successfully within the timeout window. Access code is {accessCode}",
         accessCode
       );
@@ -461,7 +461,7 @@ namespace Speckle.Core.Credentials
           serverInfo = userResponse.serverInfo,
           userInfo = userResponse.user
         };
-        Log.Information("Successfully created account for {serverUrl}", server);
+        SpeckleLog.Logger.Information("Successfully created account for {serverUrl}", server);
         account.serverInfo.url = server;
 
         return account;
@@ -528,7 +528,7 @@ namespace Speckle.Core.Credentials
     /// <returns></returns>
     public static async Task AddAccount(string server = "")
     {
-      Log.Debug("Starting to add account for {serverUrl}", server);
+      SpeckleLog.Logger.Debug("Starting to add account for {serverUrl}", server);
 
       server = _ensureCorrectServerUrl(server);
 
@@ -551,17 +551,17 @@ namespace Speckle.Core.Credentials
 
         //if the account already exists it will not be added again
         AccountStorage.SaveObject(account.id, JsonConvert.SerializeObject(account));
-        Log.Debug("Finished adding account {accountId} for {serverUrl}", account.id, server);
+        SpeckleLog.Logger.Debug("Finished adding account {accountId} for {serverUrl}", account.id, server);
       }
       catch (SpeckleAccountManagerException ex)
       {
-        Log.Fatal(ex, "Failed to add account: {exceptionMessage}", ex.Message);
+        SpeckleLog.Logger.Fatal(ex, "Failed to add account: {exceptionMessage}", ex.Message);
         // rethrowing any known errors
         throw;
       }
       catch (Exception ex)
       {
-        Log.Fatal(ex, "Failed to add account: {exceptionMessage}", ex.Message);
+        SpeckleLog.Logger.Fatal(ex, "Failed to add account: {exceptionMessage}", ex.Message);
         throw new SpeckleAccountManagerException($"Failed to add account: {ex.Message}", ex);
       }
       finally

--- a/Core/Core/Kits/KitManager.cs
+++ b/Core/Core/Kits/KitManager.cs
@@ -115,7 +115,7 @@ namespace Speckle.Core.Kits
     {
       if (_initialized)
       {
-        Log.Error("{objectType} is already initialised", typeof(KitManager));
+        SpeckleLog.Logger.Error("{objectType} is already initialised", typeof(KitManager));
         throw new SpeckleException(
           "The kit manager has already been initialised. Make sure you call this method earlier in your code!");
       }
@@ -138,7 +138,7 @@ namespace Speckle.Core.Kits
 
     private static void Load()
     {
-      Log.Information(
+      SpeckleLog.Logger.Information(
         "Initializing Kit Manager in {KitsFolder}",
         SpecklePathProvider.KitsFolderPath
       );

--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -194,7 +194,7 @@ namespace Speckle.Core.Logging
         }
         catch (Exception ex)
         {
-          Log.ForContext("eventName", eventName.ToString())
+          SpeckleLog.Logger.ForContext("eventName", eventName.ToString())
             .ForContext("isAction", isAction)
             .Warning(ex, "Analytics event failed {exceptionMessage}", ex.Message);
         }

--- a/Core/Core/Logging/SpeckleException.cs
+++ b/Core/Core/Logging/SpeckleException.cs
@@ -19,8 +19,6 @@ namespace Speckle.Core.Logging
     public SpeckleException(string message, bool log, SentryLevel level = SentryLevel.Info)
       : base(message)
     {
-      // if (log)
-      //   Log.CaptureException(this, level);
     }
 
     public SpeckleException(
@@ -33,8 +31,6 @@ namespace Speckle.Core.Logging
       GraphQLErrors = errors
         .Select(error => new KeyValuePair<string, object>("error", error.Message))
         .ToList();
-      // if (log)
-      //   Log.CaptureException(this, level, GraphQLErrors);
     }
 
     public SpeckleException(
@@ -44,10 +40,6 @@ namespace Speckle.Core.Logging
       SentryLevel level = SentryLevel.Info
     ) : base(message, inner)
     {
-      if (inner is SpeckleException)
-        return;
-      // if (log)
-      //   Log.CaptureException(this, level);
     }
   }
 }

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -80,6 +80,7 @@ namespace Speckle.Core.Logging
   /// </summary>
   public static class SpeckleLog
   {
+    public static ILogger Logger { get; private set; }
     private static bool _initialized = false;
 
     /// <summary>
@@ -94,20 +95,21 @@ namespace Speckle.Core.Logging
       if (_initialized)
         return;
 
-      logConfiguration = logConfiguration ?? new SpeckleLogConfiguration();
+      logConfiguration ??= new SpeckleLogConfiguration();
 
-      Log.Logger = CreateConfiguredLogger(
+      Logger = CreateConfiguredLogger(
         hostApplicationName,
         hostApplicationVersion,
         logConfiguration
       );
+      Log.Logger = Logger;
 
       _addUserIdToGlobalContextFromDefaultAccount();
       _addVersionInfoToGlobalContext();
       _addHostOsInfoToGlobalContext();
       _addHostApplicationDataToGlobalContext(hostApplicationName, hostApplicationVersion);
 
-      Log.ForContext("userApplicationDataPath", SpecklePathProvider.UserApplicationDataPath())
+      Logger.ForContext("userApplicationDataPath", SpecklePathProvider.UserApplicationDataPath())
         .ForContext("installApplicationDataPath", SpecklePathProvider.InstallApplicationDataPath)
         .ForContext("speckleLogConfiguration", logConfiguration)
         .Information(
@@ -207,7 +209,7 @@ namespace Speckle.Core.Logging
       }
       catch (Exception ex)
       {
-        Log.Warning(ex, "Cannot set user id for the global log context.");
+        Logger.Warning(ex, "Cannot set user id for the global log context.");
       }
       GlobalLogContext.PushProperty("id", id);
 

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -266,7 +266,7 @@ namespace Speckle.Core.Models
             }
             catch (Exception ex)
             {
-              Log.Warning(ex, "Failed to get computed member: {name}", attr.Name);
+              SpeckleLog.Logger.Warning(ex, "Failed to get computed member: {name}", attr.Name);
               dic[attr.Name] = null;
             }
           }

--- a/Core/Core/Serialisation/BaseObjectDeserializerV2.cs
+++ b/Core/Core/Serialisation/BaseObjectDeserializerV2.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Serilog;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
 using Speckle.Newtonsoft.Json;
@@ -177,7 +177,7 @@ namespace Speckle.Core.Serialisation
           catch(OverflowException ex)
           {
             var v = (object)(double)doc;
-            Log.Debug(ex, "Json property {tokenType} failed to deserialize {value} to {targetType}, will be deserialized as {fallbackType}", doc.Type, v, typeof(long), typeof(double));
+            SpeckleLog.Logger.Debug(ex, "Json property {tokenType} failed to deserialize {value} to {targetType}, will be deserialized as {fallbackType}", doc.Type, v, typeof(long), typeof(double));
             return v;
           }
         case JTokenType.Float:

--- a/Core/Core/Transports/Memory.cs
+++ b/Core/Core/Transports/Memory.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
+using Speckle.Core.Logging;
 
 namespace Speckle.Core.Transports
 {
@@ -31,7 +32,7 @@ namespace Speckle.Core.Transports
 
     public MemoryTransport()
     {
-      Log.Debug("Creating a new Memory Transport");
+      SpeckleLog.Logger.Debug("Creating a new Memory Transport");
 
       Objects = new Dictionary<string, string>();
     }

--- a/Core/Core/Transports/Server.cs
+++ b/Core/Core/Transports/Server.cs
@@ -85,7 +85,7 @@ namespace Speckle.Core.Transports
       int timeoutSeconds = 60
     )
     {
-      Log.Information("Initializing New Remote V1 Transport for {baseUri}", baseUri);
+      SpeckleLog.Logger.Information("Initializing New Remote V1 Transport for {baseUri}", baseUri);
 
       BaseUri = baseUri;
       StreamId = streamId;

--- a/Core/Core/Transports/ServerV2.cs
+++ b/Core/Core/Transports/ServerV2.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Serilog;
 using Speckle.Core.Credentials;
 using Speckle.Core.Helpers;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports.ServerUtils;
 using Speckle.Newtonsoft.Json.Linq;
@@ -94,7 +95,7 @@ namespace Speckle.Core.Transports
       int timeoutSeconds = 60
     )
     {
-      Log.Information("Initializing a new Remote Transport for {baseUri}", baseUri);
+      SpeckleLog.Logger.Information("Initializing a new Remote Transport for {baseUri}", baseUri);
 
       BaseUri = baseUri;
       StreamId = streamId;

--- a/Core/Examples/Program.cs
+++ b/Core/Examples/Program.cs
@@ -46,14 +46,14 @@ namespace ExampleApp
       // logs to the stdout console (useful when debugging)
       // note, not all props are available in the file and console log, context is not rendered there
 
-      Log.Information(
+      SpeckleLog.Logger.Information(
         "Captain's first log, stardate {stardate:.0}. This is the beginning of our journey",
         40759.5123
       );
 
-      var log = Log.ForContext("currentSpeed", "warp 5").ForContext("captain", "Jean-Luc Picard");
+      var log = SpeckleLog.Logger.ForContext("currentSpeed", "warp 5").ForContext("captain", "Jean-Luc Picard");
 
-      log.Information(
+      SpeckleLog.Logger.Information(
         "We're traveling to {destination} our current speed is {currentSpeed}",
         "Fairpoint station"
       );
@@ -63,17 +63,17 @@ namespace ExampleApp
       using (LogContext.PushProperty("actingEnsign", "Wesley Crusher"))
       {
         var bearing = new { bearing = 25, mark = 134 };
-        Log.Information("Picking up an anomaly, bearing {@bearing}", bearing);
+        SpeckleLog.Logger.Information("Picking up an anomaly, bearing {@bearing}", bearing);
       }
       try
       {
-        Log.Warning("Yellow alert, shields up");
+        SpeckleLog.Logger.Warning("Yellow alert, shields up");
         throw new Exception("Shields are not responding.");
       }
       catch (Exception ex)
       {
-        Log.Error(ex, "Cannot raise shields, {reason}", ex.Message);
-        Log.Fatal(ex, "Cannot raise shields, {reason}", ex.Message);
+        SpeckleLog.Logger.Error(ex, "Cannot raise shields, {reason}", ex.Message);
+        SpeckleLog.Logger.Fatal(ex, "Cannot raise shields, {reason}", ex.Message);
       }
 
       // await Subscriptions.SubscriptionConnection();

--- a/Core/IntegrationTests/Fixtures.cs
+++ b/Core/IntegrationTests/Fixtures.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Mime;
 using System.Text;
 using Newtonsoft.Json;
-using Serilog;
 using Speckle.Core.Api;
 using Speckle.Core.Credentials;
 using Speckle.Core.Logging;
@@ -25,7 +24,7 @@ namespace TestsIntegration
           logToSeq: false
         )
       );
-      Log.Information("Initialized logger for testing");
+      SpeckleLog.Logger.Information("Initialized logger for testing");
     }
   }
 

--- a/Core/Tests/Fixtures.cs
+++ b/Core/Tests/Fixtures.cs
@@ -24,7 +24,7 @@ namespace Tests
           logToSeq: false
         )
       );
-      Log.Information("Initialized logger for testing");
+      SpeckleLog.Logger.Information("Initialized logger for testing");
     }
   }
 

--- a/Core/Transports/MongoDBTransport/MongoDB.cs
+++ b/Core/Transports/MongoDBTransport/MongoDB.cs
@@ -7,6 +7,7 @@ using System.Timers;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Serilog;
+using Speckle.Core.Logging;
 
 namespace Speckle.Core.Transports
 {
@@ -66,7 +67,7 @@ namespace Speckle.Core.Transports
       string scope = "Objects"
     )
     {
-      Log.Information("Creating new MongoDB Transport");
+      SpeckleLog.Logger.Information("Creating new MongoDB Transport");
 
       ConnectionString = connectionString;
       Client = new MongoClient(ConnectionString);


### PR DESCRIPTION
This is a non breaking change, but enables the fixing of #2258 

Also changes the seq api key to a new one.