### PR TITLE
fix(Navisworks): Adds <UseWpf> to projects to enable CICD builds on linux/mac

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks2020/ConnectorNavisworks2020.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2020/ConnectorNavisworks2020.csproj
@@ -30,6 +30,8 @@
 		<PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle</PluginBundleTarget>
 		<PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle\Contents\$(NavisworksBuildNumber)</PluginVersionContentTarget>
 		<Platforms>AnyCPU;x64</Platforms>
+    
+    <UseWpf>true</UseWpf>
 	</PropertyGroup>
 
 	<!-- Avalonia -->

--- a/ConnectorNavisworks/ConnectorNavisworks2021/ConnectorNavisworks2021.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2021/ConnectorNavisworks2021.csproj
@@ -31,6 +31,8 @@
 		<PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle</PluginBundleTarget>
 		<PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle\Contents\$(NavisworksBuildNumber)</PluginVersionContentTarget>
 		<Platforms>AnyCPU;x64</Platforms>
+
+    <UseWpf>true</UseWpf>
 	</PropertyGroup>
 
 	<!-- Avalonia -->

--- a/ConnectorNavisworks/ConnectorNavisworks2022/ConnectorNavisworks2022.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2022/ConnectorNavisworks2022.csproj
@@ -31,6 +31,8 @@
 		<PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle</PluginBundleTarget>
 		<PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle\Contents\$(NavisworksBuildNumber)</PluginVersionContentTarget>
 		<Platforms>AnyCPU;x64</Platforms>
+
+    <UseWpf>true</UseWpf>
 	</PropertyGroup>
 
 	<!-- Avalonia -->

--- a/ConnectorNavisworks/ConnectorNavisworks2023/ConnectorNavisworks2023.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2023/ConnectorNavisworks2023.csproj
@@ -30,6 +30,8 @@
 		<PluginBundleTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle</PluginBundleTarget>
 		<PluginVersionContentTarget>$(AppData)\Autodesk\ApplicationPlugins\Speckle.ConnectorNavisworks.bundle\Contents\$(NavisworksBuildNumber)</PluginVersionContentTarget>
 		<Platforms>AnyCPU;x64</Platforms>
+
+    <UseWpf>true</UseWpf>
 	</PropertyGroup>
 
 	<!-- Avalonia -->


### PR DESCRIPTION
Fails to build without
