### PR TITLE
Archicad/reference fix

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
@@ -33,7 +33,7 @@ API_ElemTypeID GetElementType (const API_Guid& guid)
 }
 
 
-void SetElementType (API_Elem_Head header, const API_ElemTypeID& elementType)
+void SetElementType (API_Elem_Head& header, const API_ElemTypeID& elementType)
 {
 #ifdef ServerMainVers_2600
 	header.type.typeID = elementType;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
@@ -11,7 +11,7 @@ namespace Utility {
 
 API_ElemTypeID GetElementType (const API_Elem_Head& header);
 API_ElemTypeID GetElementType (const API_Guid& guid);
-void SetElementType (API_Elem_Head header, const API_ElemTypeID& elementType);
+void SetElementType (API_Elem_Head& header, const API_ElemTypeID& elementType);
 
 bool ElementExists (const API_Guid& guid);
 


### PR DESCRIPTION
## Description & motivation

In this (https://github.com/specklesystems/speckle-sharp/commit/aa0c3d0cc3441f21f589f6ef7795fc1c2c8d33bc) commit SetElementType was introduced, but the argument should be reference. 

