### PR TITLE
fix(gh): TreeBuilder was checking for List<object> when it should be IList instead

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/TreeBuilder.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/TreeBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Grasshopper;
@@ -32,7 +33,7 @@ namespace ConnectorGrasshopper.Extras
 
     private void RecurseNestedLists(object data, GH_Structure<IGH_Goo> tree)
     {
-      if (data is List<object> list)
+      if (data is IList list)
       {
         for (var i = 0; i < list.Count; i++)
         {


### PR DESCRIPTION
Fixes issue where tree builder would output a `List` object, instead of a tree with a single branch in it.

This was caused because we expected a `List<object>` but that doesn't cover all cases. Instead we should be checking for `IList`

The DSO node already did this so this was an oversight on my behalf