### PR TITLE
Revit Connector : Add Feature || Allow selection by filters

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -53,6 +53,15 @@ namespace Speckle.ConnectorRevit
       }
 
       return _categories;
+    }
+
+    public static List<ParameterFilterElement> GetFilters(Autodesk.Revit.DB.Document doc)
+    {
+      return new FilteredElementCollector(doc)
+        .OfClass(typeof(ParameterFilterElement))
+        .OfType<ParameterFilterElement>()
+        .OrderBy(x => x.Name)
+        .ToList();
     }
 
     /// <summary>
@@ -154,6 +163,11 @@ namespace Speckle.ConnectorRevit
     public static List<string> GetCategoryNames(Document doc)
     {
       return GetCategories(doc).Keys.OrderBy(x => x).ToList();
+    }
+
+    public static List<string> GetViewFilterNames(Document doc)
+    {
+      return GetFilters(doc).Select(x => x.Name).ToList();
     }
 
     public static List<string> GetWorksets(Document doc)


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Allow user easy send element by rule-base filters has setting inside Revit.
![Revit_IfkqR1amMV](https://user-images.githubusercontent.com/31106432/236746316-cb21351a-2680-45bc-87af-72c4091706fc.png)

## Changes:

- Add new option allow select by filters created in Revit

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

- Selection Filters : 
![image](https://user-images.githubusercontent.com/31106432/236746178-c20b38d0-edef-4d00-982f-9356d44d1a55.png)
- Dropdown : 

![image](https://user-images.githubusercontent.com/31106432/236746440-ed1c35b7-3b2e-483c-9a51-92da408012cf.png)
- After Send Select Window Level 2  - 7 Windows Elements sent
![image](https://user-images.githubusercontent.com/31106432/236746678-272bb984-e99c-4cb9-9f40-c33c219f5a65.png)
- After Send Select Window Level 1  - No Element
- After Send Select Window Total  - 17 Windows Elements sent
![image](https://user-images.githubusercontent.com/31106432/236747014-18d1b0d5-6fdd-4f51-b14d-ab1d480caac5.png)
- After Send Select Window Total + Window Level 2 + Window Level 1 + Door : 33 Elements sent (filtered duplicate element)
![image](https://user-images.githubusercontent.com/31106432/236747217-d9c28770-57d3-42cc-b52e-9f99193ce394.png)

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
