### PR TITLE
fix(navis): set hostapp with version

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -295,7 +295,7 @@ public partial class ConnectorBindingsNavisworks
       objectId = objectId,
       branchName = state.BranchName,
       message = state.CommitMessage ?? $"Sent {totalConversions} elements from {HostApplications.Navisworks.Name}.",
-      sourceApplication = HostApplications.Navisworks.Slug
+      sourceApplication = HostAppNameVersion
     };
 
     var commitId = await ConnectorHelpers


### PR DESCRIPTION
Passes the full Navis name and version to the `CommitCreateInput` so that on receive the right `sourceHostAppVersion` can be set.

For reference: https://github.com/specklesystems/speckle-sharp/blob/main/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs#L243