### PR TITLE
Disabling cached checkout due to failing CI's on restore

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -33,16 +33,7 @@ workflows:
 commands:
   cached-checkout:
     steps:
-      - restore_cache:
-          keys:
-            - &source-cache source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
       - checkout
-      - save_cache:
-          key: *source-cache
-          paths:
-            - ".git"
 
   packandpublish:
     steps:


### PR DESCRIPTION
Some CI jobs started failing on restore steps. Not sure exactly what the cause is, but could be related to how we're caching the checkout.

I'm removing it as it didn't give us the speed improvement we hoped for in the first place.