### PR TITLE
fix(Navisworks): avoid the `Item` reserved property name for Indexed data structures

### DIFF
--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.Properties.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.Properties.cs
@@ -42,7 +42,8 @@ namespace Objects.Converter.Navisworks
     {
       // Regex pattern from speckle-sharp/Core/Core/Models/DynamicBase.cs IsPropNameValid
       return name == "Item"
-        ? "Item"
+        // Item is a reserved term for Indexed Properties: https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/indexers/using-indexers
+        ? "Item_" 
         : Regex.Replace(name, @"[\.\/]", "_");
     }
 


### PR DESCRIPTION
- [x] Is @jsdbroughton a forgetful idiot