### PR TITLE
fix(acad): exclude adsk nugets from being copied to the output dir

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAdvanceSteel2023/ConnectorAdvanceSteel2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorAdvanceSteel2023/ConnectorAdvanceSteel2023.csproj
@@ -55,8 +55,8 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="MathNet.Spatial" Version="0.6.0" />
-    <PackageReference Include="PH.AdvanceSteel.API" Version="2023.0.3" />
-    <PackageReference Include="Speckle.AutoCAD.API" Version="2023.0.0" />
+    <PackageReference Include="PH.AdvanceSteel.API" Version="2023.0.3" IncludeAssets="compile;build" PrivateAssets="all"/>
+    <PackageReference Include="Speckle.AutoCAD.API" Version="2023.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
   </ItemGroup>
   <ItemGroup>
     <Content Include="MyAddons.xml" />

--- a/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2021/ConnectorAutocad2021.csproj
@@ -44,6 +44,6 @@
         <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Speckle.AutoCAD.API" Version="2021.0.2" />
+        <PackageReference Include="Speckle.AutoCAD.API" Version="2021.0.2" IncludeAssets="compile;build" PrivateAssets="all"/>
     </ItemGroup>
 </Project>

--- a/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2022/ConnectorAutocad2022.csproj
@@ -40,7 +40,7 @@
         <Reference Include="System.Net.Http" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Speckle.AutoCAD.API" Version="2022.0.2" />
+        <PackageReference Include="Speckle.AutoCAD.API" Version="2022.0.2" IncludeAssets="compile;build" PrivateAssets="all"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\Core\Core\Core.csproj" />

--- a/ConnectorAutocadCivil/ConnectorAutocad2023/ConnectorAutocad2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorAutocad2023/ConnectorAutocad2023.csproj
@@ -42,6 +42,6 @@
         <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Speckle.AutoCAD.API" Version="2023.0.0" />
+        <PackageReference Include="Speckle.AutoCAD.API" Version="2023.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
     </ItemGroup>
 </Project>

--- a/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2021/ConnectorCivil2021.csproj
@@ -48,7 +48,7 @@
         <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Speckle.AutoCAD.API" Version="2021.0.2" />
-        <PackageReference Include="Speckle.Civil3D.API" Version="2021.0.2" />
+        <PackageReference Include="Speckle.AutoCAD.API" Version="2021.0.2" IncludeAssets="compile;build" PrivateAssets="all"/>
+        <PackageReference Include="Speckle.Civil3D.API" Version="2021.0.2" IncludeAssets="compile;build" PrivateAssets="all"/>
     </ItemGroup>
 </Project>

--- a/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2022/ConnectorCivil2022.csproj
@@ -48,7 +48,7 @@
         <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Speckle.AutoCAD.API" Version="2022.0.2" />
-        <PackageReference Include="Speckle.Civil3D.API" Version="2022.0.2" />
+        <PackageReference Include="Speckle.AutoCAD.API" Version="2022.0.2" IncludeAssets="compile;build" PrivateAssets="all"/>
+        <PackageReference Include="Speckle.Civil3D.API" Version="2022.0.2" IncludeAssets="compile;build" PrivateAssets="all"/>
     </ItemGroup>
 </Project>

--- a/ConnectorAutocadCivil/ConnectorCivil2023/ConnectorCivil2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorCivil2023/ConnectorCivil2023.csproj
@@ -48,7 +48,7 @@
         <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Speckle.AutoCAD.API" Version="2023.0.0" />
-        <PackageReference Include="Speckle.Civil3D.API" Version="2023.0.0" />
+        <PackageReference Include="Speckle.AutoCAD.API" Version="2023.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
+        <PackageReference Include="Speckle.Civil3D.API" Version="2023.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
     </ItemGroup>
 </Project>

--- a/ConnectorNavisworks/ConnectorNavisworks2020/ConnectorNavisworks2020.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2020/ConnectorNavisworks2020.csproj
@@ -62,7 +62,7 @@
 
 	<!-- NUGETS -->
 	<ItemGroup>
-	  <PackageReference Include="Speckle.Navisworks.API" Version="2020.0.0" />
+	  <PackageReference Include="Speckle.Navisworks.API" Version="2020.0.0" IncludeAssets="compile;build" PrivateAssets="all" />
 	</ItemGroup>
 
 	<!--- Local Project Dependencies -->

--- a/ConnectorNavisworks/ConnectorNavisworks2022/ConnectorNavisworks2022.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2022/ConnectorNavisworks2022.csproj
@@ -62,7 +62,7 @@
 
 	<!-- NUGETS -->
 	<ItemGroup>
-	  <PackageReference Include="Speckle.Navisworks.API" Version="2022.0.0" />
+	  <PackageReference Include="Speckle.Navisworks.API" Version="2022.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
 	</ItemGroup>
 
 	<!--- Local Project Dependencies -->

--- a/ConnectorNavisworks/ConnectorNavisworks2023/ConnectorNavisworks2023.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2023/ConnectorNavisworks2023.csproj
@@ -62,7 +62,7 @@
 
 	<!-- NUGETS -->
 	<ItemGroup>
-	  <PackageReference Include="Speckle.Navisworks.API" Version="2023.0.0" />
+	  <PackageReference Include="Speckle.Navisworks.API" Version="2023.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
 	</ItemGroup>
 
 	<!--- Local Project Dependencies -->

--- a/ConnectorNavisworks/ConnectorNavisworks2024/ConnectorNavisworks2024.csproj
+++ b/ConnectorNavisworks/ConnectorNavisworks2024/ConnectorNavisworks2024.csproj
@@ -62,7 +62,7 @@
 
   <!-- NUGETS -->
   <ItemGroup>
-    <PackageReference Include="Speckle.Navisworks.API" Version="2024.0.0"/>
+    <PackageReference Include="Speckle.Navisworks.API" Version="2024.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
   </ItemGroup>
 
   <!--- Local Project Dependencies -->

--- a/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
+++ b/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Avalonia" Version="0.10.18" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
-    <PackageReference Include="ModPlus.Revit.API.2020" Version="1.0.0" ExcludeAssets="runtime" />
+    <PackageReference Include="ModPlus.Revit.API.2020" Version="1.0.0" ExcludeAssets="runtime" IncludeAssets="compile;build" PrivateAssets="all" />
     <PackageReference Include="Revit.Async" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
+++ b/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Avalonia" Version="0.10.18" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
-    <PackageReference Include="ModPlus.Revit.API.2021" Version="1.0.0" />
+    <PackageReference Include="ModPlus.Revit.API.2021" Version="1.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
     <PackageReference Include="Revit.Async" Version="2.0.1" />
   </ItemGroup>
   

--- a/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
+++ b/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18"/>
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18"/>
     <PackageReference Include="Revit.Async" Version="2.0.1"/>
-    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1"/>
+    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1" IncludeAssets="compile;build" PrivateAssets="all"/>
   </ItemGroup>
 
   <Target Name="Clean">

--- a/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
+++ b/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18"/>
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18"/>
     <PackageReference Include="Revit.Async" Version="2.0.1"/>
-    <PackageReference Include="Speckle.Revit.API" Version="2023.0.0"/>
+    <PackageReference Include="Speckle.Revit.API" Version="2023.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
   </ItemGroup>
 
   <Target Name="Clean">


### PR DESCRIPTION
Exclude adsk nugets from output dir