### PR TITLE
fix(core/rhino/gh/revit/navis): Adds enhancedLogContext config option and disables it on mac

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
@@ -42,6 +42,9 @@ namespace ConnectorGrasshopper
       if (RhinoApp.Version.Major == 7)
         version = HostApplications.Grasshopper.GetVersion(HostAppVersion.v7);
 
+      var logConfig = new SpeckleLogConfiguration(logToSentry: false);
+      SpeckleLog.Initialize(HostApplications.Grasshopper.Name, version, logConfig);
+      
       try
       {
         // Using reflection instead of calling `Setup.Init` to prevent loader from exploding. See comment on Catch clause.

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.cs
@@ -44,16 +44,14 @@ namespace Speckle.ConnectorNavisworks.Bindings
       return new List<MenuItem>();
     }
 
-    public override string GetHostAppName()
-    {
-      return HostApplications.Navisworks.Slug;
-    }
+    public static string HostAppName => HostApplications.Navisworks.Slug;
+
+    public static string HostAppNameVersion => Utils.VersionedAppName.Replace("Navisworks", "Navisworks ");
+    
+    public override string GetHostAppName() => HostAppName;
 
 
-    public override string GetHostAppNameVersion()
-    {
-      return Utils.VersionedAppName.Replace("Navisworks", "Navisworks ");
-    }
+    public override string GetHostAppNameVersion() => HostAppNameVersion;
 
     public override string GetFileName()
     {

--- a/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
@@ -14,95 +14,95 @@ using Application = Autodesk.Navisworks.Api.Application;
 
 namespace Speckle.ConnectorNavisworks.Entry
 {
-  [DockPanePlugin(
-    400,
-    400,
-    FixedSize = false,
-    AutoScroll = true,
-    MinimumHeight = 410,
-    MinimumWidth = 250)
-  ]
-  [Plugin(
-    LaunchSpeckleConnector.Plugin,
-    "Speckle",
-    DisplayName = "Speckle",
-    Options = PluginOptions.None,
-    ToolTip = "Speckle Connector for Navisworks",
-    ExtendedToolTip = "Speckle Connector for Navisworks")
-  ]
-  internal class SpeckleNavisworksCommandPlugin : DockPanePlugin
-  {
-    public override Control CreateControlPane()
+    [DockPanePlugin(
+      400,
+      400,
+      FixedSize = false,
+      AutoScroll = true,
+      MinimumHeight = 410,
+      MinimumWidth = 250)
+    ]
+    [Plugin(
+      LaunchSpeckleConnector.Plugin,
+      "Speckle",
+      DisplayName = "Speckle",
+      Options = PluginOptions.None,
+      ToolTip = "Speckle Connector for Navisworks",
+      ExtendedToolTip = "Speckle Connector for Navisworks")
+    ]
+    internal class SpeckleNavisworksCommandPlugin : DockPanePlugin
     {
-      Setup.Init(bindings.HostAppNameVersion, bindings.HostAppName);
-      AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
-      try
-      {
-        InitAvalonia();
-      }
-      catch
-      {
-        // ignore
-      }
-
-      var navisworksActiveDocument = Application.ActiveDocument;
-
-      var bindings = new ConnectorBindingsNavisworks(navisworksActiveDocument);
-      bindings.RegisterAppEvents();
-      var viewModel = new MainViewModel(bindings);
-
-      Analytics.TrackEvent(Analytics.Events.Registered, null, false);
-
-      var speckleHost = new ElementHost
-      {
-        AutoSize = true,
-        Child = new SpeckleHostPane
+        public override Control CreateControlPane()
         {
-          DataContext = viewModel
+            Setup.Init(ConnectorBindingsNavisworks.HostAppNameVersion, ConnectorBindingsNavisworks.HostAppName);
+            AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+            try
+            {
+                InitAvalonia();
+            }
+            catch
+            {
+                // ignore
+            }
+
+            var navisworksActiveDocument = Application.ActiveDocument;
+
+            var bindings = new ConnectorBindingsNavisworks(navisworksActiveDocument);
+            bindings.RegisterAppEvents();
+            var viewModel = new MainViewModel(bindings);
+
+            Analytics.TrackEvent(Analytics.Events.Registered, null, false);
+
+            var speckleHost = new ElementHost
+            {
+                AutoSize = true,
+                Child = new SpeckleHostPane
+                {
+                    DataContext = viewModel
+                }
+            };
+
+            speckleHost.CreateControl();
+
+            return speckleHost;
         }
-      };
 
-      speckleHost.CreateControl();
+        public override void DestroyControlPane(Control pane)
+        {
+            if (pane is UserControl control) control.Dispose();
+        }
 
-      return speckleHost;
+        public static AppBuilder BuildAvaloniaApp()
+        {
+            var app = AppBuilder.Configure<App>();
+
+            app.UsePlatformDetect();
+            app.With(new SkiaOptions { MaxGpuResourceSizeBytes = 8096000 });
+            app.With(new Win32PlatformOptions
+            { AllowEglInitialization = true, EnableMultitouch = false, UseWgl = false });
+            app.LogToTrace();
+            app.UseReactiveUI();
+
+            return app;
+        }
+
+        public static void InitAvalonia()
+        {
+            BuildAvaloniaApp().SetupWithoutStarting();
+        }
+
+        private static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            Assembly a = null;
+            var name = args.Name.Split(',')[0];
+            var path = Path.GetDirectoryName(typeof(RibbonHandler).Assembly.Location);
+
+            var assemblyFile = Path.Combine(path ?? string.Empty, name + ".dll");
+
+            if (File.Exists(assemblyFile))
+                a = Assembly.LoadFrom(assemblyFile);
+
+            return a;
+        }
     }
-
-    public override void DestroyControlPane(Control pane)
-    {
-      if (pane is UserControl control) control.Dispose();
-    }
-
-    public static AppBuilder BuildAvaloniaApp()
-    {
-      var app = AppBuilder.Configure<App>();
-
-      app.UsePlatformDetect();
-      app.With(new SkiaOptions { MaxGpuResourceSizeBytes = 8096000 });
-      app.With(new Win32PlatformOptions
-        { AllowEglInitialization = true, EnableMultitouch = false, UseWgl = false });
-      app.LogToTrace();
-      app.UseReactiveUI();
-
-      return app;
-    }
-
-    public static void InitAvalonia()
-    {
-      BuildAvaloniaApp().SetupWithoutStarting();
-    }
-
-    private static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
-    {
-      Assembly a = null;
-      var name = args.Name.Split(',')[0];
-      var path = Path.GetDirectoryName(typeof(RibbonHandler).Assembly.Location);
-
-      var assemblyFile = Path.Combine(path ?? string.Empty, name + ".dll");
-
-      if (File.Exists(assemblyFile))
-        a = Assembly.LoadFrom(assemblyFile);
-
-      return a;
-    }
-  }
 }

--- a/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
@@ -14,95 +14,95 @@ using Application = Autodesk.Navisworks.Api.Application;
 
 namespace Speckle.ConnectorNavisworks.Entry
 {
-    [DockPanePlugin(
-      400,
-      400,
-      FixedSize = false,
-      AutoScroll = true,
-      MinimumHeight = 410,
-      MinimumWidth = 250)
-    ]
-    [Plugin(
-      LaunchSpeckleConnector.Plugin,
-      "Speckle",
-      DisplayName = "Speckle",
-      Options = PluginOptions.None,
-      ToolTip = "Speckle Connector for Navisworks",
-      ExtendedToolTip = "Speckle Connector for Navisworks")
-    ]
-    internal class SpeckleNavisworksCommandPlugin : DockPanePlugin
+  [DockPanePlugin(
+    400,
+    400,
+    FixedSize = false,
+    AutoScroll = true,
+    MinimumHeight = 410,
+    MinimumWidth = 250)
+  ]
+  [Plugin(
+    LaunchSpeckleConnector.Plugin,
+    "Speckle",
+    DisplayName = "Speckle",
+    Options = PluginOptions.None,
+    ToolTip = "Speckle Connector for Navisworks",
+    ExtendedToolTip = "Speckle Connector for Navisworks")
+  ]
+  internal class SpeckleNavisworksCommandPlugin : DockPanePlugin
+  {
+    public override Control CreateControlPane()
     {
-        public override Control CreateControlPane()
+      Setup.Init(ConnectorBindingsNavisworks.HostAppNameVersion, ConnectorBindingsNavisworks.HostAppName);
+      AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+      try
+      {
+        InitAvalonia();
+      }
+      catch
+      {
+        // ignore
+      }
+
+      var navisworksActiveDocument = Application.ActiveDocument;
+
+      var bindings = new ConnectorBindingsNavisworks(navisworksActiveDocument);
+      bindings.RegisterAppEvents();
+      var viewModel = new MainViewModel(bindings);
+
+      Analytics.TrackEvent(Analytics.Events.Registered, null, false);
+
+      var speckleHost = new ElementHost
+      {
+        AutoSize = true,
+        Child = new SpeckleHostPane
         {
-            Setup.Init(ConnectorBindingsNavisworks.HostAppNameVersion, ConnectorBindingsNavisworks.HostAppName);
-            AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
-            try
-            {
-                InitAvalonia();
-            }
-            catch
-            {
-                // ignore
-            }
-
-            var navisworksActiveDocument = Application.ActiveDocument;
-
-            var bindings = new ConnectorBindingsNavisworks(navisworksActiveDocument);
-            bindings.RegisterAppEvents();
-            var viewModel = new MainViewModel(bindings);
-
-            Analytics.TrackEvent(Analytics.Events.Registered, null, false);
-
-            var speckleHost = new ElementHost
-            {
-                AutoSize = true,
-                Child = new SpeckleHostPane
-                {
-                    DataContext = viewModel
-                }
-            };
-
-            speckleHost.CreateControl();
-
-            return speckleHost;
+          DataContext = viewModel
         }
+      };
 
-        public override void DestroyControlPane(Control pane)
-        {
-            if (pane is UserControl control) control.Dispose();
-        }
+      speckleHost.CreateControl();
 
-        public static AppBuilder BuildAvaloniaApp()
-        {
-            var app = AppBuilder.Configure<App>();
-
-            app.UsePlatformDetect();
-            app.With(new SkiaOptions { MaxGpuResourceSizeBytes = 8096000 });
-            app.With(new Win32PlatformOptions
-            { AllowEglInitialization = true, EnableMultitouch = false, UseWgl = false });
-            app.LogToTrace();
-            app.UseReactiveUI();
-
-            return app;
-        }
-
-        public static void InitAvalonia()
-        {
-            BuildAvaloniaApp().SetupWithoutStarting();
-        }
-
-        private static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
-        {
-            Assembly a = null;
-            var name = args.Name.Split(',')[0];
-            var path = Path.GetDirectoryName(typeof(RibbonHandler).Assembly.Location);
-
-            var assemblyFile = Path.Combine(path ?? string.Empty, name + ".dll");
-
-            if (File.Exists(assemblyFile))
-                a = Assembly.LoadFrom(assemblyFile);
-
-            return a;
-        }
+      return speckleHost;
     }
+
+    public override void DestroyControlPane(Control pane)
+    {
+      if (pane is UserControl control) control.Dispose();
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+    {
+      var app = AppBuilder.Configure<App>();
+
+      app.UsePlatformDetect();
+      app.With(new SkiaOptions { MaxGpuResourceSizeBytes = 8096000 });
+      app.With(new Win32PlatformOptions
+        { AllowEglInitialization = true, EnableMultitouch = false, UseWgl = false });
+      app.LogToTrace();
+      app.UseReactiveUI();
+
+      return app;
+    }
+
+    public static void InitAvalonia()
+    {
+      BuildAvaloniaApp().SetupWithoutStarting();
+    }
+
+    private static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
+    {
+      Assembly a = null;
+      var name = args.Name.Split(',')[0];
+      var path = Path.GetDirectoryName(typeof(RibbonHandler).Assembly.Location);
+
+      var assemblyFile = Path.Combine(path ?? string.Empty, name + ".dll");
+
+      if (File.Exists(assemblyFile))
+        a = Assembly.LoadFrom(assemblyFile);
+
+      return a;
+    }
+  }
 }

--- a/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
@@ -34,6 +34,7 @@ namespace Speckle.ConnectorNavisworks.Entry
   {
     public override Control CreateControlPane()
     {
+      Setup.Init(bindings.HostAppNameVersion, bindings.HostAppName);
       AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
       try
       {
@@ -50,7 +51,6 @@ namespace Speckle.ConnectorNavisworks.Entry
       bindings.RegisterAppEvents();
       var viewModel = new MainViewModel(bindings);
 
-      Setup.Init(bindings.GetHostAppNameVersion(), bindings.GetHostAppName());
       Analytics.TrackEvent(Analytics.Events.Registered, null, false);
 
       var speckleHost = new ElementHost

--- a/ConnectorRevit/ConnectorRevit/Entry/App.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/App.cs
@@ -97,6 +97,8 @@ namespace Speckle.ConnectorRevit.Entry
     {
       try
       {
+        Setup.Init(ConnectorBindingsRevit.HostAppNameVersion, ConnectorBindingsRevit.HostAppName);
+        
         AppInstance = new UIApplication(sender as Application);
         AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(OnAssemblyResolve);
 
@@ -108,7 +110,6 @@ namespace Speckle.ConnectorRevit.Entry
         SchedulerCommand.Bindings = bindings;
 
         //This is also called in DUI, adding it here to know how often the connector is loaded and used
-        Setup.Init(bindings.GetHostAppNameVersion(), bindings.GetHostAppName());
         Analytics.TrackEvent(Analytics.Events.Registered, null, false);
 
         SpeckleRevitCommand.RegisterPane();

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.cs
@@ -47,9 +47,12 @@ namespace Speckle.ConnectorRevit.UI
       //NotifyUi(new UpdateSelectionEvent() { ObjectIds = selectedObjects });
     }
 
-    public override string GetHostAppNameVersion() => ConnectorRevitUtils.RevitAppName.Replace("Revit", "Revit "); //hack for ADSK store
-    public override string GetHostAppName() => HostApplications.Revit.Slug;
+    public static string HostAppNameVersion => ConnectorRevitUtils.RevitAppName.Replace("Revit", "Revit "); //hack for ADSK store
+    public static string HostAppName => HostApplications.Revit.Slug;
 
+    public override string GetHostAppName() => HostAppName;
+    public override string GetHostAppNameVersion() => HostAppNameVersion;
+    
     public override string GetDocumentId() => CurrentDoc?.Document?.GetHashCode().ToString();
 
     public override string GetDocumentLocation() => CurrentDoc.Document.PathName;

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -50,7 +50,6 @@ namespace SpeckleRhino
     {
       if (appBuilder != null)
         return;
-
 #if MAC
       InitAvaloniaMac();
 #else
@@ -87,7 +86,6 @@ namespace SpeckleRhino
       MacOSHelpers.MainMenu = rhinoMenuPtr;
       MacOSHelpers.MenuItemSetTitle(MacOSHelpers.MenuItemGetSubmenu(MacOSHelpers.MenuItemAt(rhinoMenuPtr, 0)), MacOSHelpers.NewObject("NSString"));
       MacOSHelpers.MenuItemSetTitle(MacOSHelpers.MenuItemGetSubmenu(MacOSHelpers.MenuItemAt(rhinoMenuPtr, 0)), titlePtr);
-
     }
 
     public static AppBuilder BuildAvaloniaApp()

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -150,16 +150,19 @@ namespace SpeckleRhino
     /// </summary>
     protected override LoadReturnCode OnLoad(ref string errorMessage)
     {
-      try {
+      try
+      {
         var logConfig = new SpeckleLogConfiguration(logToSentry: false);
         var hostAppName = Utils.AppName;
         var hostAppVersion = Utils.RhinoAppName;
 #if MAC
-        logConfig.restrictedLogging = true;
+        logConfig.enhancedLogContext = true;
 #endif
         SpeckleLog.Initialize(hostAppName, hostAppVersion, logConfig);
         SpeckleLog.Logger.Information("Loading Speckle Plugin for host app {hostAppName} version {hostAppVersion}", hostAppName, hostAppVersion);
-      } catch(Exception e) {
+      }
+      catch (Exception e)
+      {
         RhinoApp.CommandLineOut.WriteLine("Failed to init speckle logger: " + e.ToFormattedString());
         return LoadReturnCode.ErrorShowDialog;
       }

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -152,13 +152,19 @@ namespace SpeckleRhino
     /// </summary>
     protected override LoadReturnCode OnLoad(ref string errorMessage)
     {
-      //TODO proper host app name getting
-      var logConfig = new SpeckleLogConfiguration(logToSentry: false);
-      var hostAppName = HostApplications.Rhino.Name;
-      var hostAppVersion = HostApplications.Rhino.GetVersion(HostAppVersion.v7);
-      SpeckleLog.Initialize(hostAppName, hostAppVersion, logConfig);
-      SpeckleLog.Logger.Information("Loading Speckle Plugin for host app {hostAppName} version {hostAppVersion}", hostAppName, hostAppVersion);
-
+      try {
+        var logConfig = new SpeckleLogConfiguration(logToSentry: false);
+        var hostAppName = Utils.AppName;
+        var hostAppVersion = Utils.RhinoAppName;
+#if MAC
+        logConfig.restrictedLogging = true;
+#endif
+        SpeckleLog.Initialize(hostAppName, hostAppVersion, logConfig);
+        SpeckleLog.Logger.Information("Loading Speckle Plugin for host app {hostAppName} version {hostAppVersion}", hostAppName, hostAppVersion);
+      } catch(Exception e) {
+        RhinoApp.CommandLineOut.WriteLine("Failed to init speckle logger: " + e.ToFormattedString());
+        return LoadReturnCode.ErrorShowDialog;
+      }
       string processName = "";
       System.Version processVersion = null;
       HostUtils.GetCurrentProcessInfo(out processName, out processVersion);

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -51,6 +51,14 @@ namespace Speckle.Core.Logging
     public bool logToFile;
 
     /// <summary>
+    /// Flag to enable restricted logging. This disables the following enrich calls:
+    /// - WithClientAgent
+    /// - WithClientIp
+    /// - WithExceptionDetails
+    /// </summary>
+    public bool restrictedLogging;
+
+    /// <summary>
     /// Default SpeckleLogConfiguration constructor.
     /// These are the sane defaults we should be using across connectors.
     /// </summary>
@@ -64,7 +72,8 @@ namespace Speckle.Core.Logging
       bool logToConsole = true,
       bool logToSeq = true,
       bool logToSentry = true,
-      bool logToFile = true
+      bool logToFile = true,
+      bool restrictedLogging = false
     )
     {
       this.minimumLevel = minimumLevel;
@@ -148,11 +157,11 @@ namespace Speckle.Core.Logging
         .Enrich.FromLogContext()
         .Enrich.FromGlobalLogContext();
       
-#if !MAC
-       serilogLogConfiguration = serilogLogConfiguration.Enrich.WithClientAgent()
-                              .Enrich.WithClientIp()
-                              .Enrich.WithExceptionDetails();
-#endif
+      if(!logConfiguration.restrictedLogging)
+         serilogLogConfiguration = serilogLogConfiguration.Enrich.WithClientAgent()
+                                .Enrich.WithClientIp()
+                                .Enrich.WithExceptionDetails();
+
       
       if (logConfiguration.logToFile && canLogToFile)
         serilogLogConfiguration = serilogLogConfiguration.WriteTo.File(

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -51,12 +51,12 @@ namespace Speckle.Core.Logging
     public bool logToFile;
 
     /// <summary>
-    /// Flag to enable restricted logging. This disables the following enrich calls:
+    /// Flag to enable enhanced log context. This adds the following enrich calls:
     /// - WithClientAgent
     /// - WithClientIp
     /// - WithExceptionDetails
     /// </summary>
-    public bool restrictedLogging;
+    public bool enhancedLogContext;
 
     /// <summary>
     /// Default SpeckleLogConfiguration constructor.
@@ -73,7 +73,7 @@ namespace Speckle.Core.Logging
       bool logToSeq = true,
       bool logToSentry = true,
       bool logToFile = true,
-      bool restrictedLogging = false
+      bool enhancedLogContext = true
     )
     {
       this.minimumLevel = minimumLevel;
@@ -81,6 +81,7 @@ namespace Speckle.Core.Logging
       this.logToSeq = logToSeq;
       this.logToSentry = logToSentry;
       this.logToFile = logToFile;
+      this.enhancedLogContext = enhancedLogContext;
     }
   }
 
@@ -157,7 +158,7 @@ namespace Speckle.Core.Logging
         .Enrich.FromLogContext()
         .Enrich.FromGlobalLogContext();
       
-      if(!logConfiguration.restrictedLogging)
+      if(logConfiguration.enhancedLogContext)
          serilogLogConfiguration = serilogLogConfiguration.Enrich.WithClientAgent()
                                 .Enrich.WithClientIp()
                                 .Enrich.WithExceptionDetails();

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -67,6 +67,7 @@ namespace Speckle.Core.Logging
     /// <param name="logToSeq">Flag to enable Seq log sink</param>
     /// <param name="logToSentry">Flag to enable Sentry log sink</param>
     /// <param name="logToFile">Flag to enable File log sink</param>
+    /// <param name="enhancedLogContext">Flag to enable enhanced context on every log event</param>
     public SpeckleLogConfiguration(
       LogEventLevel minimumLevel = LogEventLevel.Debug,
       bool logToConsole = true,


### PR DESCRIPTION
Fixes logger initialisation issues in:

- Rhino for mac
- Grasshopper
- Revit
- Navisworks