### PR TITLE
bug(rhino): temporarily disables doc layer change event handler for performance

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -44,7 +44,7 @@ public class ConnectorBindingsRhino : ConnectorBindings
   public ConnectorBindingsRhino()
   {
     RhinoDoc.EndOpenDocument += RhinoDoc_EndOpenDocument;
-    RhinoDoc.LayerTableEvent += RhinoDoc_LayerChange;
+    RhinoDoc.LayerTableEvent += RhinoDoc_LayerChange; // used to update the DUI2 layer filter to reflect layer changes
   }
 
   public RhinoDoc Doc => RhinoDoc.ActiveDoc;
@@ -554,7 +554,7 @@ public class ConnectorBindingsRhino : ConnectorBindings
 
           #region layer creation
 
-          RhinoDoc.LayerTableEvent -= RhinoDoc_LayerChange;
+          RhinoDoc.LayerTableEvent -= RhinoDoc_LayerChange; // temporarily unsubscribe from layer handler since layer creation will trigger it.
 
           // sort by depth and create all the containers as layers first
           var layers = new Dictionary<string, Layer>();
@@ -604,7 +604,6 @@ public class ConnectorBindingsRhino : ConnectorBindings
 
             layers.Add(layer.FullPath, layer);
           }
-          RhinoDoc.LayerTableEvent += RhinoDoc_LayerChange;
           #endregion
 
           foreach (var previewObj in Preview)
@@ -671,6 +670,8 @@ public class ConnectorBindingsRhino : ConnectorBindings
             progress.Update(conversionProgressDict);
           }
           progress.Report.Merge(converter.Report);
+
+          RhinoDoc.LayerTableEvent += RhinoDoc_LayerChange; // reactivate the layer handler
 
           // undo notes edit
           var segments = Doc.Notes.Split(new[] { "%%%" }, StringSplitOptions.None).ToList();

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -554,6 +554,8 @@ public class ConnectorBindingsRhino : ConnectorBindings
 
           #region layer creation
 
+          RhinoDoc.LayerTableEvent -= RhinoDoc_LayerChange;
+
           // sort by depth and create all the containers as layers first
           var layers = new Dictionary<string, Layer>();
           var containers = Preview
@@ -602,6 +604,7 @@ public class ConnectorBindingsRhino : ConnectorBindings
 
             layers.Add(layer.FullPath, layer);
           }
+          RhinoDoc.LayerTableEvent += RhinoDoc_LayerChange;
           #endregion
 
           foreach (var previewObj in Preview)

--- a/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
@@ -22,6 +22,7 @@ using Material.Icons.Avalonia;
 using Material.Styles.Themes;
 using Material.Styles.Themes.Base;
 using ReactiveUI;
+using Sentry.Extensibility;
 using Speckle.Core.Api;
 using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
@@ -114,7 +115,7 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
   {
     try
     {
-      if (_selectedSavedStream != null)
+      if (_selectedSavedStream != null && !_selectedSavedStream.Progress.IsProgressing)
         _selectedSavedStream.GetBranchesAndRestoreState();
     }
     catch (Exception ex)


### PR DESCRIPTION
## Description & motivation

Disables the doc layer change event handler on layer creation during receive operations, as this was causing a huge performance issue when receiving commits that result in many layers being created.

Not the ideal solution, but should fix #2570

## Changes:

- rhino connector