### PR TITLE
feat(all): Throw errors in all Obsolete `DynamicBase` members and fix all references to them

### DIFF
--- a/ConnectorBentley/ConnectorBentleyShared/UI/Bindings.cs
+++ b/ConnectorBentley/ConnectorBentleyShared/UI/Bindings.cs
@@ -33,7 +33,6 @@ using Bentley.CifNET.LinearGeometry;
 using Bentley.CifNET.SDK;
 #endif
 
-
 namespace Speckle.ConnectorBentley.UI
 {
   public partial class ConnectorBindingsBentley : ConnectorBindings
@@ -57,10 +56,15 @@ namespace Speckle.ConnectorBentley.UI
     // As in the AutoCAD/Civil3D connectors, we therefore creating a control in the ConnectorBindings constructor (since it's called on main thread) that allows for invoking worker threads on the main thread - thank you Claire!!
     public System.Windows.Forms.Control Control;
     delegate void SetContextDelegate(object session);
-    delegate List<string> GetObjectsFromFilterDelegate(ISelectionFilter filter, ISpeckleConverter converter, ProgressViewModel progress);
+    delegate List<string> GetObjectsFromFilterDelegate(
+      ISelectionFilter filter,
+      ISpeckleConverter converter,
+      ProgressViewModel progress
+    );
     delegate Base SpeckleConversionDelegate(object commitObject);
 
-    public ConnectorBindingsBentley() : base()
+    public ConnectorBindingsBentley()
+      : base()
     {
       Control = new System.Windows.Forms.Control();
       Control.CreateControl();
@@ -93,11 +97,13 @@ namespace Speckle.ConnectorBentley.UI
 
     public override string GetHostAppName() => Utils.Slug;
 
-
     public override string GetDocumentId()
     {
       string path = GetDocumentLocation();
-      return Core.Models.Utilities.hashString(path + File.GetFileName(), Speckle.Core.Models.Utilities.HashingFuctions.MD5);
+      return Core.Models.Utilities.hashString(
+        path + File.GetFileName(),
+        Speckle.Core.Models.Utilities.HashingFuctions.MD5
+      );
     }
 
     public override string GetDocumentLocation() => Path.GetDirectoryName(File.GetFileName());
@@ -153,12 +159,49 @@ namespace Speckle.ConnectorBentley.UI
         levels.Add(level.Name);
       levels.Sort();
 
-      var elementTypes = new List<string> { "Arc", "Ellipse", "Line", "Spline", "Line String", "Complex Chain", "Shape", "Complex Shape", "Mesh" };
+      var elementTypes = new List<string>
+      {
+        "Arc",
+        "Ellipse",
+        "Line",
+        "Spline",
+        "Line String",
+        "Complex Chain",
+        "Shape",
+        "Complex Shape",
+        "Mesh"
+      };
 
       var filterList = new List<ISelectionFilter>();
-      filterList.Add(new AllSelectionFilter { Slug = "all", Name = "Everything", Icon = "CubeScan", Description = "Selects all document objects." });
-      filterList.Add(new ListSelectionFilter { Slug = "level", Name = "Levels", Icon = "LayersTriple", Description = "Selects objects based on their level.", Values = levels });
-      filterList.Add(new ListSelectionFilter { Slug = "elementType", Name = "Element Types", Icon = "Category", Description = "Selects objects based on their element type.", Values = elementTypes });
+      filterList.Add(
+        new AllSelectionFilter
+        {
+          Slug = "all",
+          Name = "Everything",
+          Icon = "CubeScan",
+          Description = "Selects all document objects."
+        }
+      );
+      filterList.Add(
+        new ListSelectionFilter
+        {
+          Slug = "level",
+          Name = "Levels",
+          Icon = "LayersTriple",
+          Description = "Selects objects based on their level.",
+          Values = levels
+        }
+      );
+      filterList.Add(
+        new ListSelectionFilter
+        {
+          Slug = "elementType",
+          Name = "Element Types",
+          Icon = "Category",
+          Description = "Selects objects based on their element type.",
+          Values = elementTypes
+        }
+      );
 
 #if (OPENROADS || OPENRAIL)
       var civilElementTypes = new List<string> { "Alignment" };
@@ -189,7 +232,9 @@ namespace Speckle.ConnectorBentley.UI
       // TODO!
     }
 
-    public override async Task<Dictionary<string, List<MappingValue>>> ImportFamilyCommand(Dictionary<string, List<MappingValue>> Mapping)
+    public override async Task<Dictionary<string, List<MappingValue>>> ImportFamilyCommand(
+      Dictionary<string, List<MappingValue>> Mapping
+    )
     {
       await Task.Delay(TimeSpan.FromMilliseconds(500));
       return new Dictionary<string, List<MappingValue>>();
@@ -198,6 +243,7 @@ namespace Speckle.ConnectorBentley.UI
 
     #region receiving
     public override bool CanPreviewReceive => false;
+
     public override Task<StreamState> PreviewReceive(StreamState state, ProgressViewModel progress)
     {
       return null;
@@ -228,16 +274,21 @@ namespace Speckle.ConnectorBentley.UI
       state.LastCommit = commit;
       Base commitObject = await ConnectorHelpers.ReceiveCommit(commit, state, progress);
       await ConnectorHelpers.TryCommitReceived(progress.CancellationToken, state, commit, Utils.VersionedAppName);
-      
+
       // invoke conversions on the main thread via control
       int count = 0;
       var flattenedObjects = FlattenCommitObject(commitObject, converter, ref count);
       List<ApplicationObject> newPlaceholderObjects;
       if (Control.InvokeRequired)
-        newPlaceholderObjects = (List<ApplicationObject>)Control.Invoke(new NativeConversionAndBakeDelegate(ConvertAndBakeReceivedObjects), new object[] { flattenedObjects, converter, state, progress });
+        newPlaceholderObjects =
+          (List<ApplicationObject>)
+            Control.Invoke(
+              new NativeConversionAndBakeDelegate(ConvertAndBakeReceivedObjects),
+              new object[] { flattenedObjects, converter, state, progress }
+            );
       else
         newPlaceholderObjects = ConvertAndBakeReceivedObjects(flattenedObjects, converter, state, progress);
-      
+
       DeleteObjects(previouslyReceivedObjects, newPlaceholderObjects);
 
       state.ReceivedObjects = newPlaceholderObjects;
@@ -260,8 +311,19 @@ namespace Speckle.ConnectorBentley.UI
       return state;
     }
 
-    delegate List<ApplicationObject> NativeConversionAndBakeDelegate(List<Base> objects, ISpeckleConverter converter, StreamState state, ProgressViewModel progress);
-    private List<ApplicationObject> ConvertAndBakeReceivedObjects(List<Base> objects, ISpeckleConverter converter, StreamState state, ProgressViewModel progress)
+    delegate List<ApplicationObject> NativeConversionAndBakeDelegate(
+      List<Base> objects,
+      ISpeckleConverter converter,
+      StreamState state,
+      ProgressViewModel progress
+    );
+
+    private List<ApplicationObject> ConvertAndBakeReceivedObjects(
+      List<Base> objects,
+      ISpeckleConverter converter,
+      StreamState state,
+      ProgressViewModel progress
+    )
     {
       var placeholders = new List<ApplicationObject>();
       var conversionProgressDict = new ConcurrentDictionary<string, int>();
@@ -292,11 +354,15 @@ namespace Speckle.ConnectorBentley.UI
           {
             var status = convertedElement.AddToModel();
             if (status == StatusInt.Error)
-              converter.Report.LogConversionError(new Exception($"Failed to bake object {@base.id} of type {@base.speckle_type}."));
+              converter.Report.LogConversionError(
+                new Exception($"Failed to bake object {@base.id} of type {@base.speckle_type}.")
+              );
           }
           else
           {
-            converter.Report.LogConversionError(new Exception($"Failed to convert object {@base.id} of type {@base.speckle_type}."));
+            converter.Report.LogConversionError(
+              new Exception($"Failed to convert object {@base.id} of type {@base.speckle_type}.")
+            );
           }
         }
         catch (Exception e)
@@ -316,7 +382,12 @@ namespace Speckle.ConnectorBentley.UI
     /// <param name="count"></param>
     /// <param name="foundConvertibleMember"></param>
     /// <returns></returns>
-    private List<Base> FlattenCommitObject(object obj, ISpeckleConverter converter, ref int count, bool foundConvertibleMember = false)
+    private List<Base> FlattenCommitObject(
+      object obj,
+      ISpeckleConverter converter,
+      ref int count,
+      bool foundConvertibleMember = false
+    )
     {
       List<Base> objects = new List<Base>();
 
@@ -329,7 +400,7 @@ namespace Speckle.ConnectorBentley.UI
         }
         else
         {
-          List<string> props = @base.GetDynamicMembers().ToList();
+          List<string> props = @base.GetMembers(DynamicBaseMemberType.Dynamic).Keys.ToList();
           if (@base.GetMembers().ContainsKey("displayValue"))
             props.Add("displayValue");
           if (@base.GetMembers().ContainsKey("elements")) // this is for builtelements like roofs, walls, and floors.
@@ -375,14 +446,17 @@ namespace Speckle.ConnectorBentley.UI
     }
 
     //delete previously sent object that are no longer in this stream
-    private void DeleteObjects(List<ApplicationObject> previouslyReceiveObjects, List<ApplicationObject> newPlaceholderObjects)
+    private void DeleteObjects(
+      List<ApplicationObject> previouslyReceiveObjects,
+      List<ApplicationObject> newPlaceholderObjects
+    )
     {
       foreach (var obj in previouslyReceiveObjects)
       {
         if (newPlaceholderObjects.Any(x => x.applicationId == obj.applicationId))
           continue;
 
-        // get the model object from id               
+        // get the model object from id
         ulong id = Convert.ToUInt64(obj.CreatedIds.FirstOrDefault());
         var element = Model.FindElementById((ElementId)id);
         if (element != null)
@@ -393,6 +467,7 @@ namespace Speckle.ConnectorBentley.UI
 
     #region sending
     public override bool CanPreviewSend => false;
+
     public override void PreviewSend(StreamState state, ProgressViewModel progress)
     {
       return;
@@ -415,14 +490,21 @@ namespace Speckle.ConnectorBentley.UI
       if (state.Filter != null)
       {
         if (Control.InvokeRequired)
-          state.SelectedObjectIds = (List<string>)Control.Invoke(new GetObjectsFromFilterDelegate(GetObjectsFromFilter), new object[] { state.Filter, converter, progress });
+          state.SelectedObjectIds =
+            (List<string>)
+              Control.Invoke(
+                new GetObjectsFromFilterDelegate(GetObjectsFromFilter),
+                new object[] { state.Filter, converter, progress }
+              );
         else
           state.SelectedObjectIds = GetObjectsFromFilter(state.Filter, converter, progress);
       }
 
       if (state.SelectedObjectIds.Count == 0 && !ExportGridLines)
       {
-        throw new InvalidOperationException("Zero objects selected; send stopped. Please select some objects, or check that your filter can actually select something.");
+        throw new InvalidOperationException(
+          "Zero objects selected; send stopped. Please select some objects, or check that your filter can actually select something."
+        );
       }
 
       var commitObj = new Base();
@@ -435,7 +517,7 @@ namespace Speckle.ConnectorBentley.UI
       progress.Max = state.SelectedObjectIds.Count();
       int convertedCount = 0;
 
-      // grab elements from active model           
+      // grab elements from active model
       var objs = new List<Element>();
 #if (OPENROADS || OPENRAIL)
       bool convertCivilObject = false;
@@ -540,7 +622,8 @@ namespace Speckle.ConnectorBentley.UI
           }
 #else
           if (Control.InvokeRequired)
-            converted = (Base)Control.Invoke(new SpeckleConversionDelegate(converter.ConvertToSpeckle), new object[] { obj });
+            converted = (Base)
+              Control.Invoke(new SpeckleConversionDelegate(converter.ConvertToSpeckle), new object[] { obj });
           else
             converted = converter.ConvertToSpeckle(obj);
 
@@ -558,7 +641,7 @@ namespace Speckle.ConnectorBentley.UI
           continue;
         }
 
-        /* TODO: adding the feature data and properties per object 
+        /* TODO: adding the feature data and properties per object
         foreach (var key in obj.ExtensionDictionary)
         {
           converted[key] = obj.ExtensionDictionary.GetUserString(key);
@@ -578,7 +661,7 @@ namespace Speckle.ConnectorBentley.UI
       }
 
       progress.Report.Merge(converter.Report);
-      
+
       if (convertedCount == 0)
       {
         throw new SpeckleException("Zero objects converted successfully. Send stopped.");
@@ -597,17 +680,21 @@ namespace Speckle.ConnectorBentley.UI
         onProgressAction: dict => progress.Update(dict),
         onErrorAction: ConnectorHelpers.DefaultSendErrorHandler,
         disposeTransports: true
-        );
+      );
       var actualCommit = new CommitCreateInput
       {
         streamId = streamId,
         objectId = commitObjId,
         branchName = state.BranchName,
-        message = state.CommitMessage != null ? state.CommitMessage : $"Pushed {convertedCount} elements from {Utils.AppName}.",
+        message =
+          state.CommitMessage != null ? state.CommitMessage : $"Pushed {convertedCount} elements from {Utils.AppName}.",
         sourceApplication = Utils.VersionedAppName
       };
 
-      if (state.PreviousCommitId != null) { actualCommit.parents = new List<string>() { state.PreviousCommitId }; }
+      if (state.PreviousCommitId != null)
+      {
+        actualCommit.parents = new List<string>() { state.PreviousCommitId };
+      }
 
       var commitId = await ConnectorHelpers.CreateCommit(progress.CancellationToken, client, actualCommit);
       return commitId;
@@ -669,7 +756,11 @@ namespace Speckle.ConnectorBentley.UI
     }
 #endif
 
-    private List<string> GetObjectsFromFilter(ISelectionFilter filter, ISpeckleConverter converter, ProgressViewModel progress)
+    private List<string> GetObjectsFromFilter(
+      ISelectionFilter filter,
+      ISpeckleConverter converter,
+      ProgressViewModel progress
+    )
     {
       var selection = new List<string>();
       switch (filter.Slug)
@@ -685,7 +776,10 @@ namespace Speckle.ConnectorBentley.UI
 
             var graphicElements = Model.GetGraphicElements();
             var elementEnumerator = (ModelElementsEnumerator)graphicElements.GetEnumerator();
-            var objs = graphicElements.Where(el => el.LevelId == levelId).Select(el => el.ElementId.ToString()).ToList();
+            var objs = graphicElements
+              .Where(el => el.LevelId == levelId)
+              .Select(el => el.ElementId.ToString())
+              .ToList();
             selection.AddRange(objs);
           }
           return selection;
@@ -730,7 +824,10 @@ namespace Speckle.ConnectorBentley.UI
             }
             var graphicElements = Model.GetGraphicElements();
             var elementEnumerator = (ModelElementsEnumerator)graphicElements.GetEnumerator();
-            var objs = graphicElements.Where(el => el.ElementType == selectedType).Select(el => el.ElementId.ToString()).ToList();
+            var objs = graphicElements
+              .Where(el => el.ElementType == selectedType)
+              .Select(el => el.ElementId.ToString())
+              .ToList();
             selection.AddRange(objs);
           }
           return selection;
@@ -759,7 +856,11 @@ namespace Speckle.ConnectorBentley.UI
           return selection;
 #endif
         default:
-          progress.Report.LogConversionError(new Exception("Filter type is not supported in this app. Why did the developer implement it in the first place?"));
+          progress.Report.LogConversionError(
+            new Exception(
+              "Filter type is not supported in this app. Why did the developer implement it in the first place?"
+            )
+          );
           return selection;
       }
     }
@@ -774,7 +875,10 @@ namespace Speckle.ConnectorBentley.UI
     private void WriteStateToFile()
     {
       if (Control.InvokeRequired)
-        Control.Invoke(new WriteStateDelegate(StreamStateManager.WriteStreamStateList), new object[] { File, DocumentStreams });
+        Control.Invoke(
+          new WriteStateDelegate(StreamStateManager.WriteStreamStateList),
+          new object[] { File, DocumentStreams }
+        );
       else
         StreamStateManager.WriteStreamStateList(File, DocumentStreams);
     }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
@@ -123,8 +123,8 @@ public static class Utilities
   {
     var dataTree = new GH_Structure<IGH_Goo>();
     @base
-      .GetDynamicMembers()
-      .ToList()
+      .GetMembers()
+      .Keys.ToList()
       .ForEach(key =>
       {
         var value = @base[key] as List<object>;
@@ -155,7 +155,7 @@ public static class Utilities
   public static bool CanConvertToDataTree(Base @base)
   {
     var regex = new Regex(dataTreePathPattern);
-    var dynamicMembers = @base.GetDynamicMembers().ToList();
+    var dynamicMembers = @base.GetMembers(DynamicBaseMemberType.Dynamic).Keys.ToList();
     if (dynamicMembers.Count == 0)
       return false;
     var isDataTree = dynamicMembers.All(el => regex.Match(el).Success);
@@ -571,7 +571,11 @@ public static class Utilities
       var converted = Converter.ConvertToNative(@base);
       data.Append(WrapInGhType(converted));
     }
-    else if (unwrap && @base.GetDynamicMembers().Count() == 1 && (@base["@data"] != null || @base["@Data"] != null))
+    else if (
+      unwrap
+      && @base.GetMembers(DynamicBaseMemberType.Dynamic).Keys.Count == 1
+      && (@base["@data"] != null || @base["@Data"] != null)
+    )
     {
       // Comes from a wrapper
       var wrappedData = @base["@data"] ?? @base["@Data"];

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/Deprecated/ExpandSpeckleObjectTaskComponent.cs
@@ -322,8 +322,8 @@ public class ExpandSpeckleObjectTaskComponent
     foreach (var ghGoo in speckleObjects.AllData(true))
     {
       var b = (ghGoo as GH_SpeckleBase)?.Value;
-      b?.GetMemberNames()
-        .ToList()
+      b?.GetMembers()
+        .Keys.ToList()
         .ForEach(prop =>
         {
           if (!fullProps.Contains(prop))

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectKeysComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Objects/GetObjectKeysComponent.cs
@@ -60,7 +60,7 @@ public class GetObjectKeysComponent : GH_SpeckleComponent
       if (speckleObject.Value == null)
         return;
 
-      var keys = speckleObject.Value.GetMemberNames();
+      var keys = speckleObject.Value.GetMembers().Keys;
 
       DA.SetDataList(0, keys);
     }
@@ -78,7 +78,7 @@ public class GetObjectKeysComponent : GH_SpeckleComponent
           if (speckleObject == null)
             return;
 
-          var objKeys = speckleObject.GetMemberNames();
+          var objKeys = speckleObject.GetMembers().Keys;
           foreach (var key in objKeys)
             if (!keys.Contains(key))
               keys.Add(key);

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -876,8 +876,8 @@ public class VariableInputReceiveComponentWorker : WorkerInstance
 
     // Get the full list of output parameters
     var fullProps = new List<string>();
-    b?.GetMemberNames()
-      .ToList()
+    b?.GetMembers()
+      .Keys.ToList()
       .ForEach(prop =>
       {
         if (!fullProps.Contains(prop))

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Mappings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Mappings.cs
@@ -19,10 +19,8 @@ using static DesktopUI2.ViewModels.MappingViewModel;
 
 namespace Speckle.ConnectorRevit.UI
 {
-
   public partial class ConnectorBindingsRevit
   {
-
     /// <summary>
     /// Updates the flattenedBase object with user selected types
     /// </summary>
@@ -32,10 +30,12 @@ namespace Speckle.ConnectorRevit.UI
     /// <returns></returns>
     public async Task UpdateForCustomMapping(StreamState state, ProgressViewModel progress, string sourceApp)
     {
-      // Get Settings for recieve on mapping 
-      if (CurrentSettings.FirstOrDefault(x => x.Slug == "receive-mappings") is not MappingSeting mappingSetting 
-        || mappingSetting.Selection == null 
-        || mappingSetting.Selection == noMapping)
+      // Get Settings for recieve on mapping
+      if (
+        CurrentSettings.FirstOrDefault(x => x.Slug == "receive-mappings") is not MappingSeting mappingSetting
+        || mappingSetting.Selection == null
+        || mappingSetting.Selection == noMapping
+      )
       {
         return;
       }
@@ -45,7 +45,9 @@ namespace Speckle.ConnectorRevit.UI
 
       if (mappingSetting.MappingJson != null)
       {
-        settingsMapping = JsonConvert.DeserializeObject<Dictionary<string, List<MappingValue>>>(mappingSetting.MappingJson);
+        settingsMapping = JsonConvert.DeserializeObject<Dictionary<string, List<MappingValue>>>(
+          mappingSetting.MappingJson
+        );
       }
       else
       {
@@ -57,17 +59,17 @@ namespace Speckle.ConnectorRevit.UI
 
       // if mappings already exist, update them and return true
       bool newTypesExist = UpdateExistingMapping(settingsMapping, hostTypesDict, incomingTypesDict, progress);
-      if (!newTypesExist && mappingSetting.Selection != everyReceive) { return; }
+      if (!newTypesExist && mappingSetting.Selection != everyReceive)
+      {
+        return;
+      }
 
       Dictionary<string, List<MappingValue>> mapping = settingsMapping;
       mapping ??= ReturnFirstPassMap(incomingTypesDict, hostTypesDict, progress);
 
       // show custom mapping dialog if the settings corrospond to what is being received
       var vm = new MappingViewModel(mapping, hostTypesDict, newTypesExist && !isFirstTimeReceiving);
-      MappingViewDialog mappingView = new MappingViewDialog
-      {
-        DataContext = vm
-      };
+      MappingViewDialog mappingView = new MappingViewDialog { DataContext = vm };
 
       mapping = await mappingView.ShowDialog<Dictionary<string, List<MappingValue>>>().ConfigureAwait(true);
 
@@ -76,10 +78,7 @@ namespace Speckle.ConnectorRevit.UI
         hostTypesDict = await ImportFamilyTypes(hostTypesDict).ConfigureAwait(true);
 
         vm = new MappingViewModel(mapping, hostTypesDict, newTypesExist && !isFirstTimeReceiving);
-        mappingView = new MappingViewDialog
-        {
-          DataContext = vm
-        };
+        mappingView = new MappingViewDialog { DataContext = vm };
 
         mapping = await mappingView.ShowDialog<Dictionary<string, List<MappingValue>>>();
       }
@@ -100,7 +99,11 @@ namespace Speckle.ConnectorRevit.UI
     /// <param name="hostTypes"></param>
     /// <param name="progress"></param>
     /// <returns></returns>
-    private Dictionary<string, List<MappingValue>> ReturnFirstPassMap(Dictionary<string, List<string>> incomingTypesDict, Dictionary<string, List<string>> hostTypes, ProgressViewModel progress)
+    private Dictionary<string, List<MappingValue>> ReturnFirstPassMap(
+      Dictionary<string, List<string>> incomingTypesDict,
+      Dictionary<string, List<string>> hostTypes,
+      ProgressViewModel progress
+    )
     {
       var mappings = new Dictionary<string, List<MappingValue>> { };
       foreach (var incomingTypeCategory in incomingTypesDict.Keys)
@@ -110,20 +113,11 @@ namespace Speckle.ConnectorRevit.UI
           string mappedValue = GetMappedValue(hostTypes, incomingTypeCategory, speckleType);
           if (mappings.ContainsKey(incomingTypeCategory))
           {
-            mappings[incomingTypeCategory].Add(new MappingValue
-              (
-                speckleType, mappedValue
-              ));
+            mappings[incomingTypeCategory].Add(new MappingValue(speckleType, mappedValue));
           }
           else
           {
-            mappings[incomingTypeCategory] = new List<MappingValue>
-              {
-                new MappingValue
-                (
-                  speckleType, mappedValue
-                )
-              };
+            mappings[incomingTypeCategory] = new List<MappingValue> { new MappingValue(speckleType, mappedValue) };
           }
         }
       }
@@ -202,9 +196,7 @@ namespace Speckle.ConnectorRevit.UI
         for (int j = 1; j <= m; j++)
         {
           int cost = (t[j - 1] == s[i - 1]) ? 0 : 1;
-          d[i, j] = Math.Min(
-              Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
-              d[i - 1, j - 1] + cost);
+          d[i, j] = Math.Min(Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1), d[i - 1, j - 1] + cost);
         }
       }
       return d[n, m];
@@ -265,9 +257,9 @@ namespace Speckle.ConnectorRevit.UI
             }
             return TypeCatMisc;
           case "csielement2d":
-            if (obj.GetMemberNames().Contains("property") && obj["property"] is Base prop)
+            if (obj.GetMembers().Keys.Contains("property") && obj["property"] is Base prop)
             {
-              if (prop.GetMemberNames().Contains("type") && (int)obj["type"] is int type)
+              if (prop.GetMembers().Keys.Contains("type") && (int)obj["type"] is int type)
               {
                 switch (type)
                 {
@@ -298,7 +290,7 @@ namespace Speckle.ConnectorRevit.UI
 
           case string a when a.Contains("wall"):
             return TypeCatWalls;
-            #endregion
+          #endregion
         }
       }
       catch (Exception _)
@@ -352,8 +344,18 @@ namespace Speckle.ConnectorRevit.UI
         TypeCatMaterials => new CustomTypesFilter(TypeCatMaterials, typeof(Autodesk.Revit.DB.Material)),
         TypeCatFloors => new CustomTypesFilter(TypeCatFloors, typeof(FloorType)),
         TypeCatWalls => new CustomTypesFilter(TypeCatWalls, typeof(WallType)),
-        TypeCatFraming => new CustomTypesFilter(TypeCatFraming, typeof(FamilySymbol), new List<BuiltInCategory> { BuiltInCategory.OST_StructuralFraming }),
-        TypeCatColumns => new CustomTypesFilter(TypeCatColumns, typeof(FamilySymbol), new List<BuiltInCategory> { BuiltInCategory.OST_Columns, BuiltInCategory.OST_StructuralColumns }),
+        TypeCatFraming
+          => new CustomTypesFilter(
+            TypeCatFraming,
+            typeof(FamilySymbol),
+            new List<BuiltInCategory> { BuiltInCategory.OST_StructuralFraming }
+          ),
+        TypeCatColumns
+          => new CustomTypesFilter(
+            TypeCatColumns,
+            typeof(FamilySymbol),
+            new List<BuiltInCategory> { BuiltInCategory.OST_Columns, BuiltInCategory.OST_StructuralColumns }
+          ),
         _ => new CustomTypesFilter(TypeCatMisc),
       };
     }
@@ -407,7 +409,7 @@ namespace Speckle.ConnectorRevit.UI
               returnDict[typeCategory] = new List<string>();
             if (@object.GetMembers().ContainsKey("property") && @object["property"] is Base prop)
             {
-              if (prop.GetMemberNames().Contains("name") && !string.IsNullOrEmpty(prop["name"] as string))
+              if (prop.GetMembers().Keys.Contains("name") && !string.IsNullOrEmpty(prop["name"] as string))
               {
                 if (!returnDict[typeCategory].Contains(prop["name"] as string))
                   returnDict[typeCategory].Add(prop["name"] as string);
@@ -427,9 +429,9 @@ namespace Speckle.ConnectorRevit.UI
             if (!returnDict.ContainsKey(typeCategory))
               returnDict[typeCategory] = new List<string>();
 
-            if (@object.GetMemberNames().Contains("profile") && @object["profile"] is Base profile)
+            if (@object.GetMembers().Keys.Contains("profile") && @object["profile"] is Base profile)
             {
-              if (profile.GetMemberNames().Contains("name") && !string.IsNullOrEmpty(profile["name"] as string))
+              if (profile.GetMembers().Keys.Contains("name") && !string.IsNullOrEmpty(profile["name"] as string))
               {
                 if (!returnDict[typeCategory].Contains(profile["name"] as string))
                   returnDict[typeCategory].Add(profile["name"] as string);
@@ -451,9 +453,12 @@ namespace Speckle.ConnectorRevit.UI
     /// <summary>
     /// Update receive object to include the user's custom mapping
     /// </summary>
-    private void SetMappedValues(Dictionary<string, List<MappingValue>> userMap, ProgressViewModel progress, string sourceApp)
+    private void SetMappedValues(
+      Dictionary<string, List<MappingValue>> userMap,
+      ProgressViewModel progress,
+      string sourceApp
+    )
     {
-
       string typeCategory = null;
       List<string> mappedValues = new List<string>();
 
@@ -474,15 +479,21 @@ namespace Speckle.ConnectorRevit.UI
                 if (!userMap.ContainsKey(typeCategory))
                   continue;
 
-                if (el.GetMemberNames().Contains("property") && el["property"] is Base prop)
+                if (el.GetMembers().Keys.Contains("property") && el["property"] is Base prop)
                 {
-                  if (prop.GetMemberNames().Contains("name") && prop.GetType().GetProperty("name") is System.Reflection.PropertyInfo info)
+                  if (
+                    prop.GetMembers().Keys.Contains("name")
+                    && prop.GetType().GetProperty("name") is System.Reflection.PropertyInfo info
+                  )
                   {
                     if (mappedValues.Contains(info.GetValue(prop) as string))
                       continue;
 
-                    MappingValue mappingWithMatchingType = userMap[typeCategory].Where(i => i.IncomingType == info.GetValue(prop) as string).First();
-                    string mappingProperty = mappingWithMatchingType.OutgoingType ?? mappingWithMatchingType.InitialGuess;
+                    MappingValue mappingWithMatchingType = userMap[typeCategory]
+                      .Where(i => i.IncomingType == info.GetValue(prop) as string)
+                      .First();
+                    string mappingProperty =
+                      mappingWithMatchingType.OutgoingType ?? mappingWithMatchingType.InitialGuess;
 
                     info.SetValue(prop, mappingProperty);
                     mappedValues.Add(mappingProperty);
@@ -496,12 +507,17 @@ namespace Speckle.ConnectorRevit.UI
             if (!userMap.ContainsKey(typeCategory))
               continue;
 
-            if (@object.GetMemberNames().Contains("type") && @object.GetType().GetProperty("type") is System.Reflection.PropertyInfo revType)
+            if (
+              @object.GetMembers().Keys.Contains("type")
+              && @object.GetType().GetProperty("type") is System.Reflection.PropertyInfo revType
+            )
             {
               if (mappedValues.Contains(revType.GetValue(@object) as string))
                 continue;
 
-              MappingValue mappingWithMatchingType = userMap[typeCategory].Where(i => i.IncomingType == revType.GetValue(@object) as string).First();
+              MappingValue mappingWithMatchingType = userMap[typeCategory]
+                .Where(i => i.IncomingType == revType.GetValue(@object) as string)
+                .First();
               string mappingProperty = mappingWithMatchingType.OutgoingType ?? mappingWithMatchingType.InitialGuess;
 
               revType.SetValue(@object, mappingProperty);
@@ -514,14 +530,19 @@ namespace Speckle.ConnectorRevit.UI
             if (!userMap.ContainsKey(typeCategory))
               continue;
 
-            if (@object.GetMemberNames().Contains("profile") && @object["profile"] is Base profile)
+            if (@object.GetMembers().Keys.Contains("profile") && @object["profile"] is Base profile)
             {
-              if (profile.GetMemberNames().Contains("name") && profile.GetType().GetProperty("name") is System.Reflection.PropertyInfo info)
+              if (
+                profile.GetMembers().Keys.Contains("name")
+                && profile.GetType().GetProperty("name") is System.Reflection.PropertyInfo info
+              )
               {
                 if (mappedValues.Contains(info.GetValue(profile) as string))
                   continue;
 
-                MappingValue mappingWithMatchingType = userMap[typeCategory].Where(i => i.IncomingType == info.GetValue(profile) as string).First();
+                MappingValue mappingWithMatchingType = userMap[typeCategory]
+                  .Where(i => i.IncomingType == info.GetValue(profile) as string)
+                  .First();
                 string mappingProperty = mappingWithMatchingType.OutgoingType ?? mappingWithMatchingType.InitialGuess;
 
                 info.SetValue(profile, mappingProperty);
@@ -532,14 +553,22 @@ namespace Speckle.ConnectorRevit.UI
         }
       }
 
-      Analytics.TrackEvent(Analytics.Events.DUIAction, new Dictionary<string, object>() { { "name", "Mappings Applied" } });
+      Analytics.TrackEvent(
+        Analytics.Events.DUIAction,
+        new Dictionary<string, object>() { { "name", "Mappings Applied" } }
+      );
     }
 
     /// <summary>
     /// Update the custom type mapping that the user has saved
     /// </summary>
     /// <returns>A bool indicating whether there are new incoming types or not</returns>
-    private bool UpdateExistingMapping(Dictionary<string, List<MappingValue>> settingsMapping, Dictionary<string, List<string>> hostTypesDict, Dictionary<string, List<string>> incomingTypesDict, ProgressViewModel progress)
+    private bool UpdateExistingMapping(
+      Dictionary<string, List<MappingValue>> settingsMapping,
+      Dictionary<string, List<string>> hostTypesDict,
+      Dictionary<string, List<string>> incomingTypesDict,
+      ProgressViewModel progress
+    )
     {
       // no existing mappings exist
       if (settingsMapping == null)
@@ -578,7 +607,6 @@ namespace Speckle.ConnectorRevit.UI
       return newTypesExist;
     }
 
-
     /// <summary>
     /// Imports family symbols into Revit
     /// </summary>
@@ -586,7 +614,9 @@ namespace Speckle.ConnectorRevit.UI
     /// <returns>
     /// New mapping value with newly imported types added (if applicable)
     /// </returns>
-    public override async Task<Dictionary<string, List<MappingValue>>> ImportFamilyCommand(Dictionary<string, List<MappingValue>> Mapping)
+    public override async Task<Dictionary<string, List<MappingValue>>> ImportFamilyCommand(
+      Dictionary<string, List<MappingValue>> Mapping
+    )
     {
       return Mapping;
     }
@@ -598,7 +628,9 @@ namespace Speckle.ConnectorRevit.UI
     /// <returns>
     /// New host types dictionary with newly imported types added (if applicable)
     /// </returns>
-    public async Task<Dictionary<string, List<string>>> ImportFamilyTypes(Dictionary<string, List<string>> hostTypesDict)
+    public async Task<Dictionary<string, List<string>>> ImportFamilyTypes(
+      Dictionary<string, List<string>> hostTypesDict
+    )
     {
       var windowsDialog = new OpenFileDialog();
       windowsDialog.Title = "Choose Revit Families";
@@ -650,7 +682,10 @@ namespace Speckle.ConnectorRevit.UI
               var families = new FilteredElementCollector(CurrentDoc.Document).OfClass(typeof(Family));
               var list = families.ToElements().Cast<Family>().ToList();
 
-              match = list.FirstOrDefault(x => x.Name == familyName && filter.categories.Contains((BuiltInCategory)x.FamilyCategory?.Id.IntegerValue));
+              match = list.FirstOrDefault(
+                x =>
+                  x.Name == familyName && filter.categories.Contains((BuiltInCategory)x.FamilyCategory?.Id.IntegerValue)
+              );
               if (match != null)
                 break;
             }
@@ -695,26 +730,21 @@ namespace Speckle.ConnectorRevit.UI
             }
           }
         }
-        catch (Exception e)
-        { }
+        catch (Exception e) { }
 
         // delete the newly created xml file
         try
         {
           System.IO.File.Delete(path + ".xml");
         }
-        catch (Exception ex)
-        { }
+        catch (Exception ex) { }
       }
 
       //close current dialog body
       MainViewModel.CloseDialog();
 
       var vm = new ImportFamiliesDialogViewModel(allSymbols);
-      var importFamilies = new ImportFamiliesDialog
-      {
-        DataContext = vm
-      };
+      var importFamilies = new ImportFamiliesDialog { DataContext = vm };
 
       await importFamilies.ShowDialog<object>();
 
@@ -734,7 +764,10 @@ namespace Speckle.ConnectorRevit.UI
 
           foreach (var symbol in vm.selectedFamilySymbols)
           {
-            bool successfullyImported = CurrentDoc.Document.LoadFamilySymbol(familyInfo[symbol.FamilyName].Path, symbol.Name);
+            bool successfullyImported = CurrentDoc.Document.LoadFamilySymbol(
+              familyInfo[symbol.FamilyName].Path,
+              symbol.Name
+            );
             if (successfullyImported)
             {
               symbolLoaded = true;
@@ -746,19 +779,20 @@ namespace Speckle.ConnectorRevit.UI
           if (symbolLoaded)
           {
             t.Commit();
-            Analytics.TrackEvent(Analytics.Events.DUIAction, new Dictionary<string, object>() {
-              { "name", "Mappings Import Families" },
-              { "count", vm.selectedFamilySymbols.Count }});
+            Analytics.TrackEvent(
+              Analytics.Events.DUIAction,
+              new Dictionary<string, object>()
+              {
+                { "name", "Mappings Import Families" },
+                { "count", vm.selectedFamilySymbols.Count }
+              }
+            );
           }
-
           else
             t.RollBack();
           return hostTypesDict;
         }
       });
-
-
-
 
       //close current dialog body
       MainViewModel.CloseDialog();
@@ -770,6 +804,7 @@ namespace Speckle.ConnectorRevit.UI
     {
       public string Path { get; set; }
       public string Category { get; set; }
+
       public FamilyInfo(string path, string category)
       {
         Path = path;

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -1333,7 +1333,7 @@ public class ConnectorBindingsRhino : ConnectorBindings
   /// <param name="dict"></param>
   private void ParseDictionaryToArchivable(ArchivableDictionary target, Base @base)
   {
-    foreach (var prop in @base.GetMemberNames())
+    foreach (var prop in @base.GetMembers().Keys)
     {
       var obj = @base[prop];
       switch (obj)

--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -153,7 +153,7 @@ public class Base : DynamicBase
       }
     }
 
-    var dynamicProps = @base.GetDynamicMembers();
+    var dynamicProps = @base.GetMembers(DynamicBaseMemberType.Dynamic).Keys;
     foreach (var propName in dynamicProps)
     {
       if (!propName.StartsWith("@"))

--- a/Core/Core/Models/DynamicBase.cs
+++ b/Core/Core/Models/DynamicBase.cs
@@ -162,7 +162,7 @@ public class DynamicBase : DynamicObject, IDynamicMetaObjectProvider
   /// <summary>
   /// Gets all of the property names on this class, dynamic or not.
   /// </summary> <returns></returns>
-  [Obsolete("Use `GetMembers(DynamicBaseMemberType.All).Keys` instead")]
+  [Obsolete("Use `GetMembers(DynamicBaseMemberType.All).Keys` instead", true)]
   public override IEnumerable<string> GetDynamicMemberNames()
   {
     PopulatePropInfoCache(GetType());
@@ -181,7 +181,7 @@ public class DynamicBase : DynamicObject, IDynamicMetaObjectProvider
   /// Gets the names of the defined class properties (typed).
   /// </summary>
   /// <returns></returns>
-  [Obsolete("Use GetMembers(DynamicBaseMemberType.InstanceAll).Keys instead")]
+  [Obsolete("Use GetMembers(DynamicBaseMemberType.InstanceAll).Keys instead", true)]
   public IEnumerable<string> GetInstanceMembersNames()
   {
     return GetInstanceMembersNames(GetType());
@@ -226,7 +226,7 @@ public class DynamicBase : DynamicObject, IDynamicMetaObjectProvider
   /// Gets the names of the typed and dynamic properties that don't have a [SchemaIgnore] attribute.
   /// </summary>
   /// <returns></returns>
-  [Obsolete("Use GetMembers().Keys instead")]
+  [Obsolete("Use GetMembers().Keys instead", true)]
   public IEnumerable<string> GetMemberNames()
   {
     return GetMembers().Keys;
@@ -293,7 +293,7 @@ public class DynamicBase : DynamicObject, IDynamicMetaObjectProvider
   /// Gets the dynamically added property names only.
   /// </summary>
   /// <returns></returns>
-  [Obsolete("Use GetMembers(DynamicBaseMemberType.Dynamic).Keys instead")]
+  [Obsolete("Use GetMembers(DynamicBaseMemberType.Dynamic).Keys instead", true)]
   public IEnumerable<string> GetDynamicMembers()
   {
     return properties.Keys;

--- a/Core/Core/Models/GraphTraversal/DefaultTraversal.cs
+++ b/Core/Core/Models/GraphTraversal/DefaultTraversal.cs
@@ -23,7 +23,9 @@ public static class DefaultTraversal
       .When(HasDisplayValue)
       .ContinueTraversing(b =>
       {
-        var membersToTraverse = b.GetDynamicMembers().Concat(elementsAliases).Except(ignoreProps);
+        var membersToTraverse = b.GetMembers(DynamicBaseMemberType.Dynamic)
+          .Keys.Concat(elementsAliases)
+          .Except(ignoreProps);
         return membersToTraverse;
       });
 
@@ -56,8 +58,8 @@ public static class DefaultTraversal
       .When(HasDisplayValue)
       .ContinueTraversing(b =>
       {
-        var membersToTraverse = b.GetDynamicMembers()
-          .Concat(elementsAliases)
+        var membersToTraverse = b.GetMembers(DynamicBaseMemberType.Dynamic)
+          .Keys.Concat(elementsAliases)
           .Except(ignoreProps)
           .Concat(displayValueAliases);
         return membersToTraverse;
@@ -129,7 +131,7 @@ public static class DefaultTraversal
 
   internal static SelectMembers DynamicMembers()
   {
-    return x => x.GetDynamicMembers();
+    return x => x.GetMembers(DynamicBaseMemberType.Dynamic).Keys;
   }
 
   internal static SelectMembers Concat(params SelectMembers[] selectProps)

--- a/Core/Core/Models/Utilities.cs
+++ b/Core/Core/Models/Utilities.cs
@@ -166,7 +166,7 @@ public static class Utilities
   /// <param name="props">The base class object representing application props</param>
   public static void SetApplicationProps(object o, Type t, Base props)
   {
-    var propNames = props.GetDynamicMembers();
+    var propNames = props.GetMembers(DynamicBaseMemberType.Dynamic).Keys;
     IEnumerable<string> names = propNames.ToList();
     if (o == null || names.Any())
       return;

--- a/Core/Core/Serialisation/BaseObjectSerializerV2.cs
+++ b/Core/Core/Serialisation/BaseObjectSerializerV2.cs
@@ -177,7 +177,7 @@ public class BaseObjectSerializerV2
       ParentClosures.Add(closure);
 
     List<(PropertyInfo, PropertyAttributeInfo)> typedProperties = GetTypedPropertiesWithCache(baseObj);
-    IEnumerable<string> dynamicProperties = baseObj.GetDynamicMembers();
+    IEnumerable<string> dynamicProperties = baseObj.GetMembers(DynamicBaseMemberType.Dynamic).Keys;
 
     // propertyName -> (originalValue, isDetachable, isChunkable, chunkSize)
     Dictionary<string, (object, PropertyAttributeInfo)> allProperties = new();

--- a/Core/Tests/BaseTests.cs
+++ b/Core/Tests/BaseTests.cs
@@ -105,7 +105,7 @@ public class BaseTests
     var @base = new SampleObject();
     var dynamicProp = "dynamicProp";
     @base[dynamicProp] = 123;
-    var names = @base.GetMemberNames();
+    var names = @base.GetMembers().Keys;
     Assert.That(names, Has.No.Member(nameof(@base.IgnoredSchemaProp)));
     Assert.That(names, Has.No.Member(nameof(@base.ObsoleteSchemaProp)));
     Assert.That(names, Has.Member(dynamicProp));

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -68,16 +68,14 @@ namespace Objects.Converter.Revit
         var elementId = element.Id;
         if (!hostedElementIds.Contains(elementId))
         {
-          extraProps["speckleHost"] = new Base()
-          {
-            applicationId = host.UniqueId,
-            ["category"] = host.Category.Name,
-          };
+          extraProps["speckleHost"] = new Base() { applicationId = host.UniqueId, ["category"] = host.Category.Name, };
         }
-        else return false;
+        else
+          return false;
       }
       return true;
     }
+
     /// <summary>
     /// Gets the hosted element of a host and adds the to a Base object
     /// </summary>
@@ -98,7 +96,12 @@ namespace Objects.Converter.Revit
       GetHostedElementsFromIds(@base, host, hostedElementIds, out notes);
     }
 
-    public void GetHostedElementsFromIds(Base @base, Element host, IList<ElementId> hostedElementIds, out List<string> notes)
+    public void GetHostedElementsFromIds(
+      Base @base,
+      Element host,
+      IList<ElementId> hostedElementIds,
+      out List<string> notes
+    )
     {
       notes = new List<string>();
       var convertedHostedElements = new List<Base>();
@@ -111,7 +114,9 @@ namespace Objects.Converter.Revit
           continue;
         }
 
-        var reportObj = Report.ReportObjects.TryGetValue(element.UniqueId, out ApplicationObject value) ? value : new ApplicationObject(element.UniqueId, element.GetType().ToString());
+        var reportObj = Report.ReportObjects.TryGetValue(element.UniqueId, out ApplicationObject value)
+          ? value
+          : new ApplicationObject(element.UniqueId, element.GetType().ToString());
 
         if (CanConvertToSpeckle(element))
         {
@@ -121,7 +126,10 @@ namespace Objects.Converter.Revit
             if (obj != null)
             {
               ContextObjects.Remove(element.UniqueId);
-              reportObj.Update(status: ApplicationObject.State.Created, logItem: $"Attached as hosted element to {host.UniqueId}");
+              reportObj.Update(
+                status: ApplicationObject.State.Created,
+                logItem: $"Attached as hosted element to {host.UniqueId}"
+              );
               convertedHostedElements.Add(obj);
               ConvertedObjects.Add(obj.applicationId);
             }
@@ -156,6 +164,7 @@ namespace Objects.Converter.Revit
         }
       }
     }
+
     public IList<ElementId> GetHostedElementIds(Element host)
     {
       IList<ElementId> ids = null;
@@ -172,7 +181,9 @@ namespace Objects.Converter.Revit
             BuiltInCategory.OST_CLines,
             BuiltInCategory.OST_SketchLines,
             BuiltInCategory.OST_WeakDims
-          }, true);
+          },
+          true
+        );
         ids = host.GetDependentElements(new LogicalAndFilter(typeFilter, categoryFilter));
       }
 
@@ -184,12 +195,14 @@ namespace Objects.Converter.Revit
 
     public ApplicationObject SetHostedElements(Base @base, Element host, ApplicationObject appObj)
     {
-      if (@base == null) return appObj;
+      if (@base == null)
+        return appObj;
 
       //we used to use "elements" but have now switched to "@elements"
       //this extra check is for backwards compatibility
       var nestedElements = @base["elements"] ?? @base["@elements"];
-      if (nestedElements == null) return appObj;
+      if (nestedElements == null)
+        return appObj;
 
       CurrentHostElement = host;
       foreach (var obj in GraphTraversal.TraverseMember(nestedElements))
@@ -208,7 +221,9 @@ namespace Objects.Converter.Revit
         }
         catch (Exception e)
         {
-          appObj.Update(logItem: $"Failed to create hosted element {obj.speckle_type} in host ({host.Id}): \n{e.Message}");
+          appObj.Update(
+            logItem: $"Failed to create hosted element {obj.speckle_type} in host ({host.Id}): \n{e.Message}"
+          );
           continue;
         }
         CurrentHostElement = host; // set this again in case this is a deeply hosted element
@@ -228,19 +243,31 @@ namespace Objects.Converter.Revit
     /// <param name="speckleElement"></param>
     /// <param name="revitElement"></param>
     /// <param name="exclusions">List of BuiltInParameters or GUIDs used to indicate what parameters NOT to get,
-    /// we exclude all params already defined on the top level object to avoid duplication and 
+    /// we exclude all params already defined on the top level object to avoid duplication and
     /// potential conflicts when setting them back on the element</param>
     public void GetAllRevitParamsAndIds(Base speckleElement, DB.Element revitElement, List<string> exclusions = null)
     {
       var instParams = GetElementParams(revitElement, false, exclusions);
-      var typeParams = speckleElement is Level ? null : GetTypeParams(revitElement);  //ignore type props of levels..!
+      var typeParams = speckleElement is Level ? null : GetTypeParams(revitElement); //ignore type props of levels..!
       var allParams = new Dictionary<string, Parameter>();
 
       if (instParams != null)
-        instParams.ToList().ForEach(x => { if (!allParams.ContainsKey(x.Key)) allParams.Add(x.Key, x.Value); });
+        instParams
+          .ToList()
+          .ForEach(x =>
+          {
+            if (!allParams.ContainsKey(x.Key))
+              allParams.Add(x.Key, x.Value);
+          });
 
       if (typeParams != null)
-        typeParams.ToList().ForEach(x => { if (!allParams.ContainsKey(x.Key)) allParams.Add(x.Key, x.Value); });
+        typeParams
+          .ToList()
+          .ForEach(x =>
+          {
+            if (!allParams.ContainsKey(x.Key))
+              allParams.Add(x.Key, x.Value);
+          });
 
       //sort by key
       allParams = allParams.OrderBy(x => x.Key).ToDictionary(x => x.Key, x => x.Value);
@@ -258,7 +285,7 @@ namespace Objects.Converter.Revit
         }
       }
 
-      if (paramBase.GetDynamicMembers().Any())
+      if (paramBase.GetMembers(DynamicBaseMemberType.Dynamic).Keys.Any())
         speckleElement["parameters"] = paramBase;
       speckleElement["elementId"] = revitElement.Id.ToString();
       speckleElement.applicationId = revitElement.UniqueId;
@@ -293,7 +320,7 @@ namespace Objects.Converter.Revit
         speckleElement["materialQuantities"] = qs;
     }
 
-    //private List<string> alltimeExclusions = new List<string> { 
+    //private List<string> alltimeExclusions = new List<string> {
     //  "ELEM_CATEGORY_PARAM" };
     private Dictionary<string, Parameter> GetTypeParams(DB.Element element)
     {
@@ -304,24 +331,31 @@ namespace Objects.Converter.Revit
         return new Dictionary<string, Parameter>();
       }
       return GetElementParams(elementType, true);
-
     }
 
-    private Dictionary<string, Parameter> GetElementParams(DB.Element element, bool isTypeParameter = false, List<string> exclusions = null)
+    private Dictionary<string, Parameter> GetElementParams(
+      DB.Element element,
+      bool isTypeParameter = false,
+      List<string> exclusions = null
+    )
     {
       exclusions = (exclusions != null) ? exclusions : new List<string>();
 
       //exclude parameters that don't have a value and those pointing to other elements as we don't support them
-      var revitParameters = element.Parameters.Cast<DB.Parameter>()
-        .Where(x => x.HasValue
-          && x.StorageType != StorageType.ElementId
-          && !exclusions.Contains(GetParamInternalName(x))).ToList();
+      var revitParameters = element.Parameters
+        .Cast<DB.Parameter>()
+        .Where(
+          x => x.HasValue && x.StorageType != StorageType.ElementId && !exclusions.Contains(GetParamInternalName(x))
+        )
+        .ToList();
 
       //exclude parameters that failed to convert
-      var speckleParameters = revitParameters.Select(x => ParameterToSpeckle(x, isTypeParameter))
-        .Where(x => x != null);
+      var speckleParameters = revitParameters.Select(x => ParameterToSpeckle(x, isTypeParameter)).Where(x => x != null);
 
-      return speckleParameters.GroupBy(x => x.applicationInternalName).Select(x => x.First()).ToDictionary(x => x.applicationInternalName, x => x);
+      return speckleParameters
+        .GroupBy(x => x.applicationInternalName)
+        .Select(x => x.First())
+        .ToDictionary(x => x.applicationInternalName, x => x);
     }
 
     /// <summary>
@@ -354,7 +388,11 @@ namespace Objects.Converter.Revit
     /// <param name="unitsOverride">The units in which to return the value in the case where you want to override the Built-In <see cref="DB.Parameter"/>'s units</param>
     /// <returns></returns>
     /// <remarks>The <see cref="rp"/> must have a value (<see cref="DB.Parameter.HasValue"/></remarks>
-    private static Parameter ParameterToSpeckle(DB.Parameter rp, bool isTypeParameter = false, string unitsOverride = null)
+    private static Parameter ParameterToSpeckle(
+      DB.Parameter rp,
+      bool isTypeParameter = false,
+      string unitsOverride = null
+    )
     {
       var sp = new Parameter
       {
@@ -374,7 +412,10 @@ namespace Objects.Converter.Revit
           try
           {
             sp.applicationUnit = rp.GetDisplayUnityTypeString(); //eg DUT_MILLIMITERS, this can throw!
-            sp.value = unitsOverride == null ? RevitVersionHelper.ConvertFromInternalUnits(val, rp) : ScaleToSpeckle(val, unitsOverride);
+            sp.value =
+              unitsOverride == null
+                ? RevitVersionHelper.ConvertFromInternalUnits(val, rp)
+                : ScaleToSpeckle(val, unitsOverride);
           }
           catch
           {
@@ -438,16 +479,22 @@ namespace Objects.Converter.Revit
         TrySetParam(revitElement, BuiltInParameter.PHASE_CREATED, GetRevitPhase(revitElement.Document, phaseCreated));
       //Set the phaseDemolished parameter
       if (speckleElement["phaseDemolished"] is string phaseDemolished && !string.IsNullOrEmpty(phaseDemolished))
-        TrySetParam(revitElement, BuiltInParameter.PHASE_DEMOLISHED, GetRevitPhase(revitElement.Document, phaseDemolished));
+        TrySetParam(
+          revitElement,
+          BuiltInParameter.PHASE_DEMOLISHED,
+          GetRevitPhase(revitElement.Document, phaseDemolished)
+        );
 
-      // NOTE: we are using the ParametersMap here and not Parameters, as it's a much smaller list of stuff and 
+      // NOTE: we are using the ParametersMap here and not Parameters, as it's a much smaller list of stuff and
       // Parameters most likely contains extra (garbage) stuff that we don't need to set anyways
       // so it's a much faster conversion. If we find that's not the case, we might need to change it in the future
       IEnumerable<DB.Parameter> revitParameters = null;
       if (exclusions == null)
         revitParameters = revitElement.ParametersMap.Cast<DB.Parameter>().Where(x => x != null && !x.IsReadOnly);
       else
-        revitParameters = revitElement.ParametersMap.Cast<DB.Parameter>().Where(x => x != null && !x.IsReadOnly && !exclusions.Contains(GetParamInternalName(x)));
+        revitParameters = revitElement.ParametersMap
+          .Cast<DB.Parameter>()
+          .Where(x => x != null && !x.IsReadOnly && !exclusions.Contains(GetParamInternalName(x)));
 
       // Here we are creating two  dictionaries for faster lookup
       // one uses the BuiltInName / GUID the other the name as Key
@@ -460,7 +507,8 @@ namespace Objects.Converter.Revit
       // its member names will have for Key either a BuiltInName, GUID or Name of the parameter (depending onwhere it comes from)
       // and as value the full Parameter object, that might come from Revit or SchemaBuilder
       // We only loop params we can set and that actually exist on the revit element
-      var filteredSpeckleParameters = speckleParameters.GetMembers()
+      var filteredSpeckleParameters = speckleParameters
+        .GetMembers()
         .Where(x => revitParameterById.ContainsKey(x.Key) || revitParameterByName.ContainsKey(x.Key));
 
       foreach (var spk in filteredSpeckleParameters)
@@ -490,7 +538,7 @@ namespace Objects.Converter.Revit
             }
             // the following two cases are for parameters comimg form schema builder
             // they do not have applicationUnit but just units
-            // units are automatically set but the user can override them 
+            // units are automatically set but the user can override them
             // users might set them to "none" so that we convert them by using the Revit destination parameter display units
             // this is needed to correctly receive non lenght based parameters (eg air flow)
             else if (units == Speckle.Core.Kits.Units.None)
@@ -584,7 +632,6 @@ namespace Objects.Converter.Revit
       if (param != null && !param.IsReadOnly)
       {
         param.Set(value ? 1 : 0);
-
       }
     }
 
@@ -640,12 +687,10 @@ namespace Objects.Converter.Revit
       return null;
     }
 
-
-
     #endregion
 
     #region  element types
-    
+
     private T GetElementType<T>(Base element, ApplicationObject appObj, out bool isExactMatch)
     {
       isExactMatch = false;
@@ -658,7 +703,10 @@ namespace Objects.Converter.Revit
         if (element["category"] is string category && !string.IsNullOrWhiteSpace(category))
           name = category;
 
-        appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not find any loaded family to use for category {name}.");
+        appObj.Update(
+          status: ApplicationObject.State.Failed,
+          logItem: $"Could not find any loaded family to use for category {name}."
+        );
 
         return default;
       }
@@ -669,7 +717,14 @@ namespace Objects.Converter.Revit
       return GetElementType<T>(element, family, type, types, appObj, out isExactMatch);
     }
 
-    private T GetElementType<T>(Base element, string family, string type, List<ElementType> types, ApplicationObject appObj, out bool isExactMatch)
+    private T GetElementType<T>(
+      Base element,
+      string family,
+      string type,
+      List<ElementType> types,
+      ApplicationObject appObj,
+      out bool isExactMatch
+    )
     {
       isExactMatch = false;
       ElementType match = null;
@@ -716,7 +771,9 @@ namespace Objects.Converter.Revit
       }
 
       if (!isExactMatch)
-        appObj.Update(logItem: $"Missing type. Family: {family} Type: {type}\nType was replaced with: {match.FamilyName}, {match.Name}");
+        appObj.Update(
+          logItem: $"Missing type. Family: {family} Type: {type}\nType was replaced with: {match.FamilyName}, {match.Name}"
+        );
 
       if (match is FamilySymbol fs && !fs.IsActive)
         fs.Activate();
@@ -742,7 +799,8 @@ namespace Objects.Converter.Revit
             return new ElementMulticategoryFilter(Categories.columnCategories);
           else if (o.type == OSG.ElementType1D.Beam || o.type == OSG.ElementType1D.Brace)
             return new ElementMulticategoryFilter(Categories.beamCategories);
-          else return null;
+          else
+            return null;
         case OSG.Element2D _:
         case Floor _:
           return new ElementMulticategoryFilter(Categories.floorCategories);
@@ -753,7 +811,9 @@ namespace Objects.Converter.Revit
         default:
           if (element["category"] != null)
           {
-            var cat = Doc.Settings.Categories.Cast<Category>().FirstOrDefault(x => x.Name == element["category"].ToString());
+            var cat = Doc.Settings.Categories
+              .Cast<Category>()
+              .FirstOrDefault(x => x.Name == element["category"].ToString());
             if (cat != null)
             {
               return new ElementCategoryFilter(cat.Id);
@@ -768,7 +828,13 @@ namespace Objects.Converter.Revit
       using var collector = new FilteredElementCollector(Doc);
       if (filter != null)
       {
-        return collector.WhereElementIsElementType().OfClass(typeof(T)).WherePasses(filter).ToElements().Cast<ElementType>().ToList();
+        return collector
+          .WhereElementIsElementType()
+          .OfClass(typeof(T))
+          .WherePasses(filter)
+          .ToElements()
+          .Cast<ElementType>()
+          .ToList();
       }
       return collector.WhereElementIsElementType().OfClass(typeof(T)).ToElements().Cast<ElementType>().ToList();
     }
@@ -792,7 +858,7 @@ namespace Objects.Converter.Revit
 
     /// <summary>
     /// Returns, if found, the corresponding doc element.
-    /// The doc object can be null if the user deleted it. 
+    /// The doc object can be null if the user deleted it.
     /// </summary>
     /// <param name="applicationId">Id of the application that originally created the element, in Revit it's the UniqueId</param>
     /// <returns>The element, if found, otherwise null</returns>
@@ -812,7 +878,7 @@ namespace Objects.Converter.Revit
         yield break;
 
       var cachedIds = PreviouslyReceivedObjectIds.GetCreatedIdsFromConvertedId(applicationId);
-      foreach ( var id in cachedIds)
+      foreach (var id in cachedIds)
       {
         yield return Doc.GetElement(id);
       }
@@ -831,12 +897,22 @@ namespace Objects.Converter.Revit
       {
         if (ReceiveMode == ReceiveMode.Ignore)
         {
-          appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: $"ApplicationId already exists in document, new object ignored.");
+          appObj.Update(
+            status: ApplicationObject.State.Skipped,
+            createdId: docObj.UniqueId,
+            convertedItem: docObj,
+            logItem: $"ApplicationId already exists in document, new object ignored."
+          );
           return true;
         }
         else if (docObj.Pinned)
         {
-          appObj.Update(status: ApplicationObject.State.Skipped, createdId: docObj.UniqueId, convertedItem: docObj, logItem: "Element is pinned and cannot be updated");
+          appObj.Update(
+            status: ApplicationObject.State.Skipped,
+            createdId: docObj.UniqueId,
+            convertedItem: docObj,
+            logItem: "Element is pinned and cannot be updated"
+          );
           return true;
         }
       }
@@ -858,13 +934,18 @@ namespace Objects.Converter.Revit
       get
       {
         if (_revitLinkInstances == null)
-          _revitLinkInstances = new FilteredElementCollector(Doc).OfClass(typeof(RevitLinkInstance)).ToElements().Cast<RevitLinkInstance>().ToList();
+          _revitLinkInstances = new FilteredElementCollector(Doc)
+            .OfClass(typeof(RevitLinkInstance))
+            .ToElements()
+            .Cast<RevitLinkInstance>()
+            .ToList();
 
         return _revitLinkInstances;
       }
     }
 
     private Dictionary<string, DB.Transform> _docTransforms = new Dictionary<string, DB.Transform>();
+
     private DB.Transform GetDocReferencePointTransform(Document doc)
     {
       //linked files are always saved to disc and will have a path name
@@ -874,7 +955,9 @@ namespace Objects.Converter.Revit
       if (!_docTransforms.ContainsKey(id))
       {
         // get from settings
-        var referencePointSetting = Settings.ContainsKey("reference-point") ? Settings["reference-point"] : string.Empty;
+        var referencePointSetting = Settings.ContainsKey("reference-point")
+          ? Settings["reference-point"]
+          : string.Empty;
         _docTransforms[id] = GetReferencePointTransform(referencePointSetting, doc);
       }
 
@@ -904,7 +987,9 @@ namespace Objects.Converter.Revit
           // note that the project base (ui) rotation is registered on the survey pt, not on the base point
           // retrieve the survey point rotation from the project point
           var angle = projectPoint.get_Parameter(BuiltInParameter.BASEPOINT_ANGLETON_PARAM)?.AsDouble() ?? 0;
-          referencePointTransform = DB.Transform.CreateTranslation(surveyPoint.Position).Multiply(DB.Transform.CreateRotation(XYZ.BasisZ, angle));
+          referencePointTransform = DB.Transform
+            .CreateTranslation(surveyPoint.Position)
+            .Multiply(DB.Transform.CreateRotation(XYZ.BasisZ, angle));
           break;
         case InternalOrigin:
           break;
@@ -968,7 +1053,9 @@ namespace Objects.Converter.Revit
         openings.AddRange(elements.Where(x => x is RevitVerticalOpening).Cast<RevitVerticalOpening>());
 
       //list of shafts part of this conversion set
-      var shafts = ContextObjects.Values.SelectMany(x => x.Converted.Where(y => y is RevitShaft).Cast<RevitShaft>()).ToList();
+      var shafts = ContextObjects.Values
+        .SelectMany(x => x.Converted.Where(y => y is RevitShaft).Cast<RevitShaft>())
+        .ToList();
 
       openings.AddRange(shafts);
 
@@ -1016,7 +1103,6 @@ namespace Objects.Converter.Revit
           var result = cA.Intersect(cB);
           if (result != SetComparisonResult.BothEmpty && result != SetComparisonResult.Disjoint)
             return true;
-
         }
       }
 
@@ -1029,7 +1115,12 @@ namespace Objects.Converter.Revit
 
     public string GetTemplatePath(string templateName)
     {
-      var directoryPath = Path.Combine(SpecklePathProvider.ObjectsFolderPath, "Templates", "Revit", RevitVersionHelper.Version);
+      var directoryPath = Path.Combine(
+        SpecklePathProvider.ObjectsFolderPath,
+        "Templates",
+        "Revit",
+        RevitVersionHelper.Version
+      );
       string templatePath = "";
       switch (Doc.DisplayUnitSystem)
       {
@@ -1092,7 +1183,7 @@ namespace Objects.Converter.Revit
 
       if (matId == null)
       {
-        // TODO: Fallback to display color or something? 
+        // TODO: Fallback to display color or something?
         return null;
       }
 
@@ -1110,7 +1201,9 @@ namespace Objects.Converter.Revit
         opacity = 1 - (revitMaterial.Transparency / 100d),
         //metalness = revitMaterial.Shininess / 128d, //Looks like these are not valid conversions
         //roughness = 1 - (revitMaterial.Smoothness / 100d),
-        diffuse = System.Drawing.Color.FromArgb(revitMaterial.Color.Red, revitMaterial.Color.Green, revitMaterial.Color.Blue).ToArgb()
+        diffuse = System.Drawing.Color
+          .FromArgb(revitMaterial.Color.Red, revitMaterial.Color.Green, revitMaterial.Color.Blue)
+          .ToArgb()
       };
 
       return material;
@@ -1118,7 +1211,8 @@ namespace Objects.Converter.Revit
 
     public ElementId RenderMaterialToNative(RenderMaterial speckleMaterial)
     {
-      if (speckleMaterial == null) return ElementId.InvalidElementId;
+      if (speckleMaterial == null)
+        return ElementId.InvalidElementId;
 
       string matName = RemoveProhibitedCharacters(speckleMaterial.name);
 
@@ -1128,7 +1222,8 @@ namespace Objects.Converter.Revit
         .Cast<DB.Material>()
         .FirstOrDefault(m => string.Equals(m.Name, matName, StringComparison.CurrentCultureIgnoreCase));
 
-      if (existing != null) return existing.Id;
+      if (existing != null)
+        return existing.Id;
 
       // Create new material
       ElementId materialId = DB.Material.Create(Doc, matName ?? Guid.NewGuid().ToString());
@@ -1177,7 +1272,8 @@ namespace Objects.Converter.Revit
         }
       }
 
-      if (idType == ElementId.InvalidElementId) return null;
+      if (idType == ElementId.InvalidElementId)
+        return null;
 
       if (e.Document.GetElement(idType) is MEPSystemType mechType)
       {
@@ -1235,7 +1331,9 @@ namespace Objects.Converter.Revit
     {
       if (IsLineTooShort(line))
       {
-        appObj.Log.Add("Some lines in the CurveArray where ignored due to being smaller than the allowed curve length.");
+        appObj.Log.Add(
+          "Some lines in the CurveArray where ignored due to being smaller than the allowed curve length."
+        );
         return false;
       }
       try
@@ -1251,11 +1349,12 @@ namespace Objects.Converter.Revit
     }
 
     public bool UnboundCurveIfSingle(DB.CurveArray array)
-
     {
-      if (array.Size != 1) return false;
+      if (array.Size != 1)
+        return false;
       var item = array.get_Item(0);
-      if (!item.IsBound) return false;
+      if (!item.IsBound)
+        return false;
       item.MakeUnbound();
       return true;
     }
@@ -1288,13 +1387,11 @@ namespace Objects.Converter.Revit
 
     public class FallbackToDxfException : Exception
     {
-      public FallbackToDxfException(string message) : base(message)
-      {
-      }
+      public FallbackToDxfException(string message)
+        : base(message) { }
 
-      public FallbackToDxfException(string message, Exception innerException) : base(message, innerException)
-      {
-      }
+      public FallbackToDxfException(string message, Exception innerException)
+        : base(message, innerException) { }
     }
 
     public ApplicationObject CheckForExistingObject(Base @base)
@@ -1308,7 +1405,7 @@ namespace Objects.Converter.Revit
       if (IsIgnore(docObj, appObj))
         return appObj;
 
-      // otherwise just create new one 
+      // otherwise just create new one
       if (docObj != null)
         Doc.Delete(docObj.Id);
 
@@ -1339,7 +1436,8 @@ namespace Objects.Converter.Revit
 
       foreach (var elementId in elementIds)
       {
-        if (element.Document.GetElement(elementId) is not ModelLine line) continue;
+        if (element.Document.GetElement(elementId) is not ModelLine line)
+          continue;
 
         var offsetAtTailParameter = line.get_Parameter(BuiltInParameter.SLOPE_START_HEIGHT);
         if (offsetAtTailParameter != null)
@@ -1349,21 +1447,32 @@ namespace Objects.Converter.Revit
       }
       return null;
     }
+
     private Point GetSlopeArrowHead(ModelLine slopeArrow, Document doc)
     {
-      if (slopeArrow == null) return null;
+      if (slopeArrow == null)
+        return null;
       return PointToSpeckle(((LocationCurve)slopeArrow.Location).Curve.GetEndPoint(1), doc);
     }
+
     private Point GetSlopeArrowTail(ModelLine slopeArrow, Document doc)
     {
-      if (slopeArrow == null) return null;
+      if (slopeArrow == null)
+        return null;
       return PointToSpeckle(((LocationCurve)slopeArrow.Location).Curve.GetEndPoint(0), doc);
     }
+
     public static double GetSlopeArrowTailOffset(ModelLine slopeArrow, Document doc)
     {
       return GetParamValue<double>(slopeArrow, BuiltInParameter.SLOPE_START_HEIGHT);
     }
-    public static double GetSlopeArrowHeadOffset(ModelLine slopeArrow, Document doc, double tailOffset, out double slope)
+
+    public static double GetSlopeArrowHeadOffset(
+      ModelLine slopeArrow,
+      Document doc,
+      double tailOffset,
+      out double slope
+    )
     {
       var specifyOffset = GetParamValue<int>(slopeArrow, BuiltInParameter.SPECIFY_SLOPE_OR_OFFSET);
       var lineLength = GetParamValue<double>(slopeArrow, BuiltInParameter.CURVE_ELEM_LENGTH);


### PR DESCRIPTION
Partially fixes #1033 (the final task for this would be to remove them altogether).
Fixes #1837 

Forces all obsolete methods in `DynamicBase` to throw a compiler error.

Updates all existing calls to depend on `GetMembers()` calls instead as expected.

**Should be reviewed by all main speckle-sharp connector owners before merging**