### PR TITLE
Fix: Removes or demotes warnings in monorepo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -193,16 +193,23 @@ dotnet_diagnostic.ca1507.severity = warning
 dotnet_diagnostic.ca1508.severity = warning
 dotnet_diagnostic.ca1509.severity = warning
 
+dotnet_diagnostic.ca1002.severity = suggestion
+
 # Misc
 dotnet_diagnostic.ca1051.severity = none # Do not declare visible instance fields
-dotnet_diagnostic.ca1062.severity = none # Public method must check all parameters for null
+dotnet_diagnostic.ca1056.severity = suggestion
+dotnet_diagnostic.ca1062.severity = suggestion # Public method must check all parameters for null
 dotnet_diagnostic.ca1707.severity = none # Remove underscores in names
+dotnet_diagnostic.ca1822.severity = suggestion # Mark member as static
+
+dotnet_diagnostic.ca2211.severity = suggestion # Non constant fields should not be visible
+dotnet_diagnostic.ca2227.severity = suggestion # Collection props should be read-only
 
 
-dotnet_analyzer_diagnostic.category-globalization.severity = none
-dotnet_analyzer_diagnostic.category-security.severity = none
-dotnet_analyzer_diagnostic.category-interoperability.severity = none
-dotnet_analyzer_diagnostic.category-singlefile.severity = none
+dotnet_analyzer_diagnostic.category-Globalization.severity = none
+dotnet_analyzer_diagnostic.category-Security.severity = none
+dotnet_analyzer_diagnostic.category-Interoperability.severity = none
+dotnet_analyzer_diagnostic.category-SingleFile.severity = none
 
 [*.{appxmanifest,asax,ascx,aspx,axaml,build,c,c++,cc,cginc,compute,cp,cpp,cs,cshtml,cu,cuh,cxx,dtd,fs,fsi,fsscript,fsx,fx,fxh,h,hh,hlsl,hlsli,hlslinc,hpp,hxx,inc,inl,ino,ipp,ixx,master,ml,mli,mpp,mq4,mq5,mqh,nuspec,paml,razor,resw,resx,shader,skin,tpp,usf,ush,vb,xaml,xamlx,xoml,xsd}]
 indent_style = space

--- a/Core/Core/Api/GraphQL/Serializer/MapConverter.cs
+++ b/Core/Core/Api/GraphQL/Serializer/MapConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/DialogUserControl.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/DialogUserControl.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/ImportFamiliesDialog.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/ImportFamiliesDialog.xaml.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/MappingViewDialog.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/MappingViewDialog.xaml.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,11 +23,15 @@
 
     <!-- Ignore some warnings for now -->
     <NoWarn>
-      CS1591;CS1573;CS1572;CS1570;CS1587;CS1574;CS1711;CS1734;
+      CS1591;CS1573;CS1572;CS1570;CS1587;CS1574;
+      CS1711;CS1734;
       CS8618;CS8602;CS8600;
       CS1998; IDE0007; CS0618
       CA1054;
-      NU1701
+      <!-- Globalization rules disabled -->
+      CA1303;CA1304;CA1305;CA1307;CA1308;CA1309;CA1310;CA1311;CA2101
+      NU1701;
+      $(NoWarn)
     </NoWarn>
 
     <!-- False if running on CI, will prevent copying of files to local folders -->

--- a/Objects/Objects/Objects.csproj
+++ b/Objects/Objects/Objects.csproj
@@ -10,6 +10,7 @@
     <PackageTags>$(PackageTags), objects</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CopyToKitFolder>true</CopyToKitFolder>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some of our NetAnalyzers were quite noisy, and were warning about things that were not our priority right now (globalization, moving functions to be static...)

Some were still useful so they'll still appear as suggestions, but not as compile time warnings.