### PR TITLE
feat(gh/dyn): Adds `isMultiplayer` property to receive events

### DIFF
--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -215,7 +215,8 @@ namespace Speckle.ConnectorDynamo.Functions
       Analytics.TrackEvent(client.Account, Analytics.Events.Receive, new Dictionary<string, object>()
       {
         { "sourceHostApp", HostApplications.GetHostAppFromString(commit.sourceApplication)?.Slug },
-        { "sourceHostAppVersion", commit.sourceApplication }
+        { "sourceHostAppVersion", commit.sourceApplication },
+        { "isMultiplayer", commit.authorId != client.Account.userInfo.id }
       });
 
       return new Dictionary<string, object> { { "data", data }, { "commit", commit } };

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
@@ -280,7 +280,8 @@ namespace ConnectorGrasshopper.Ops.Deprecated
           {
             { "sync", true },
             { "sourceHostApp", HostApplications.GetHostAppFromString(myCommit.sourceApplication).Slug },
-            { "sourceHostAppVersion", myCommit.sourceApplication }
+            { "sourceHostAppVersion", myCommit.sourceApplication },
+            { "isMultiplayer", myCommit.authorId != acc.userInfo.id }
           });
 
           var TotalObjectCount = 1;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
@@ -197,7 +197,8 @@ namespace ConnectorGrasshopper.Ops
           {
             { "sync", true },
             { "sourceHostApp", HostApplications.GetHostAppFromString(myCommit.sourceApplication).Slug },
-            { "sourceHostAppVersion", myCommit.sourceApplication }
+            { "sourceHostAppVersion", myCommit.sourceApplication },
+            { "isMultiplayer", myCommit.authorId != acc.userInfo.id }
           });
 
           var TotalObjectCount = 1;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -583,7 +583,8 @@ namespace ConnectorGrasshopper.Ops
           receiveComponent.ApiResetTask = receiveComponent.ResetApiClient(InputWrapper);
         receiveComponent.ApiResetTask.Wait();
 
-        var remoteTransport = new ServerTransport(receiveComponent.ApiClient.Account, InputWrapper?.StreamId);
+        Account acc = receiveComponent.ApiClient.Account;
+        var remoteTransport = new ServerTransport(acc, InputWrapper?.StreamId);
         remoteTransport.TransportName = "R";
 
         // Means it's a copy paste of an empty non-init component; set the record and exit fast unless ReceiveOnOpen is true.
@@ -619,10 +620,11 @@ namespace ConnectorGrasshopper.Ops
           }
 
           ReceivedCommit = myCommit;
-          Speckle.Core.Logging.Analytics.TrackEvent(receiveComponent.ApiClient.Account, Speckle.Core.Logging.Analytics.Events.Receive, new Dictionary<string, object>()
+          Speckle.Core.Logging.Analytics.TrackEvent(acc, Speckle.Core.Logging.Analytics.Events.Receive, new Dictionary<string, object>
           { { "auto", receiveComponent.AutoReceive },
             { "sourceHostApp", HostApplications.GetHostAppFromString(myCommit.sourceApplication).Slug },
-            { "sourceHostAppVersion", myCommit.sourceApplication }
+            { "sourceHostAppVersion", myCommit.sourceApplication },
+            { "isMultiplayer", myCommit.authorId != acc.userInfo.id }
           });
 
           if (CancellationToken.IsCancellationRequested)


### PR DESCRIPTION
Partially fixes specklesystems/admin#389

Adds `isMultiplayer` property to the dictionary of every Receive event sent from Dynamo or Grasshopper