### PR TITLE
feat(revit): DirectShape conversion is now capable of updating existing DS

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -388,7 +388,7 @@ namespace Objects.Converter.Revit
       }
       return speckleSchema;
     }
-    
+
     public object ConvertToNative(Base @object)
     {
       // Get setting for if the user is only trying to preview the geometry
@@ -408,7 +408,7 @@ namespace Objects.Converter.Revit
           //List<GE.Mesh> meshes = (List<GE.Mesh>)property;
           var cat = GetObjectCategory(@object);
           var speckleCat = Categories.GetSchemaBuilderCategoryFromBuiltIn(cat.ToString());
-          return DirectShapeToNative(new ApplicationObject(@object.id, @object.speckle_type), meshes, speckleCat);
+          return TryDirectShapeToNative(new ApplicationObject(@object.id, @object.speckle_type), meshes, ToNativeMeshSetting, speckleCat);
         }
         catch
         {
@@ -432,7 +432,7 @@ namespace Objects.Converter.Revit
             return null;
         }
       }
-      
+
       // Check if object has inner `SpeckleSchema` prop and swap if appropriate
       @object = SwapGeometrySchemaObject(@object);
 
@@ -442,7 +442,7 @@ namespace Objects.Converter.Revit
         case ICurve o:
           return ModelCurveToNative(o);
         case Geometry.Brep o:
-          return DirectShapeToNative(o);
+          return TryDirectShapeToNative(o, ToNativeMeshSetting);
         case Geometry.Mesh mesh:
           switch (ToNativeMeshSetting)
           {
@@ -452,7 +452,7 @@ namespace Objects.Converter.Revit
               return MeshToDxfImportFamily(mesh, Doc);
             case ToNativeMeshSettingEnum.Default:
             default:
-              return DirectShapeToNative(mesh);
+              return TryDirectShapeToNative(mesh, ToNativeMeshSettingEnum.Default);
           }
         // non revit built elems
         case BE.Alignment o:
@@ -462,7 +462,7 @@ namespace Objects.Converter.Revit
           return AlignmentToNative(o);
 
         case BE.Structure o:
-          return DirectShapeToNative(new ApplicationObject(o.id, o.speckle_type){ applicationId = o.applicationId }, o.displayValue);
+          return TryDirectShapeToNative(new ApplicationObject(o.id, o.speckle_type){ applicationId = o.applicationId }, o.displayValue, ToNativeMeshSetting);
         //built elems
         case BER.AdaptiveComponent o:
           return AdaptiveComponentToNative(o);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -407,7 +407,8 @@ namespace Objects.Converter.Revit
           //dynamic property = propInfo;
           //List<GE.Mesh> meshes = (List<GE.Mesh>)property;
           var cat = GetObjectCategory(@object);
-          return DirectShapeToNative(new ApplicationObject(@object.id, @object.speckle_type), meshes, cat);
+          var speckleCat = Categories.GetSchemaBuilderCategoryFromBuiltIn(cat.ToString());
+          return DirectShapeToNative(new ApplicationObject(@object.id, @object.speckle_type), meshes, speckleCat);
         }
         catch
         {
@@ -451,7 +452,7 @@ namespace Objects.Converter.Revit
               return MeshToDxfImportFamily(mesh, Doc);
             case ToNativeMeshSettingEnum.Default:
             default:
-              return DirectShapeToNative(new ApplicationObject(mesh.id, mesh.speckle_type), new[] { mesh }, BuiltInCategory.OST_GenericModel, mesh.applicationId ?? mesh.id);
+              return DirectShapeToNative(mesh);
           }
         // non revit built elems
         case BE.Alignment o:
@@ -461,7 +462,7 @@ namespace Objects.Converter.Revit
           return AlignmentToNative(o);
 
         case BE.Structure o:
-          return DirectShapeToNative(new ApplicationObject(o.id, o.speckle_type), o.displayValue, applicationId: o.applicationId);
+          return DirectShapeToNative(new ApplicationObject(o.id, o.speckle_type){ applicationId = o.applicationId }, o.displayValue);
         //built elems
         case BER.AdaptiveComponent o:
           return AdaptiveComponentToNative(o);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -97,7 +97,7 @@ namespace Objects.Converter.Revit
       int skippedBreps = breps.Count;
       breps.ForEach(o =>
       {
-        var ds = DirectShapeToNative(o).Converted.FirstOrDefault() as DB.DirectShape;
+        var ds = TryDirectShapeToNative(o, ToNativeMeshSettingEnum.Default).Converted.FirstOrDefault() as DB.DirectShape;
         if (ds != null)
         {
           ids.Add(ds.Id);
@@ -108,7 +108,7 @@ namespace Objects.Converter.Revit
       int skippedMeshes = meshes.Count;
       meshes.ForEach(o =>
       {
-        var ds = DirectShapeToNative(o).Converted.FirstOrDefault() as DB.DirectShape;
+        var ds = TryDirectShapeToNative(o, ToNativeMeshSettingEnum.Default).Converted.FirstOrDefault() as DB.DirectShape;
         if (ds != null)
         {
           ids.Add(ds.Id);


### PR DESCRIPTION
Fixes #1674 

I refactored the entire direct shape logic so that:
- DirectShapeToNative can only take a `DirectShape` object, and has no fallback DXF handling
- TryDirectShapeToNative calls `DirectShapeToNative` and handles DXF fallback
- Other `TryDirectShapeToNative` calls accept the existing options (Mesh, Brep, List<Mesh>) but now consistently handle DXF fallback mode too.
- Removed the previous `DirectShapeToNative` overloads
- Updated any use of the removed functions throughout the converter

DirectShape now checks if the object exists in the doc and, if so, will no longer delete it. Instead it will grab that existing DirectShape and call `SetShape` on it.

The previous logic would remove the existing direct shape and create a new one. This will still happen in create mode, only update mode affects this as expected.
![2023-04-05 12 24 03](https://user-images.githubusercontent.com/2316535/230073958-99360b74-98b7-4831-8b26-397da62c0338.gif)

This means it will keep references to any part of the DS that remains unchanged. This is managed by revit in an obscure way so we have no way of controlling how it determines if geometry is new or not.