### PR TITLE
fix(dynamo): broken project after build step

### DIFF
--- a/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
+++ b/ConnectorDynamo/ConnectorDynamo/ConnectorDynamo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
         <RootNamespace>Speckle.ConnectorDynamo</RootNamespace>
         <AssemblyName>SpeckleConnectorDynamo</AssemblyName>
@@ -22,12 +22,18 @@
         <DyfFolder>$(PackageFolder)dyf\</DyfFolder>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="PresentationCore" />
-        <Reference Include="PresentationFramework" />
-        <Reference Include="System.Xaml" />
-        <Reference Include="System.Data.DataSetExtensions" />
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="WindowsBase" />
+      <Reference Include="PresentationCore" />
+      <Reference Include="PresentationFramework" />
+      <Reference Include="System" />
+      <Reference Include="System.Core" />
+      <Reference Include="System.Drawing" />
+      <Reference Include="System.Xaml" />
+      <Reference Include="System.Xml.Linq" />
+      <Reference Include="System.Data.DataSetExtensions" />
+      <Reference Include="Microsoft.CSharp" />
+      <Reference Include="System.Data" />
+      <Reference Include="System.Xml" />
+      <Reference Include="WindowsBase" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="DynamoVisualProgramming.Core" Version="2.8.0.2471"
@@ -157,27 +163,34 @@
 
     <Target Name="AfterBuildMigrated" AfterTargets="Build">
 
-        <CSC TargetType="library"
-            Resources="$(ProjectDir)\SpeckleConnectorDynamoImages.resx"
-            OutputAssembly="$(OutDir)SpeckleConnectorDynamo.customization.dll" />
-        <!-- Icons stuff end -->
-        <ItemGroup>
-            <Dlls Include="$(OutDir)\**\*.*" />
-            <!--<Pdbs
-            Include="$(OutDir)*.pdb" />-->
-            <SourceExtension Include="$(OutDir)*Extension_ViewExtensionDefinition.xml" />
-            <!--<XML
-            Include="$(OutDir)*.xml" />-->
-            <PackageJson Include="$(ProjectDir)pkg.json" />
-        </ItemGroup>
-        <MakeDir Directories="$(ExtraFolder)" Condition="!Exists($(ExtraFolder))" />
-        <MakeDir Directories="$(DyfFolder)" Condition="!Exists($(DyfFolder))" />
-        <Copy SourceFiles="@(Dlls)" DestinationFolder="$(BinFolder)\%(RecursiveDir)" />
-        <!--<Copy
-        SourceFiles="@(Pdbs)" DestinationFolder="$(BinFolder)" />-->
-        <!--<Copy
-        SourceFiles="@(XML)" DestinationFolder="$(BinFolder)" />-->
-        <Copy SourceFiles="@(PackageJson)" DestinationFolder="$(PackageFolder)" />
-        <Copy SourceFiles="@(SourceExtension)" DestinationFolder="$(ExtraFolder)" />
+      <!-- Icons stuff -->
+      <!-- Get System.Drawing.dll -->
+      <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v4.8">
+        <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
+      </GetReferenceAssemblyPaths>
+      <!-- Get assembly -->
+      <GetAssemblyIdentity AssemblyFiles="$(OutDir)$(TargetName).dll">
+        <Output TaskParameter="Assemblies" ItemName="AssemblyInfo" />
+      </GetAssemblyIdentity>
+      <!-- Generate customization dll -->
+      <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)\SpeckleConnectorDynamoImages.resx" OutputResources="$(ProjectDir)\SpeckleConnectorDynamoImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+      <AL SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" TargetType="library" EmbedResources="$(ProjectDir)\SpeckleConnectorDynamoImages.resources" OutputAssembly="$(OutDir)SpeckleConnectorDynamo.customization.dll" Version="%(AssemblyInfo.Version)" />
+      <!-- Icons stuff end -->
+      <ItemGroup>
+        <Dlls Include="$(OutDir)\**\*.*" />
+        <!--<Pdbs Include="$(OutDir)*.pdb" />-->
+        <SourceExtension Include="$(OutDir)*Extension_ViewExtensionDefinition.xml" />
+        <!--<XML Include="$(OutDir)*.xml" />-->
+        <PackageJson Include="$(ProjectDir)pkg.json" />
+      </ItemGroup>
+      <MakeDir Directories="$(ExtraFolder)" Condition="!Exists($(ExtraFolder))">
+      </MakeDir>
+      <MakeDir Directories="$(DyfFolder)" Condition="!Exists($(DyfFolder))">
+      </MakeDir>
+      <Copy SourceFiles="@(Dlls)" DestinationFolder="$(BinFolder)\%(RecursiveDir)" />
+      <!--<Copy SourceFiles="@(Pdbs)" DestinationFolder="$(BinFolder)" />-->
+      <!--<Copy SourceFiles="@(XML)" DestinationFolder="$(BinFolder)" />-->
+      <Copy SourceFiles="@(PackageJson)" DestinationFolder="$(PackageFolder)" />
+      <Copy SourceFiles="@(SourceExtension)" DestinationFolder="$(ExtraFolder)" />
     </Target>
 </Project>

--- a/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/ConnectorDynamoFunctions.csproj
@@ -39,15 +39,23 @@
     </ItemGroup>
 
     <Target Name="AfterBuildMigrated" AfterTargets="Build">
-        <!-- Generate customization dll -->
-        <CSC TargetType="library"
-            Resources="$(ProjectDir)\SpeckleConnectorDynamoFunctionsImages.resx"
-            OutputAssembly="$(OutDir)SpeckleConnectorDynamoFunctions.customization.dll" />
-        <!-- Icons stuff end -->
-        <ItemGroup>
-            <Dll Include="$(OutDir)SpeckleConnectorDynamoFunctions.customization.dll" />
-        </ItemGroup>
+      <!-- Icons stuff -->
+      <!-- Get System.Drawing.dll -->
+      <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v4.8">
+        <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
+      </GetReferenceAssemblyPaths>
+      <!-- Get assembly -->
+      <GetAssemblyIdentity AssemblyFiles="$(OutDir)$(TargetName).dll">
+        <Output TaskParameter="Assemblies" ItemName="AssemblyInfo" />
+      </GetAssemblyIdentity>
+      <!-- Generate customization dll -->
+      <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)\SpeckleConnectorDynamoFunctionsImages.resx" OutputResources="$(ProjectDir)\SpeckleConnectorDynamoFunctionsImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+      <AL SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" TargetType="library" EmbedResources="$(ProjectDir)\SpeckleConnectorDynamoFunctionsImages.resources" OutputAssembly="$(OutDir)SpeckleConnectorDynamoFunctions.customization.dll" Version="%(AssemblyInfo.Version)" />
+      <!-- Icons stuff end -->
+      <ItemGroup>
+        <Dll Include="$(OutDir)SpeckleConnectorDynamoFunctions.customization.dll" />
+      </ItemGroup>
         <Copy SourceFiles="@(Dll)"
-            DestinationFolder="$(ProjectDir)\..\ConnectorDynamo\bin\$(ConfigurationName)" />
+            DestinationFolder="$(ProjectDir)\..\ConnectorDynamo\bin\$(ConfigurationName)\win-x64\" />
     </Target>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/specklesystems/speckle-sharp/issues/2612

Not sure why these after-build steps were modified during the SDK project migration, but that broke the Connector.
This PR restores the after-build step to what it was before.