### PR TITLE
fix(logging): Adds a difference in initialisation between Win and Mac

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -127,6 +127,7 @@ namespace SpeckleRhino
           SpeckleCommandMac.CreateOrFocusSpeckle();
         } catch (Exception ex)
         {
+          Log.Fatal(ex, "Failed to create or focus Speckle window");
           RhinoApp.CommandLineOut.WriteLine($"Speckle error - {ex.ToFormattedString()}");
         }
 #else

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -127,7 +127,7 @@ namespace SpeckleRhino
           SpeckleCommandMac.CreateOrFocusSpeckle();
         } catch (Exception ex)
         {
-          Log.Fatal(ex, "Failed to create or focus Speckle window");
+          SpeckleLog.Logger.Fatal(ex, "Failed to create or focus Speckle window");
           RhinoApp.CommandLineOut.WriteLine($"Speckle error - {ex.ToFormattedString()}");
         }
 #else

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleCommandMac.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleCommandMac.cs
@@ -8,6 +8,7 @@ using DesktopUI2.ViewModels;
 using DesktopUI2.Views;
 using Rhino;
 using Rhino.Commands;
+using Serilog;
 using Speckle.Core.Models.Extensions;
 
 namespace SpeckleRhino
@@ -37,6 +38,7 @@ namespace SpeckleRhino
       }
       catch (Exception e)
       {
+        Log.Fatal(e, "Failed to create or focus Speckle window");
         RhinoApp.CommandLineOut.WriteLine($"Speckle Error - { e.ToFormattedString() }");
         return Result.Failure;
       }

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleCommandMac.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleCommandMac.cs
@@ -9,6 +9,7 @@ using DesktopUI2.Views;
 using Rhino;
 using Rhino.Commands;
 using Serilog;
+using Speckle.Core.Logging;
 using Speckle.Core.Models.Extensions;
 
 namespace SpeckleRhino
@@ -38,7 +39,7 @@ namespace SpeckleRhino
       }
       catch (Exception e)
       {
-        Log.Fatal(e, "Failed to create or focus Speckle window");
+        SpeckleLog.Logger.Fatal(e, "Failed to create or focus Speckle window");
         RhinoApp.CommandLineOut.WriteLine($"Speckle Error - { e.ToFormattedString() }");
         return Result.Failure;
       }

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleMappingsCommandMac.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleMappingsCommandMac.cs
@@ -9,6 +9,7 @@ using DesktopUI2.ViewModels.MappingTool;
 using DesktopUI2.Views;
 using Rhino;
 using Rhino.Commands;
+using Serilog;
 using Speckle.Core.Models.Extensions;
 
 namespace SpeckleRhino
@@ -47,6 +48,7 @@ namespace SpeckleRhino
       }
       catch (Exception e)
       {
+        Log.Fatal(e, "Failed to create or focus Speckle mappings window");
         RhinoApp.CommandLineOut.WriteLine($"Speckle Error - {e.ToFormattedString()}");
         return Result.Failure;
       }

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleMappingsCommandMac.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/SpeckleMappingsCommandMac.cs
@@ -10,6 +10,7 @@ using DesktopUI2.Views;
 using Rhino;
 using Rhino.Commands;
 using Serilog;
+using Speckle.Core.Logging;
 using Speckle.Core.Models.Extensions;
 
 namespace SpeckleRhino
@@ -48,7 +49,7 @@ namespace SpeckleRhino
       }
       catch (Exception e)
       {
-        Log.Fatal(e, "Failed to create or focus Speckle mappings window");
+        SpeckleLog.Logger.Fatal(e, "Failed to create or focus Speckle mappings window");
         RhinoApp.CommandLineOut.WriteLine($"Speckle Error - {e.ToFormattedString()}");
         return Result.Failure;
       }

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -140,19 +140,17 @@ namespace Speckle.Core.Logging
         SpecklePathProvider.LogFolderPath(hostApplicationName, hostApplicationVersion),
         "SpeckleCoreLog.txt"
       );
-      LoggerConfiguration serilogLogConfiguration;
-      try
-      {
-        serilogLogConfiguration = new LoggerConfiguration().MinimumLevel
+      var serilogLogConfiguration = new LoggerConfiguration().MinimumLevel
         .Is(logConfiguration.minimumLevel)
         .Enrich.FromLogContext()
         .Enrich.FromGlobalLogContext();
-
-      } catch(Exception e)
-      {
-        throw;
-      }
-
+      
+#if !MAC
+       serilogLogConfiguration.Enrich.WithClientAgent()
+                              .Enrich.WithClientIp()
+                              .Enrich.WithExceptionDetails();
+#endif
+      
       if (logConfiguration.logToFile && canLogToFile)
         serilogLogConfiguration = serilogLogConfiguration.WriteTo.File(
           logFilePath,

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -140,13 +140,18 @@ namespace Speckle.Core.Logging
         SpecklePathProvider.LogFolderPath(hostApplicationName, hostApplicationVersion),
         "SpeckleCoreLog.txt"
       );
-      var serilogLogConfiguration = new LoggerConfiguration().MinimumLevel
+      LoggerConfiguration serilogLogConfiguration;
+      try
+      {
+        serilogLogConfiguration = new LoggerConfiguration().MinimumLevel
         .Is(logConfiguration.minimumLevel)
-        .Enrich.WithClientAgent()
-        .Enrich.WithClientIp()
         .Enrich.FromLogContext()
-        .Enrich.FromGlobalLogContext()
-        .Enrich.WithExceptionDetails();
+        .Enrich.FromGlobalLogContext();
+
+      } catch(Exception e)
+      {
+        throw;
+      }
 
       if (logConfiguration.logToFile && canLogToFile)
         serilogLogConfiguration = serilogLogConfiguration.WriteTo.File(


### PR DESCRIPTION
This fixes the initial issue when configuring the logger in RhinoMac, by essentially removing the problematic Enrich calls.

Also adds a couple of Log.Fatal calls to the new logger so we can track what's wrong (if anything) in the next beta release