### PR TITLE
fix: Legacy Ellipse curve checks + missing return on ellipse clause in CurveToSpeckle

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -522,6 +522,7 @@ namespace Objects.Converter.RhinoGh
         curve.TryGetEllipse(pln, out var getObj, tolerance);
         var ellipse = EllipseToSpeckle(getObj, u);
         ellipse.domain = IntervalToSpeckle(curve.Domain);
+        return ellipse;
       }
 
       if (curve.IsLinear(tolerance) || curve.IsPolyline()) // defaults to polyline

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -247,10 +247,7 @@ namespace Objects.Converter.RhinoGh
             @base = PolylineToSpeckle(o) as Base;
             break;
           case NurbsCurve o:
-            if (o.TryGetEllipse(out RH.Ellipse ellipse))
-              @base = EllipseToSpeckle(ellipse);
-            else
-              @base = CurveToSpeckle(o) as Base;
+            @base = CurveToSpeckle(o) as Base;
             break;
           case PolylineCurve o:
             @base = PolylineToSpeckle(o);


### PR DESCRIPTION
Fixes issue reported by Pavol where a specific brep was not converting properlly.

Turned out it was a clash of a legacy edge case condition in the nurbs curve conversion + a bug in the actual conversion of ellipses inside `ConvertToSpeckle`