### PR TITLE
bug(rhino): mapper tool bugs with walls and floors

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
@@ -100,7 +100,6 @@ public class MappingBindingsRhino : MappingsBindings
             var extrusionBrp = e.ToBrep(false);
             var extrusionSurfaceSchemas = EvaluateBrepSurfaceSchemas(extrusionBrp, true);
             result.AddRange(extrusionSurfaceSchemas);
-            result.Add(new RevitDefaultWallViewModel());
             break;
 
           case Curve c:
@@ -201,6 +200,7 @@ public class MappingBindingsRhino : MappingsBindings
       if (isHorizontal)
       {
         schemas.Add(new RevitFloorViewModel());
+        schemas.Add(new RevitDefaultFloorViewModel());
       }
       else if (isVertical)
       {
@@ -218,6 +218,7 @@ public class MappingBindingsRhino : MappingsBindings
           schemas.Add(new RevitProfileWallViewModel());
         }
         schemas.Add(new RevitFaceWallViewModel());
+        schemas.Add(new RevitDefaultWallViewModel());
       }
       else
       {

--- a/DesktopUI2/DesktopUI2/ViewModels/MappingTool/MappingsViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/MappingTool/MappingsViewModel.cs
@@ -259,6 +259,7 @@ public class MappingsViewModel : ViewModelBase, IScreen
           schema is DirectShapeFreeformViewModel
           || schema is RevitTopographyViewModel
           || schema is RevitDefaultWallViewModel
+          || schema is RevitDefaultFloorViewModel
           || schema is RevitDefaultBeamViewModel
           || schema is RevitDefaultBraceViewModel
           || schema is RevitDefaultColumnViewModel

--- a/DesktopUI2/DesktopUI2/ViewModels/MappingTool/Schemas.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/MappingTool/Schemas.cs
@@ -420,6 +420,21 @@ public class RevitDefaultWallViewModel : Schema
   }
 }
 
+public class RevitDefaultFloorViewModel : Schema
+{
+  public override string Name => "Default Floor";
+
+  public override string Summary => Name;
+
+  public override bool IsValid => true;
+
+  public override string GetSerializedSchema()
+  {
+    var obj = new Floor();
+    return Operations.Serialize(obj);
+  }
+}
+
 public class RevitDefaultBeamViewModel : Schema
 {
   public override string Name => "Default Beam";

--- a/DesktopUI2/DesktopUI2/Views/MappingsControl.xaml
+++ b/DesktopUI2/DesktopUI2/Views/MappingsControl.xaml
@@ -263,6 +263,7 @@
                         <ContentControl.DataTemplates>
                           <!--  Default = empty  -->
                           <DataTemplate DataType="{x:Type s:RevitDefaultWallViewModel}" />
+                          <DataTemplate DataType="{x:Type s:RevitDefaultFloorViewModel}" />
                           <DataTemplate DataType="{x:Type s:RevitDefaultBeamViewModel}" />
                           <DataTemplate DataType="{x:Type s:RevitDefaultBraceViewModel}" />
                           <DataTemplate DataType="{x:Type s:RevitDefaultColumnViewModel}" />


### PR DESCRIPTION
## Description & motivation

- Removes `Default Wall` option from all extrusions, and only adds that option when the extrusion is a vertical single surface
- Adds `Default Floor` option for all horizontal single surface breps and extrusions.

Fixes #2558 
Fixes #2557 

Rhino mapping tool and dui mapping tool


## Screenshots:
removing default wall from solid extrusion:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/40a6a098-bf3f-4866-b509-2781da6287d5)

adding default floor:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/c61c9935-5538-4b63-b52b-15ade922191e)
