### PR TITLE
Remove parameter filter

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -23,7 +23,6 @@ namespace Speckle.ConnectorRevit
     public static string RevitAppName = HostApplications.Revit.GetVersion(HostAppVersion.v2019);
 #endif
 
-    private static List<string> _cachedParameters = null;
     private static List<string> _cachedViews = null;
     public static List<SpeckleException> ConversionErrors { get; set; }
 
@@ -176,45 +175,6 @@ namespace Speckle.ConnectorRevit
         .Where(x => x.Kind == WorksetKind.UserWorkset)
         .Select(x => x.Name)
         .ToList();
-    }
-
-    private static async Task<List<string>> GetParameterNamesAsync(Document doc)
-    {
-      var els = new FilteredElementCollector(doc)
-        .WhereElementIsNotElementType()
-        .WhereElementIsViewIndependent()
-        .Where(x => x.IsPhysicalElement());
-
-      List<string> parameters = new List<string>();
-
-      foreach (var e in els)
-      {
-        foreach (Parameter p in e.Parameters)
-        {
-          if (!parameters.Contains(p.Definition.Name))
-            parameters.Add(p.Definition.Name);
-        }
-      }
-
-      _cachedParameters = parameters.OrderBy(x => x).ToList();
-      return _cachedParameters;
-    }
-
-    /// <summary>
-    /// Each time it's called the cached parameters are returned, and a new copy is cached
-    /// </summary>
-    /// <param name="doc"></param>
-    /// <returns></returns>
-    public static List<string> GetParameterNames(Document doc)
-    {
-      if (_cachedParameters != null)
-      {
-        //don't wait for it to finish
-        GetParameterNamesAsync(doc);
-        return _cachedParameters;
-      }
-
-      return GetParameterNamesAsync(doc).Result;
     }
 
     private static async Task<List<string>> GetViewNamesAsync(Document doc)

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
@@ -35,20 +35,23 @@ namespace Speckle.ConnectorRevit.UI
          new AllSelectionFilter {Slug="all",  Name = "Everything", Icon = "CubeScan", Description = "Sends all supported elements and project information." },
         new ManualSelectionFilter(),
         new ListSelectionFilter {Slug="category", Name = "Category", Icon = "Category", Values = categories, Description="Adds all elements belonging to the selected categories"},
-        new ListSelectionFilter {Slug="filters", Name = "Filters", Icon = "Filters", Values = viewFilters, Description="Adds all elements belonging to the selected filters"},
-        new ListSelectionFilter {Slug="view", Name = "View", Icon = "RemoveRedEye", Values = views, Description="Adds all objects visible in the selected views" },
-        new ListSelectionFilter {Slug="project-info", Name = "Project Information", Icon = "Information", Values = projectInfo, Description="Adds the selected project information such as levels, views and family names to the stream"},
+
+        new ListSelectionFilter { Slug = "view", Name = "View", Icon = "RemoveRedEye", Values = views, Description = "Adds all objects visible in the selected views" },
+        new ListSelectionFilter { Slug = "project-info", Name = "Project Information", Icon = "Information", Values = projectInfo, Description = "Adds the selected project information such as levels, views and family names to the stream" },
           new PropertySelectionFilter
-        {
-          Slug="param",
-          Name = "Parameter",
-          Description="Adds all objects satisfying the selected parameter",
-          Icon = "FilterList",
-          Values = parameters,
-          Operators = new List<string> {"equals", "contains", "is greater than", "is less than"}
-        }
+          {
+            Slug = "param",
+            Name = "Parameter",
+            Description = "Adds all objects satisfying the selected parameter",
+            Icon = "FilterList",
+            Values = parameters,
+            Operators = new List<string> { "equals", "contains", "is greater than", "is less than" }
+          }
 
       };
+
+      if (viewFilters.Any())
+        filters.Insert(3, new ListSelectionFilter { Slug = "filter", Name = "Filters", Icon = "FilterList", Values = viewFilters, Description = "Adds all elements that pass the selected filters" });
       if (worksets.Any())
         filters.Insert(4, new ListSelectionFilter { Slug = "workset", Name = "Workset", Icon = "Group", Values = worksets, Description = "Adds all elements belonging to the selected workset" });
 
@@ -85,18 +88,18 @@ namespace Speckle.ConnectorRevit.UI
       var selection = args.Select(x => CurrentDoc.Document.GetElement(x)).Where(x => x != null && x.IsPhysicalElement()).Select(x => x.Id)?.ToList();
       if (!selection.Any())
         return;
-      
+
       //merge two lists
       if (!deselect)
       {
         var currentSelection = CurrentDoc.Selection.GetElementIds().ToList();
         selection = currentSelection.Union(selection).ToList();
       }
-  
-        CurrentDoc.Selection.SetElementIds(selection);
-        CurrentDoc.ShowElements(selection);
-     
-      
+
+      CurrentDoc.Selection.SetElementIds(selection);
+      CurrentDoc.ShowElements(selection);
+
+
     }
 
     private List<Document> GetLinkedDocuments()
@@ -207,7 +210,7 @@ namespace Speckle.ConnectorRevit.UI
             {
               List<Element> elements = new List<Element>();
               var viewFilters = ConnectorRevitUtils.GetFilters(doc)
-                .Where(x=>rvtFilters.Selection.Contains(x.Name));
+                .Where(x => rvtFilters.Selection.Contains(x.Name));
               foreach (ParameterFilterElement filterElement in viewFilters)
               {
                 ICollection<ElementId> cates = filterElement.GetCategories();
@@ -234,13 +237,13 @@ namespace Speckle.ConnectorRevit.UI
                     .WherePasses(cateFilter)
                     .ToList());
                 }
-               
+
               }
               if (elements.Count > 0)
               {
                 selection.AddRange(elements.GroupBy(x => x.Id.IntegerValue).Select(x => x.First()).ToList());
               }
-               
+
             }
             return selection;
           case "view":

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
@@ -15,7 +15,7 @@ namespace Speckle.ConnectorRevit.UI
     {
       var categories = new List<string>();
       var viewFilters = new List<string>();
-      var parameters = new List<string>();
+
       var views = new List<string>();
       var worksets = new List<string>();
       var projectInfo = new List<string> { "Project Info", "Levels", "Views 2D", "Views 3D", "Families & Types" };
@@ -25,7 +25,6 @@ namespace Speckle.ConnectorRevit.UI
         //selectionCount = CurrentDoc.Selection.GetElementIds().Count();
         categories = ConnectorRevitUtils.GetCategoryNames(CurrentDoc.Document);
         viewFilters = ConnectorRevitUtils.GetViewFilterNames(CurrentDoc.Document);
-        parameters = ConnectorRevitUtils.GetParameterNames(CurrentDoc.Document);
         views = ConnectorRevitUtils.GetViewNames(CurrentDoc.Document);
         worksets = ConnectorRevitUtils.GetWorksets(CurrentDoc.Document);
       }
@@ -35,19 +34,8 @@ namespace Speckle.ConnectorRevit.UI
          new AllSelectionFilter {Slug="all",  Name = "Everything", Icon = "CubeScan", Description = "Sends all supported elements and project information." },
         new ManualSelectionFilter(),
         new ListSelectionFilter {Slug="category", Name = "Category", Icon = "Category", Values = categories, Description="Adds all elements belonging to the selected categories"},
-
         new ListSelectionFilter { Slug = "view", Name = "View", Icon = "RemoveRedEye", Values = views, Description = "Adds all objects visible in the selected views" },
-        new ListSelectionFilter { Slug = "project-info", Name = "Project Information", Icon = "Information", Values = projectInfo, Description = "Adds the selected project information such as levels, views and family names to the stream" },
-          new PropertySelectionFilter
-          {
-            Slug = "param",
-            Name = "Parameter",
-            Description = "Adds all objects satisfying the selected parameter",
-            Icon = "FilterList",
-            Values = parameters,
-            Operators = new List<string> { "equals", "contains", "is greater than", "is less than" }
-          }
-
+        new ListSelectionFilter { Slug = "project-info", Name = "Project Information", Icon = "Information", Values = projectInfo, Description = "Adds the selected project information such as levels, views and family names to the stream" }
       };
 
       if (viewFilters.Any())


### PR DESCRIPTION
Removes the parameter filter in Revit in favor of the Filter one as it does the same and is more powerful. See https://github.com/specklesystems/speckle-sharp/pull/2517

This will also make opening streams inside large models faster.