### PR TITLE
refactor(revit): deprecates old revit mesh display value methods

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAdaptiveComponent.cs
@@ -89,7 +89,7 @@ namespace Objects.Converter.Revit
 
       speckleAc.basePoints = GetAdaptivePoints(revitAc);
       speckleAc.flipped = AdaptiveComponentInstanceUtils.IsInstanceFlipped(revitAc);
-      speckleAc.displayValue = GetElementMesh(revitAc);
+      speckleAc.displayValue = GetElementDisplayValue(revitAc, SolidDisplayValueOptions);
 
       GetAllRevitParamsAndIds(speckleAc, revitAc);
       Report.Log($"Converted AdaptiveComponent {revitAc.Id}");

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalStick.cs
@@ -267,7 +267,7 @@ namespace Objects.Converter.Revit
       speckleElement1D.property = prop;
 
       GetAllRevitParamsAndIds(speckleElement1D, revitStick);
-      speckleElement1D.displayValue = GetElementDisplayMesh(revitStick.Document.GetElement(revitStick.GetElementId()));
+      speckleElement1D.displayValue = GetElementDisplayValue(revitStick.Document.GetElement(revitStick.GetElementId()));
       return speckleElement1D;
     }
 
@@ -338,7 +338,7 @@ namespace Objects.Converter.Revit
       {
         var physicalElementId = analyticalToPhysicalManager.GetAssociatedElementId(revitStick.Id);
         var physicalElement = Doc.GetElement(physicalElementId);
-        speckleElement1D.displayValue = GetElementDisplayMesh(physicalElement);
+        speckleElement1D.displayValue = GetElementDisplayValue(physicalElement);
       }
 
       return speckleElement1D;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertAnalyticalSurface.cs
@@ -218,7 +218,7 @@ namespace Objects.Converter.Revit
       }
 
       speckleElement2D.topology = edgeNodes;
-      speckleElement2D.displayValue = GetElementDisplayMesh(revitSurface, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
+      speckleElement2D.displayValue = GetElementDisplayValue(revitSurface, new Options() { DetailLevel = ViewDetailLevel.Fine });
 
       var voidNodes = new List<List<Node>> { };
       var voidLoops = revitSurface.GetLoops(AnalyticalLoopType.Void);
@@ -321,7 +321,7 @@ namespace Objects.Converter.Revit
       {
         var physicalElementId = analyticalToPhysicalManager.GetAssociatedElementId(revitSurface.Id);
         var physicalElement = Doc.GetElement(physicalElementId);
-        speckleElement2D.displayValue = GetElementDisplayMesh(physicalElement, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
+        speckleElement2D.displayValue = GetElementDisplayValue(physicalElement, new Options() { DetailLevel = ViewDetailLevel.Fine });
       }
 
       speckleElement2D.openings = GetOpenings(revitSurface);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertArea.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertArea.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using System.Linq;
 using DB = Autodesk.Revit.DB;
 using Point = Objects.Geometry.Point;
@@ -57,7 +57,7 @@ namespace Objects.Converter.Revit
 
       GetAllRevitParamsAndIds(speckleArea, revitArea);
 
-      speckleArea.displayValue = GetElementDisplayMesh(revitArea);
+      speckleArea.displayValue = GetElementDisplayValue(revitArea);
       return speckleArea;
     }
   }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBeam.cs
@@ -133,10 +133,9 @@ namespace Objects.Converter.Revit
       // so we need to pass in the view we want in order to get the correct geometry
       // TODO: we need to make sure we are passing in the correct view
       var connectionHandlerFilter = new ElementClassFilter(typeof(DB.Structure.StructuralConnectionHandler));
-      if (revitBeam.GetSubelements().Where(o => (BuiltInCategory)o.Category.Id.IntegerValue == DB.BuiltInCategory.OST_StructConnectionModifiers).Any() || revitBeam.GetDependentElements(connectionHandlerFilter).Any())
-        speckleBeam.displayValue = GetElementDisplayMesh(revitBeam, new Options() { View = Doc.ActiveView, ComputeReferences = true });
-      else
-        speckleBeam.displayValue = GetElementMesh(revitBeam);
+      var options = revitBeam.GetSubelements().Where(o => (BuiltInCategory)o.Category.Id.IntegerValue == DB.BuiltInCategory.OST_StructConnectionModifiers).Any() || revitBeam.GetDependentElements(connectionHandlerFilter).Any() ?
+        new Options() { View = Doc.ActiveView, ComputeReferences = true } : SolidDisplayValueOptions;
+      speckleBeam.displayValue = GetElementDisplayValue(revitBeam, options);
 
       GetAllRevitParamsAndIds(speckleBeam, revitBeam);
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBuildingPad.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBuildingPad.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Autodesk.Revit.DB;
 using Objects.BuiltElements.Revit;
 using System.Collections.Generic;
@@ -24,7 +24,7 @@ namespace Objects.Converter.Revit
 
       GetAllRevitParamsAndIds(specklePad, revitPad, new List<string> { "LEVEL_PARAM" });
 
-      specklePad.displayValue = GetElementDisplayMesh(revitPad, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
+      specklePad.displayValue = GetElementDisplayValue(revitPad, new Options() { DetailLevel = ViewDetailLevel.Fine });
 
       return specklePad;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCableTray.cs
@@ -79,7 +79,7 @@ namespace Objects.Converter.Revit
         width = GetParamValue<double>(revitCableTray, BuiltInParameter.RBS_CABLETRAY_WIDTH_PARAM),
         length = GetParamValue<double>(revitCableTray, BuiltInParameter.CURVE_ELEM_LENGTH),
         level = ConvertAndCacheLevel(revitCableTray, BuiltInParameter.RBS_START_LEVEL_PARAM),
-        displayValue = GetElementMesh(revitCableTray)
+        displayValue = GetElementDisplayValue(revitCableTray, SolidDisplayValueOptions)
       };
 
       GetAllRevitParamsAndIds(speckleCableTray, revitCableTray,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
@@ -30,7 +30,7 @@ namespace Objects.Converter.Revit
       GetHostedElements(speckleCeiling, revitCeiling, out List<string> hostedNotes);
       if (hostedNotes.Any()) notes.AddRange(hostedNotes); //TODO: what are we doing here?
 
-      speckleCeiling.displayValue = GetElementDisplayMesh(revitCeiling, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
+      speckleCeiling.displayValue = GetElementDisplayValue(revitCeiling, new Options() { DetailLevel = ViewDetailLevel.Fine });
 
       return speckleCeiling;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertColumn.cs
@@ -251,10 +251,9 @@ namespace Objects.Converter.Revit
       // so we need to pass in the view we want in order to get the correct geometry
       // TODO: we need to make sure we are passing in the correct view
       var connectionHandlerFilter = new ElementClassFilter(typeof(DB.Structure.StructuralConnectionHandler));
-      if (revitColumn.GetSubelements().Where(o => (BuiltInCategory)o.Category.Id.IntegerValue == DB.BuiltInCategory.OST_StructConnectionModifiers).Any() || revitColumn.GetDependentElements(connectionHandlerFilter).Any())
-        speckleColumn.displayValue = GetElementDisplayMesh(revitColumn, new Options() { View = Doc.ActiveView, ComputeReferences = true });
-      else
-        speckleColumn.displayValue = GetElementMesh(revitColumn);
+      var options = revitColumn.GetSubelements().Where(o => (BuiltInCategory)o.Category.Id.IntegerValue == DB.BuiltInCategory.OST_StructConnectionModifiers).Any() || revitColumn.GetDependentElements(connectionHandlerFilter).Any() ?
+        new Options() { View = Doc.ActiveView, ComputeReferences = true } : SolidDisplayValueOptions;
+      speckleColumn.displayValue = GetElementDisplayValue(revitColumn, options);
 
       return speckleColumn;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertConduit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertConduit.cs
@@ -80,7 +80,7 @@ namespace Objects.Converter.Revit
         diameter = GetParamValue<double>(revitConduit, BuiltInParameter.RBS_CONDUIT_DIAMETER_PARAM),
         length = GetParamValue<double>(revitConduit, BuiltInParameter.CURVE_ELEM_LENGTH),
         level = ConvertAndCacheLevel(revitConduit, BuiltInParameter.RBS_START_LEVEL_PARAM),
-        displayValue = GetElementMesh(revitConduit)
+        displayValue = GetElementDisplayValue(revitConduit, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = true })
       };
 
       GetAllRevitParamsAndIds(speckleConduit, revitConduit,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -115,7 +115,7 @@ namespace Objects.Converter.Revit
         length = GetParamValue<double>(revitDuct, BuiltInParameter.CURVE_ELEM_LENGTH),
         velocity = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_VELOCITY),
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
-        displayValue = GetElementMesh(revitDuct),
+        displayValue = GetElementDisplayValue(revitDuct, SolidDisplayValueOptions)
       };
 
       if (revitDuct.MEPSystem != null)
@@ -161,7 +161,7 @@ namespace Objects.Converter.Revit
         endTangent = VectorToSpeckle(revitDuct.EndTangent, revitDuct.Document),
         velocity = GetParamValue<double>(revitDuct, BuiltInParameter.RBS_VELOCITY),
         level = ConvertAndCacheLevel(revitDuct, BuiltInParameter.RBS_START_LEVEL_PARAM),
-        displayValue = GetElementMesh(revitDuct)
+        displayValue = GetElementDisplayValue(revitDuct, SolidDisplayValueOptions)
       };
 
       if (revitDuct.MEPSystem != null)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -387,7 +387,7 @@ namespace Objects.Converter.Revit
       if (revitFi.Location is LocationPoint locationPoint)
         speckleFi.rotation = locationPoint.Rotation;
 
-      speckleFi.displayValue = GetElementMesh(revitFi);
+      speckleFi.displayValue = GetElementDisplayValue(revitFi, SolidDisplayValueOptions);
 
       var material = ConverterRevit.GetMEPSystemMaterial(revitFi);
 
@@ -852,7 +852,7 @@ namespace Objects.Converter.Revit
       // get the displayvalue of the family symbol
       try
       {
-        var meshes = GetElementDisplayValue(instance, new Options() { DetailLevel = ViewDetailLevel.Fine }, true); // previous point-based family instnace conversion was using GetElementMesh(revitFi);
+        var meshes = GetElementDisplayValue(instance, new Options() { DetailLevel = ViewDetailLevel.Fine }, true);
         symbol.displayValue = meshes;
       }
       catch (Exception e)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFloor.cs
@@ -179,10 +179,9 @@ namespace Objects.Converter.Revit
         }
       }
 
-      speckleFloor.displayValue = GetElementDisplayMesh(
+      speckleFloor.displayValue = GetElementDisplayValue(
         revitFloor,
-        new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false }
-      );
+        new Options() { DetailLevel = ViewDetailLevel.Fine });
 
       GetHostedElements(speckleFloor, revitFloor, out List<string> hostedNotes);
       if (hostedNotes.Any())

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -139,7 +139,7 @@ namespace Objects.Converter.Revit
         diameter = GetParamValue<double>(revitPipe, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM),
         length = GetParamValue<double>(revitPipe, BuiltInParameter.CURVE_ELEM_LENGTH),
         level = ConvertAndCacheLevel(revitPipe, BuiltInParameter.RBS_START_LEVEL_PARAM),
-        displayValue = GetElementMesh(revitPipe)
+        displayValue = GetElementDisplayValue(revitPipe, SolidDisplayValueOptions)
       };
 
       var material = ConverterRevit.GetMEPSystemMaterial(revitPipe);
@@ -183,7 +183,7 @@ namespace Objects.Converter.Revit
         startTangent = VectorToSpeckle(revitPipe.StartTangent, revitPipe.Document),
         endTangent = VectorToSpeckle(revitPipe.EndTangent, revitPipe.Document),
         level = ConvertAndCacheLevel(revitPipe, BuiltInParameter.RBS_START_LEVEL_PARAM),
-        displayValue = GetElementMesh(revitPipe)
+        displayValue = GetElementDisplayValue(revitPipe, SolidDisplayValueOptions)
       };
 
       var material = ConverterRevit.GetMEPSystemMaterial(revitPipe);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -111,7 +111,10 @@ namespace Objects.Converter.Revit
 
       GetAllRevitParamsAndIds(speckleRailing, revitRailing, new List<string> { "STAIRS_RAILING_BASE_LEVEL_PARAM" });
 
-      speckleRailing.displayValue = GetElementDisplayMesh(revitRailing, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
+      speckleRailing.displayValue = GetElementDisplayValue(
+        revitRailing,
+        new Options() { DetailLevel = ViewDetailLevel.Fine }
+      );
 
       if (revitRailing.TopRail != ElementId.InvalidElementId)
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRevitElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRevitElement.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Autodesk.Revit.DB;
 
@@ -6,6 +6,7 @@ using Speckle.Core.Models;
 
 using Objects.BuiltElements.Revit;
 using RevitElementType = Objects.BuiltElements.Revit.RevitElementType;
+using System.Linq;
 
 namespace Objects.Converter.Revit
 {
@@ -34,24 +35,20 @@ namespace Objects.Converter.Revit
         speckleElement["baseLine"] = line;
 
       speckleElement.category = revitElement.Category.Name;
-      speckleElement.displayValue = GetElementDisplayMesh(revitElement, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
 
       GetHostedElements(speckleElement, revitElement, out notes);
       
       var elements = (speckleElement["elements"] ?? @speckleElement["@elements"]) as List<Base>;
       elements ??= new List<Base>();
 
-      //Only send elements that have a mesh, if not we should probably support them properly via direct conversions
-      if (speckleElement.displayValue == null || speckleElement.displayValue.Count == 0)
+      // get the displayvalue of this revit element
+      var displayValue = GetElementDisplayValue(revitElement, new Options() { DetailLevel = ViewDetailLevel.Fine });
+      if (!displayValue.Any() && elements.Count == 0)
       {
-        speckleElement.displayValue = GetFabricationMeshes(revitElement);
-
-        if ((speckleElement.displayValue == null || speckleElement.displayValue.Count == 0) && elements.Count == 0)
-        {
-          notes.Add("Not sending elements without display meshes");
-          return null;
-        }
+        notes.Add("Not sending elements without display meshes");
+        return null;
       }
+      speckleElement.displayValue = displayValue;
 
       GetAllRevitParamsAndIds(speckleElement, revitElement);
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -232,7 +232,10 @@ namespace Objects.Converter.Revit
       GetAllRevitParamsAndIds(speckleRoof, revitRoof,
         new List<string> { "ROOF_CONSTRAINT_LEVEL_PARAM", "ROOF_BASE_LEVEL_PARAM", "ROOF_UPTO_LEVEL_PARAM", "EXTRUSION_START_PARAM", "EXTRUSION_END_PARAM", "ROOF_SLOPE" });
 
-      speckleRoof.displayValue = GetElementDisplayMesh(revitRoof, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
+      speckleRoof.displayValue = GetElementDisplayValue(
+        revitRoof,
+        new Options() { DetailLevel = ViewDetailLevel.Fine }
+      );
 
       GetHostedElements(speckleRoof, revitRoof, out List<string> hostedNotes);
       if (hostedNotes.Any()) notes.AddRange(hostedNotes);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoom.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using Objects.BuiltElements;
 using Speckle.Core.Models;
 using System.Collections.Generic;
@@ -57,7 +57,7 @@ namespace Objects.Converter.Revit
 
       GetAllRevitParamsAndIds(speckleRoom, revitRoom);
 
-      speckleRoom.displayValue = GetElementDisplayMesh(revitRoom);
+      speckleRoom.displayValue = GetElementDisplayValue(revitRoom);
 
       return speckleRoom;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using Objects.BuiltElements;
 using Speckle.Core.Models;
 using System;
@@ -107,7 +107,7 @@ namespace Objects.Converter.Revit
 
       GetAllRevitParamsAndIds(speckleSpace, revitSpace);
 
-      speckleSpace.displayValue = GetElementDisplayMesh(revitSpace);
+      speckleSpace.displayValue = GetElementDisplayValue(revitSpace);
 
       return speckleSpace;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertStair.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertStair.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
@@ -34,7 +34,7 @@ namespace Objects.Converter.Revit
 
       GetAllRevitParamsAndIds(speckleStair, revitStair, new List<string> { "STAIRS_BASE_LEVEL_PARAM", "STAIRS_TOP_LEVEL_PARAM" });
 
-      speckleStair.displayValue = GetElementDisplayMesh(revitStair, new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false });
+      speckleStair.displayValue = GetElementDisplayValue(revitStair, new Options() { DetailLevel = ViewDetailLevel.Fine });
 
       return speckleStair;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertStructuralConnectionHandlers.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertStructuralConnectionHandlers.cs
@@ -1,4 +1,4 @@
-﻿using Objects.BuiltElements.Revit;
+using Objects.BuiltElements.Revit;
 using Speckle.Core.Models;
 using System.Collections.Generic;
 using DB = Autodesk.Revit.DB;
@@ -63,7 +63,7 @@ namespace Objects.Converter.Revit
 
       // Structural Connection Handlers are (supposedly) view specific which requires getting mesh by view
       // TODO: not guarenteed that the active view is what we need (3D view with fine detail where the element is visible
-      speckleConnection.displayValue = GetElementDisplayMesh(revitConnection, new DB.Options() { ComputeReferences = false, View = Doc.ActiveView });
+      speckleConnection.displayValue = GetElementDisplayValue(revitConnection, new DB.Options() { View = Doc.ActiveView });
 
       GetAllRevitParamsAndIds(speckleConnection, revitConnection);
       

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertTopRail.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertTopRail.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Objects.BuiltElements.Revit;
 using System.Collections.Generic;
@@ -13,8 +13,7 @@ namespace Objects.Converter.Revit
       var speckleTopRail = new RevitTopRail
       {
         type = topRailType.Name,
-        displayValue = GetElementDisplayMesh(revitTopRail,
-                new Options() { DetailLevel = ViewDetailLevel.Fine, ComputeReferences = false })
+        displayValue = GetElementDisplayValue(revitTopRail, new Options() { DetailLevel = ViewDetailLevel.Fine })
       };
 
       GetAllRevitParamsAndIds(speckleTopRail, revitTopRail, new List<string> { });

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertTopography.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertTopography.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Objects.BuiltElements;
 using Objects.BuiltElements.Revit;
@@ -49,7 +49,7 @@ namespace Objects.Converter.Revit
     public RevitTopography TopographyToSpeckle(TopographySurface revitTopo)
     {
       var speckleTopo = new RevitTopography();
-      speckleTopo.displayValue = GetElementMesh(revitTopo);
+      speckleTopo.displayValue = GetElementDisplayValue(revitTopo, SolidDisplayValueOptions);
       GetAllRevitParamsAndIds(speckleTopo, revitTopo);
       return speckleTopo;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -232,15 +232,15 @@ namespace Objects.Converter.Revit
     {
       var grid = wall.CurtainGrid;
 
-      var solidPanels = new List<Solid>();
-      var solidMullions = new List<Solid>();
+      var meshPanels = new List<Mesh>();
+      var meshMullions = new List<Mesh>();
       foreach (ElementId panelId in grid.GetPanelIds())
       {
         //TODO: sort these so we consistently get sub-elements from the wall element in case also individual sub-elements are sent
         if (SubelementIds.Contains(panelId))
           continue;
         SubelementIds.Add(panelId);
-        solidPanels.AddRange(GetElementSolids(wall.Document.GetElement(panelId)));
+        meshPanels.AddRange(GetElementDisplayValue(wall.Document.GetElement(panelId)));
       }
       foreach (ElementId mullionId in grid.GetMullionIds())
       {
@@ -248,11 +248,8 @@ namespace Objects.Converter.Revit
         if (SubelementIds.Contains(mullionId))
           continue;
         SubelementIds.Add(mullionId);
-        solidMullions.AddRange(GetElementSolids(wall.Document.GetElement(mullionId)));
+        meshMullions.AddRange(GetElementDisplayValue(wall.Document.GetElement(mullionId)));
       }
-
-      var meshPanels = ConvertSolidsByRenderMaterial(solidPanels, wall.Document);
-      var meshMullions = ConvertSolidsByRenderMaterial(solidMullions, wall.Document);
 
       return (meshPanels, meshMullions);
     }


### PR DESCRIPTION
## Description & motivation
Removes all references to the old mesh display value methods in Revit conversions. This needs to be thoroughly tested to ensure no regressions in how element display meshes were previously being retrieved in revit conversions.

Closes #2314

**note: this pr is replacing #2426 due to the other pr becoming unwieldy from cumulative reformatting hook changes**

## Changes:
Revit converter
