### PR TITLE
Feat(Revit): add support for openings in analytical surfaces in 2023+

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
@@ -322,14 +323,8 @@ namespace Objects.Converter.Revit
         var physicalElement = Doc.GetElement(physicalElementId);
         speckleElement2D.displayValue = GetElementDisplayMesh(physicalElement, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
       }
-      //speckleElement2D["displayValue"] = displayLine;
 
-      //speckleElement2D.voids = voidNodes;
-
-      //var mesh = new Geometry.Mesh();
-      //var solidGeom = GetElementSolids(structuralElement);
-      //(mesh.faces, mesh.vertices) = GetFaceVertexArrFromSolids(solidGeom);
-      //speckleElement2D.baseMesh = mesh;	  
+      speckleElement2D.openings = GetOpenings(revitSurface);
 
       var prop = new Property2D();
 
@@ -368,6 +363,19 @@ namespace Objects.Converter.Revit
       // new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
 
       return speckleElement2D;
+    }
+
+    private List<Polycurve> GetOpenings(AnalyticalPanel revitSurface)
+    {
+      var openings = new List<Polycurve>();
+      foreach (var openingId in revitSurface.GetAnalyticalOpeningsIds())
+      {
+        if (revitSurface.Document.GetElement(openingId) is not AnalyticalOpening opening) continue;
+
+        var curveLoop = opening.GetOuterContour();
+        openings.Add(CurveLoopToSpeckle(curveLoop, revitSurface.Document));
+      }
+      return openings;
     }
 #endif
   }

--- a/Objects/Objects/Structural/Geometry/Element2D.cs
+++ b/Objects/Objects/Structural/Geometry/Element2D.cs
@@ -43,6 +43,7 @@ public class Element2D : Base, IDisplayValue<List<Mesh>>
 
   [DetachProperty]
   public List<Node> topology { get; set; }
+  public List<Polycurve> openings { get; set; }
 
   public string units { get; set; }
 


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- previously we were not adding openings to Speckle analyical 2D elements.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- add 'openings' prop for 2D analytical elements
- get analytical openings and convert to speckle

<!---

- Item 1
- Item 2

-->

## Screenshots:

There is now an openings prop that wasn't there before
https://latest.speckle.dev/streams/85bc4f61c6/commits/8d6c547560?filter=%7B%7D&c=%5B19.32601,-11.31229,4.78412,-4.24437,4.38822,-4,0,1%5D
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/4b238454-282c-4b45-889a-c6f9557938b4)

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

https://speckle.community/t/etabs-20-3-and-revit-2022-interoperability-issue/5065/8

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
