### PR TITLE
fix(core): remove deprecated user queries in account management

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/Core/Tests/bin/Debug/net6.0/TestsUnit.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Core/Tests",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/Core/.vscode/launch.json
+++ b/Core/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Examples",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/Examples/bin/Debug/net6.0/ExampleApp.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Examples",
+      "stopAtEntry": false,
+      "console": "internalConsole",
+      "justMyCode": false
+    },
+    
+    {
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/IntegrationTests/bin/Debug/netcoreapp3.1/TestsIntegration.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/IntegrationTests",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/Core/.vscode/settings.json
+++ b/Core/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main"
+  ],
+  "editor.formatOnType": true,
+  "[csharp]": {
+    "editor.maxTokenizationLineLength": 2500,
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true
+  },
+  "cSpell.words": [
+    "serilog"
+  ],
+  "dotnet-test-explorer.testProjectPath": "**/Test*.@(csproj|vbproj|fsproj)"
+  
+}

--- a/Core/.vscode/tasks.json
+++ b/Core/.vscode/tasks.json
@@ -1,0 +1,77 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/IntegrationTests/TestsIntegration.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/IntegrationTests/TestsIntegration.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/IntegrationTests/TestsIntegration.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Examples/ExampleApp.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/Examples/ExampleApp.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/Examples/ExampleApp.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -81,7 +81,7 @@ public class Account : IEquatable<Account>
       httpClient
     );
 
-    var request = new GraphQLRequest { Query = @" query { user { name email id company } }" };
+    var request = new GraphQLRequest { Query = @" query { activeUser { name email id company } }" };
 
     var response = await gqlClient.SendQueryAsync<UserInfoResponse>(request).ConfigureAwait(false);
 

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -75,7 +75,7 @@ public static class AccountManager
       httpClient
     );
 
-    var request = new GraphQLRequest { Query = @" query { user { name email id company } }" };
+    var request = new GraphQLRequest { Query = @" query { activeUser { name email id company } }" };
 
     var response = await gqlClient.SendQueryAsync<UserInfoResponse>(request).ConfigureAwait(false);
 

--- a/Core/IntegrationTests/.vscode/launch.json
+++ b/Core/IntegrationTests/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/TestsIntegration.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/Core/IntegrationTests/.vscode/tasks.json
+++ b/Core/IntegrationTests/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/TestsIntegration.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/TestsIntegration.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/TestsIntegration.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}


### PR DESCRIPTION
The fixed 2 gql queries were still using the old deprecated user query.

I'd like to push this out as a hotfix since its blocking the proper deprecation of the endpoint in the server.