### PR TITLE
fix(gh): Lower AccountList "no accounts" message to be warning

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
@@ -56,7 +56,7 @@ namespace ConnectorGrasshopper.Accounts
       {
 
         SelectItem(0);
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No accounts found. Please use the Speckle Manager to manage your accounts on this computer.");
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "No accounts found. Please use the Speckle Manager to manage your accounts on this computer.");
         return;
       }
 


### PR DESCRIPTION
Requested by Arup folks.

This was causing their scripts to fail on Rhino compute and return a 500 error.

A warning is all that is necessary for a user that has no accounts to be aware of what to do about it, and will allow any Compute run that uses this node to succeed.