### PR TITLE
Revert "Fix(CSiBridge): remove objs ref"

### DIFF
--- a/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
+++ b/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
@@ -70,6 +70,10 @@
       <Project>{bf1a4f95-acf7-4353-b60a-4d79c2f44651}</Project>
       <Name>PolygonMesher</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Objects\Objects\Objects.csproj">
+      <Project>{f6f813fc-153b-49fe-9b33-25152be85ba8}</Project>
+      <Name>Objects</Name>
+    </ProjectReference>
     <ProjectReference Include="..\DriverCSharp\DriverCSharp.csproj">
       <Project>{c091e499-597d-4077-b83f-08e069091090}</Project>
       <Name>DriverCSharp</Name>


### PR DESCRIPTION
This has been fixed in the latest `dev` branch while doing the monorepo cleanup and the change now conflicts with the `dev` branch.

If this is the way CSIBridge has always been shipped, I saw we just wait 1 release cycle and it will fix itself with no conflicts 🙌🏼

That is, unless it was removed for a specific reason on `2.13.0-rc3`