### PR TITLE
fix(rhino): Use correct configuration in CI + copy to output condition

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -401,7 +401,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c Release -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
+            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c << pipeline.build-config >> -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -401,7 +401,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
+            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -r osx-x64 -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -401,7 +401,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c << pipeline.build-config >> -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
+            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c << parameters.build-config >> -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -401,7 +401,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c << parameters.build-config >> -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
+            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -401,7 +401,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           command: |
             TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -r osx-x64 -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
+            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
+++ b/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
@@ -26,7 +26,7 @@
     <DefineConstants>$(DefineConstants);RHINO7</DefineConstants>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(Configuration)'=='Debug Mac' OR '$(Configuration)'=='Release Mac'">
     <DefineConstants>$(DefinesConstants);MAC</DefineConstants>
   </PropertyGroup>
@@ -36,32 +36,40 @@
     <StartAction>Program</StartAction>
   </PropertyGroup>
 
-  <Import Project="..\ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems" Label="Shared" />
+  <Import Project="..\ConnectorRhino\ConnectorRhinoShared\ConnectorRhinoShared.projitems"
+    Label="Shared"/>
 
   <ItemGroup>
-    <EmbeddedResource Include="EmbeddedResources\**\*" />
+    <EmbeddedResource Include="EmbeddedResources\**\*"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RhinoCommon" Version="7.4.21078.1001" IncludeAssets="compile;build" PrivateAssets="all" />
-    <PackageReference Include="RhinoWindows" Version="7.4.21078.1001" IncludeAssets="compile;build" PrivateAssets="all" />
-    <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
+    <PackageReference Include="RhinoCommon" Version="7.4.21078.1001" IncludeAssets="compile;build"
+      PrivateAssets="all"/>
+    <PackageReference Include="RhinoWindows" Version="7.4.21078.1001" IncludeAssets="compile;build"
+      PrivateAssets="all"/>
+    <PackageReference Include="System.Resources.Extensions" Version="7.0.0"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\ConnectorGrasshopper\ConnectorGrasshopper7\ConnectorGrasshopper7.csproj" />
-    <ProjectReference Include="..\..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj" />
-    <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj" />
+    <ProjectReference
+      Include="..\..\ConnectorGrasshopper\ConnectorGrasshopper7\ConnectorGrasshopper7.csproj"/>
+    <ProjectReference Include="..\..\DesktopUI2\AvaloniaHwndHost\AvaloniaHwndHost.csproj"/>
+    <ProjectReference Include="..\..\DesktopUI2\DesktopUI2\DesktopUI2.csproj"/>
   </ItemGroup>
-  
+
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    <Reference Include="PresentationCore"/>
+    <Reference Include="PresentationFramework"/>
   </ItemGroup>
 
   <!-- We are building for win-x64 on mac too, so these deps are not automatically copied/loaded -->
-  <ItemGroup Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">
-    <None Include="$(HOME)/.nuget/packages/avalonia.native/0.10.18/runtimes/osx/native/libAvaloniaNative.dylib" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <None Include="$(HOME)/.nuget/packages/sqlitepclraw.lib.e_sqlite3/2.1.4/runtimes/osx-x64/native/libe_sqlite3.dylib" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+  <ItemGroup Condition="'$(Configuration)'=='Debug Mac' OR '$(Configuration)'=='Release Mac'">
+    <None
+      Include="$(HOME)/.nuget/packages/avalonia.native/0.10.18/runtimes/osx/native/libAvaloniaNative.dylib"
+      CopyToOutputDirectory="PreserveNewest" Visible="false"/>
+    <None
+      Include="$(HOME)/.nuget/packages/sqlitepclraw.lib.e_sqlite3/2.1.4/runtimes/osx-x64/native/libe_sqlite3.dylib"
+      CopyToOutputDirectory="PreserveNewest" Visible="false"/>
   </ItemGroup>
 </Project>

--- a/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
+++ b/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug Mac' OR '$(Configuration)'=='Release Mac'">
-    <DefineConstants>$(DefinesConstants);MAC</DefineConstants>
+    <DefineConstants>$(DefineConstants);MAC</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">


### PR DESCRIPTION
Jonathon reported that our mac installers did not work.

After a bit of digging I realised we were using the wrong configuration when building (it was hard-coded to `release` instead of the input parameter.

Additionally, our condition to copy to the output folder the necessary mac files was not being executed anymore since we were checking for the os to be `OSX` specifically, but this is no longer the case as we're building Rhino mac on linux already.

These 2 changes should fix the installer, but a new release needs to be made to test this