### PR TITLE
fix(ci): Run deploy on dotnet7.0

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -210,7 +210,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 
   deploy-connector-new:
     docker:
-      - image: mcr.microsoft.com/dotnet/6.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
     parameters:
       slug:
         type: string


### PR DESCRIPTION
Upgrades deploy jobs to use dotnet 7.0 (same one we have on our computers)