### PR TITLE
fix(gh): Adds "is Base" check to ESO-K/V input

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectByKeyValueV2TaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/ExtendSpeckleObjectByKeyValueV2TaskComponent.cs
@@ -102,7 +102,11 @@ public class ExtendSpeckleObjectByKeyValueV2TaskComponent : SelectKitTaskCapable
         if (inputObj != null)
         {
           var value = inputObj.GetType().GetProperty("Value")?.GetValue(inputObj);
-          if (Converter.CanConvertToSpeckle(value))
+          if (value is Base baseObj)
+          {
+            @base = baseObj;
+          }
+          else if (Converter.CanConvertToSpeckle(value))
           {
             @base = Converter.ConvertToSpeckle(value);
             AddRuntimeMessage(


### PR DESCRIPTION
Fixes #2609

Adds verification to ensure any IGH_Goo that has a `Base` as it's value is compatible with our nodes.