### PR TITLE
fix(Revit): don't modify points when flattening floor outline

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
@@ -123,8 +123,7 @@ namespace Objects.Converter.Revit
       //create analytical panel (floor or wall)
       if (revitMember == null)
       {
-        var polycurve = PolycurveFromTopology(speckleElement.topology);
-        var level = LevelFromPoint(PointToNative(speckleElement.topology[0].basePoint));
+        var polycurve = PolycurveFromTopology(speckleElement.topology);       
         var curveArray = CurveToNative(polycurve, true);
         var curveLoop = CurveArrayToCurveLoop(curveArray);
         revitMember = AnalyticalPanel.Create(Doc, curveLoop);
@@ -135,6 +134,7 @@ namespace Objects.Converter.Revit
       {
         var physicalMemberAppObj = CreatePhysicalMember(speckleElement);
         physicalMember = (DB.Element)physicalMemberAppObj.Converted.FirstOrDefault();
+        analyticalToPhysicalManager.AddAssociation(revitMember.Id, physicalMember.Id);
 
         appObj.Update(createdId: physicalMember.UniqueId, convertedItem: physicalMember);
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -226,10 +226,11 @@ namespace Objects.Converter.Revit
 
         case OG.Curve nurbs:
           var curvePoints = new List<double>();
+          var nurbsConversionFactor = Speckle.Core.Kits.Units.GetConversionFactor(ModelUnits, nurbs.units);
           for (var i = 0; i < nurbs.points.Count; i++)
           {
             if (i % 3 == 2)
-              curvePoints.Add(z * Speckle.Core.Kits.Units.GetConversionFactor(ModelUnits, nurbs.units));
+              curvePoints.Add(z * nurbsConversionFactor);
             else
               curvePoints.Add(nurbs.points[i]);
           }
@@ -240,10 +241,11 @@ namespace Objects.Converter.Revit
         case OG.Polyline poly:
           var polylinePonts = new List<double>();
           var originalPolylinePoints = poly.ToList();
+          var polyConversionFactor = z * Speckle.Core.Kits.Units.GetConversionFactor(ModelUnits, poly.units);
           for (var i = 0; i < originalPolylinePoints.Count; i++)
           {
             if (i % 3 == 2)
-              polylinePonts.Add(z * Speckle.Core.Kits.Units.GetConversionFactor(ModelUnits, poly.units));
+              polylinePonts.Add(z * polyConversionFactor);
             else
               polylinePonts.Add(originalPolylinePoints[i]);
           }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

in order to make a floor, Revit needs to be passed a flat floor outline, even if the floor is actually sloped. Previous we were editing the floor outline to be flat, but this ended up messing up the import of analytical panels which do not need to be passed in as a flat outline.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- return a copy of of the floor outline with flattened points instead of changing the values of the object

<!---

- Item 1
- Item 2

-->

## Screenshots:

Receiving [this commit](https://latest.speckle.dev/streams/85bc4f61c6/commits/ef41f8402c) results in many object baking failures including one that causes the entire transaction to be rolled back
![image](https://user-images.githubusercontent.com/43247197/226930335-bc8df8f3-2f9f-4f81-add3-e01128cc06c3.png)

After this PR, the commit bakes with no failures
![image](https://user-images.githubusercontent.com/43247197/226934507-64ba858c-d0dc-47a0-a740-dacca15cba81.png)

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

Forum post that brough this issue to my attention
https://speckle.community/t/errors-in-receiving-slabs-and-walls-from-etabs-to-revit/5183/4

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
