### PR TITLE
fix(revit): disable getting floor slope on send

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
@@ -160,32 +160,33 @@ namespace Objects.Converter.Revit
         new List<string> { "LEVEL_PARAM", "FLOOR_PARAM_IS_STRUCTURAL", "ROOF_SLOPE" }
       );
 
-      GetSlopeArrowHack(
-        revitFloor.Id,
-        revitFloor.Document,
-        out var tail,
-        out var head,
-        out double tailOffset,
-        out double headOffset,
-        out double slope
-      );
+      //DISABLED BECAUSE OF MAJOR PERFORMANCE IMPACT
+      //GetSlopeArrowHack(
+      //  revitFloor.Id,
+      //  revitFloor.Document,
+      //  out var tail,
+      //  out var head,
+      //  out double tailOffset,
+      //  out double headOffset,
+      //  out double slope
+      //);
 
-      slopeParam ??= slope;
-      speckleFloor.slope = (double)slopeParam;
+      //slopeParam ??= slope;
+      //speckleFloor.slope = (double)slopeParam;
 
-      if (tail != null && head != null)
-      {
-        speckleFloor.slopeDirection = new Geometry.Line(tail, head);
-        if (
-          speckleFloor["parameters"] is Base parameters
-          && parameters["FLOOR_HEIGHTABOVELEVEL_PARAM"] is BuiltElements.Revit.Parameter offsetParam
-          && offsetParam.value is double offset
-        )
-        {
-          offsetParam.value = offset + tailOffset;
-          parameters["FLOOR_HEIGHTABOVELEVEL_PARAM"] = offsetParam;
-        }
-      }
+      //if (tail != null && head != null)
+      //{
+      //  speckleFloor.slopeDirection = new Geometry.Line(tail, head);
+      //  if (
+      //    speckleFloor["parameters"] is Base parameters
+      //    && parameters["FLOOR_HEIGHTABOVELEVEL_PARAM"] is BuiltElements.Revit.Parameter offsetParam
+      //    && offsetParam.value is double offset
+      //  )
+      //  {
+      //    offsetParam.value = offset + tailOffset;
+      //    parameters["FLOOR_HEIGHTABOVELEVEL_PARAM"] = offsetParam;
+      //  }
+      //}
 
       speckleFloor.displayValue = GetElementDisplayMesh(
         revitFloor,


### PR DESCRIPTION
We're disabling getting the slope of floors on send as this is causing significant performance issues on large models.
Quick tests made 1h+ conversion time go down to ~4-7min.