### PR TITLE
Fix(Revit): set schedule headers correctly

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.Schedule.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.Schedule.cs
@@ -159,9 +159,10 @@ namespace Objects.Converter.Revit
       var columnHeaders = new List<string>();
 
       DefineColumnMetadata(revitSchedule, speckleTable, originalTableIds, columnHeaders);
-      PopulateDataTableRows(revitSchedule, speckleTable, originalTableIds, skippedIndicies);
 
-      speckleTable.headerRowIndex = Math.Max(0, GetTableHeaderIndex(revitSchedule, skippedIndicies, columnHeaders.FirstOrDefault()));
+      var headerIndexArray = GetTableHeaderIndexArray(revitSchedule, columnHeaders);
+
+      PopulateDataTableRows(revitSchedule, speckleTable, originalTableIds, headerIndexArray, columnHeaders);
 
       if (!revitSchedule.Definition.ShowHeaders)
       {
@@ -231,73 +232,101 @@ namespace Objects.Converter.Revit
       speckleTable.DefineColumn(columnMetadata);
     }
 
-    private void PopulateDataTableRows(ViewSchedule revitSchedule, DataTable speckleTable, ICollection<ElementId> originalTableIds, Dictionary<SectionType, List<int>> skippedIndicies)
+    private void PopulateDataTableRows(ViewSchedule revitSchedule, DataTable speckleTable, ICollection<ElementId> originalTableIds, int[] columnHeaderIndexArray, List<string> columnHeaders)
     {
+      var minHeaderIndex = columnHeaderIndexArray.Min();
+      var maxHeaderIndex = columnHeaderIndexArray.Max();
+      speckleTable.headerRowIndex = maxHeaderIndex;
       foreach (var rowInfo in RevitScheduleUtils.ScheduleRowIteration(revitSchedule))
       {
-        try
+        var rowValues = new List<string>();
+
+        if (rowInfo.masterRowIndex == maxHeaderIndex)
         {
-          var rowAdded = AddRowToSpeckleTable(
-            revitSchedule,
-            speckleTable,
-            originalTableIds,
-            rowInfo.tableSection,
-            rowInfo.section,
-            rowInfo.columnCount,
-            rowInfo.rowIndex
-          );
-          if (!rowAdded)
+          rowValues = columnHeaders;
+        }
+        else
+        {
+          rowValues = GetRowValues(revitSchedule, rowInfo.tableSection, rowInfo.columnCount, rowInfo.rowIndex);
+        }
+
+        if (rowInfo.masterRowIndex >= minHeaderIndex && rowInfo.masterRowIndex < maxHeaderIndex)
+        {
+          for (var i = 0; i < rowInfo.columnCount; i++)
           {
-            if (!skippedIndicies.ContainsKey(rowInfo.tableSection))
+            if (columnHeaderIndexArray[i] == rowInfo.masterRowIndex)
             {
-              skippedIndicies.Add(rowInfo.tableSection, new List<int>());
+              rowValues[i] = string.Empty;
             }
-            skippedIndicies[rowInfo.tableSection].Add(rowInfo.rowIndex);
           }
         }
-        catch (Autodesk.Revit.Exceptions.ArgumentOutOfRangeException ex)
+
+        var rowAdded = AddRowToSpeckleTable(
+          revitSchedule,
+          speckleTable,
+          originalTableIds,
+          rowInfo.tableSection,
+          rowInfo.section,
+          rowValues,
+          rowInfo.rowIndex
+        );
+        if (!rowAdded && rowInfo.masterRowIndex < maxHeaderIndex)
         {
+          speckleTable.headerRowIndex--;
         }
       }
     }
 
-    private int GetTableHeaderIndex(ViewSchedule revitSchedule, Dictionary<SectionType, List<int>> skippedIndicies, string firstColumnHeader)
+    private int[] GetTableHeaderIndexArray(ViewSchedule revitSchedule, List<string> columnHeaders)
     {
       if (!revitSchedule.Definition.ShowHeaders)
       {
         return RevitScheduleUtils.ExecuteInTemporaryTransaction(() =>
         {
           revitSchedule.Definition.ShowHeaders = true;
-          return GetHeaderIndexFromScheduleWithHeaders(revitSchedule, skippedIndicies, firstColumnHeader);
+          return GetHeaderIndexArrayFromScheduleWithHeaders(revitSchedule, columnHeaders);
         }, Doc);
       }
 
-      return GetHeaderIndexFromScheduleWithHeaders(revitSchedule, skippedIndicies, firstColumnHeader);
+      return GetHeaderIndexArrayFromScheduleWithHeaders(revitSchedule, columnHeaders);
     }
 
-    private static int GetHeaderIndexFromScheduleWithHeaders(ViewSchedule revitSchedule, Dictionary<SectionType, List<int>> skippedIndicies, string firstColumnHeader)
+    private static int[] GetHeaderIndexArrayFromScheduleWithHeaders(ViewSchedule revitSchedule, List<string> columnHeaders)
     {
-      foreach (var rowInfo in RevitScheduleUtils.ScheduleRowIteration(revitSchedule, skippedIndicies))
+      string nextCellValue = null;
+      var headerIndexArray = new int[columnHeaders.Count];
+      var headersSetArray = new bool[columnHeaders.Count];
+      foreach (var rowInfo in RevitScheduleUtils.ScheduleRowIteration(revitSchedule))
       {
-        var cellValue = revitSchedule.GetCellText(rowInfo.tableSection, rowInfo.rowIndex, 0);
-        if (cellValue != firstColumnHeader)
+        if (rowInfo.columnCount != columnHeaders.Count)
         {
           continue;
         }
-        return rowInfo.masterRowIndex;
+
+        for (var columnIndex = 0; columnIndex < rowInfo.columnCount; columnIndex++)
+        {
+          var cellValue = revitSchedule.GetCellText(rowInfo.tableSection, rowInfo.rowIndex, columnIndex);
+
+          if (cellValue != columnHeaders[columnIndex])
+          {
+            continue;
+          }
+
+          headerIndexArray[columnIndex] = rowInfo.masterRowIndex;
+          headersSetArray[columnIndex] = true;
+
+          if (!headersSetArray.Where(o => o == false).Any())
+          {
+            return headerIndexArray;
+          }
+        }
       }
-      return -1;
+      return Enumerable.Repeat(0, columnHeaders.Count).ToArray();
     }
 
-    private bool AddRowToSpeckleTable(ViewSchedule revitSchedule, DataTable speckleTable, ICollection<ElementId> originalTableIds, SectionType tableSection, TableSectionData section, int columnCount, int rowIndex)
+    private bool AddRowToSpeckleTable(ViewSchedule revitSchedule, DataTable speckleTable, ICollection<ElementId> originalTableIds, SectionType tableSection, TableSectionData section, List<string> rowValues, int rowIndex)
     {
-      var rowData = new List<string>();
-      for (var columnIndex = 0; columnIndex < columnCount; columnIndex++)
-      {
-        rowData.Add(revitSchedule.GetCellText(tableSection, rowIndex, columnIndex));
-      }
-
-      if (!rowData.Where(s => !string.IsNullOrEmpty(s)).Any())
+      if (!rowValues.Where(s => !string.IsNullOrEmpty(s)).Any())
       {
         return false;
       }
@@ -306,7 +335,7 @@ namespace Objects.Converter.Revit
 
       try
       {
-        speckleTable.AddRow(metadata: metadata, objects: rowData.ToArray());
+        speckleTable.AddRow(metadata: metadata, objects: rowValues.ToArray());
       }
       catch (ArgumentException)
       {
@@ -315,6 +344,17 @@ namespace Objects.Converter.Revit
       }
 
       return true;
+    }
+
+    private static List<string> GetRowValues(ViewSchedule revitSchedule, SectionType tableSection, int columnCount, int rowIndex)
+    {
+      var rowData = new List<string>();
+      for (var columnIndex = 0; columnIndex < columnCount; columnIndex++)
+      {
+        rowData.Add(revitSchedule.GetCellText(tableSection, rowIndex, columnIndex));
+      }
+
+      return rowData;
     }
     #endregion
 
@@ -393,7 +433,8 @@ namespace Objects.Converter.Revit
             tableSection = tableSection,
             section = section,
             rowIndex = rowIndex, 
-            columnCount = columnCount 
+            columnCount = columnCount,
+            masterRowIndex = masterRowIndex
           };
 
           if (skippedIndicies == null || !skippedIndicies.TryGetValue(tableSection, out var indicies) || !indicies.Contains(rowIndex))

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.Schedule.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.Schedule.cs
@@ -305,8 +305,12 @@ namespace Objects.Converter.Revit
 
         for (var columnIndex = 0; columnIndex < rowInfo.columnCount; columnIndex++)
         {
-          var cellValue = revitSchedule.GetCellText(rowInfo.tableSection, rowInfo.rowIndex, columnIndex);
+          if (headersSetArray[columnIndex])
+          {
+            continue;
+          }
 
+          var cellValue = revitSchedule.GetCellText(rowInfo.tableSection, rowInfo.rowIndex, columnIndex);
           if (cellValue != columnHeaders[columnIndex])
           {
             continue;


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

schedule headers can come in as different rows. Therefore we need to shuffle some values around when building the datatable

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- chance the single header index to an array of indicies for each column
- add all headers to a single row
- if the headers exist in multiple rows, delete the value in the row with the lower index 

<!---

- Item 1
- Item 2

-->

## Validation of changes:

here are some correctly set schedules that were not working correctly before
https://latest.speckle.dev/streams/85bc4f61c6/commits/f67fbf699e
https://latest.speckle.dev/streams/85bc4f61c6/commits/1940396e26

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
