### PR TITLE
Revit Connector : Improve selection by View

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -63,7 +63,7 @@ namespace Speckle.ConnectorRevit
         .OrderBy(x => x.Name)
         .ToList();
     }
-
+    
     /// <summary>
     /// We want to display a user-friendly category names when grouping objects
     /// For this we are simplifying the BuiltIn one as otherwise, by using the display value, we'd be getting localized category names
@@ -223,11 +223,17 @@ namespace Speckle.ConnectorRevit
         .WhereElementIsNotElementType()
         .OfClass(typeof(View))
         .Cast<View>()
-        .Where(x => !x.Name.Contains($"<Revision Schedule>"))
+        .Where(x => !IsViewRevisionSchedule(x.Name))
         .Where(x => !x.IsTemplate)
         .ToList();
       _cachedViews = els.Select(x => x.Name).OrderBy(x => x).ToList();
       return _cachedViews;
+    }
+    private static bool IsViewRevisionSchedule(string input)
+    {
+      string pattern =  @"<[\w\s]+>(\s*\d+)?";
+      Regex rgx = new Regex(pattern);
+      return rgx.IsMatch(input);
     }
 
     /// <summary>

--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -219,8 +219,13 @@ namespace Speckle.ConnectorRevit
 
     private static async Task<List<string>> GetViewNamesAsync(Document doc)
     {
-      var els = new FilteredElementCollector(doc).WhereElementIsNotElementType().OfClass(typeof(View)).ToElements();
-
+      var els = new FilteredElementCollector(doc)
+        .WhereElementIsNotElementType()
+        .OfClass(typeof(View))
+        .Cast<View>()
+        .Where(x => !x.Name.Contains($"<Revision Schedule>"))
+        .Where(x => !x.IsTemplate)
+        .ToList();
       _cachedViews = els.Select(x => x.Name).OrderBy(x => x).ToList();
       return _cachedViews;
     }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Some of view is no need to show : 
- View revision Schedule 
- View Templete 

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

Before :
 
![Revit_84dGxdtZmF](https://user-images.githubusercontent.com/31106432/236823897-af41d023-e1c1-4ba5-b1ee-92e0888aa852.png)

After : 

![Revit_p8uL4mBU2x](https://user-images.githubusercontent.com/31106432/236823920-fb47cc75-bad1-4f6d-9323-a2f737d95eec.png)

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
