### PR TITLE
Core/DUI: Wraps disposable objects in using statements

### DIFF
--- a/Core/Core/Api/Helpers.cs
+++ b/Core/Core/Api/Helpers.cs
@@ -104,9 +104,8 @@ public static class Helpers
       };
     }
 
-    var client = new Client(account);
-
-    var transport = new ServerTransport(client.Account, sw.StreamId);
+    using var client = new Client(account);
+    using var transport = new ServerTransport(client.Account, sw.StreamId);
 
     string objectId = "";
     Commit commit = null;
@@ -201,7 +200,7 @@ public static class Helpers
   {
     var sw = new StreamWrapper(stream);
 
-    var client = new Client(account ?? await sw.GetAccount().ConfigureAwait(false));
+    using var client = new Client(account ?? await sw.GetAccount().ConfigureAwait(false));
 
     var transport = new ServerTransport(client.Account, sw.StreamId);
     var branchName = string.IsNullOrEmpty(sw.BranchName) ? "main" : sw.BranchName;

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -73,6 +73,7 @@ public static partial class Operations
   )
   {
     transports ??= new List<ITransport>();
+    using var sqLiteTransport = new SQLiteTransport { TransportName = "LC" };
 
     if (transports.Count == 0 && useDefaultCache == false)
       throw new ArgumentException(
@@ -81,7 +82,9 @@ public static partial class Operations
       );
 
     if (useDefaultCache)
-      transports.Insert(0, new SQLiteTransport { TransportName = "LC" });
+    {
+      transports.Insert(0, sqLiteTransport);
+    }
 
     var transportContext = transports.ToDictionary(t => t.TransportName, t => t.TransportContext);
 

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -95,10 +95,10 @@ public static class AccountManager
   {
     try
     {
-      var httpClient = Http.GetHttpProxyClient();
+      using var httpClient = Http.GetHttpProxyClient();
       httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
-      var client = new GraphQLHttpClient(
+      using var client = new GraphQLHttpClient(
         new GraphQLHttpClientOptions { EndPoint = new Uri(new Uri(server), "/graphql") },
         new NewtonsoftJsonSerializer(),
         httpClient
@@ -341,10 +341,9 @@ public static class AccountManager
 
     Process.Start(new ProcessStartInfo($"{server}/authn/verify/sca/{challenge}") { UseShellExecute = true });
 
-    var listener = new HttpListener();
-
     var task = Task.Run(() =>
     {
+      using var listener = new HttpListener();
       var localUrl = "http://localhost:29363/";
       listener.Prefixes.Add(localUrl);
       listener.Start();
@@ -375,10 +374,6 @@ public static class AccountManager
     });
 
     var completedTask = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
-
-    //ensure the listener is closed even if the task has timed out or failed
-    if (listener.IsListening)
-      listener.Abort();
 
     // this is means the task timed out
     if (completedTask != task)
@@ -544,7 +539,7 @@ public static class AccountManager
         challenge
       };
 
-      var content = new StringContent(JsonConvert.SerializeObject(body));
+      using var content = new StringContent(JsonConvert.SerializeObject(body));
       content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
       var response = await client.PostAsync($"{server}/auth/token", content).ConfigureAwait(false);
 
@@ -573,7 +568,7 @@ public static class AccountManager
         refreshToken
       };
 
-      var content = new StringContent(JsonConvert.SerializeObject(body));
+      using var content = new StringContent(JsonConvert.SerializeObject(body));
       content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
       var response = await client.PostAsync($"{server}/auth/token", content).ConfigureAwait(false);
 

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -259,7 +259,7 @@ public class StreamWrapper
     if (!hasInternet)
       throw new Exception("You are not connected to the internet.");
 
-    var client = new Client(acc);
+    using var client = new Client(acc);
     // First check if the stream exists
     try
     {

--- a/Core/Core/Helpers/Http.cs
+++ b/Core/Core/Helpers/Http.cs
@@ -165,7 +165,7 @@ public static class Http
     SpeckleLog.Logger.Information("HttpPinging {address}", address);
     try
     {
-      var _httpClient = GetHttpProxyClient();
+      using var _httpClient = GetHttpProxyClient();
       var response = await _httpClient.GetAsync(address).ConfigureAwait(false);
       return response.IsSuccessStatusCode;
     }

--- a/Core/Core/Models/Utilities.cs
+++ b/Core/Core/Models/Utilities.cs
@@ -43,11 +43,10 @@ public static class Utilities
     if (func == HashingFuctions.MD5)
       hashAlgorithm = MD5.Create();
 
-    using (var stream = File.OpenRead(filePath))
-    {
-      var hash = hashAlgorithm.ComputeHash(stream);
-      return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant().Substring(0, HashLength);
-    }
+    using var stream = File.OpenRead(filePath);
+    using var h = hashAlgorithm;
+    var hash = h.ComputeHash(stream);
+    return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant().Substring(0, HashLength);
   }
 
   private static string sha256(string input)

--- a/Core/Core/Transports/Server.cs
+++ b/Core/Core/Transports/Server.cs
@@ -264,13 +264,13 @@ public class ServerTransportV1 : IDisposable, ICloneable, ITransport
       return;
 
     IS_WRITING = true;
-    var message = new HttpRequestMessage
+    using var message = new HttpRequestMessage
     {
       RequestUri = new Uri($"/objects/{StreamId}", UriKind.Relative),
       Method = HttpMethod.Post
     };
 
-    var multipart = new MultipartFormDataContent("--obj--");
+    using var multipart = new MultipartFormDataContent("--obj--");
 
     SavedObjectCount = 0;
     var addedMpCount = 0;
@@ -414,7 +414,7 @@ public class ServerTransportV1 : IDisposable, ICloneable, ITransport
       return null;
     }
 
-    var message = new HttpRequestMessage
+    using var message = new HttpRequestMessage
     {
       RequestUri = new Uri($"/objects/{StreamId}/{hash}/single", UriKind.Relative),
       Method = HttpMethod.Get
@@ -439,7 +439,7 @@ public class ServerTransportV1 : IDisposable, ICloneable, ITransport
     }
 
     // Get root object
-    var rootHttpMessage = new HttpRequestMessage
+    using var rootHttpMessage = new HttpRequestMessage
     {
       RequestUri = new Uri($"/objects/{StreamId}/{hash}/single", UriKind.Relative),
       Method = HttpMethod.Get
@@ -503,7 +503,7 @@ public class ServerTransportV1 : IDisposable, ICloneable, ITransport
 
     if (hashes.Count > 0)
     {
-      var childrenHttpMessage = new HttpRequestMessage
+      using var childrenHttpMessage = new HttpRequestMessage
       {
         RequestUri = new Uri($"/api/getobjects/{StreamId}", UriKind.Relative),
         Method = HttpMethod.Post

--- a/Core/Core/Transports/ServerUtils/GzipContent.cs
+++ b/Core/Core/Transports/ServerUtils/GzipContent.cs
@@ -22,8 +22,9 @@ internal sealed class GzipContent : HttpContent
     this.content = content;
 
     // Keep the original content's headers ...
-    foreach (KeyValuePair<string, IEnumerable<string>> header in content.Headers)
-      Headers.TryAddWithoutValidation(header.Key, header.Value);
+    if (content != null)
+      foreach (KeyValuePair<string, IEnumerable<string>> header in content.Headers)
+        Headers.TryAddWithoutValidation(header.Key, header.Value);
 
     // ... and let the server know we've Gzip-compressed the body of this request.
     Headers.ContentEncoding.Add("gzip");
@@ -39,7 +40,6 @@ internal sealed class GzipContent : HttpContent
       await content.CopyToAsync(gzip).ConfigureAwait(false);
     else
       await stringContent.CopyToAsync(gzip).ConfigureAwait(false);
-
     await gzip.FlushAsync().ConfigureAwait(false);
   }
 

--- a/DesktopUI2/DesktopUI2/ConnectorHelpers.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorHelpers.cs
@@ -39,7 +39,7 @@ public static class ConnectorHelpers
   {
     progress.CancellationToken.ThrowIfCancellationRequested();
 
-    var transport = new ServerTransport(state.Client.Account, state.StreamId);
+    using var transport = new ServerTransport(state.Client.Account, state.StreamId);
 
     Base? commitObject = await Operations
       .Receive(

--- a/DesktopUI2/DesktopUI2/ViewModels/DesignViewModels/DesignHomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/DesignViewModels/DesignHomeViewModel.cs
@@ -14,7 +14,7 @@ public class DesignHomeViewModel
     Accounts = AccountManager.GetAccounts().Select(x => new AccountViewModel(x)).ToList();
     if (acc == null)
       return;
-    var client = new Client(acc);
+    using var client = new Client(acc);
     FilteredStreams = client.StreamsGet().Result.Select(x => new StreamAccountWrapper(x, acc)).ToList();
 
     var d = new DesignSavedStreamsViewModel();

--- a/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
@@ -588,7 +588,7 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
     if (result)
       try
       {
-        var client = new Client(dialog.Account);
+        using var client = new Client(dialog.Account);
         var streamId = await client
           .StreamCreate(
             new StreamCreateInput
@@ -645,7 +645,7 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
       {
         var sw = new StreamWrapper(result);
         var account = await sw.GetAccount().ConfigureAwait(true);
-        var client = new Client(account);
+        using var client = new Client(account);
         var stream = await client.StreamGet(sw.StreamId).ConfigureAwait(true);
         var streamState = new StreamState(account, stream);
         streamState.BranchName = sw.BranchName;

--- a/DesktopUI2/DesktopUI2/ViewModels/MappingTool/MappingsViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/MappingTool/MappingsViewModel.cs
@@ -200,11 +200,18 @@ public class MappingsViewModel : ViewModelBase, IScreen
 
     ShowProgress = true;
 
-    var client = new Client(StreamSelector.SelectedStream.Account);
-    string referencedObject = StreamSelector.SelectedBranch.commits.items.FirstOrDefault().referencedObject;
+    using var client = new Client(StreamSelector.SelectedStream.Account);
+    Commit commit = StreamSelector.SelectedBranch.commits.items.FirstOrDefault();
+    if (commit == null)
+      throw new Exception(
+        $"Branch {StreamSelector.SelectedBranch.name} in stream {StreamSelector.SelectedStream.Stream.id} has no commits"
+      );
 
-    var transport = new ServerTransport(StreamSelector.SelectedStream.Account, StreamSelector.SelectedStream.Stream.id);
-    return await Operations.Receive(referencedObject, transport, disposeTransports: true).ConfigureAwait(true);
+    using var transport = new ServerTransport(
+      StreamSelector.SelectedStream.Account,
+      StreamSelector.SelectedStream.Stream.id
+    );
+    return await Operations.Receive(commit.referencedObject, transport, disposeTransports: true).ConfigureAwait(true);
   }
 
   private void GetTypesAndLevels(Base model)

--- a/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
@@ -156,7 +156,7 @@ public class OneClickViewModel : ReactiveObject, IRoutableViewModel
   {
     // get default account
     var account = AccountManager.GetDefaultAccount();
-    var client = new Client(account);
+    using var client = new Client(account);
 
     SavedStreams = Bindings.GetStreamsInFile();
     var fileStream = SavedStreams

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
@@ -96,7 +96,7 @@ public class StreamSelectorViewModel : ReactiveObject
 
   private async void GetBranches()
   {
-    var client = new Client(SelectedStream.Account);
+    using var client = new Client(SelectedStream.Account);
 
     Branches = (await client.StreamGetBranches(SelectedStream.Stream.id, 100, 1).ConfigureAwait(true))
       .Where(x => x.commits.totalCount > 0)

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -77,7 +77,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       Subscribe();
       GenerateMenuItems();
 
-      var updateTextTimer = new Timer();
+      using var updateTextTimer = new Timer();
       updateTextTimer.Elapsed += UpdateTextTimer_Elapsed;
       updateTextTimer.Interval = TimeSpan.FromMinutes(1).TotalMilliseconds;
       updateTextTimer.Enabled = true;

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -77,7 +77,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       Subscribe();
       GenerateMenuItems();
 
-      using var updateTextTimer = new Timer();
+      var updateTextTimer = new Timer();
       updateTextTimer.Elapsed += UpdateTextTimer_Elapsed;
       updateTextTimer.Interval = TimeSpan.FromMinutes(1).TotalMilliseconds;
       updateTextTimer.Enabled = true;


### PR DESCRIPTION
Many of our classes being used in core and DUI are disposable, meaning we need to manually dispose of them or things may linger and break unexpectedly.

This is usually related to our `Client` and `Transports`, but other classes such as `DUI ViewModels` may need reviewing.