### PR TITLE
fix(revit): uses old family instance method for converting structural foundations

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -76,7 +76,7 @@ namespace Objects.Converter.Revit
       // point based, convert these as revit instances
       if (@base == null)
       {
-        if (revitFi.Category.Name.Contains("Structural Foundations")) // don't know why, but the transforms on some one level based structural elements are really messed up 
+        if (revitFi.Category.Name.Contains("Structural Foundation")) // don't know why, but the transforms on structural foundation elements are really messed up 
         {
           @base = PointBasedFamilyInstanceToSpeckle(revitFi, basePoint, out notes);
         }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -401,7 +401,7 @@ namespace Objects.Converter.RhinoGh
         var attribute = new ObjectAttributes();
 
         // layer
-        var geoLayer = item.Value;
+        var geoLayer = item.Key["layer"] is string s ?  s : item.Value; // blocks sent from rhino will have a layer prop dynamically attached
         var layerName = ReceiveMode == ReceiveMode.Create ? $"{commitInfo}{Layer.PathSeparator}{geoLayer}" : $"{geoLayer}";
         int index = 1;
         if (layerName != null)


### PR DESCRIPTION
## Description & motivation
Uses the old point based family instance conversion method for structrual foundations, because i couldn't figure out why the transforms on the instances were out of place.

!! also fixes an issue with recieving rhino blocks on the correct layers

## Changes:

- revit converter


## Screenshots:

Before:
![opera_UJyHCsgp39](https://user-images.githubusercontent.com/16748799/227317525-a2915ddf-a94d-4c56-ae1e-eeb24bbd654f.gif)

After:
![image](https://user-images.githubusercontent.com/16748799/227319298-14ecaf03-1380-4eca-96f5-b0917d1bdc9b.png)


