### PR TITLE
fix(rhino): adds missing user attributes to block instances on receive

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -899,6 +899,11 @@ public class ConnectorBindingsRhino : ConnectorBindings
           }
           break;
         case RhinoObject o: // this was prbly a block instance, baked during conversion
+
+          o.Attributes.LayerIndex = layer.Index; // assign layer
+          SetUserInfo(obj, o.Attributes, parent); // handle user info, including application id
+          o.CommitChanges();
+
           if (parent != null)
             parent.Update(o.Id.ToString());
           else

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -564,16 +564,6 @@ public partial class ConverterRhinoGh
     }
 
     var _instance = Doc.Objects.FindId(instanceId) as RH.InstanceObject;
-
-    // add application id
-    try
-    {
-      _instance.Attributes.SetUserString(ApplicationIdKey, instance.applicationId);
-    }
-    catch (Exception e)
-    {
-      appObj.Update(logItem: $"Could not set application id user string: {e.Message}");
-    }
 
     // update appobj
     appObj.Update(convertedItem: _instance);


### PR DESCRIPTION
## Description & motivation
Fixes a regression where user attributes were no longer being added to block instances on receive
Fixes #2445 

## Changes:
- Rhino connector

## Screenshots:

user strings and other user atts now received:
![image](https://user-images.githubusercontent.com/16748799/233347666-92408a2c-d251-4227-b18b-01d45b1e60b5.png)


