### PR TITLE
fix(mapping): Added default beam mapping to planar curves

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
@@ -135,6 +135,7 @@ public class MappingBindingsRhino : MappingsBindings
             else if (c.IsPlanar())
             {
               // If the curve is non-linear, but is planar, it can still be a beam.
+              result.Add(new RevitDefaultBeamViewModel());
               result.Add(new RevitBeamViewModel());
             }
 


### PR DESCRIPTION
Fixes #2379 

Default beam view model was left out of the planar beam options, but there was no reason to do so, as the default beam holds an `ICurve`.