### PR TITLE
fix: exclude face hosted families from new instancing logic

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -76,7 +76,8 @@ namespace Objects.Converter.Revit
       // point based, convert these as revit instances
       if (@base == null)
       {
-        if (revitFi.Category.Name.Contains("Structural Foundation")) // don't know why, but the transforms on structural foundation elements are really messed up 
+        if ((revitFi.Host!=null && revitFi.HostFace!=null) ||
+          ((BuiltInCategory)revitFi.Category.Id.IntegerValue == BuiltInCategory.OST_StructuralFoundation)) // don't know why, but the transforms on structural foundation elements are really messed up 
         {
           @base = PointBasedFamilyInstanceToSpeckle(revitFi, basePoint, out notes);
         }


### PR DESCRIPTION
Following [this user-reported bug](https://speckle.community/t/speckle-2-12-2-generic-model-with-void-or-solid-face-based-family-as-cutout/5071) it seems that face-hosted family instances are not converting well when sending from Revit.
This PR excludes then and also improves the exclusion for "Structural Framing" making it language agnostic.
If we want to look at it again it might be tackled together with: https://github.com/specklesystems/speckle-sharp/issues/586

Source:
![image](https://user-images.githubusercontent.com/2679513/232427972-2a6eca41-f711-4694-93fb-eb1ac3ab90d6.png)

Before:
![image](https://user-images.githubusercontent.com/2679513/232427876-93c94dea-1177-4e70-a40f-dba11e295257.png)

After:
![image](https://user-images.githubusercontent.com/2679513/232428045-cea4003d-af2a-4ec6-972c-cab04b9dbecd.png)

Sample file:
`G:\Shared drives\All Company\07 Sample Models\Revit\Generic Model with cutout`