### PR TITLE
fix(ci): Move to dotnet changed output paths for some projects

### DIFF
--- a/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
+++ b/ConnectorCSI/ConnectorCSIBridge/ConnectorCSIBridge.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyName>DummySpeckleConnectorCSI</AssemblyName>
+    <AssemblyName>SpeckleConnectorCSI</AssemblyName>
     <TargetFramework>net48</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DriverPluginCSharp\DriverPluginCSharp.csproj" />
+    <ProjectReference Include="..\DriverPluginCSharp\DriverPluginCSharp.csproj"/>
   </ItemGroup>
 </Project>

--- a/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
+++ b/ConnectorCSI/ConnectorSAP2000/ConnectorSAP2000.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyName>DummySpeckleConnectorCSI</AssemblyName>
+    <AssemblyName>SpeckleConnectorCSI</AssemblyName>
     <TargetFramework>net48</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DriverPluginCSharp\DriverPluginCSharp.csproj" />
+    <ProjectReference Include="..\DriverPluginCSharp\DriverPluginCSharp.csproj"/>
   </ItemGroup>
 </Project>

--- a/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
+++ b/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
@@ -11,6 +11,7 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseWPF>true</UseWPF>
     <DefineConstants>$(DefineConstants);REVIT2020</DefineConstants>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   
   <Import Project="..\ConnectorRevit\ConnectorRevit.projitems" Label="Shared" />

--- a/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
+++ b/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
@@ -11,6 +11,7 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseWPF>true</UseWPF>
     <DefineConstants>$(DefineConstants);REVIT2021</DefineConstants>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   
   <Import Project="..\ConnectorRevit\ConnectorRevit.projitems" Label="Shared" />

--- a/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
+++ b/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
@@ -11,55 +11,66 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseWPF>true</UseWPF>
     <DefineConstants>$(DefineConstants);REVIT2022</DefineConstants>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <Import Project="..\ConnectorRevit\ConnectorRevit.projitems" Label="Shared" />
+  <Import Project="..\ConnectorRevit\ConnectorRevit.projitems" Label="Shared"/>
 
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Web" />
-    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore"/>
+    <Reference Include="PresentationFramework"/>
+    <Reference Include="System.Web.Extensions"/>
+    <Reference Include="System.Xaml"/>
+    <Reference Include="System.Web"/>
+    <Reference Include="WindowsBase"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Core\Core\Core.csproj" />
-    <ProjectReference Include="..\..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj" />
-    <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
+    <ProjectReference Include="..\..\Core\Core\Core.csproj"/>
+    <ProjectReference Include="..\..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj"/>
+    <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.18" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
-    <PackageReference Include="Revit.Async" Version="2.0.1" />
-    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1" />
+    <PackageReference Include="Avalonia" Version="0.10.18"/>
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.18"/>
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18"/>
+    <PackageReference Include="Revit.Async" Version="2.0.1"/>
+    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1"/>
   </ItemGroup>
 
   <Target Name="Clean">
-    <RemoveDir Directories="$(TargetDir);$(ProjectDir)\..\Release\Release2022;$(AppData)\Autodesk\Revit\Addins\2022\SpeckleRevit2" />
+    <RemoveDir
+      Directories="$(TargetDir);$(ProjectDir)\..\Release\Release2022;$(AppData)\Autodesk\Revit\Addins\2022\SpeckleRevit2"/>
   </Target>
-  <Target Name="AfterBuildMigrated" AfterTargets="Build" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <CallTarget Condition="'$(Configuration)' == 'Debug' AND '$(IsDesktopBuild)' == true" Targets="AfterBuildDebug" />
-    <CallTarget Condition="'$(Configuration)' == 'Release'" Targets="AfterBuildRelease" />
+  <Target Name="AfterBuildMigrated" AfterTargets="Build"
+  >
+    <CallTarget Condition="'$(Configuration)' == 'Debug' AND '$(IsDesktopBuild)' == true"
+      Targets="AfterBuildDebug"/>
+    <CallTarget Condition="'$(Configuration)' == 'Release'" Targets="AfterBuildRelease"/>
   </Target>
   <Target Name="AfterBuildDebug">
     <ItemGroup>
-      <SourceDLLs Include="$(TargetDir)\**\*.*" />
-      <SourceManifest Include="$(TargetDir)*.addin" />
+      <SourceDLLs Include="$(TargetDir)\**\*.*"/>
+      <SourceManifest Include="$(TargetDir)*.addin"/>
     </ItemGroup>
-    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)" SourceFiles="@(SourceDLLs)" />
-    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\" SourceFiles="@(SourceManifest)" />
+    <Copy
+      DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)"
+      SourceFiles="@(SourceDLLs)"/>
+    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\"
+      SourceFiles="@(SourceManifest)"/>
   </Target>
   <Target Name="AfterBuildRelease">
     <ItemGroup>
-      <SourceDLLs Include="$(TargetDir)\**\*.*" />
-      <SourceManifest Include="$(TargetDir)*.addin" />
+      <SourceDLLs Include="$(TargetDir)\**\*.*"/>
+      <SourceManifest Include="$(TargetDir)*.addin"/>
     </ItemGroup>
-    <Message Importance="High" Text="RELEASE copy from $(TargetDir) to $(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\" />
-    <Copy DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)" SourceFiles="@(SourceDLLs)" />
-    <Copy DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\" SourceFiles="@(SourceManifest)" />
+    <Message Importance="High"
+      Text="RELEASE copy from $(TargetDir) to $(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\"/>
+    <Copy
+      DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)"
+      SourceFiles="@(SourceDLLs)"/>
+    <Copy DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\"
+      SourceFiles="@(SourceManifest)"/>
   </Target>
 </Project>

--- a/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
+++ b/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
@@ -11,55 +11,66 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseWPF>true</UseWPF>
     <DefineConstants>$(DefineConstants);REVIT2023</DefineConstants>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <Import Project="..\ConnectorRevit\ConnectorRevit.projitems" Label="Shared" />
-  
+  <Import Project="..\ConnectorRevit\ConnectorRevit.projitems" Label="Shared"/>
+
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Web" />
-    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore"/>
+    <Reference Include="PresentationFramework"/>
+    <Reference Include="System.Web.Extensions"/>
+    <Reference Include="System.Xaml"/>
+    <Reference Include="System.Web"/>
+    <Reference Include="WindowsBase"/>
   </ItemGroup>
-  
+
   <ItemGroup>
-    <ProjectReference Include="..\..\Core\Core\Core.csproj" />
-    <ProjectReference Include="..\..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj" />
-    <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
+    <ProjectReference Include="..\..\Core\Core\Core.csproj"/>
+    <ProjectReference Include="..\..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj"/>
+    <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj"/>
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.18" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
-    <PackageReference Include="Revit.Async" Version="2.0.1" />
-    <PackageReference Include="Speckle.Revit.API" Version="2023.0.0" />
+    <PackageReference Include="Avalonia" Version="0.10.18"/>
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.18"/>
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18"/>
+    <PackageReference Include="Revit.Async" Version="2.0.1"/>
+    <PackageReference Include="Speckle.Revit.API" Version="2023.0.0"/>
   </ItemGroup>
 
   <Target Name="Clean">
-    <RemoveDir Directories="$(TargetDir);$(ProjectDir)\..\Release\Release2023;$(AppData)\Autodesk\Revit\Addins\2023\SpeckleRevit2" />
+    <RemoveDir
+      Directories="$(TargetDir);$(ProjectDir)\..\Release\Release2023;$(AppData)\Autodesk\Revit\Addins\2023\SpeckleRevit2"/>
   </Target>
-  <Target Name="AfterBuildMigrated" AfterTargets="Build" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <CallTarget Condition="'$(Configuration)' == 'Debug' AND '$(IsDesktopBuild)' == true" Targets="AfterBuildDebug" />
-    <CallTarget Condition="'$(Configuration)' == 'Release'" Targets="AfterBuildRelease" />
+  <Target Name="AfterBuildMigrated" AfterTargets="Build"
+    Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+    <CallTarget Condition="'$(Configuration)' == 'Debug' AND '$(IsDesktopBuild)' == true"
+      Targets="AfterBuildDebug"/>
+    <CallTarget Condition="'$(Configuration)' == 'Release'" Targets="AfterBuildRelease"/>
   </Target>
   <Target Name="AfterBuildDebug">
     <ItemGroup>
-      <SourceDLLs Include="$(TargetDir)\**\*.*" />
-      <SourceManifest Include="$(TargetDir)*.addin" />
+      <SourceDLLs Include="$(TargetDir)\**\*.*"/>
+      <SourceManifest Include="$(TargetDir)*.addin"/>
     </ItemGroup>
-    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)" SourceFiles="@(SourceDLLs)" />
-    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\" SourceFiles="@(SourceManifest)" />
+    <Copy
+      DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)"
+      SourceFiles="@(SourceDLLs)"/>
+    <Copy DestinationFolder="$(AppData)\Autodesk\REVIT\Addins\$(RevitVersion)\"
+      SourceFiles="@(SourceManifest)"/>
   </Target>
   <Target Name="AfterBuildRelease">
     <ItemGroup>
-      <SourceDLLs Include="$(TargetDir)\**\*.*" />
-      <SourceManifest Include="$(TargetDir)*.addin" />
+      <SourceDLLs Include="$(TargetDir)\**\*.*"/>
+      <SourceManifest Include="$(TargetDir)*.addin"/>
     </ItemGroup>
-    <Message Importance="High" Text="RELEASE copy from $(TargetDir) to $(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\" />
-    <Copy DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)" SourceFiles="@(SourceDLLs)" />
-    <Copy DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\" SourceFiles="@(SourceManifest)" />
+    <Message Importance="High"
+      Text="RELEASE copy from $(TargetDir) to $(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\"/>
+    <Copy
+      DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\$(RevitFolderName)\%(RecursiveDir)"
+      SourceFiles="@(SourceDLLs)"/>
+    <Copy DestinationFolder="$(SolutionDir)\Release\Release$(RevitVersion)\"
+      SourceFiles="@(SourceManifest)"/>
   </Target>
 </Project>


### PR DESCRIPTION
Some projects (revit) needed to have this added:

```    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
```

We also pushed some dummy changes for CSI and SAP that should have never been pushed when we were figuring out what was the CSI and sap release strategy.