### PR TITLE
feat(Archicad): instancing + other improvements

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
@@ -58,9 +58,12 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, startPoint.z, element.header.floorInd, element.beam.offset);
-		ACAPI_ELEMENT_MASK_SET (beamMask, API_Elem_Head, floorInd);
-		ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamType, offset);
 	}
+	else {
+		Utility::SetStoryLevelAndFloor (startPoint.z, element.header.floorInd, element.beam.offset);
+	}
+	ACAPI_ELEMENT_MASK_SET (beamMask, API_Elem_Head, floorInd);
+	ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamType, offset);
 
 	if (os.Contains (Beam::level)) {
 		os.Get (Beam::level, element.beam.level);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.cpp
@@ -54,9 +54,12 @@ GSErrCode CreateColumn::GetElementFromObjectState (const GS::ObjectState& os,
 
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, origoPos.z, element.header.floorInd, element.column.bottomOffset);
-		ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, floorInd);
-		ACAPI_ELEMENT_MASK_SET (elementMask, API_ColumnType, bottomOffset);
 	}
+	else {
+		Utility::SetStoryLevelAndFloor (origoPos.z, element.header.floorInd, element.column.bottomOffset);
+	}
+	ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, floorInd);
+	ACAPI_ELEMENT_MASK_SET (elementMask, API_ColumnType, bottomOffset);
 
 	if (os.Contains (Column::height)) {
 		os.Get (Column::height, element.column.height);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
@@ -75,40 +75,46 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 					ACAPI_DisposeElemMemoHdls (&marker->memo);
 			});
 
+			GSErrCode err = NoError;
+
 			GS::String speckleId;
 			{
 				objectState.Get (ElementBase::Id, speckleId);
 				
 				if (speckleId.IsEmpty())
-					return Error;
+					err = Error;
 			}
-			
-			bool isConverted = false;
-			API_Guid convertedArchicadId;
-			ExchangeManager::GetInstance().GetState (speckleId, isConverted, convertedArchicadId);
-			
-			bool elementExists = isConverted && Utility::ElementExists (convertedArchicadId);
-			
-			{
-				// if already converted and element exists, use that
-				if (elementExists) {
-					element.header.guid = convertedArchicadId;
-				}
-				// otherwise try to use applicationId
-				else {
-					GS::UniString applicationId;
-					objectState.Get (ElementBase::ApplicationId, applicationId);
-					element.header.guid = APIGuidFromString (applicationId.ToCStr ());
-				}
-			}
-
+	
+			bool elementExists = false;
 			GS::Array<GS::UniString> log;
-			GSErrCode err = GetElementFromObjectState (objectState, element, elementMask, memo, memoMask, &marker, *attributeManager, *libpartImportManager, log);
+			
 			if (err == NoError) {
-				if (elementExists) {
-					err = ModifyExistingElement (element, elementMask, memo, memoMask);
-				} else {
-					err = CreateNewElement (element, memo, marker);
+				bool isConverted = false;
+				API_Guid convertedArchicadId;
+				ExchangeManager::GetInstance().GetState (speckleId, isConverted, convertedArchicadId);
+				
+				elementExists = isConverted && Utility::ElementExists (convertedArchicadId);
+				
+				{
+					// if already converted and element exists, use that
+					if (elementExists) {
+						element.header.guid = convertedArchicadId;
+					}
+					// otherwise try to use applicationId
+					else {
+						GS::UniString applicationId;
+						objectState.Get (ElementBase::ApplicationId, applicationId);
+						element.header.guid = APIGuidFromString (applicationId.ToCStr ());
+					}
+				}
+				
+				err = GetElementFromObjectState (objectState, element, elementMask, memo, memoMask, &marker, *attributeManager, *libpartImportManager, log);
+				if (err == NoError) {
+					if (elementExists) {
+						err = ModifyExistingElement (element, elementMask, memo, memoMask);
+					} else {
+						err = CreateNewElement (element, memo, marker);
+					}
 				}
 			}
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.cpp
@@ -32,7 +32,7 @@ GSErrCode CreateObject::GetElementFromObjectState (const GS::ObjectState& os,
 	API_ElementMemo& memo,
 	GS::UInt64& memoMask,
 	API_SubElement** /*marker*/,
-	AttributeManager& attributeManager,
+	AttributeManager& /*attributeManager*/,
 	LibpartImportManager& libpartImportManager,
 	GS::Array<GS::UniString>& log) const
 {
@@ -45,17 +45,60 @@ GSErrCode CreateObject::GetElementFromObjectState (const GS::ObjectState& os,
 		return err;
 
 	// get the mesh
-	ModelInfo modelInfo;
-	os.Get (Model::Model, modelInfo);
+	GS::Array<GS::UniString> modelIds;
+	os.Get (Model::ModelIds, modelIds);
 
 	API_LibPart libPart;
-	err = libpartImportManager.GetLibpart (modelInfo, attributeManager, libPart);
+	err = libpartImportManager.GetLibpartFromCache (modelIds, libPart);
 	if (err != NoError)
 		return err;
 
 	element.object.libInd = libPart.index;
 	ACAPI_ELEMENT_MASK_SET (elementMask, API_ObjectType, libInd);
 
+	// transform transformation matrix
+	API_Tranmat transform;
+	if (os.Contains (Object::transform)) {
+		GS::ObjectState transformOs;
+		os.Get (Object::transform, transformOs);
+
+		Utility::CreateTransform (transformOs, transform);
+		
+		// set transformation GDL parameter
+		{
+			Int32 				addParNumDef = 0;
+			API_AddParType		**addParDefault = nullptr;
+
+			err = ACAPI_LibPart_GetParams (libPart.index, nullptr, nullptr, &addParNumDef, &addParDefault);
+			if (err != NoError)
+				return err;
+			
+			for (Int32 i = 0; i < addParNumDef; i++) {
+				API_AddParType &parameter = (*addParDefault)[i];
+				if (CHCompareCStrings (parameter.name, "map_xform", CS_CaseSensitive) == 0) {
+					if (parameter.dim1 != 4 || parameter.dim2 != 3) {
+						err = Error;
+						break;
+					}
+					
+					double** arrHdl = reinterpret_cast<double**>(parameter.value.array);
+					for (Int32 k = 0; k < parameter.dim1; k++)
+						for (Int32 j = 0; j < parameter.dim2; j++)
+							// transpose matrix
+							(*arrHdl)[k * parameter.dim2 + j] = transform.tmx[k + j * parameter.dim1];
+					
+					break;
+				}
+			}
+		
+			BMKillHandle (reinterpret_cast<GSHandle*>(&memo.params));
+			if (err != NoError)
+				return err;
+
+			memo.params = addParDefault;
+		}
+	}
+	
 	Objects::Point3D pos;
 	if (os.Contains (Object::pos)) {
 		os.Get (Object::pos, pos);
@@ -72,6 +115,27 @@ GSErrCode CreateObject::GetElementFromObjectState (const GS::ObjectState& os,
 GS::String CreateObject::GetName () const
 {
 	return CreateObjectCommandName;
+}
+
+
+GS::ObjectState CreateObject::Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const
+{
+	GS::Array<ModelInfo> meshModels;
+	parameters.Get (FieldNames::MeshModels, meshModels);
+
+	ACAPI_CallUndoableCommand (GetUndoableCommandName (), [&] () -> GSErrCode {
+		AttributeManager* attributeManager = AttributeManager::GetInstance ();
+		LibpartImportManager* libpartImportManager = LibpartImportManager::GetInstance ();
+		for (ModelInfo meshModel : meshModels) {
+			API_LibPart libPart;
+			GS::ErrCode err = libpartImportManager->GetLibpart (meshModel, *attributeManager, libPart);
+			if (err != NoError)
+				return err;
+		}
+		return NoError;
+	});
+
+	return CreateCommand::Execute (parameters, processControl);
 }
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.hpp
@@ -8,21 +8,22 @@ namespace AddOnCommands {
 
 
 class CreateObject : public CreateCommand {
-	GS::String			GetFieldName () const override;
-	GS::UniString		GetUndoableCommandName () const override;
+	GS::String		GetFieldName () const override;
+	GS::UniString	GetUndoableCommandName () const override;
 
-	GSErrCode			GetElementFromObjectState (const GS::ObjectState& os,
-							API_Element& element,
-							API_Element& elementMask,
-							API_ElementMemo& memo,
-							GS::UInt64& memoMask,
-							API_SubElement** marker,
-							AttributeManager& attributeManager,
-							LibpartImportManager& libpartImportManager,
-							GS::Array<GS::UniString>& log) const override;
+	GSErrCode	GetElementFromObjectState (const GS::ObjectState& os,
+					API_Element& element,
+					API_Element& elementMask,
+					API_ElementMemo& memo,
+					GS::UInt64& memoMask,
+					API_SubElement** marker,
+					AttributeManager& attributeManager,
+					LibpartImportManager& libpartImportManager,
+					GS::Array<GS::UniString>& log) const override;
 
 public:
-	virtual GS::String	GetName () const override;
+	virtual GS::String		GetName () const override;
+	virtual GS::ObjectState	Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.cpp
@@ -182,10 +182,12 @@ GSErrCode CreateRoof::GetElementFromObjectState (const GS::ObjectState& os,
 	// The floor index and level of the roof
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, roofShape.Level (), element.header.floorInd, element.roof.shellBase.level);
-
-		ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, floorInd);
-		ACAPI_ELEMENT_MASK_SET (elementMask, API_RoofType, shellBase.level);
 	}
+	else {
+		Utility::SetStoryLevelAndFloor (roofShape.Level (), element.header.floorInd, element.roof.shellBase.level);
+	}
+	ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, floorInd);
+	ACAPI_ELEMENT_MASK_SET (elementMask, API_RoofType, shellBase.level);
 
 	// The thickness of the roof
 	if (os.Contains (Roof::Thickness)) {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.cpp
@@ -908,10 +908,12 @@ GSErrCode CreateShell::GetElementFromObjectState (const GS::ObjectState& os,
 	// The floor index and level of the shell
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, shellShape.Level (), element.header.floorInd, element.shell.shellBase.level);
-
+	}
+	else {
+		Utility::SetStoryLevelAndFloor (shellShape.Level (), element.header.floorInd, element.shell.shellBase.level);
+	}
 		ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, floorInd);
 		ACAPI_ELEMENT_MASK_SET (elementMask, API_ShellType, shellBase.level);
-	}
 
 	// The thickness of the shell
 	if (os.Contains (Shell::Thickness)) {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
@@ -65,9 +65,12 @@ GSErrCode CreateSlab::GetElementFromObjectState (const GS::ObjectState& os,
 	// The floor index and level of the slab
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, slabShape.Level (), element.header.floorInd, element.slab.level);
-		ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, level);
-		ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
 	}
+	else {
+		Utility::SetStoryLevelAndFloor (slabShape.Level (), element.header.floorInd, element.slab.level);
+	}
+	ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, level);
+	ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
 
 	// The thickness of the slab
 	if (os.Contains (Slab::Thickness)) {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.cpp
@@ -67,9 +67,12 @@ GSErrCode CreateWall::GetElementFromObjectState (const GS::ObjectState& os,
 	// The floor index and bottom offset of the wall
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, startPoint.z, element.header.floorInd, element.wall.bottomOffset);
-		ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, floorInd);
-		ACAPI_ELEMENT_MASK_SET (elementMask, API_WallType, bottomOffset);
 	}
+	else {
+		Utility::SetStoryLevelAndFloor (startPoint.z, element.header.floorInd, element.wall.bottomOffset);
+	}
+	ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, floorInd);
+	ACAPI_ELEMENT_MASK_SET (elementMask, API_WallType, bottomOffset);
 
 	// The profile type of the wall
 	short profileType = 0;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
@@ -79,9 +79,11 @@ GSErrCode CreateZone::GetElementFromObjectState (const GS::ObjectState& os,
 	// The floor index and level of the zone
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, zoneShape.Level (), element.header.floorInd, element.zone.roomBaseLev);
-		ACAPI_ELEMENT_MASK_SET (mask, API_ZoneType, roomBaseLev);
-		ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
+	} else {
+		Utility::SetStoryLevelAndFloor (zoneShape.Level (), element.header.floorInd, element.zone.roomBaseLev);
 	}
+	ACAPI_ELEMENT_MASK_SET (mask, API_ZoneType, roomBaseLev);
+	ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
 
 	return NoError;
 }

--- a/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
@@ -41,6 +41,7 @@ static const char* Columns = "columns";
 static const char* DirectShapes = "directShapes";
 static const char* Doors = "doors";
 static const char* Objects = "objects";
+static const char* MeshModels = "meshModels";
 static const char* Roofs = "roofs";
 static const char* Shells = "shells";
 static const char* Skylights = "skylights";
@@ -436,6 +437,7 @@ namespace Object
 {
 // Main
 static const char* pos = "pos";
+static const char* transform = "transform";
 }
 
 
@@ -718,6 +720,7 @@ static const char* AmbientColor = "ambientColor";
 static const char* EmissionColor = "emissionColor";
 static const char* Material = "material";
 static const char* Model = "model";
+static const char* ModelIds = "modelIds";
 static const char* Ids = "ids";
 static const char* Edges = "edges";
 }

--- a/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
@@ -73,6 +73,20 @@ static GSErrCode CreateSubFolder (const GS::UniString& name, IO::Location& locat
 }
 
 
+
+GSErrCode LibpartImportManager::GetLibpartFromCache (const GS::Array<GS::UniString> modelIds,
+	API_LibPart& libPart)
+{
+	GS::UInt64 checksum = GenerateFingerPrint (modelIds);
+	GSErrCode err = Error;
+	if (cache.Get (checksum, &libPart)) {
+		err = NoError;
+	}
+
+	return err;
+}
+
+
 GSErrCode LibpartImportManager::GetLibpart (const ModelInfo& modelInfo,
 	AttributeManager& attributeManager,
 	API_LibPart& libPart)

--- a/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.hpp
@@ -28,6 +28,8 @@ public:
 
 	GSErrCode	GetLibpart (const ModelInfo& modelInfo, AttributeManager& attributeManager, API_LibPart& libPart);
 
+	GSErrCode GetLibpartFromCache(const GS::Array<GS::UniString> modelIds, API_LibPart& libPart);
+
 private:
 	GSErrCode	CreateLibraryPart (const ModelInfo& modelInfo, AttributeManager& attributeManager, API_LibPart& libPart);
 	GSErrCode	GetLocation (bool useEmbeddedLibrary, IO::Location*& libraryFolderLocation) const;

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateObject.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateObject.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Speckle.Core.Models;
 using Speckle.Newtonsoft.Json;
 using Objects.BuiltElements.Archicad;
+using Archicad.Model;
 
 namespace Archicad.Communication.Commands
 {
@@ -13,10 +14,14 @@ namespace Archicad.Communication.Commands
     {
       [JsonProperty("objects")]
       private IEnumerable<ArchicadObject> Objects { get; }
+      [JsonProperty("meshModels")]
+      private IEnumerable<MeshModel> MeshModels { get; }
 
-      public Parameters(IEnumerable<ArchicadObject> objects)
+
+      public Parameters(IEnumerable<ArchicadObject> objects, IEnumerable<MeshModel> meshModels)
       {
         Objects = objects;
+        MeshModels = meshModels;
       }
     }
 
@@ -28,15 +33,17 @@ namespace Archicad.Communication.Commands
     }
 
     private IEnumerable<ArchicadObject> Objects { get; }
+    private IEnumerable<MeshModel> MeshModels { get; }
 
-    public CreateObject(IEnumerable<ArchicadObject> objects)
+    public CreateObject(IEnumerable<ArchicadObject> objects, IEnumerable<MeshModel> meshModels)
     {
       Objects = objects;
+      MeshModels = meshModels;
     }
 
     public async Task<IEnumerable<ApplicationObject>> Execute()
     {
-      var result = await HttpCommandExecutor.Execute<Parameters, Result>("CreateObject", new Parameters(Objects));
+      var result = await HttpCommandExecutor.Execute<Parameters, Result>("CreateObject", new Parameters(Objects, MeshModels));
       return result == null ? null : result.ApplicationObjects;
     }
   }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
@@ -1,15 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Archicad.Communication;
 using Archicad.Model;
 using Archicad.Operations;
-using Objects.BuiltElements;
 using Objects.Geometry;
+using Objects.Other;
+using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
 
@@ -25,51 +24,122 @@ namespace Archicad.Converters
 
     #region --- Functions ---
 
+    static List<Mesh> GetDisplayValue(Base element)
+    {
+      List<Mesh> meshes = null;
+      var m = element["displayValue"] ?? element["@displayValue"];
+      if (m is List<Mesh> meshList)
+        meshes = meshList;
+      else if (m is List<object> objectList)
+        meshes = objectList.Cast<Mesh>().ToList();
+      return meshes;
+    }
+
+    static List<string> TraverseDefinitions(Base element, Transform baseTransform, Transform transform, Dictionary<string, Transform> transformMatrixById, Dictionary<string, Mesh> transformedMeshById)
+    {
+      // calculate commulative transforms
+      Transform commulativeTansform = baseTransform * transform;
+      commulativeTansform.id = Utilities.hashString(baseTransform.id + transform.id);
+      transformMatrixById.TryAdd(commulativeTansform.id, commulativeTansform);
+      
+      // get the geometry
+      List<Mesh> meshes = null;
+      if (element is Mesh mesh)
+        meshes = new List<Mesh>() { mesh };
+      else
+        meshes = GetDisplayValue(element);
+
+      // in case no instance-level geometry, get it from definition
+      Base definition = null;
+      if (meshes == null)
+      {
+        definition = (Base)(element["definition"] ?? element["@definition"]);
+        if (definition != null)
+          meshes = GetDisplayValue(definition);
+      }
+
+      // transform meshes
+      var meshesIds = meshes?.ConvertAll(mesh => Utilities.hashString(commulativeTansform.id + mesh.id));
+      meshes = meshes?.Select(mesh => {
+        var transformedMeshId = Utilities.hashString(commulativeTansform.id + mesh.id);
+        if (!transformedMeshById.TryGetValue(transformedMeshId, out Mesh transformedMesh))
+        {
+          transformedMesh = (Mesh)mesh.ShallowCopy();
+          transformedMesh.Transform (commulativeTansform);
+          transformedMesh.id = transformedMeshId;
+          transformedMeshById.Add(transformedMeshId, transformedMesh);
+        }
+        return transformedMesh;
+      }).ToList();
+
+      // continue traversal via "elements" of definition
+      if (definition != null)
+      { 
+        var subElements = definition["elements"] ?? definition["@elements"];
+        var subElementList = subElements is List<Base> baseList ? baseList : (subElements is List<object> objList ? objList.Cast<Base>().ToList() : null);
+        subElementList?.ForEach(subElement =>
+        {
+          var subElementTransform = (Transform)(subElement["transform"]) ?? new Transform();
+          meshesIds.AddRange(TraverseDefinitions(subElement, commulativeTansform, subElementTransform, transformMatrixById, transformedMeshById));
+        });
+      }
+
+      return meshesIds;
+    }
+
     public async Task<List<ApplicationObject>> ConvertToArchicad(IEnumerable<TraversalContext> elements, CancellationToken token)
     {
-      var objects = new List<Archicad.ArchicadObject>();
+      var archicadObjects = new List<Archicad.ArchicadObject>();
+      var meshModels = new List<MeshModel>();
+      var transformMatrixById = new Dictionary<string, Transform>();
+      var transformedMeshById = new Dictionary<string, Mesh>();
+      
       foreach (var tc in elements)
       {
         var element = tc.current;
 
         // base point
-        var basePoint = new Point (0, 0, 0);
-        var specialKeys = element.GetMembers();
+        var basePoint = new Point(0, 0, 0);
+        // var specialKeys = element.GetMembers();
+        var transform = (Transform)(element["transform"]) ?? new Transform();
 
         // todo Speckle schema
         //if (specialKeys.ContainsKey("basePoint"))
         //  basePoint = (Point)element["basePoint"];
 
-        // get the geometry
-        List<Mesh> meshes = null;
-        if (element is Mesh mesh)
-          meshes = new List<Mesh>() { mesh };
-        else
+        List<string> meshIdHashes;
         {
-          var m = element["displayValue"] ?? element["@displayValue"];
-          if (m is List<Mesh>)
-            meshes = (List<Mesh>)m;
-          else if (m is List<object>)
-            meshes = ((List<object>)m).Cast<Mesh>().ToList();
+          Transform baseTransform = new Transform();
+          baseTransform.id = "1530eda076784bfaa61728b060ed8d43";
+          Transform newTransform = new Transform();
+          newTransform.id = "0cecc0af9be7465b958d736618817315";
+
+          meshIdHashes = TraverseDefinitions(element, baseTransform, newTransform, transformMatrixById, transformedMeshById);
+
+          if (meshIdHashes == null)
+            continue;
         }
 
-        if (meshes == null)
-          continue;
-       
-        var meshModel = ModelConverter.MeshToNative(meshes);
-
-        Archicad.ArchicadObject newObject = new Archicad.ArchicadObject
+        // if the same geometry representation is not used before
+        if (!archicadObjects.Any(archicadObject => archicadObject.modelIds.SequenceEqual(meshIdHashes)))
+        {
+          var meshes = meshIdHashes.ConvertAll(meshIdHash => transformedMeshById[meshIdHash]);
+          var meshModel = ModelConverter.MeshToNative(meshes);
+          meshModels.Add(meshModel);
+        }
+        
+        var newObject = new Archicad.ArchicadObject
         {
           id = element.id,
           applicationId = element.applicationId,
           pos = Utils.ScaleToNative(basePoint),
-          model = meshModel
+          transform = new Objects.Other.Transform(transform.ConvertToUnits(Units.Meters), Units.Meters),
+          modelIds = meshIdHashes
         };
-
-        objects.Add(newObject);
+        archicadObjects.Add(newObject);
       }
 
-      var result = await AsyncCommandProcessor.Execute(new Communication.Commands.CreateObject(objects), token);
+      var result = await AsyncCommandProcessor.Execute(new Communication.Commands.CreateObject(archicadObjects, meshModels), token);
       return result is null ? new List<ApplicationObject>() : result.ToList();
     }
 

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -36,7 +36,7 @@ namespace Archicad.Converters
               shape = Utils.PolycurvesToElementShape(room.outline, room.voids),
               name = room.name,
               number = room.number,
-              basePoint = Utils.ScaleToNative(room.basePoint)
+              basePoint = (room.basePoint != null) ? Utils.ScaleToNative(room.basePoint) : new Point()
             };
 
             rooms.Add(newRoom);

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
@@ -21,6 +21,11 @@ namespace Archicad.Converters
       return new Vector { x = vertex.x, y = vertex.y, z = vertex.z };
     }
 
+    public static System.Numerics.Vector3 VertexToVector3(MeshModel.Vertex vertex)
+    {
+      return new System.Numerics.Vector3 { X = (float)vertex.x, Y = (float)vertex.y, Z = (float)vertex.z };
+    }
+
     public static Point ScaleToNative(Point point, string? units = null)
     {
       units ??= point.units;

--- a/ConnectorArchicad/ConnectorArchicad/Elements/Object.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Elements/Object.cs
@@ -1,4 +1,4 @@
-﻿using Objects.Geometry;
+using Objects.Geometry;
 using Objects.Structural.Materials;
 using Objects.Structural.Properties.Profiles;
 using Objects.Utils;
@@ -20,8 +20,9 @@ namespace Archicad
     public string applicationId { get; set; }
 
     public Point pos { get; set; }
+    public Objects.Other.Transform transform { get; set; }
 
-    public Archicad.Model.MeshModel model { get; set; }
+    public List<string> modelIds { get; set; }
 
     public string units { get; set; }
 
@@ -29,12 +30,12 @@ namespace Archicad
 
     [SchemaInfo("ArchicadObject", "Creates an Archicad object.", "Archicad", "Structure")]
 
-    public ArchicadObject(string id, string applicationId, Point basePoint, Archicad.Model.MeshModel model)
+    public ArchicadObject(string id, string applicationId, Point basePoint, List<string> modelIds)
     {
       this.id = id;
       this.applicationId = applicationId;
       this.pos = basePoint;
-      this.model = model;
+      this.modelIds = modelIds;
     }
   }
 }

--- a/ConnectorArchicad/ConnectorArchicad/Model/MeshModel.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Model/MeshModel.cs
@@ -141,7 +141,8 @@ namespace Archicad.Model
 
     private bool IsCoplanar(Vector vector1, Vector vector2, Vector vector3, Vector vector4)
     {
-      return Vector.DotProduct(vector2 - vector1, Vector.CrossProduct(vector4 - vector1, vector3 - vector1)) == 0;
+      var dotProduct = Vector.DotProduct(vector2 - vector1, Vector.CrossProduct(vector4 - vector1, vector3 - vector1)); 
+      return Math.Abs(dotProduct) < Speckle.Core.Helpers.Constants.Eps;
     }
 
     #endregion

--- a/Core/Core/Helpers/Constants.cs
+++ b/Core/Core/Helpers/Constants.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Speckle.Core.Helpers;
+
+public static class Constants
+{
+  public const double Eps = 1e-5;
+  public const double Eps2 = Eps * Eps;
+}

--- a/Objects/Objects/Geometry/Mesh.cs
+++ b/Objects/Objects/Geometry/Mesh.cs
@@ -79,6 +79,17 @@ public class Mesh : Base, IHasBoundingBox, IHasVolume, IHasArea, ITransformable<
   public double volume { get; set; }
 
   /// <inheritdoc/>
+  public bool Transform(Transform transform)
+  {
+    // transform vertices
+    vertices = GetPoints().SelectMany(vertex => { 
+      vertex.TransformTo(transform, out Point transformedVertex); return transformedVertex.ToList();
+    }).ToList();
+
+    return true;
+  }
+
+  /// <inheritdoc/>
   public bool TransformTo(Transform transform, out Mesh mesh)
   {
     // transform vertices


### PR DESCRIPTION
## Description & motivation

* Receiving instances in Archicad (https://github.com/specklesystems/speckle-sharp/issues/2340)
   * two-level instancing is used in Archicad: `instance` = `Archicad Object` + `1 definition` = `GDL library part`
   * currently custom definition traversal (`TraverseDefinitions`) is used, however usage of Core's traversal mechanism should be considered
   * Revit to Archicad workflow checked deeply, other workflows might need improvement
* New oriented polygon normal calculation for edge classification introduced for concave polygons
* Per element type try-catch blocks used in element conversion
* Performance decreased a bit: started to use System.Numerics.Vector3 instead of our Vector classes, however not finished, need further validation


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
