### PR TITLE
fix(acad): style transparency fix

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -624,6 +624,7 @@ namespace Speckle.ConnectorAutocadCivil
       var units = styleBase["units"] as string;
       var color = styleBase["color"] as int?;
       if (color == null) color = styleBase["diffuse"] as int?; // in case this is from a rendermaterial base
+      var transparency = styleBase["opacity"] as double?;
       var lineType = styleBase["linetype"] as string;
       var lineWidth = styleBase["lineweight"] as double?;
 
@@ -631,7 +632,10 @@ namespace Speckle.ConnectorAutocadCivil
       {
         var systemColor = System.Drawing.Color.FromArgb((int)color);
         entity.Color = Color.FromRgb(systemColor.R, systemColor.G, systemColor.B);
-        entity.Transparency = new Transparency(systemColor.A);
+        var alpha = transparency != null 
+          ? (byte)(transparency * 255d) //render material
+          : systemColor.A; //display style
+        entity.Transparency = new Transparency(alpha);
       }
 
       double conversionFactor = (units != null) ? Units.GetConversionFactor(Units.GetUnitsFromString(units), Units.Millimeters) : 1;

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -49,13 +49,15 @@ namespace Objects.Converter.AutocadCivil
         entity.LineWeight = GetLineWeight(style.lineweight);
         if (LineTypeDictionary.ContainsKey(style.linetype))
           entity.LinetypeId = LineTypeDictionary[style.linetype];
+        entity.Transparency = new Transparency(color.A);
       }
       else if (styleBase is RenderMaterial material) // this is the fallback value if a rendermaterial is passed instead
       {
         color = System.Drawing.Color.FromArgb(material.diffuse);
+        var alpha = (byte)(material.opacity * 255d);
+        entity.Transparency = new Transparency(alpha);
       }
       entity.Color = Color.FromRgb(color.R, color.G, color.B);
-      entity.Transparency = new Transparency(color.A);
 
       return entity;
     }


### PR DESCRIPTION
Fixed issue with some instances receiving invisible

There was a bug where we were converting the dispalyStyle as null, and falling back to the RenderMaterial color, but the render material color.alpha does NOT encode transparency the way autocad expects. 
I've fixed this by using the alpha for dispalyStyles only, and `renderMaterial.transparency` for `RenderMaterial`s being converted as fallbacks to `DisplayStyle`s

Also fixed a regression where the  opacity on Render materials weren't being used.
Now translucent/transparent meshes will appear correctly.

There's potential for some further cleanup, I notice we are converting displayStyles and render materials both in the connector, and converter, but for now This works!

---

Before: (unselected)
![image](https://user-images.githubusercontent.com/45512892/228675963-7207132b-13a2-4c5f-b6d7-3a967fcf3dc2.png)
Before: (selected)
![image](https://user-images.githubusercontent.com/45512892/228675903-fbc160fc-3694-45d1-b3b3-09922d8bafcb.png)
After:
![image](https://user-images.githubusercontent.com/45512892/228675643-254fd356-3824-4b60-8144-949650337d2f.png)

Before (PBR):
![image](https://user-images.githubusercontent.com/45512892/228675473-965a888f-2122-4d1b-98a2-1aa1769c9a1f.png)

After:
![image](https://user-images.githubusercontent.com/45512892/228675412-f88e6e28-8b4c-4d4d-8d95-dac0a9beb254.png)
