### PR TITLE
hotfix(collections): Deprecated object models for backwards compatibility.

### DIFF
--- a/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
+++ b/Core/Core/Serialisation/BaseObjectSerialzerUtilities.cs
@@ -217,9 +217,23 @@ internal static class SerializationUtilities
       var type = KitManager.Types.FirstOrDefault(tp => tp.FullName == typeName);
       if (type != null)
         return type;
+
+      //To allow for backwards compatibility saving deserialization target types.
+      //We also check a ".Deprecated" prefixed namespace
+      string deprecatedTypeName = GetDeprecatedTypeName(typeName);
+
+      var deprecatedType = KitManager.Types.FirstOrDefault(tp => tp.FullName == deprecatedTypeName);
+      if (deprecatedType != null)
+        return deprecatedType;
     }
 
     return typeof(Base);
+  }
+
+  internal static string GetDeprecatedTypeName(string typeName, string deprecatedSubstring = "Deprecated.")
+  {
+    int lastDotIndex = typeName.LastIndexOf('.');
+    return typeName.Insert(lastDotIndex + 1, deprecatedSubstring);
   }
 
   internal static Dictionary<string, PropertyInfo> GetTypePropeties(string objFullType)

--- a/Core/Tests/ObjectModelDeprecationTests.cs
+++ b/Core/Tests/ObjectModelDeprecationTests.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using Speckle.Core.Models;
+using Speckle.Core.Serialisation.Deprecated;
+
+namespace Speckle.Core.Serialisation
+{
+  [TestFixture, TestOf(typeof(BaseObjectSerializer))]
+  public class ObjectModelDeprecationTests
+  {
+    [Test]
+    public void GetDeprecatedAtomicType()
+    {
+      string destinationType = $"Speckle.Core.Serialisation.{nameof(MySpeckleBase)}";
+
+      var result = SerializationUtilities.GetAtomicType(destinationType);
+      Assert.That(result, Is.EqualTo(typeof(MySpeckleBase)));
+    }
+
+    [Test]
+    [TestCase("Objects.Geometry.Mesh", "Objects.Geometry.Deprecated.Mesh")]
+    [TestCase("Objects.Mesh", "Objects.Deprecated.Mesh")]
+    public void GetDeprecatedTypeName(string input, string expected)
+    {
+      var actual = SerializationUtilities.GetDeprecatedTypeName(input);
+      Assert.That(actual, Is.EqualTo(expected));
+    }
+  }
+}
+
+namespace Speckle.Core.Serialisation.Deprecated
+{
+  public class MySpeckleBase : Base { }
+}

--- a/Objects/Objects/Organization/Deprecated/Collection.cs
+++ b/Objects/Objects/Organization/Deprecated/Collection.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Objects.Organization.Deprecated;
+
+[Obsolete("Replaced by " + nameof(Speckle.Core.Models.Collection))]
+public class Collection : Speckle.Core.Models.Collection
+{
+  //Deserializer target for 2.13 Collection objects in the `Objects.Orgainzation` namespace
+  
+  //Objects.Organization.Deprecated.Collection:Speckle.Core.Models.Collection
+}


### PR DESCRIPTION
To allow us to have backwards compatibility saving object models, as targets for deserialization, I have changed the way the deserialiser looks for types to also check for a ".Deprecated" namespace that otherwise matches an incoming speckle type.

This provides us a convenient way to change/move the namespace/type name of our object models, without having to change converters in anyway.

This was motivated by a change made by #2382 that breaks older commits from 2.13