### PR TITLE
CI: Fixes incorrect FileVersion on releases

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -39,10 +39,12 @@ commands:
       - run:
           name: Set version environment variables
           command: |
+            $BASH_ENV
             echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
             echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$BASH_ENV"
+            $BASH_ENV
 
   packandpublish:
     steps:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -39,10 +39,10 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$Bash_ENV"
-            echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$Bash_ENV"
-            echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$Bash_ENV"
-            echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$Bash_ENV"
+            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
+            echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
+            echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
+            echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$BASH_ENV"
 
   packandpublish:
     steps:
@@ -79,6 +79,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - image: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
       - cached-checkout
+      - set-version-vars
       - run:
           name: Build SDK Projects
           command: dotnet build SDK.slnf -c Release -v m -p:WarningLevel=0 -p:IsDesktopBuild=false

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -49,7 +49,6 @@ commands:
 
   packandpublish:
     steps:
-      - set-version-vars
       - run:
           name: Build nuget packages
           command: |
@@ -86,7 +85,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - image: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
       - cached-checkout
-      - set-version-vars
       - run:
           name: Build SDK Projects
           command: dotnet build SDK.slnf -c Release -v m -p:WarningLevel=0 -p:IsDesktopBuild=false
@@ -230,7 +228,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
     steps:
       - attach_workspace:
           at: ./
-      - set-version-vars
       - run:
           name: Install Manager Feed CLI
           command: dotnet tool install --global Speckle.Manager.Feed
@@ -290,7 +287,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                 name: Install mono
                 command: |
                   HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install mono mono-libgdiplus
-      - set-version-vars
       - run:
           name: Create installer target dir
           command: |
@@ -412,7 +408,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
           environment:
             WORKFLOW_NUM: << pipeline.number >>
-      - set-version-vars
       - run:
           name: Build
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -46,6 +46,8 @@ commands:
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
             echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$BASH_ENV"
+          environment:
+            WORKFLOW_NUM: << pipeline.number >>
 
   packandpublish:
     steps:
@@ -92,6 +94,8 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
             dotnet build SDK.slnf -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
+          environment:
+            WORKFLOW_NUM: << pipeline.number >>
       - run-tests:
           title: Core Unit Tests
           project: Core/Tests/TestsUnit.csproj
@@ -238,6 +242,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Upload new version
           command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+            VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             /root/.dotnet/tools/Speckle.Manager.Feed deploy -s << parameters.slug >> -v ${SEMVER} -u https://releases.speckle.dev/installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >> -o << parameters.os >> -a << parameters.arch >> -f speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >>
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -295,8 +303,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Create installer target dir
           command: |
             mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
-          environment:
-            WORKFLOW_NUM: << pipeline.number >>
       - when:
           condition: << parameters.build-with-mono >>
           steps:
@@ -308,6 +314,8 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
                   VERSION=$(echo $VER.$WORKFLOW_NUM)
                   msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER /p:FileVersion=$VERSION
+                environment:
+                  WORKFLOW_NUM: << pipeline.number >>
             # Compress build files
             - run:
                 name: Zip Objects Kit files
@@ -407,11 +415,9 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - attach_workspace:
           at: ./
       - run:
-          name: Set environment variables
+          name: Create installer target directory
           command: |
             mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
-          environment:
-            WORKFLOW_NUM: << pipeline.number >>
       - run:
           name: Build
           command: |

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            touch $BASH_ENV
+            source $BASH_ENV
             echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -34,16 +34,23 @@ commands:
   cached-checkout:
     steps:
       - checkout
+  set-version-vars:
+    steps:
+      - run:
+          name: Set version environment variables
+          command: |
+            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$Bash_ENV"
+            echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$Bash_ENV"
+            echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$Bash_ENV"
+            echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$Bash_ENV"
 
   packandpublish:
     steps:
+      - set-version-vars
       - run:
           name: Build nuget packages
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
-            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]+//')
-            VERSION=$(echo "$SEMVER" | sed -e 's/[a-zA-Z]*\///')
-            dotnet pack All.sln -p:Version=$VERSION -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false
+            dotnet pack All.sln -p:Version=$SEMVER -p:FileVersion=$VERSION -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -160,7 +167,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   $semver = if($tag.Contains('/')) {$tag.Split("/")[0] } else { $tag }
                   $ver = if($semver.Contains('-')) {$semver.Split("-")[0] } else { $semver }
                   $version = "$($ver).$($env:WORKFLOW_NUM)"
-                  msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$semver
+                  msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /p:Configuration=Release /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$semver /p:FileVersion=$version
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
       - unless:
@@ -173,7 +180,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   $semver = if($tag.Contains('/')) {$tag.Split("/")[0] } else { $tag }
                   $ver = if($semver.Contains('-')) {$semver.Split("-")[0] } else { $semver }
                   $version = "$($ver).$($env:WORKFLOW_NUM)"
-                  dotnet publish << parameters.slnname >>/<< parameters.slnname >>/<< parameters.projname >>.csproj -c Release -v q -r win-x64 --self-contained /p:WarningLevel=0 /p:Version=$semver
+                  dotnet publish << parameters.slnname >>/<< parameters.slnname >>/<< parameters.projname >>.csproj -c Release -v q -r win-x64 --self-contained /p:WarningLevel=0 /p:Version=$semver /p:FileVersion=$version
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -215,14 +222,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
     steps:
       - attach_workspace:
           at: ./
+      - set-version-vars
       - run:
           name: Install Manager Feed CLI
           command: dotnet tool install --global Speckle.Manager.Feed
       - run:
           name: Upload new version
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
-            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             /root/.dotnet/tools/Speckle.Manager.Feed deploy -s << parameters.slug >> -v ${SEMVER} -u https://releases.speckle.dev/installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >> -o << parameters.os >> -a << parameters.arch >> -f speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >>
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -276,14 +282,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                 name: Install mono
                 command: |
                   HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install mono mono-libgdiplus
+      - set-version-vars
       - run:
-          name: Set environment variables
+          name: Create installer target dir
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
-            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            VER=$(echo "$SEMVER" | sed -e 's/-beta//')
-            VERSION=$(echo $VER.$WORKFLOW_NUM)
-            CHANNEL=$(if [[ "$VERSION" == *"-"* ]]; then echo $(cut -d "-" -f2 \<\<\< $VERSION); else echo latest; fi)
             mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -293,9 +295,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build << parameters.slnname >>
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
-                  SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-                  msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER
+                  msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER /p:FileVersion=$VERSION
             # Compress build files
             - run:
                 name: Zip Objects Kit files
@@ -319,9 +319,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Publish x64 and arm64
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
-                  SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-                  $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -v q -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER
+                  $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -v q -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
             - run:
@@ -352,8 +350,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
-            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -396,12 +392,11 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             mkdir -p speckle-sharp-ci-tools/Installers/<< parameters.slug >>
           environment:
             WORKFLOW_NUM: << pipeline.number >>
+      - set-version-vars
       - run:
           name: Build
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
-            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
-            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:IsDesktopBuild=false
+            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -441,8 +436,6 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
-            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -91,7 +91,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
-            dotnet build SDK.slnf -c Release -v m -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
+            dotnet build SDK.slnf -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
       - run-tests:
           title: Core Unit Tests
           project: Core/Tests/TestsUnit.csproj
@@ -190,7 +190,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   $semver = if($tag.Contains('/')) {$tag.Split("/")[0] } else { $tag }
                   $ver = if($semver.Contains('-')) {$semver.Split("-")[0] } else { $semver }
                   $version = "$($ver).$($env:WORKFLOW_NUM)"
-                  dotnet publish << parameters.slnname >>/<< parameters.slnname >>/<< parameters.projname >>.csproj -c Release -v q -r win-x64 --self-contained /p:WarningLevel=0 /p:Version=$semver /p:FileVersion=$version
+                  dotnet publish << parameters.slnname >>/<< parameters.slnname >>/<< parameters.projname >>.csproj -c Release -r win-x64 --self-contained /p:WarningLevel=0 /p:Version=$semver /p:FileVersion=$version
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
       - run:
@@ -335,7 +335,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
                   VERSION=$(echo $VER.$WORKFLOW_NUM)
-                  $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -v q -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
+                  $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
             - run:
@@ -419,7 +419,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
-            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
+            dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
       - run:

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            $BASH_ENV
+            touch $BASH_ENV
             echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -42,20 +42,20 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)' >> "$BASH_ENV"
+            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
-            echo 'export VERSION=$(echo $VER)' >> "$BASH_ENV"
+            echo 'export VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)' >> "$BASH_ENV"
 
   packandpublish:
     steps:
       - run:
           name: Build nuget packages
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             dotnet pack All.sln -p:Version=$SEMVER -p:FileVersion=$VERSION -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -87,10 +87,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build SDK Projects
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             dotnet build SDK.slnf -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
       - run-tests:
           title: Core Unit Tests
@@ -303,10 +303,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build << parameters.slnname >>
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER)
+                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
                   msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER /p:FileVersion=$VERSION
             # Compress build files
             - run:
@@ -331,10 +331,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Publish x64 and arm64
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER)
+                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
                   $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
@@ -366,10 +366,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -415,10 +415,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -459,10 +459,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -42,7 +42,7 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
+            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
             echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$BASH_ENV"
@@ -54,7 +54,7 @@ commands:
       - run:
           name: Build nuget packages
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
@@ -89,7 +89,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build SDK Projects
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
@@ -242,7 +242,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Upload new version
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
@@ -309,7 +309,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build << parameters.slnname >>
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
                   VERSION=$(echo $VER.$WORKFLOW_NUM)
@@ -339,7 +339,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Publish x64 and arm64
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
                   VERSION=$(echo $VER.$WORKFLOW_NUM)
@@ -374,7 +374,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
@@ -421,7 +421,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
@@ -465,7 +465,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -34,17 +34,18 @@ commands:
   cached-checkout:
     steps:
       - checkout
+
+  # Leaving this here to investigate further but currently IT DOES NOT WORK
+  # BASH_ENV says it doesn't exist or I don't have access to it.
   set-version-vars:
     steps:
       - run:
           name: Set version environment variables
           command: |
-            source $BASH_ENV
             echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
             echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$BASH_ENV"
-            $BASH_ENV
 
   packandpublish:
     steps:
@@ -52,6 +53,10 @@ commands:
       - run:
           name: Build nuget packages
           command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+            VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             dotnet pack All.sln -p:Version=$SEMVER -p:FileVersion=$VERSION -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -298,6 +303,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build << parameters.slnname >>
                 command: |
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+                  SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+                  VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+                  VERSION=$(echo $VER.$WORKFLOW_NUM)
                   msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER /p:FileVersion=$VERSION
             # Compress build files
             - run:
@@ -322,6 +331,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Publish x64 and arm64
                 command: |
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+                  SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+                  VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+                  VERSION=$(echo $VER.$WORKFLOW_NUM)
                   $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -v q -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
@@ -353,6 +366,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+            VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -399,6 +416,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build
           command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+            VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -v q -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -439,6 +460,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+            VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -42,20 +42,20 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)' >> "$BASH_ENV"
+            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
-            echo 'export VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)' >> "$BASH_ENV"
+            echo 'export VERSION=$(echo $VER)' >> "$BASH_ENV"
 
   packandpublish:
     steps:
       - run:
           name: Build nuget packages
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER)
             dotnet pack All.sln -p:Version=$SEMVER -p:FileVersion=$VERSION -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -87,10 +87,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build SDK Projects
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER)
             dotnet build SDK.slnf -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
       - run-tests:
           title: Core Unit Tests
@@ -303,10 +303,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build << parameters.slnname >>
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+                  VERSION=$(echo $VER)
                   msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER /p:FileVersion=$VERSION
             # Compress build files
             - run:
@@ -331,10 +331,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Publish x64 and arm64
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+                  VERSION=$(echo $VER)
                   $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
@@ -366,10 +366,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -415,10 +415,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER)
             dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -459,10 +459,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -74,7 +74,6 @@ commands:
           name: << parameters.title >>
           command: dotnet test << parameters.project >>
             -c Release
-            -v q
             --logger:"junit;LogFileName={assembly}.results.xml"
             --results-directory=TestResults
             --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
@@ -87,7 +86,12 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - cached-checkout
       - run:
           name: Build SDK Projects
-          command: dotnet build SDK.slnf -c Release -v m -p:WarningLevel=0 -p:IsDesktopBuild=false
+          command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+            VER=$(echo "$SEMVER" | sed -e 's/-.*//')
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
+            dotnet build SDK.slnf -c Release -v m -p:WarningLevel=0 -p:IsDesktopBuild=false
       - run-tests:
           title: Core Unit Tests
           project: Core/Tests/TestsUnit.csproj

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -42,20 +42,20 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)' >> "$BASH_ENV"
+            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
-            echo 'export VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)' >> "$BASH_ENV"
+            echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$BASH_ENV"
 
   packandpublish:
     steps:
       - run:
           name: Build nuget packages
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             dotnet pack All.sln -p:Version=$SEMVER -p:FileVersion=$VERSION -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -87,10 +87,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build SDK Projects
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             dotnet build SDK.slnf -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
       - run-tests:
           title: Core Unit Tests
@@ -303,10 +303,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build << parameters.slnname >>
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+                  VERSION=$(echo $VER.$WORKFLOW_NUM)
                   msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER /p:FileVersion=$VERSION
             # Compress build files
             - run:
@@ -331,10 +331,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Publish x64 and arm64
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+                  VERSION=$(echo $VER.$WORKFLOW_NUM)
                   $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
@@ -366,10 +366,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -415,10 +415,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -459,10 +459,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
+            VERSION=$(echo $VER.$WORKFLOW_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -42,20 +42,20 @@ commands:
       - run:
           name: Set version environment variables
           command: |
-            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)' >> "$BASH_ENV"
+            echo 'export TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)' >> "$BASH_ENV"
             echo 'export SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')' >> "$BASH_ENV"
             echo 'export VER=$(echo "$SEMVER" | sed -e 's/-.*//')' >> "$BASH_ENV"
-            echo 'export VERSION=$(echo $VER.$WORKFLOW_NUM)' >> "$BASH_ENV"
+            echo 'export VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)' >> "$BASH_ENV"
 
   packandpublish:
     steps:
       - run:
           name: Build nuget packages
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$WORKFLOW_NUM)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             dotnet pack All.sln -p:Version=$SEMVER -p:FileVersion=$VERSION -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -87,10 +87,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build SDK Projects
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$WORKFLOW_NUM)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             dotnet build SDK.slnf -c Release -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
       - run-tests:
           title: Core Unit Tests
@@ -303,10 +303,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Build << parameters.slnname >>
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER.$WORKFLOW_NUM)
+                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
                   msbuild << parameters.slnname >>/<< parameters.slnname >>.sln /r /p:Configuration='<< parameters.build-config >>' /p:WarningLevel=0 /p:IsDesktopBuild=false /p:Version=$SEMVER /p:FileVersion=$VERSION
             # Compress build files
             - run:
@@ -331,10 +331,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             - run:
                 name: Publish x64 and arm64
                 command: |
-                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+                  TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
                   SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
                   VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-                  VERSION=$(echo $VER.$WORKFLOW_NUM)
+                  VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
                   $HOME/.dotnet/dotnet publish << parameters.slnname >>/<< parameters.projname >>/<< parameters.projname >>.csproj -c Release -r osx-x64 --self-contained /p:WarningLevel=0 /p:Version=$SEMVER /p:FileVersion=$VERSION
                 environment:
                   WORKFLOW_NUM: << pipeline.number >>
@@ -366,10 +366,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$WORKFLOW_NUM)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -415,10 +415,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Build
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$WORKFLOW_NUM)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             dotnet build << parameters.slnname >>/<< parameters.slnname >>.slnf -c "<< parameters.build-config >>" -p:WarningLevel=0 -p:Version=$SEMVER -p:FileVersion=$VERSION -p:IsDesktopBuild=false
           environment:
             WORKFLOW_NUM: << pipeline.number >>
@@ -459,10 +459,10 @@ jobs: # Each project will have individual jobs for each specific task it has to 
       - run:
           name: Copy to installer location
           command: |
-            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$WORKFLOW_NUM"; fi;)
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "2.0.999.$CIRCLE_BUILD_NUM"; fi;)
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
-            VERSION=$(echo $VER.$WORKFLOW_NUM)
+            VERSION=$(echo $VER.$CIRCLE_BUILD_NUM)
             cp speckle-sharp-ci-tools/Mac/<<parameters.installername>>/bin/Release/net6.0/osx-x64/publish/<<parameters.slug>>.zip speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<<parameters.slug>>-$SEMVER.zip
           environment:
             WORKFLOW_NUM: << pipeline.number >>

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -91,7 +91,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
             SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
             VER=$(echo "$SEMVER" | sed -e 's/-.*//')
             VERSION=$(echo $VER.$WORKFLOW_NUM)
-            dotnet build SDK.slnf -c Release -v m -p:WarningLevel=0 -p:IsDesktopBuild=false
+            dotnet build SDK.slnf -c Release -v m -p:WarningLevel=0 -p:IsDesktopBuild=false -p:Version=$SEMVER -p:FileVersion=$VERSION
       - run-tests:
           title: Core Unit Tests
           project: Core/Tests/TestsUnit.csproj


### PR DESCRIPTION
File version was not properly set on our releases since our mono-repo cleanup.

This PR fixes this for every job available.

Verified in WIN and MAC builds from the CI logs.