### PR TITLE
fix(revit): correct transforms when sending linked models and with a reference point setting

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.cs
@@ -473,6 +473,10 @@ namespace Speckle.ConnectorAutocadCivil.UI
           return new ApplicationObject(current.id, speckleType) { applicationId = current.applicationId, Container = containerId };
         }
 
+        // skip if it is the base commit collection
+        if (current.speckle_type.Contains("Collection") && string.IsNullOrEmpty(containerId))
+          return null;
+
         //Handle convertable objects
         if (converter.CanConvertToNative(current))
         {
@@ -503,12 +507,19 @@ namespace Speckle.ConnectorAutocadCivil.UI
       {
         if (context.propName == null) return stringBuilder;
 
-        var objectLayerName = context.propName[0] == '@'
-          ? context.propName.Substring(1)
-          : context.propName;
-
+        string objectLayerName = string.Empty;
+        if (context.propName.ToLower() == "elements" && context.current.speckle_type.Contains("Collection"))
+        {
+          objectLayerName = context.current["name"] as string;
+        }
+        else if (context.propName.ToLower() != "elements")// this is for any other property on the collection. skip elements props in layer structure.
+        {
+          objectLayerName = context.propName[0] == '@'
+            ? context.propName.Substring(1)
+            : context.propName;
+        }
         LayerIdRecurse(context.parent, stringBuilder);
-        stringBuilder.Append('$');
+        if (stringBuilder.Length != 0 && !string.IsNullOrEmpty(objectLayerName)) { stringBuilder.Append('$'); }
         stringBuilder.Append(objectLayerName);
 
         return stringBuilder;

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -114,7 +114,6 @@ namespace Speckle.ConnectorAutocadCivil
             handles.Add(obj.Handle.ToString());
           }
         }
-        tr.Commit();
       }
 
       return handles;

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -491,7 +491,7 @@ namespace Objects.Converter.AutocadCivil
 
         case Dimension _:
         case BlockDefinition _:
-        case BlockInstance _:
+        case Instance _:
         case Text _:
 
         case Alignment _:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -863,7 +863,7 @@ namespace Objects.Converter.Revit
     private DB.Transform GetDocReferencePointTransform(Document doc)
     {
       //linked files are always saved to disc and will have a path name
-      //if the durrent doc is unsaved it will not, but then it'll be the only one :)
+      //if the current doc is unsaved it will not, but then it'll be the only one :)
       var id = doc.PathName;
 
       if (!_docTransforms.ContainsKey(id))
@@ -896,6 +896,8 @@ namespace Objects.Converter.Revit
 
       //in the case of linked models, it seems they get aligned base off their surey point
       //the translations below for linked models were retrieved a bit empirically
+      // TODO: This linked model code is hacky and incorrect for any linked models that have been moved! Use the `RevitLinkInstance` class transform to determine the full transform between an element in a linked model in the coordinate system of the main doc.
+      // See: https://thebuildingcoder.typepad.com/blog/2013/11/determining-host-document-location-of-a-linked-element.html
       switch (type)
       {
         case ProjectBase:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -653,7 +653,7 @@ namespace Objects.Converter.Revit
       var transform = TransformToSpeckle(localTransform, instance.Document);
 
       // get the definition base of this instance
-      RevitSymbolElementType definition = GetRevitInstanceDefinition(instance, out List<string> definitionNotes, localTransform);
+      RevitSymbolElementType definition = GetRevitInstanceDefinition(instance, out List<string> definitionNotes, instanceTransform);
       notes.AddRange(definitionNotes);
 
       var _instance = new RevitInstance();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -416,9 +416,10 @@ namespace Objects.Converter.Revit
       // get the 3x3 rotation matrix and translation as part of the 4x4 identity matrix
       var point = PointToSpeckle(transform.Origin, doc);
       var t = new Vector(point.x, point.y, point.z, point.units);
-      var rX = new Vector(transform.BasisX.X, transform.BasisX.Y, transform.BasisX.Z);
-      var rY = new Vector(transform.BasisY.X, transform.BasisY.Y, transform.BasisY.Z);
-      var rZ = new Vector(transform.BasisZ.X, transform.BasisZ.Y, transform.BasisZ.Z);
+
+      var rX = VectorToSpeckle(transform.BasisX, doc);
+      var rY = VectorToSpeckle(transform.BasisY, doc);
+      var rZ = VectorToSpeckle(transform.BasisZ, doc);
 
       // get the scale: TODO: do revit transforms ever have scaling?
       var scale = (float)transform.Scale;
@@ -648,7 +649,7 @@ namespace Objects.Converter.Revit
       var transform = TransformToSpeckle(localTransform, instance.Document);
 
       // get the definition base of this instance
-      RevitSymbolElementType definition = GetRevitInstanceDefinition(instance, out List<string> definitionNotes, instanceTransform);
+      RevitSymbolElementType definition = GetRevitInstanceDefinition(instance, out List<string> definitionNotes, localTransform);
       notes.AddRange(definitionNotes);
 
       var _instance = new RevitInstance();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -410,10 +410,10 @@ namespace Objects.Converter.Revit
     #region new instancing
 
     // transforms
-    private Other.Transform TransformToSpeckle(Transform transform)
+    private Other.Transform TransformToSpeckle(Transform transform, Document doc)
     {
       // get the reference point transform 
-      var docTransform = GetDocReferencePointTransform(Doc);
+      var docTransform = GetDocReferencePointTransform(doc);
       var externalTransform = docTransform.Inverse.Multiply(transform);
 
       // translation
@@ -650,7 +650,7 @@ namespace Objects.Converter.Revit
       {
         localTransform = parentTransform.Inverse.Multiply(instanceTransform);
       }
-      var transform = TransformToSpeckle(localTransform);
+      var transform = TransformToSpeckle(localTransform, instance.Document);
 
       // get the definition base of this instance
       RevitSymbolElementType definition = GetRevitInstanceDefinition(instance, out List<string> definitionNotes, localTransform);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -68,10 +68,11 @@ namespace Objects.Converter.Revit
       return intPt;
     }
 
-    public Point PointToSpeckle(XYZ pt, Document doc, string units = null)
+    public Point PointToSpeckle(XYZ pt, Document doc, string units = null, bool doNotTransformWithReferencePoint = false)
     {
       var u = units ?? ModelUnits;
-      var extPt = ToExternalCoordinates(pt, true, doc);
+      
+      var extPt = doNotTransformWithReferencePoint ? pt : ToExternalCoordinates(pt, true, doc);
 
       var pointToSpeckle = new Point(
         u == Units.None ? extPt.X : ScaleToSpeckle(extPt.X),
@@ -116,10 +117,10 @@ namespace Objects.Converter.Revit
       return _pointcloud;
     }
 
-    public Vector VectorToSpeckle(XYZ pt, Document doc, string units = null)
+    public Vector VectorToSpeckle(XYZ pt, Document doc, string units = null, bool doNotTransformWithReferencePoint = false)
     {
       var u = units ?? ModelUnits;
-      var extPt = ToExternalCoordinates(pt, false, doc);
+      var extPt = doNotTransformWithReferencePoint ? pt : ToExternalCoordinates(pt, false, doc);
       var pointToSpeckle = new Vector(
         u == Units.None ? extPt.X : ScaleToSpeckle(extPt.X),
         u == Units.None ? extPt.Y : ScaleToSpeckle(extPt.Y),

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -19,7 +19,7 @@ namespace Objects.Converter.Revit
     /// <remarks>
     /// See https://www.revitapidocs.com/2023/e0f15010-0e19-6216-e2f0-ab7978145daa.htm for a full Geometry Object inheritance
     /// </remarks>
-    public List<Mesh> GetElementDisplayValue(DB.Element element, Options options = null, bool useOriginGeom4FamilyInstance = false)
+    public List<Mesh> GetElementDisplayValue(DB.Element element, Options options = null, bool doNotTransformWithReferencePoint = false)
     {
       var displayMeshes = new List<Mesh>();
 
@@ -28,7 +28,7 @@ namespace Objects.Converter.Revit
       {
         foreach (var id in g.GetMemberIds())
         {
-          var groupMeshes = GetElementDisplayValue(element.Document.GetElement(id));
+          var groupMeshes = GetElementDisplayValue(element.Document.GetElement(id), options, doNotTransformWithReferencePoint);
           displayMeshes.AddRange(groupMeshes);
         }
         return displayMeshes;
@@ -54,7 +54,7 @@ namespace Objects.Converter.Revit
               meshes.Add(mesh);
               break;
             case GeometryInstance instance:
-              var instanceGeo = useOriginGeom4FamilyInstance ? instance.GetSymbolGeometry() : instance.GetInstanceGeometry();
+              var instanceGeo = doNotTransformWithReferencePoint ? instance.GetSymbolGeometry() : instance.GetInstanceGeometry();
               SortGeometry(instanceGeo);
               break;
             case GeometryElement element:
@@ -65,8 +65,8 @@ namespace Objects.Converter.Revit
       }
 
       // convert meshes and solids
-      displayMeshes.AddRange(ConvertMeshesByRenderMaterial(meshes, element.Document));
-      displayMeshes.AddRange(ConvertSolidsByRenderMaterial(solids, element.Document));
+      displayMeshes.AddRange(ConvertMeshesByRenderMaterial(meshes, element.Document, doNotTransformWithReferencePoint));
+      displayMeshes.AddRange(ConvertSolidsByRenderMaterial(solids, element.Document, doNotTransformWithReferencePoint));
 
       return displayMeshes;
     }
@@ -77,7 +77,7 @@ namespace Objects.Converter.Revit
     /// <param name="meshes"></param>
     /// <param name="d"></param>
     /// <returns></returns>
-    public List<Mesh> ConvertMeshesByRenderMaterial(List<DB.Mesh> meshes, Document d)
+    public List<Mesh> ConvertMeshesByRenderMaterial(List<DB.Mesh> meshes, Document d, bool doNotTransformWithReferencePoint = false)
     {
       MeshBuildHelper buildHelper = new MeshBuildHelper();
 
@@ -85,7 +85,7 @@ namespace Objects.Converter.Revit
       {
         var revitMaterial = d.GetElement(mesh.MaterialElementId) as DB.Material;
         Mesh speckleMesh = buildHelper.GetOrCreateMesh(revitMaterial, ModelUnits);
-        ConvertMeshData(mesh, speckleMesh.faces, speckleMesh.vertices, d);
+        ConvertMeshData(mesh, speckleMesh.faces, speckleMesh.vertices, d, doNotTransformWithReferencePoint);
       }
 
       return buildHelper.GetAllValidMeshes();
@@ -97,7 +97,7 @@ namespace Objects.Converter.Revit
     /// <param name="solids"></param>
     /// <param name="d"></param>
     /// <returns></returns>
-    public List<Mesh> ConvertSolidsByRenderMaterial(IEnumerable<Solid> solids, Document d)
+    public List<Mesh> ConvertSolidsByRenderMaterial(IEnumerable<Solid> solids, Document d, bool doNotTransformWithReferencePoint = false)
     {
       MeshBuildHelper meshBuildHelper = new MeshBuildHelper();
 
@@ -133,7 +133,7 @@ namespace Objects.Converter.Revit
         foreach (DB.Mesh mesh in meshData.Value)
         {
           if (mesh == null) continue;
-          ConvertMeshData(mesh, meshData.Key.faces, meshData.Key.vertices, d);
+          ConvertMeshData(mesh, meshData.Key.faces, meshData.Key.vertices, d, doNotTransformWithReferencePoint);
         }
       }
 
@@ -146,13 +146,13 @@ namespace Objects.Converter.Revit
     /// <param name="mesh">The revit mesh to convert</param>
     /// <param name="faces">The faces list to add to</param>
     /// <param name="vertices">The vertices list to add to</param>
-    private void ConvertMeshData(DB.Mesh mesh, List<int> faces, List<double> vertices, Document doc)
+    private void ConvertMeshData(DB.Mesh mesh, List<int> faces, List<double> vertices, Document doc, bool doNotTransformWithReferencePoint = false)
     {
       int faceIndexOffset = vertices.Count / 3;
 
       foreach (var vert in mesh.Vertices)
       {
-        var (x, y, z) = PointToSpeckle(vert, doc);
+        var (x, y, z) = PointToSpeckle(vert, doc, null, doNotTransformWithReferencePoint);
         vertices.Add(x);
         vertices.Add(y);
         vertices.Add(z);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -14,7 +14,7 @@ namespace Objects.Converter.Revit
     /// Retreives the meshes on an element to use as the speckle displayvalue
     /// </summary>
     /// <param name="element"></param>
-    /// <param name="useOriginGeom4FamilyInstance">Whether to refer to the orignal geometry of the family (if it's a family).</param>
+    /// <param name="doNotTransformWithReferencePoint">For instances, determines if the retrieved geometry should be transformed by the selected document reference point.</param>
     /// <returns></returns>
     /// <remarks>
     /// See https://www.revitapidocs.com/2023/e0f15010-0e19-6216-e2f0-ab7978145daa.htm for a full Geometry Object inheritance
@@ -48,7 +48,8 @@ namespace Objects.Converter.Revit
           switch (geomObj)
           {
             case Solid solid:
-              solids.Add(solid);
+              if (solid.Faces.Size > 0 && Math.Abs(solid.SurfaceArea) > 0) // skip invalid solid
+                solids.Add(solid);
               break;
             case DB.Mesh mesh:
               meshes.Add(mesh);


### PR DESCRIPTION
## Description & motivation

Fixes how display value meshes were being retrieved on instance definitions, as well as taking into consideration linked models and reference point settings when computing transforms.

Now revit instance display values are always retreived relative to the internal origin, and the linked model and reference point setting transforms are baked into the instance transform.

Also includes a small fix for autocad, which now correctly traverses revit instances on receive.

## Changes:

- Revit converter
- Autocad connector and converter

