### PR TITLE
fix(gh): Adding root namespace to GH6 project fixes missing resource error.

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopper6/ConnectorGrasshopper6.csproj
+++ b/ConnectorGrasshopper/ConnectorGrasshopper6/ConnectorGrasshopper6.csproj
@@ -1,5 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <RootNamespace>ConnectorGrasshopper</RootNamespace>
     <AssemblyName>SpeckleConnectorGrasshopper</AssemblyName>
     <TargetFramework>net462</TargetFramework>
     <TargetExt>.gha</TargetExt>


### PR DESCRIPTION
Fixes #2628 

Adds `RootNamespace` to Grasshopper6 connector project, mirroring Grasshopper7

This seems to resolve the resources missing warning locally.