### PR TITLE
fix(dui): fatal crash when the SavedStrems state collection had items…

### DIFF
--- a/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
@@ -517,6 +517,8 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
       SavedStreams[i].Dispose();
       SavedStreams.RemoveAt(i);
 
+      SavedStreams = SavedStreams.ToList();
+
       WriteStreamsToFile();
 
       this.RaisePropertyChanged(nameof(SavedStreams));


### PR DESCRIPTION
Fixes #2623 .

A fatal crash was happening when the `SavedStrems` state collection had items removed and scroll happened on their `ItemsRepeater`. The exception thrown had to do with the visual elements and their sizes, so seems to be a problem in Avalonia itself.

Refreshing the collection is fixing the issue.

Steps to repro the crash:
- open DUI
- add a saved stream
- remove the stream
- scroll down the list of streams

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/f89d934b-1e75-420f-a413-acc1cff54043)
![crash](https://github.com/specklesystems/speckle-sharp/assets/2679513/9b9f6eda-2c49-4463-a0f8-4dcf05fd7eb9)
