### PR TITLE
add default initialization to logger with Core as the app name

### DIFF
--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -93,8 +93,15 @@ namespace Speckle.Core.Logging
   {
     private static ILogger? _logger;
 
-    public static ILogger Logger => _logger ?? throw new SpeckleException(
-      $"The logger has not been initialized. Please call {typeof(SpeckleLog).FullName}.{nameof(Initialize)}");
+    public static ILogger Logger
+    {
+      get 
+      { 
+        if(_logger == null) Initialize("Core", "unknown");
+        return _logger;
+      }
+    }
+
     private static bool _initialized = false;
 
     /// <summary>


### PR DESCRIPTION
initialize logger by default as Core logger instead of throwing
