### PR TITLE
fix(gh): Adds the ability for `key value by object` to fetch schemaComputed properties

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectValueByKeyTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectValueByKeyTaskComponent.cs
@@ -54,6 +54,8 @@ public class GetObjectValueByKeyTaskComponent : SelectKitTaskCapableComponentBas
         Tracker.TrackNodeRun("Object Value by Key");
 
       var @base = speckleObj?.Value;
+      if (@base == null)
+        return;
       var task = Task.Run(() => DoWork(@base, key, CancelToken));
       TaskList.Add(task);
       return;
@@ -74,7 +76,6 @@ public class GetObjectValueByKeyTaskComponent : SelectKitTaskCapableComponentBas
     switch (value)
     {
       case null:
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Key not found in object");
         break;
       case IEnumerable list:
       {
@@ -98,6 +99,13 @@ public class GetObjectValueByKeyTaskComponent : SelectKitTaskCapableComponentBas
         return null;
 
       var obj = @base[key] ?? @base["@" + key];
+      if (obj == null)
+      {
+        // Try check if it's a computed value
+        var members = @base.GetMembers(DynamicBaseMemberType.SchemaComputed);
+        if (members.TryGetValue(key, out object member))
+          obj = member;
+      }
 
       switch (obj)
       {


### PR DESCRIPTION
We originally added the `schemaComputed` properties (and it's corresponding flag in `Base.GetMembers()`) and it was added to the expandSpeckleObject functionality, but apparently we never did so for the Key Value by Object component.

This PR fixes this issue, and removes a double warning that was being reported when the key was not found.