### PR TITLE
fix(dui2): Fixed issues with date time formatting

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -106,8 +106,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rhino", "Rhino", "{E94E7327-5A9B-48EE-93CC-E9E9A5B980F1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorRhino6", "ConnectorRhino\ConnectorRhino6\ConnectorRhino6.csproj", "{D648BB69-B992-4D34-906E-7A547374B86C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3CDEF4CC-2CFA-4939-8427-3ED00FA9DB55} = {3CDEF4CC-2CFA-4939-8427-3ED00FA9DB55}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorRhino7", "ConnectorRhino\ConnectorRhino7\ConnectorRhino7.csproj", "{A64ACBF9-DB82-4839-AF99-57ED2E7989F4}"
+	ProjectSection(ProjectDependencies) = postProject
+		{26ECA1BE-F5B2-4A41-9658-46A4A917BFE6} = {26ECA1BE-F5B2-4A41-9658-46A4A917BFE6}
+	EndProjectSection
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ConnectorRhinoShared", "ConnectorRhino\ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.shproj", "{B7376EC8-5D3E-47D2-96A7-748552F14C39}"
 EndProject

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
@@ -335,6 +335,7 @@ public static class Formatting
 
   public static string TimeAgo(string timestamp)
   {
+    //TODO: this implementation is almost the same as Speckle.Core.Api.Helpers
     TimeSpan timeAgo;
     try
     {

--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -109,8 +109,8 @@ public class Stream
 
   public bool isPublic { get; set; }
   public string role { get; set; }
-  public string createdAt { get; set; }
-  public string updatedAt { get; set; }
+  public DateTime createdAt { get; set; }
+  public DateTime updatedAt { get; set; }
   public string favoritedDate { get; set; }
 
   public int commentCount { get; set; }
@@ -198,7 +198,7 @@ public class Commit
   public string authorName { get; set; }
   public string authorId { get; set; }
   public string authorAvatar { get; set; }
-  public string createdAt { get; set; }
+  public DateTime createdAt { get; set; }
   public string sourceApplication { get; set; }
 
   public string referencedObject { get; set; }
@@ -225,7 +225,7 @@ public class ActivityItem
   public string streamId { get; set; }
   public string resourceId { get; set; }
   public string resourceType { get; set; }
-  public string time { get; set; }
+  public DateTime time { get; set; }
   public Info info { get; set; }
   public string message { get; set; }
 }
@@ -251,7 +251,7 @@ public class SpeckleObject
   public string speckleType { get; set; }
   public string applicationId { get; set; }
   public int totalChildrenCount { get; set; }
-  public string createdAt { get; set; }
+  public DateTime createdAt { get; set; }
 }
 
 public class Branch

--- a/Core/Core/Api/Helpers.cs
+++ b/Core/Core/Api/Helpers.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -269,22 +271,31 @@ public static class Helpers
     return false;
   }
 
+  [Obsolete("Use DateTime overload")]
   public static string TimeAgo(string timestamp)
   {
     return TimeAgo(DateTime.Parse(timestamp));
   }
 
+#nullable enable
+
+  /// <inheritdoc cref="TimeAgo(DateTime)"/>
+  /// <param name="fallback">value to fallback to if the given <paramref name="timestamp"/> is <see langword="null"/></param>
+  public static string TimeAgo(DateTime? timestamp, string fallback = "Never")
+  {
+    return timestamp.HasValue ? TimeAgo(timestamp.Value) : fallback;
+  }
+
+  /// <summary>Formats the given difference between the current system time and the provided <paramref name="timestamp"/>
+  /// into a human readable string
+  /// </summary>
+  /// <param name="timestamp"></param>
+  /// <returns>A Human readable string</returns>
   public static string TimeAgo(DateTime timestamp)
   {
     TimeSpan timeAgo;
-    try
-    {
-      timeAgo = DateTime.Now.Subtract(timestamp);
-    }
-    catch (FormatException e)
-    {
-      return "never";
-    }
+
+    timeAgo = DateTime.UtcNow.Subtract(timestamp);
 
     if (timeAgo.TotalSeconds < 60)
       return "just now";
@@ -299,9 +310,22 @@ public static class Helpers
     if (timeAgo.TotalDays < 365)
       return $"{timeAgo.Days / 30} month{PluralS(timeAgo.Days / 30)} ago";
 
-    return $"{timeAgo.Days / 356} year{PluralS(timeAgo.Days / 356)} ago";
+    if (timestamp <= new DateTime(1800, 1, 1))
+    {
+      SpeckleLog.Logger.Warning(
+        "Tried to calculate {functionName} of a DateTime value that was way in the past: {dateTimeValue}",
+        nameof(TimeAgo),
+        timestamp
+      );
+      // We assume this was an error, Likely a non-nullable DateTime was initialized/deserialized to the default
+      // Instead of potentially lying to the user, lets tell them we don't know what happened.
+      return "Unknown";
+    }
+
+    return $"{timeAgo.Days / 365} year{PluralS(timeAgo.Days / 365)} ago";
   }
 
+  [Pure]
   public static string PluralS(int num)
   {
     return num != 1 ? "s" : "";

--- a/Core/Tests/Helpers.cs
+++ b/Core/Tests/Helpers.cs
@@ -24,7 +24,8 @@ public class Helpers
   public void TimeAgo_DisplaysTextCorrectly(int secondsAgo, string expectedText)
   {
     // Get current time and substract the input amount
-    var dateTime = DateTime.Now;
+    var dateTime = DateTime.UtcNow;
+
     dateTime = dateTime.Subtract(new TimeSpan(0, 0, secondsAgo));
 
     // Get the timeAgo text representation

--- a/DesktopUI2/DesktopUI2/DummyBindings.cs
+++ b/DesktopUI2/DesktopUI2/DummyBindings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Tasks;
 using DesktopUI2.Models;
 using DesktopUI2.Models.Filters;
@@ -259,14 +260,14 @@ public class DummyBindings : ConnectorBindings
                 authorName = "izzy 2.0",
                 id = "commit123",
                 message = "a totally real commit 💫",
-                createdAt = "sometime"
+                createdAt = DateTime.UtcNow
               },
               new()
               {
                 authorName = "izzy bot",
                 id = "commit321",
                 message = "look @ all these changes 👩‍🎤",
-                createdAt = "03/05/2030"
+                createdAt = DateTime.Parse("03/05/2030", CultureInfo.InvariantCulture)
               }
             }
           }
@@ -293,14 +294,14 @@ public class DummyBindings : ConnectorBindings
                 authorName = "izzy 2.0",
                 id = "commit123",
                 message = "a totally real commit 💫",
-                createdAt = "sometime"
+                createdAt = DateTime.UtcNow
               },
               new()
               {
                 authorName = "izzy bot",
                 id = "commit321",
                 message = "look @ all these changes 👩‍🎤",
-                createdAt = "03/05/2030"
+                createdAt = DateTime.Parse("03/05/2030", CultureInfo.InvariantCulture)
               }
             }
           }

--- a/DesktopUI2/DesktopUI2/Models/StreamState.cs
+++ b/DesktopUI2/DesktopUI2/Models/StreamState.cs
@@ -117,7 +117,7 @@ public class StreamState
   /// Last time the stream card was used to receive or send
   /// </summary>
   [JsonProperty]
-  public string LastUsed { get; set; }
+  public DateTime? LastUsed { get; set; }
 
   /// <summary>
   /// If a receiver, the last commit it received from

--- a/DesktopUI2/DesktopUI2/Utils.cs
+++ b/DesktopUI2/DesktopUI2/Utils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -62,37 +63,18 @@ public static class Dialogs
 
 public static class Formatting
 {
-  public static string TimeAgo(string timestamp)
+  /// <inheritdoc cref="Helpers.TimeAgo(DateTime, string)"/>
+  [DebuggerStepThrough]
+  public static string TimeAgo(DateTime? timestamp)
   {
-    TimeSpan timeAgo;
-    try
-    {
-      timeAgo = DateTime.Now.Subtract(DateTime.Parse(timestamp));
-    }
-    catch (FormatException e)
-    {
-      return "never";
-    }
-
-    if (timeAgo.TotalSeconds < 60)
-      return "just now";
-    if (timeAgo.TotalMinutes < 60)
-      return $"{timeAgo.Minutes} minute{PluralS(timeAgo.Minutes)} ago";
-    if (timeAgo.TotalHours < 24)
-      return $"{timeAgo.Hours} hour{PluralS(timeAgo.Hours)} ago";
-    if (timeAgo.TotalDays < 7)
-      return $"{timeAgo.Days} day{PluralS(timeAgo.Days)} ago";
-    if (timeAgo.TotalDays < 30)
-      return $"{timeAgo.Days / 7} week{PluralS(timeAgo.Days / 7)} ago";
-    if (timeAgo.TotalDays < 365)
-      return $"{timeAgo.Days / 30} month{PluralS(timeAgo.Days / 30)} ago";
-
-    return $"{timeAgo.Days / 356} year{PluralS(timeAgo.Days / 356)} ago";
+    return Helpers.TimeAgo(timestamp);
   }
 
-  public static string PluralS(int num)
+  /// <inheritdoc cref="Helpers.TimeAgo(DateTime)"/>
+  [DebuggerStepThrough]
+  public static string TimeAgo(DateTime timestamp)
   {
-    return num != 1 ? "s" : "";
+    return Helpers.TimeAgo(timestamp);
   }
 
   public static string CommitInfo(string stream, string branch, string commitId)

--- a/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
@@ -229,7 +229,7 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
       if (StreamGetCancelTokenSource.IsCancellationRequested)
         return;
 
-      Streams = streams.OrderByDescending(x => DateTime.Parse(x.Stream.updatedAt)).ToList();
+      Streams = streams.OrderByDescending(x => x.Stream.updatedAt).ToList();
     }
     catch (Exception ex)
     {

--- a/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
@@ -131,7 +132,7 @@ public class OneClickViewModel : ReactiveObject, IRoutableViewModel
           Analytics.Events.Send,
           new Dictionary<string, object> { { "method", "OneClick" } }
         );
-        _fileStream.LastUsed = DateTime.Now.ToString();
+        _fileStream.LastUsed = DateTime.UtcNow;
       }
     }
     catch (Exception ex)

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
@@ -82,7 +82,7 @@ public class StreamSelectorViewModel : ReactiveObject
 
     try
     {
-      Streams = streams.OrderByDescending(x => DateTime.Parse(x.Stream.updatedAt)).ToList();
+      Streams = streams.OrderByDescending(x => x.Stream.updatedAt).ToList();
     }
     catch (Exception ex)
     {

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -560,21 +560,28 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     private set => this.RaiseAndSetIfChanged(ref _menuItems, value);
   }
 
+  /// Human Readable String
   public string LastUpdated => "Updated " + Formatting.TimeAgo(StreamState.CachedStream.updatedAt);
 
+  /// Human Readable String
   public string LastUsed
   {
     get
     {
       var verb = StreamState.IsReceiver ? "Received" : "Sent";
       if (StreamState.LastUsed == null)
-        return "Never " + verb.ToLower();
+        return $"Never {verb.ToLower()}";
       return $"{verb} {Formatting.TimeAgo(StreamState.LastUsed)}";
     }
+  }
+
+  public DateTime? LastUsedTime
+  {
+    get => StreamState.LastUsed;
     set
     {
       StreamState.LastUsed = value;
-      this.RaisePropertyChanged();
+      this.RaisePropertyChanged(nameof(LastUsed));
     }
   }
 
@@ -1245,7 +1252,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
         throw new Exception(message);
       }
 
-      LastUsed = DateTime.Now.ToString();
+      LastUsedTime = DateTime.UtcNow;
       var view = MainViewModel.RouterInstance.NavigationStack.Last() is StreamViewModel ? "Stream" : "Home";
 
       Analytics.TrackEvent(
@@ -1369,7 +1376,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
 
       // Track receive operation
       var view = MainViewModel.RouterInstance.NavigationStack.Last() is StreamViewModel ? "Stream" : "Home";
-      LastUsed = DateTime.Now.ToString();
+      LastUsedTime = DateTime.UtcNow;
+
       Analytics.TrackEvent(
         StreamState.Client.Account,
         Analytics.Events.Receive,


### PR DESCRIPTION
Previously, we were using `DateTime.Parse` and `DateTime.ToString` in several places across DUI2 and Core.

`DateTime.Parse` is dependent on system culture and TimeZone.

While debugging, I noticed some US formatted dates were failing to parse as UK dates.

I have replaced occurrences of raw string dates with `DateTime` comparisons, which resolves the problem.

I have also consolidated `DesktopUI2\Utils.TimeAgo` and `Speckle.Core.API.Formatting.TimeAgo` to use the same implementation.

Additionally, There was a third variant of this "TimeAgo" function in `ConnectorRhinoShared\Utils.cs`
This is unused, and I haven't touched it, since its implementation was slightly different to that of Core & DUI