### PR TITLE
fix(archicad): Fixed issue where logger was used before initialising

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Program.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Program.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.ReactiveUI;
 using DesktopUI2.ViewModels;
 using DesktopUI2.Views;
+using Speckle.Core.Logging;
 
 namespace Archicad.Launcher
 {
@@ -37,6 +38,8 @@ namespace Archicad.Launcher
       Communication.ConnectionManager.Instance.Start(portNumber);
 
       Bindings = new ArchicadBinding(archicadVersion);
+      Setup.Init(Bindings.GetHostAppName(), Bindings.GetHostAppNameVersion());
+      
       CreateOrFocusSpeckle(args);
       // BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, Avalonia.Controls.ShutdownMode.OnMainWindowClose);
     }

--- a/ConnectorArchicad/ConnectorArchicad/Program.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using Avalonia;
@@ -38,8 +38,8 @@ namespace Archicad.Launcher
       Communication.ConnectionManager.Instance.Start(portNumber);
 
       Bindings = new ArchicadBinding(archicadVersion);
-      Setup.Init(Bindings.GetHostAppName(), Bindings.GetHostAppNameVersion());
-      
+      Setup.Init(Bindings.GetHostAppNameVersion(), Bindings.GetHostAppName());
+
       CreateOrFocusSpeckle(args);
       // BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, Avalonia.Controls.ShutdownMode.OnMainWindowClose);
     }

--- a/Core/Core/Logging/Setup.cs
+++ b/Core/Core/Logging/Setup.cs
@@ -41,7 +41,17 @@ public static class Setup
   public static void Init(string versionedHostApplication, string hostApplication)
   {
     if (initialized)
+    {
+      SpeckleLog.Logger
+        .ForContext("newVersionedHostApplication", versionedHostApplication)
+        .ForContext("newHostApplication", hostApplication)
+        .Information(
+          "Setup was already initialized with {currentHostApp} {currentVersionedHostApp}",
+          hostApplication,
+          versionedHostApplication
+        );
       return;
+    }
 
     initialized = true;
 

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -92,30 +92,37 @@ public class SpeckleLogConfiguration
 /// </summary>
 public static class SpeckleLog
 {
-    private static ILogger? _logger;
+  private static ILogger? _logger;
 
-    public static ILogger Logger
+  public static ILogger Logger
+  {
+    get
     {
-      get 
-      { 
-        if(_logger == null) Initialize("Core", "unknown");
-        return _logger;
-      }
+      if (_logger == null)
+        Initialize("Core", "unknown");
+      return _logger;
     }
+  }
 
-    private static bool _initialized = false;
+  private static bool _initialized = false;
 
-    /// <summary>
-    /// Initialize logger configuration for a global Serilog.Log logger.
-    /// </summary>
-    public static void Initialize(
-      string hostApplicationName,
-      string? hostApplicationVersion,
-      SpeckleLogConfiguration? logConfiguration = null
-    )
+  /// <summary>
+  /// Initialize logger configuration for a global Serilog.Log logger.
+  /// </summary>
+  public static void Initialize(
+    string hostApplicationName,
+    string? hostApplicationVersion,
+    SpeckleLogConfiguration? logConfiguration = null
+  )
+  {
+    if (_initialized)
     {
-      if (_initialized)
-        return;
+      SpeckleLog.Logger
+        .ForContext("hostApplicationVersion", hostApplicationVersion)
+        .ForContext("hostApplicationName", hostApplicationName)
+        .Information("Setup was already initialized");
+      return;
+    }
 
     logConfiguration ??= new SpeckleLogConfiguration();
 

--- a/Core/Core/Models/CommitObjectBuilder.cs
+++ b/Core/Core/Models/CommitObjectBuilder.cs
@@ -153,7 +153,7 @@ public abstract class CommitObjectBuilder<TNativeObjectData>
       catch (Exception ex)
       {
         // A parent was found, but it was invalid (Likely because of a type mismatch on a `elements` property)
-        SpeckleLog.Logger.Warning(ex, "Failed to add object {speckleType} to a converted parent.", current?.GetType());
+        SpeckleLog.Logger.Warning(ex, "Failed to add object {speckleType} to a converted parent", current?.GetType());
       }
     }
 


### PR DESCRIPTION
I noticed while testing that the archicad connector was logging to console/file/seq under "Coreunknown"

After some investigation, it seems that the kit loading done by `App` uses the logger before its initialised by DUI2.

This fix adds an extra log in the entry point of the Archicad connector to ensure Setup is initialised before DUI2.
This is similar to how we do things in Rhino and Revit connectors.


@AlanRynne please could you review the changes made in Core
@jozseflkiss , I didn't figure out how to run the archicad connector locally, if you are available tommorow to give this a quick test for me. 
Simply running the connector from this branch. I expect the first console line to read "Archicad26" and not "Coreunknown"
![image](https://github.com/specklesystems/speckle-sharp/assets/45512892/f3c37942-b67d-450a-a4a0-35a77ed1fb71)
