### PR TITLE
fix(revit): preview send crashing Revit

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Previews.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Previews.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Drawing;
@@ -41,51 +40,64 @@ namespace Speckle.ConnectorRevit.UI
 
     public override async Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
-      // first check if commit is the same and preview objects have already been generated
-      Commit commit = await ConnectorHelpers.GetCommitFromState(progress.CancellationToken, state);
-      progress.Report = new ProgressReport();
-
-      if (commit.id != SelectedReceiveCommit)
+      try
       {
-        // check for converter 
-        var converter = KitManager.GetDefaultKit().LoadConverter(ConnectorRevitUtils.RevitAppName);
-        converter.SetContextDocument(CurrentDoc.Document);
+        // first check if commit is the same and preview objects have already been generated
+        Commit commit = await ConnectorHelpers.GetCommitFromState(progress.CancellationToken, state);
+        progress.Report = new ProgressReport();
 
-        var settings = new Dictionary<string, string>();
-        CurrentSettings = state.Settings;
-        foreach (var setting in state.Settings)
-          settings.Add(setting.Slug, setting.Selection);
-
-        settings["preview"] = "true";
-        converter.SetConverterSettings(settings);
-
-        var commitObject = await ConnectorHelpers.ReceiveCommit(commit, state, progress);
-
-        Preview.Clear();
-        StoredObjects.Clear();
-
-        Preview = FlattenCommitObject(commitObject, converter);
-        foreach (var previewObj in Preview)
-          progress.Report.Log(previewObj);
-
-        List<ApplicationObject> applicationObjects = null;
-        await RevitTask.RunAsync(app =>
+        if (commit.id != SelectedReceiveCommit)
         {
-          using (var t = new Transaction(CurrentDoc.Document, $"Baking stream {state.StreamId}"))
-          {
-            t.Start();
-            applicationObjects = ConvertReceivedObjects(converter, progress);
-            t.Commit();
-          }
+          // check for converter 
+          var converter = KitManager.GetDefaultKit().LoadConverter(ConnectorRevitUtils.RevitAppName);
+          converter.SetContextDocument(CurrentDoc.Document);
 
-          AddMultipleRevitElementServers(applicationObjects);
-        });
+          var settings = new Dictionary<string, string>();
+          CurrentSettings = state.Settings;
+          foreach (var setting in state.Settings)
+            settings.Add(setting.Slug, setting.Selection);
+
+          settings["preview"] = "true";
+          converter.SetConverterSettings(settings);
+
+          var commitObject = await ConnectorHelpers.ReceiveCommit(commit, state, progress);
+
+          Preview.Clear();
+          StoredObjects.Clear();
+
+          Preview = FlattenCommitObject(commitObject, converter);
+          foreach (var previewObj in Preview)
+            progress.Report.Log(previewObj);
+
+          List<ApplicationObject> applicationObjects = null;
+          await RevitTask.RunAsync(
+            app =>
+            {
+              using (var t = new Transaction(CurrentDoc.Document, $"Baking stream {state.StreamId}"))
+              {
+                t.Start();
+                applicationObjects = ConvertReceivedObjects(converter, progress);
+                t.Commit();
+              }
+
+              AddMultipleRevitElementServers(applicationObjects);
+            });
+        }
+        else // just generate the log
+        {
+          foreach (var previewObj in Preview)
+            progress.Report.Log(previewObj);
+        }
       }
-      else // just generate the log
+      catch (Exception ex)
       {
-        foreach (var previewObj in Preview)
-          progress.Report.Log(previewObj);
+        SpeckleLog.Logger.Error(
+          ex,
+          "Failed to preview receive: {exceptionMessage}",
+          ex.Message
+        );
       }
+
       return null;
     }
 
@@ -93,10 +105,11 @@ namespace Speckle.ConnectorRevit.UI
     {
       UnregisterServers();
     }
-    
+
     public void AddMultipleRevitElementServers(List<ApplicationObject> applicationObjects)
     {
-      ExternalService directContext3DService = ExternalServiceRegistry.GetService(ExternalServices.BuiltInExternalServices.DirectContext3DService);
+      ExternalService directContext3DService =
+        ExternalServiceRegistry.GetService(ExternalServices.BuiltInExternalServices.DirectContext3DService);
       MultiServerService msDirectContext3DService = directContext3DService as MultiServerService;
       IList<Guid> serverIds = msDirectContext3DService.GetActiveServerIds();
 
@@ -142,19 +155,33 @@ namespace Speckle.ConnectorRevit.UI
 
     public override void PreviewSend(StreamState state, ProgressViewModel progress)
     {
-      var filterObjs = GetSelectionFilterObjects(state.Filter);
-      foreach (var filterObj in filterObjs)
+      try
       {
-        var converter = (ISpeckleConverter)Activator.CreateInstance(Converter.GetType());
-        var descriptor = ConnectorRevitUtils.ObjectDescriptor(filterObj);
-        var reportObj = new ApplicationObject(filterObj.UniqueId, descriptor);
-        if (!converter.CanConvertToSpeckle(filterObj))
-          reportObj.Update(status: ApplicationObject.State.Skipped, logItem: $"Sending this object type is not supported in Revit");
-        else
-          reportObj.Update(status: ApplicationObject.State.Created);
-        progress.Report.Log(reportObj);
+        var filterObjs = GetSelectionFilterObjects(state.Filter);
+        foreach (var filterObj in filterObjs)
+        {
+          var converter = (ISpeckleConverter)Activator.CreateInstance(Converter.GetType());
+          var descriptor = ConnectorRevitUtils.ObjectDescriptor(filterObj);
+          var reportObj = new ApplicationObject(filterObj.UniqueId, descriptor);
+          if (!converter.CanConvertToSpeckle(filterObj))
+            reportObj.Update(
+              status: ApplicationObject.State.Skipped,
+              logItem: $"Sending this object type is not supported in Revit");
+          else
+            reportObj.Update(status: ApplicationObject.State.Created);
+          progress.Report.Log(reportObj);
+        }
+
+        SelectClientObjects(filterObjs.Select(o => o.UniqueId).ToList(), true);
       }
-      SelectClientObjects(filterObjs.Select(o => o.UniqueId).ToList());
+      catch (Exception ex)
+      {
+        SpeckleLog.Logger.Error(
+          ex,
+          "Failed to preview send: {exceptionMessage}",
+          ex.Message
+        );
+      }
     }
   }
 }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
@@ -79,28 +79,21 @@ namespace Speckle.ConnectorRevit.UI
 
     public override void SelectClientObjects(List<string> args, bool deselect = false)
     {
-      var selection = args.Select(x => CurrentDoc.Document.GetElement(x))?.Where(x => x != null)?.Select(x => x.Id)?.ToList();
-      if (selection != null)
+      var selection = args.Select(x => CurrentDoc.Document.GetElement(x)).Where(x => x != null && x.IsPhysicalElement()).Select(x => x.Id)?.ToList();
+      if (!selection.Any())
+        return;
+      
+      //merge two lists
+      if (!deselect)
       {
-        if (!deselect)
-        {
-          var currentSelection = CurrentDoc.Selection.GetElementIds().ToList();
-          if (currentSelection != null) currentSelection.AddRange(selection);
-          else currentSelection = selection;
-          try
-          {
-            CurrentDoc.Selection.SetElementIds(currentSelection);
-            CurrentDoc.ShowElements(currentSelection);
-          }
-          catch (Exception e) { }
-        }
-        else
-        {
-          var updatedSelection = CurrentDoc.Selection.GetElementIds().Where(x => !selection.Contains(x)).ToList();
-          CurrentDoc.Selection.SetElementIds(updatedSelection);
-          if (updatedSelection.Any()) CurrentDoc.ShowElements(updatedSelection);
-        }
+        var currentSelection = CurrentDoc.Selection.GetElementIds().ToList();
+        selection = currentSelection.Union(selection).ToList();
       }
+  
+        CurrentDoc.Selection.SetElementIds(selection);
+        CurrentDoc.ShowElements(selection);
+     
+      
     }
 
     private List<Document> GetLinkedDocuments()

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -1323,7 +1323,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       if (IsReceiver)
         await Task.Run(() => Bindings.PreviewReceive(StreamState, Progress)).ConfigureAwait(true);
       else
-        await Task.Run(() => Bindings.PreviewSend(StreamState, Progress)).ConfigureAwait(true);
+      //NOTE: do not wrap in a Task or it will crash Revit
+        Bindings.PreviewSend(StreamState, Progress);
 
       GetReport();
       SpeckleLog.Logger


### PR DESCRIPTION
Fix for this user-reported issue: https://speckle.community/t/curtain-wall-panel-with-nested-shared-famillies/5508/4

Using the Preview Send button in Revit 22 or lower would lead to a fatal crash ([unmanaged exception](https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/Revit-crashes-with-CER-when-selecting-specific-elements-in-a-model.html)), and it throws a managed exception and does not work in Revit 23.

This was caused by the `Bindings.PreviewSend(StreamState, Progress);` being wrapped inside a `Task` and probably some multi-threading issues.

The PR also cleans up the selection logic a bit and wraps the bindings in try catches with logging. 

Tested in Revit 22, 23 and Rhino 7, and all seem to work fine.