### PR TITLE
bug(revit): reverts to using the new `RevitInstance` class for face hosted instances

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -712,7 +712,7 @@ namespace Objects.Converter.Revit
 
       Doc.Regenerate(); //required for mirroring and face flipping to work!
 
-      if (instance.mirrored)
+      if (instance.mirrored != familyInstance.Mirrored)
       {
         // mirroring
         // note: mirroring a hosted instance via api will fail, thanks revit: there is workaround hack to group the element -> mirror -> ungroup

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -710,6 +710,8 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
+      Doc.Regenerate(); //required for mirroring and face flipping to work!
+
       if (instance.mirrored)
       {
         // mirroring
@@ -734,7 +736,6 @@ namespace Objects.Converter.Revit
       }
 
       // face flipping must happen after mirroring
-      Doc.Regenerate(); //required for face flipping to work!
       if (familyInstance.CanFlipHand && instance.handFlipped != familyInstance.HandFlipped)
         familyInstance.flipHand();
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -80,10 +80,7 @@ namespace Objects.Converter.Revit
       // point based, convert these as revit instances
       if (@base == null)
       {
-        if (
-          (revitFi.Host != null && revitFi.HostFace != null)
-          || ((BuiltInCategory)revitFi.Category.Id.IntegerValue == BuiltInCategory.OST_StructuralFoundation)
-        ) // don't know why, but the transforms on structural foundation elements are really messed up
+        if ((BuiltInCategory)revitFi.Category.Id.IntegerValue == BuiltInCategory.OST_StructuralFoundation) // don't know why, but the transforms on structural foundation elements are really messed up
         {
           @base = PointBasedFamilyInstanceToSpeckle(revitFi, basePoint, out notes);
         }


### PR DESCRIPTION
## Description & motivation
Previously, face-hosted instances were reverted to using the old `FamilyInstance` class in #2441 due to a community reported issue. However this is caused regressions in many other face-hosted instances to not be received correctly, and while the old method did result in the correct display value for the hosted instance, it still wasn't receiving correctly in Revit.

Based on these factors, I've decided to revert the reversion and use the new instance class for face-hosted instances.

Fixes #2583