### PR TITLE
Fix: Filter out view templates from View element collector

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevitUtils.cs
@@ -199,7 +199,8 @@ namespace Speckle.ConnectorRevit
       var els = new FilteredElementCollector(doc)
         .WhereElementIsNotElementType()
         .OfClass(typeof(View))
-        .ToElements();
+        .Where(view => !(view as View).IsTemplate)
+        .ToList();
 
       _cachedViews = els.Select(x => x.Name).OrderBy(x => x).ToList();
       return _cachedViews;


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Fixes https://github.com/specklesystems/speckle-sharp/issues/2566

View templates appears on the View option on the revit connector, however, selecting them and pushing data gives an error as View templates don't contain any elements.


<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

I suspect the function that is being used to show the names of the views in the UI is `GetViewNamesAsync()` on ConnectorRevitUtils.cs. When I tested this function on my Revit Plugin it returns all the views including View Template.

Proposed changed: 
- Adds a filter with LINQ to remove Views that are templates from the function. Revit API provides a property called `View.isTemplate`

<!---

- Item 1
- Item 2

-->


## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.


-->

I simply ran this change on a Revit Addin, and verified that the changes filter out the Revit View Templates from the list. I did not build the speckle connector with this change to verifiy if the changes reflect on the UI.

![image](https://github.com/specklesystems/speckle-sharp/assets/63083862/fde83ee8-e79e-466c-acbc-db38698850aa)

![image](https://github.com/specklesystems/speckle-sharp/assets/63083862/7ef2edac-c9df-45ea-9f7d-32bacb6b4016)

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

Number of elements collected with original solution: 231. Are there View Templates on this list? yes

Number of elements collected with proposed solution: 156. Are there View templates on this list? no

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
