### PR TITLE
fix(rhino): handle invalid curve conversions to speckle

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -470,33 +470,41 @@ public partial class ConverterRhinoGh
 
     if (curve.IsCircle(tolerance) && curve.IsClosed)
     {
-      curve.TryGetCircle(out var getObj, tolerance);
-      var cir = CircleToSpeckle(getObj, u);
-      cir.domain = IntervalToSpeckle(curve.Domain);
-      return cir;
+      if (curve.TryGetCircle(out var getObj, tolerance))
+      {
+        var cir = CircleToSpeckle(getObj, u);
+        cir.domain = IntervalToSpeckle(curve.Domain);
+        return cir;
+      }
     }
 
     if (curve.IsArc(tolerance))
     {
-      curve.TryGetArc(out var getObj, tolerance);
-      var arc = ArcToSpeckle(getObj, u);
-      arc.domain = IntervalToSpeckle(curve.Domain);
-      return arc;
+      if (curve.TryGetArc(out var getObj, tolerance))
+      {
+        var arc = ArcToSpeckle(getObj, u);
+        arc.domain = IntervalToSpeckle(curve.Domain);
+        return arc;
+      }
     }
 
     if (curve.IsEllipse(tolerance) && curve.IsClosed)
     {
-      curve.TryGetEllipse(pln, out var getObj, tolerance);
-      var ellipse = EllipseToSpeckle(getObj, u);
-      ellipse.domain = IntervalToSpeckle(curve.Domain);
-      return ellipse;
+      if (curve.TryGetEllipse(pln, out var getObj, tolerance))
+      {
+        var ellipse = EllipseToSpeckle(getObj, u);
+        ellipse.domain = IntervalToSpeckle(curve.Domain);
+        return ellipse;
+      }
     }
 
     if (curve.IsLinear(tolerance) || curve.IsPolyline()) // defaults to polyline
     {
-      curve.TryGetPolyline(out var getObj);
-      if (null != getObj)
-        return PolylineToSpeckle(getObj, IntervalToSpeckle(curve.Domain), u);
+      if (curve.TryGetPolyline(out var getObj))
+      {
+        var polyline = PolylineToSpeckle(getObj, IntervalToSpeckle(curve.Domain), u);
+        return polyline;
+      }
     }
 
     return NurbsToSpeckle(curve.ToNurbsCurve(), u);


### PR DESCRIPTION
## Description & motivation
 Falls back to using nurbs conversions in the `CurveToSpeckle` method when attempts to convert a curve to circles, ellipses, and polylines fail.

This was causing an error in some models that have curves which return true for being a subclass of Curve but fail when trying to convert the curve into its subclass curve.
Fixes [https://github.com/specklesystems/admin/issues/395](https://github.com/specklesystems/admin/issues/395)
## Changes:
Rhino converter


