### PR TITLE
fix(Archicad): detailed error reporting

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
@@ -28,9 +28,10 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 	API_Element& beamMask,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
+	API_SubElement** /*marker*/,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** /*marker = nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -39,7 +40,7 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 #else
 	element.header.typeID = API_BeamID;
 #endif
-	err = Utility::GetBaseElementData (element, &memo);
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.hpp
@@ -9,20 +9,21 @@ namespace AddOnCommands {
 
 
 class CreateBeam : public CreateCommand {
-	GS::String			GetFieldName () const override;
-	GS::UniString		GetUndoableCommandName () const override;
+	GS::String		GetFieldName () const override;
+	GS::UniString	GetUndoableCommandName () const override;
 
-	GSErrCode			GetElementFromObjectState (const GS::ObjectState& os,
-		API_Element& element,
-		API_Element& elementMask,
-		API_ElementMemo& memo,
-		GS::UInt64& memoMask,
-		AttributeManager& attributeManager,
-		LibpartImportManager& libpartImportManager,
-		API_SubElement** marker = nullptr) const override;
+	GSErrCode		GetElementFromObjectState (const GS::ObjectState& os,
+						API_Element& element,
+						API_Element& elementMask,
+						API_ElementMemo& memo,
+						GS::UInt64& memoMask,
+						API_SubElement** marker,
+						AttributeManager& attributeManager,
+						LibpartImportManager& libpartImportManager,
+						GS::Array<GS::UniString>& log) const override;
 
 public:
-	GS::String			GetName () const override;
+	GS::String		GetName () const override;
 };
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.cpp
@@ -31,9 +31,10 @@ GSErrCode CreateColumn::GetElementFromObjectState (const GS::ObjectState& os,
 	API_Element& elementMask,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
+	API_SubElement** /*marker*/,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** /*marker = nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -42,7 +43,7 @@ GSErrCode CreateColumn::GetElementFromObjectState (const GS::ObjectState& os,
 #else
 	element.header.typeID = API_ColumnID;
 #endif
-	err = Utility::GetBaseElementData (element, &memo);
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.hpp
@@ -16,9 +16,10 @@ class CreateColumn : public CreateCommand {
 							API_Element& elementMask,
 							API_ElementMemo& memo,
 							GS::UInt64& memoMask,
+							API_SubElement** marker,
 							AttributeManager& attributeManager,
 							LibpartImportManager& libpartImportManager,
-							API_SubElement** marker = nullptr) const override;
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	virtual GS::String	GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
@@ -56,6 +56,9 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 
 		GS::Array<GS::ObjectState> applicationObjects;
 
+		AttributeManager* attributeManager = AttributeManager::GetInstance ();
+		LibpartImportManager* libpartImportManager = LibpartImportManager::GetInstance ();
+
 		Utility::Database db;
 		db.SwitchToFloorPlan ();
 
@@ -99,7 +102,8 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 				}
 			}
 
-			GSErrCode err = GetElementFromObjectState (objectState, element, elementMask, memo, memoMask, *AttributeManager::GetInstance (), *LibpartImportManager::GetInstance (), &marker);
+			GS::Array<GS::UniString> log;
+			GSErrCode err = GetElementFromObjectState (objectState, element, elementMask, memo, memoMask, &marker, *attributeManager, *libpartImportManager, log);
 			if (err == NoError) {
 				if (elementExists) {
 					err = ModifyExistingElement (element, elementMask, memo, memoMask);
@@ -126,6 +130,7 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 				ExchangeManager::GetInstance().UpdateState (speckleId, element.header.guid);
 			} else {
 				applicationObject.Add (ApplicationObject::Status, ApplicationObject::StateFailed);
+				applicationObject.Add (ApplicationObject::Log, log);
 			}
 
 			applicationObjects.Push (applicationObject);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.hpp
@@ -28,9 +28,10 @@ class CreateCommand : public BaseCommand {
 								API_Element& elementMask,
 								API_ElementMemo& memo,
 								GS::UInt64& memoMask,
+								API_SubElement** marker,
 								AttributeManager& attributeManager,
 								LibpartImportManager& libpartImportManager,
-								API_SubElement** marker = nullptr) const = 0;
+								GS::Array<GS::UniString>& log) const = 0;
 
 protected:
 	void					GetStoryFromObjectState (const GS::ObjectState& os,

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDirectShape.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDirectShape.cpp
@@ -30,9 +30,10 @@ GSErrCode CreateDirectShape::GetElementFromObjectState (const GS::ObjectState& o
 	API_Element& /*elementMask*/,
 	API_ElementMemo& memo,
 	GS::UInt64& /*memoMask*/,
+	API_SubElement** /*marker*/,
 	AttributeManager& attributeManager,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** /*marker = nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -41,7 +42,7 @@ GSErrCode CreateDirectShape::GetElementFromObjectState (const GS::ObjectState& o
 #else
 	element.header.typeID = API_MorphID;
 #endif
-	err = Utility::GetBaseElementData (element, &memo);
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDirectShape.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDirectShape.hpp
@@ -12,13 +12,14 @@ class CreateDirectShape : public CreateCommand {
 	GS::UniString		GetUndoableCommandName () const override;
 
 	GSErrCode			GetElementFromObjectState (const GS::ObjectState& os,
-		API_Element& element,
-		API_Element& elementMask,
-		API_ElementMemo& memo,
-		GS::UInt64& memoMask,
-		AttributeManager& attributeManager,
-		LibpartImportManager& libpartImportManager,
-		API_SubElement** marker = nullptr) const override;
+							API_Element& element,
+							API_Element& elementMask,
+							API_ElementMemo& memo,
+							GS::UInt64& memoMask,
+							API_SubElement** marker,
+							AttributeManager& attributeManager,
+							LibpartImportManager& libpartImportManager,
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	GS::String			GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDoor.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDoor.cpp
@@ -1,6 +1,5 @@
 #include "CreateDoor.hpp"
 #include "CreateOpeningBase.hpp"
-#include "ResourceIds.hpp"
 #include "ObjectState.hpp"
 #include "Utility.hpp"
 #include "Objects/Point.hpp"
@@ -34,9 +33,10 @@ GSErrCode CreateDoor::GetElementFromObjectState (const GS::ObjectState& currentD
 	API_Element& elementMask,
 	API_ElementMemo& memo,
 	GS::UInt64& /*memoMask*/,
+	API_SubElement** marker,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** marker /*= nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -48,14 +48,14 @@ GSErrCode CreateDoor::GetElementFromObjectState (const GS::ObjectState& currentD
 
 	* marker = new API_SubElement ();
 	BNZeroMemory (*marker, sizeof (API_SubElement));
-	err = Utility::GetBaseElementData (element, &memo, marker);
+	err = Utility::GetBaseElementData (element, &memo, marker, log);
 	if (err != NoError)
 		return err;
 
 	if (!CheckEnvironment (currentDoor, element))
 		return Error;
 
-	err = GetOpeningBaseFromObjectState<API_DoorType> (currentDoor, element.door, elementMask);
+	err = GetOpeningBaseFromObjectState<API_DoorType> (currentDoor, element.door, elementMask, log);
 
 	return err;
 }

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDoor.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDoor.hpp
@@ -14,9 +14,10 @@ class CreateDoor : public CreateOpeningBase {
 							API_Element& elementMask,
 							API_ElementMemo& memo,
 							GS::UInt64& memoMask,
+							API_SubElement** marker,
 							AttributeManager& attributeManager,
 							LibpartImportManager& libpartImportManager,
-							API_SubElement** marker = nullptr) const override;
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	virtual GS::String	GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.cpp
@@ -31,9 +31,10 @@ GSErrCode CreateObject::GetElementFromObjectState (const GS::ObjectState& os,
 	API_Element& elementMask,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
+	API_SubElement** /*marker*/,
 	AttributeManager& attributeManager,
 	LibpartImportManager& libpartImportManager,
-	API_SubElement** /*marker = nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -43,7 +44,7 @@ GSErrCode CreateObject::GetElementFromObjectState (const GS::ObjectState& os,
 	element.header.typeID = API_ObjectID;
 #endif
 
-	err = Utility::GetBaseElementData (element, &memo);
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.hpp
@@ -16,9 +16,10 @@ class CreateObject : public CreateCommand {
 							API_Element& elementMask,
 							API_ElementMemo& memo,
 							GS::UInt64& memoMask,
+							API_SubElement** marker,
 							AttributeManager& attributeManager,
 							LibpartImportManager& libpartImportManager,
-							API_SubElement** marker = nullptr) const override;
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	virtual GS::String	GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpeningBase.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpeningBase.hpp
@@ -5,11 +5,13 @@
 #include "FieldNames.hpp"
 #include "TypeNameTables.hpp"
 #include "Objects/Point.hpp"
+#include "Utility.hpp"
+#include "ResourceIds.hpp"
 
 namespace AddOnCommands {
 
 template<typename T>
-GSErrCode GetOpeningBaseFromObjectState (const GS::ObjectState& os, T& element, API_Element& mask)
+GSErrCode GetOpeningBaseFromObjectState (const GS::ObjectState& os, T& element, API_Element& mask, GS::Array<GS::UniString>& log)
 {
 	GSErrCode err = NoError;
 
@@ -44,6 +46,8 @@ GSErrCode GetOpeningBaseFromObjectState (const GS::ObjectState& os, T& element, 
 
 			if (err == NoError)
 				element.openingBase.mat = attrib.header.index;
+			else
+				log.Push (Utility::ComposeLogMessage (ID_LOG_MESSAGE_ATTRIBUTE_SEARCH_ERROR, attrName.ToPrintf ()));
 		}
 	}
 
@@ -59,6 +63,8 @@ GSErrCode GetOpeningBaseFromObjectState (const GS::ObjectState& os, T& element, 
 			err = ACAPI_LibPart_Search (&libPart, false, true);
 			if (err == NoError)
 				element.openingBase.libInd = libPart.index;
+			else
+				log.Push (Utility::ComposeLogMessage (ID_LOG_MESSAGE_LIBPART_SEARCH_ERROR, libPartName.ToPrintf ()));
 		}
 	}
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.cpp
@@ -29,9 +29,10 @@ GSErrCode CreateRoof::GetElementFromObjectState (const GS::ObjectState& os,
 	API_Element& elementMask,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
+	API_SubElement** /*marker = nullptr*/,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** /*marker = nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -40,7 +41,7 @@ GSErrCode CreateRoof::GetElementFromObjectState (const GS::ObjectState& os,
 #else
 	element.header.typeID = API_RoofID;
 #endif
-	err = Utility::GetBaseElementData (element, &memo);
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.hpp
@@ -13,13 +13,14 @@ class CreateRoof : public CreateCommand {
 	GS::UniString		GetUndoableCommandName () const override;
 
 	GSErrCode			GetElementFromObjectState (const GS::ObjectState& os,
-		API_Element& element,
-		API_Element& elementMask,
-		API_ElementMemo& memo,
-		GS::UInt64& memoMask,
-		AttributeManager& attributeManager,
-		LibpartImportManager& libpartImportManager,
-		API_SubElement** marker = nullptr) const override;
+							API_Element& element,
+							API_Element& elementMask,
+							API_ElementMemo& memo,
+							GS::UInt64& memoMask,
+							API_SubElement** marker,
+							AttributeManager& attributeManager,
+							LibpartImportManager& libpartImportManager,
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	GS::String			GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.cpp
@@ -26,13 +26,14 @@ GS::UniString CreateShell::GetUndoableCommandName () const
 
 
 GSErrCode CreateShell::GetElementFromObjectState (const GS::ObjectState& os,
-  API_Element& element,
-  API_Element& elementMask,
-  API_ElementMemo& memo,
-  GS::UInt64& memoMask,
-  AttributeManager& /*attributeManager*/,
-  LibpartImportManager& /*libpartImportManager*/,
-  API_SubElement** /*marker = nullptr*/) const
+	API_Element& element,
+	API_Element& elementMask,
+	API_ElementMemo& memo,
+	GS::UInt64& memoMask,
+	API_SubElement** /*marker = nullptr*/,
+	AttributeManager& /*attributeManager*/,
+	LibpartImportManager& /*libpartImportManager*/,
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -42,7 +43,7 @@ GSErrCode CreateShell::GetElementFromObjectState (const GS::ObjectState& os,
 	element.header.typeID = API_ShellID;
 #endif
 
-	err = Utility::GetBaseElementData (element, &memo);
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.hpp
@@ -13,13 +13,14 @@ class CreateShell : public CreateCommand {
 	GS::UniString		GetUndoableCommandName () const override;
 
 	GSErrCode			GetElementFromObjectState (const GS::ObjectState& os,
-		API_Element& element,
-		API_Element& elementMask,
-		API_ElementMemo& memo,
-		GS::UInt64& memoMask,
-		AttributeManager& attributeManager,
-		LibpartImportManager& libpartImportManager,
-		API_SubElement** marker = nullptr) const override;
+							API_Element& element,
+							API_Element& elementMask,
+							API_ElementMemo& memo,
+							GS::UInt64& memoMask,
+							API_SubElement** marker,
+							AttributeManager& attributeManager,
+							LibpartImportManager& libpartImportManager,
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	GS::String			GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
@@ -31,9 +31,10 @@ GSErrCode CreateSlab::GetElementFromObjectState (const GS::ObjectState& os,
 	API_Element& mask,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
+	API_SubElement** /*marker*/,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** /*marker = nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 #ifdef ServerMainVers_2600
 	element.header.type.typeID = API_SlabID;
@@ -41,7 +42,7 @@ GSErrCode CreateSlab::GetElementFromObjectState (const GS::ObjectState& os,
 	element.header.typeID = API_SlabID;
 #endif
 
-	GSErrCode err = Utility::GetBaseElementData (element, &memo);
+	GSErrCode err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.hpp
@@ -16,9 +16,10 @@ class CreateSlab : public CreateCommand {
 							API_Element& elementMask,
 							API_ElementMemo& memo,
 							GS::UInt64& memoMask,
+							API_SubElement** marker,
 							AttributeManager& attributeManager,
 							LibpartImportManager& libpartImportManager,
-							API_SubElement** marker = nullptr) const override;
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	virtual GS::String	GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.cpp
@@ -33,9 +33,10 @@ GSErrCode CreateWall::GetElementFromObjectState (const GS::ObjectState& os,
 	API_Element& elementMask,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
+	API_SubElement** /*marker*/,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** /*marker = nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err;
 
@@ -45,7 +46,7 @@ GSErrCode CreateWall::GetElementFromObjectState (const GS::ObjectState& os,
 	element.header.typeID = API_WallID;
 #endif
 
-	err = Utility::GetBaseElementData (element, &memo);
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.hpp
@@ -17,9 +17,10 @@ class CreateWall : public CreateCommand {
 							API_Element& elementMask,
 							API_ElementMemo& memo,
 							GS::UInt64& memoMask,
+							API_SubElement** marker,
 							AttributeManager& attributeManager,
 							LibpartImportManager& libpartImportManager,
-							API_SubElement** marker = nullptr) const override;
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	virtual GS::String	GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWindow.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWindow.cpp
@@ -34,9 +34,10 @@ GSErrCode CreateWindow::GetElementFromObjectState (const GS::ObjectState& curren
 	API_Element& elementMask,
 	API_ElementMemo& memo,
 	GS::UInt64& /*memoMask*/,
+	API_SubElement** marker,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** marker /*= nullptr*/) const
+	GS::Array<GS::UniString>& log) const
 {
 	GSErrCode err = NoError;
 
@@ -48,14 +49,14 @@ GSErrCode CreateWindow::GetElementFromObjectState (const GS::ObjectState& curren
 
 	*marker = new API_SubElement ();
 	BNZeroMemory (*marker, sizeof (API_SubElement));
-	err = Utility::GetBaseElementData (element, &memo, marker);
+	err = Utility::GetBaseElementData (element, &memo, marker, log);
 	if (err != NoError)
 		return err;
 
 	if (!CheckEnvironment (currentWindow, element))
 		return Error;
 
-	err = GetOpeningBaseFromObjectState<API_WindowType> (currentWindow, element.window, elementMask);
+	err = GetOpeningBaseFromObjectState<API_WindowType> (currentWindow, element.window, elementMask, log);
 
 	return err;
 }

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWindow.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWindow.hpp
@@ -14,9 +14,10 @@ class CreateWindow : public CreateOpeningBase {
 							API_Element& elementMask,
 							API_ElementMemo& memo,
 							GS::UInt64& memoMask,
+							API_SubElement** marker,
 							AttributeManager& attributeManager,
 							LibpartImportManager& libpartImportManager,
-							API_SubElement** marker = nullptr) const override;
+							GS::Array<GS::UniString>& log) const override;
 
 public:
 	virtual GS::String	GetName () const override;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
@@ -31,10 +31,10 @@ GSErrCode CreateZone::GetElementFromObjectState (const GS::ObjectState& os,
 	API_Element& mask,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
+	API_SubElement** /*marker*/,
 	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& /*libpartImportManager*/,
-	API_SubElement** /*marker = nullptr*/) const
-
+	GS::Array<GS::UniString>& log) const
 {
 #ifdef ServerMainVers_2600
 	element.header.type.typeID = API_ZoneID;
@@ -42,7 +42,7 @@ GSErrCode CreateZone::GetElementFromObjectState (const GS::ObjectState& os,
 	element.header.typeID = API_ZoneID;
 #endif
 
-	GSErrCode err = Utility::GetBaseElementData (element, &memo);
+	GSErrCode err = Utility::GetBaseElementData (element, &memo, nullptr, log);
 	if (err != NoError)
 		return err;
 
@@ -92,7 +92,7 @@ GSErrCode CreateZone::GetElementFromObjectState (const GS::ObjectState& os,
 
 GS::String CreateZone::GetName () const
 {
-	return CreateZoneCommandName
+	return CreateZoneCommandName;
 }
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.hpp
@@ -16,12 +16,13 @@ class CreateZone : public CreateCommand {
 							API_Element& elementMask,
 							API_ElementMemo& memo,
 							GS::UInt64& memoMask,
+							API_SubElement** marker,
 							AttributeManager& attributeManager,
 							LibpartImportManager& libpartImportManager,
-							API_SubElement** marker = nullptr) const override;
+							GS::Array<GS::UniString>& log) const override;
 
 public:
-	virtual GS::String							GetName () const override;
+	virtual GS::String	GetName () const override;
 };
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoofData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoofData.cpp
@@ -288,7 +288,7 @@ GS::ErrCode GetRoofData::SerializeElementType (const API_Element& element,
 
 GS::String GetRoofData::GetName () const
 {
-	return GetRoofDataCommandName
+	return GetRoofDataCommandName;
 }
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoomData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoomData.cpp
@@ -82,7 +82,7 @@ GS::ErrCode GetRoomData::SerializeElementType (const API_Element& element,
 
 GS::String GetRoomData::GetName () const
 {
-	return GetRoomDataCommandName
+	return GetRoomDataCommandName;
 }
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
@@ -16,6 +16,7 @@ static const char* StateRemoved = "Removed";
 static const char* StateUnknown = "Unknown";
 static const char* OriginalId = "OriginalId";
 static const char* CreatedIds = "CreatedIds";
+static const char* Log = "Log";
 }
 
 namespace ElementBase

--- a/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
@@ -4,6 +4,11 @@
 #define ID_ADDON_INFO			32000
 #define ID_ADDON_MENU			32500
 #define ID_DEFAULT_STORY_FORMAT	32800
+#define ID_LOG_MESSAGES			33000
+
+#define ID_LOG_MESSAGE_LIBPART_SEARCH_ERROR			1
+#define ID_LOG_MESSAGE_ATTRIBUTE_SEARCH_ERROR		2
+#define ID_LOG_MESSAGE_DEFAULT_MARKER_SEARCH_ERROR	3
 
 #define CommandNamespace						"Speckle";
 #define GetModelForElementsCommandName			"GetModelForElements";

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
@@ -4,6 +4,7 @@
 #include "ObjectState.hpp"
 #include "FieldNames.hpp"
 #include "TypeNameTables.hpp"
+#include "ResourceIds.hpp"
 using namespace FieldNames;
 
 namespace Utility {
@@ -32,7 +33,7 @@ bool ElementExists (const API_Guid& guid)
 }
 
 
-GSErrCode GetBaseElementData (API_Element& element, API_ElementMemo* memo /*= nullptr*/, API_SubElement** marker /*= nullptr*/)
+GSErrCode GetBaseElementData (API_Element& element, API_ElementMemo* memo, API_SubElement** marker, GS::Array<GS::UniString>& log)
 {
 	GSErrCode err = NoError;
 	API_Guid guid = element.header.guid;
@@ -79,8 +80,10 @@ GSErrCode GetBaseElementData (API_Element& element, API_ElementMemo* memo /*= nu
 			if (libPart.location != nullptr)
 				delete libPart.location;
 
-			if (err != NoError)
+			if (err != NoError) {
+				log.Push (ComposeLogMessage (ID_LOG_MESSAGE_DEFAULT_MARKER_SEARCH_ERROR));
 				return err;
+			}
 
 			double a = .0, b = .0;
 			Int32 addParNum = 0;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
@@ -3,6 +3,7 @@
 
 #include "APIEnvir.h"
 #include "ACAPinc.h"
+#include "ResourceIds.hpp"
 
 
 namespace Utility {
@@ -14,7 +15,7 @@ bool ElementExists (const API_Guid& guid);
 
 bool IsElement3D (const API_Guid& guid);
 
-GSErrCode GetBaseElementData (API_Element& elem, API_ElementMemo* memo = nullptr, API_SubElement** marker = nullptr);
+GSErrCode GetBaseElementData (API_Element& elem, API_ElementMemo* memo, API_SubElement** marker, GS::Array<GS::UniString>& log);
 
 GS::Array<API_StoryType> GetStoryItems ();
 
@@ -69,6 +70,15 @@ GSErrCode ImportHatchOrientation (const GS::ObjectState& os, API_HatchOrientatio
 // Transformation matrix
 GSErrCode ExportTransform (API_Tranmat transform, GS::ObjectState& out);
 GSErrCode ImportTransform (const GS::ObjectState& os, API_Tranmat& transform);
+
+// Conversion logging
+template<typename... Args>
+GS::UniString ComposeLogMessage (const Int32 resourceIndex, Args... args)
+{
+	GS::UniString errMsgFromatString;
+	RSGetIndString (&errMsgFromatString, ID_LOG_MESSAGES, resourceIndex, ACAPI_GetOwnResModule ());
+	return GS::UniString::Printf (errMsgFromatString, args...);
+}
 
 }
 

--- a/ConnectorArchicad/AddOn/Sources/AddOnResources/RINT/AddOn.grc
+++ b/ConnectorArchicad/AddOn/Sources/AddOnResources/RINT/AddOn.grc
@@ -9,8 +9,10 @@
 /* [  1] */		"ALPHA Speckle Connector ^E3 ^ES ^EE ^EI ^ED ^ET ^10001"
 }
 
-'STR#'  32700 "Messages for conversion log" {
-/* [  1] */		"Could not create library part: %s"
+'STR#' ID_LOG_MESSAGES "Messages for conversion log" {
+/* [  1] */		"Could not find library part: %T."
+/* [  2] */		"Could not find attribute: %T."
+/* [  3] */		"Could not find default marker."
 }
 
 'STR#'  ID_DEFAULT_STORY_FORMAT "Default story name format" {

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManagerReceive.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManagerReceive.cs
@@ -62,7 +62,7 @@ namespace Archicad
             {
               ApplicationObject obj = dict[contextObject.OriginalId];
 
-              contextObject.Update(status: obj.Status, createdIds: obj.CreatedIds);
+              contextObject.Update(status: obj.Status, createdIds: obj.CreatedIds, log: obj.Log);
               progress.Report.UpdateReportObject(contextObject);
             }
           }


### PR DESCRIPTION
## Description & motivation

Detailed error description for missing library parts for doors/windows


## Changes:

ApplicationObject log parameter is used. If a library part (door, window, marker) is missing red warning is reported.

## Screenshots:

<img width="395" alt="image" src="https://user-images.githubusercontent.com/50739844/236794440-4422b03d-e102-48ea-8507-9b6b334697fb.png">


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

