### PR TITLE
fix(revit): fixed issue with elements prop dynamic detaching issue

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -17,6 +17,7 @@ using Speckle.Core.Api;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Transports;
 
 namespace Speckle.ConnectorRevit.UI
@@ -124,7 +125,7 @@ namespace Speckle.ConnectorRevit.UI
 
             // here we are checking to see if we're receiving an object that has a host
             // but the host doesn't know that it is a host
-            if (conversionResult["speckleHost"] is Base host && host["category"] is string catName)
+            if (conversionResult["speckleHost"] is Base dummyHost && dummyHost["category"] is string catName)
             {
               //ensure we use english names for hosted elements too!
               var cat = ConnectorRevitUtils.GetCategories(CurrentDoc.Document)[catName];
@@ -132,19 +133,25 @@ namespace Speckle.ConnectorRevit.UI
               commitObject[$"@{catName}"] ??= new List<Base>();
               if (commitObject[$"@{catName}"] is List<Base> objs)
               {
-                var hostIndex = objs.FindIndex(obj => obj.applicationId == host.applicationId);
+                var hostIndex = objs.FindIndex(obj => obj.applicationId == dummyHost.applicationId);
                 // if the "host" is present, then it has already been converted and we need to
                 // attach the current, dependent, elements as a hosted element
                 if (hostIndex != -1)
                 {
-                  objs[hostIndex]["@elements"] ??= new List<Base>();
-                  ((List<Base>)objs[hostIndex]["@elements"]).Add(conversionResult);
+                  var host = objs[hostIndex];
+
+                  if (host.GetDetachedProp("elements") is not List<Base> els)
+                  {
+                    els = new List<Base>();
+                    host.SetDetachedProp("elements", els);
+                  }
+                  els.Add(conversionResult);
                 }
                 // if host is not present, then it hasn't been converted yet
                 // create a placeholder that will be overridden later, but that will contain the hosted element
                 else
                 {
-                  var newBase = new Base() { applicationId = host.applicationId };
+                  var newBase = new Base() { applicationId = dummyHost.applicationId };
                   newBase["@elements"] = new List<Base>() { conversionResult };
                   objs.Add(newBase);
                 }
@@ -153,7 +160,7 @@ namespace Speckle.ConnectorRevit.UI
                 conversionResult["speckleHost"] = null;
 
                 reportObj.Update(status: ApplicationObject.State.Created,
-                  logItem: $"Attached as hosted element to {host.applicationId}");
+                  logItem: $"Attached as hosted element to {dummyHost.applicationId}");
               }
             }
             //is an element type, nest it under Types instead
@@ -186,13 +193,13 @@ namespace Speckle.ConnectorRevit.UI
 
                 // here we are checking to see if we're converting a host that doesn't know it is a host
                 // and if dependent elements of that host have already been converted
-                if (hostIndex != -1 && objs[hostIndex]["@elements"] is List<Base> elements)
+                if (hostIndex != -1 && objs[hostIndex].GetDetachedProp("elements") is List<Base> elements)
                 {
                   objs.RemoveAt(hostIndex);
-                  if (conversionResult["@elements"] is List<Base> els)
+                  if (conversionResult.GetDetachedProp("elements") is List<Base> els)
                     els.AddRange(elements);
                   else
-                    conversionResult["@elements"] = elements;
+                    conversionResult.SetDetachedProp("elements", elements);
                 }
 
                 objs.Add(conversionResult);

--- a/Core/Tests/BaseExtensionsTests.cs
+++ b/Core/Tests/BaseExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
+
+namespace TestsUnit;
+
+[TestFixture, TestOf(nameof(BaseExtensions))]
+public class BaseExtensionsTests
+{
+  
+  [Test]
+  [TestCase("myDynamicProp")]
+  [TestCase("elements")]
+  public void GetDetachedPropName_Dynamic(string propertyName)
+  {
+    var data = new TestBase();
+    
+    var result = data.GetDetachedPropName(propertyName);
+    var expected = $"@{propertyName}";
+    Assert.That(result, Is.EqualTo(expected));
+  }
+  
+  [Test]
+  [TestCase(nameof(TestBase.myProperty))]
+  [TestCase(nameof(TestBase.myOtherProperty))]
+  public void GetDetachedPropName_Instance(string propertyName)
+  {
+    var data = new TestBase();
+    var result = data.GetDetachedPropName(propertyName);
+
+    Assert.That(result, Is.EqualTo(propertyName));
+  }
+
+  public class TestBase : Base
+  {
+    public string myProperty { get; set; }
+    public string myOtherProperty { get; set; }
+  }
+
+}

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -11,6 +11,7 @@ using Objects.Other;
 using Speckle.Core.Helpers;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Core.Models.Extensions;
 using Speckle.Core.Models.GraphTraversal;
 using DB = Autodesk.Revit.DB;
 using Duct = Objects.BuiltElements.Duct;
@@ -141,10 +142,15 @@ namespace Objects.Converter.Revit
       if (convertedHostedElements.Any())
       {
         notes.Add($"Converted and attached {convertedHostedElements.Count} hosted elements");
-        if (@base["@elements"] == null || !(@base["@elements"] is List<Base>))
-          @base["@elements"] = new List<Base>();
 
-        (@base["@elements"] as List<Base>).AddRange(convertedHostedElements);
+        if (@base.GetDetachedProp("elements") is List<Base> elements)
+        {
+          elements.AddRange(convertedHostedElements);
+        }
+        else
+        {
+          @base.SetDetachedProp("elements", convertedHostedElements);
+        }
       }
     }
     public IList<ElementId> GetHostedElementIds(Element host)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -8,6 +8,7 @@ using Objects.BuiltElements.Revit.RevitRoof;
 using Objects.Geometry;
 using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
+using FamilyInstance = Objects.BuiltElements.Revit.FamilyInstance;
 using Line = Objects.Geometry.Line;
 
 namespace Objects.Converter.Revit
@@ -72,8 +73,8 @@ namespace Objects.Converter.Revit
             var revitFootprintRoof = Doc.Create.NewFootPrintRoof(outline, level, roofType, out curveArray);
 
             // if the roof is a curtain roof then set the mullions at the borders
-            var nestedElements = speckleFootprintRoof["elements"] ?? speckleFootprintRoof["@elements"];
-            if (revitFootprintRoof.CurtainGrids != null && nestedElements is List<Base> elements && elements.Count != 0)
+            var nestedElements = speckleFootprintRoof.elements;
+            if (revitFootprintRoof.CurtainGrids != null && nestedElements is not null && nestedElements.Count != 0)
             {
               // TODO: Create a new type instead of overriding the type. This could affect other elements
               var param = roofType.get_Parameter(BuiltInParameter.AUTO_MULLION_BORDER1_GRID1);
@@ -81,7 +82,7 @@ namespace Objects.Converter.Revit
               if (type == null)
               {
                 // assuming first mullion is the desired mullion for the whole roof...
-                var mullionType = GetElementType<MullionType>(elements.Where(b => b is BuiltElements.Revit.FamilyInstance f).First(), appObj, out bool _);
+                var mullionType = GetElementType<MullionType>(nestedElements.First(b => b is FamilyInstance f), appObj, out bool _);
                 if (mullionType != null)
                 {
                   TrySetParam(roofType, BuiltInParameter.AUTO_MULLION_BORDER1_GRID1, mullionType);


### PR DESCRIPTION
#2456 introduced an issue where objects were being sent with both an "elements" instance prop (null) and an "@elements" dynamic prop (populated)

This PR provides a hacky work around, by checking for the presence of an instance prop before trying to set "@elements" dynamically.

I have put a few helper extension methods in core for this (with unit tests), unsure if this is the best place for them seeing as we likely want to push a more robust fix for this issue (potentially one that changes the way dynamic detaching works)