### PR TITLE
feat(rhino): Allow mapping of extrusions to DirectShapes

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
@@ -133,6 +133,8 @@ namespace SpeckleRhino
               break;
 
             case Extrusion e:
+              result.Add(new DirectShapeFreeformViewModel());
+              
               if (e.ProfileCount > 1) break;
               var crv = e.Profile3d(new ComponentIndex(ComponentIndexType.ExtrusionBottomProfile, 0));
               if (!(crv.IsLinear() || crv.IsArc())) break;


### PR DESCRIPTION
Adds the DirectShape option to all extrusions in Rhino.

This change also respects any other mappings that may be added too, but the DS option should always be available for any extrusion.

<img width="676" alt="Screenshot 2023-04-06 at 18 15 28" src="https://user-images.githubusercontent.com/2316535/230437563-be87a018-b193-494f-8f44-d2e0f8802ca7.png">