### PR TITLE
fix(husky): Fixed install on restore in Core target

### DIFF
--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <Target Name="husky" BeforeTargets="Restore"
-    Condition="'$(IsDesktopBuild)' != 0">
+    Condition="'$(IsDesktopBuild)' == true">
     <Exec
       Command="dotnet tool restore"
       StandardOutputImportance="Low"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,8 @@
       CS1591;CS1573;CS1572;CS1570;CS1587;CS1574;CS1711;CS1734;
       CS8618;CS8602;CS8600;
       CS1998; IDE0007; CS0618
-      CA1054
+      CA1054;
+      NU1701
     </NoWarn>
 
     <!-- False if running on CI, will prevent copying of files to local folders -->


### PR DESCRIPTION
Fixes the new target that runs in Core for every restore. Condition for IsDesktopBuild was wrong.