### PR TITLE
fix(csi): Add polygonmesher to copy to kit task

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIBridge/ConverterCSIBridge.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterCSIBridge/ConverterCSIBridge.csproj
@@ -1,37 +1,44 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <AssemblyName>Objects.Converter.CSIBridge</AssemblyName>
-        <RootNamespace>Objects.Converter.CSIBridge</RootNamespace>
-        <CopyToKitFolder>true</CopyToKitFolder>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Objects.Converter.CSIBridge</AssemblyName>
+    <RootNamespace>Objects.Converter.CSIBridge</RootNamespace>
+    <CopyToKitFolder>true</CopyToKitFolder>
+  </PropertyGroup>
 
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <DefineConstants>TRACE;CSIBRIDGE</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;CSIBRIDGE</DefineConstants>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <DefineConstants>TRACE;CSIBRIDGE</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;CSIBRIDGE</DefineConstants>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="CSiAPIv1" Version="1.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CSiAPIv1" Version="1.0.0"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
-        <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
-        <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj"/>
+    <ProjectReference Include="..\..\..\Objects\Objects.csproj"/>
+    <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Reference Include="CSiAPIv1">
-            <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
-                23\CSiAPIv1.dll</HintPath>
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="CSiAPIv1">
+      <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
+        23\CSiAPIv1.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 
-    <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared" />
+  <Target Name="CopyDependenciesToKitfolder" AfterTargets="CopyToKitFolder"
+    Condition="'$(IsDesktopBuild)' == true">
+    <Message Text="Copying dependencies to kit folder"/>
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))"
+      Command="xcopy /Y /S &quot;$(TargetDir)PolygonMesher.dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;"/>
+  </Target>
+
+  <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared"/>
 </Project>

--- a/Objects/Converters/ConverterCSI/ConverterETABS/ConverterETABS.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterETABS/ConverterETABS.csproj
@@ -1,36 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <AssemblyName>Objects.Converter.ETABS</AssemblyName>
-        <RootNamespace>Objects.Converter.ETABS</RootNamespace>
-        <CopyToKitFolder>true</CopyToKitFolder>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Objects.Converter.ETABS</AssemblyName>
+    <RootNamespace>Objects.Converter.ETABS</RootNamespace>
+    <CopyToKitFolder>true</CopyToKitFolder>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <DefineConstants>TRACE;ETABS</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;ETABS</DefineConstants>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <DefineConstants>TRACE;ETABS</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;ETABS</DefineConstants>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="CSiAPIv1" Version="1.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CSiAPIv1" Version="1.0.0"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
-        <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
-        <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj"/>
+    <ProjectReference Include="..\..\..\Objects\Objects.csproj"/>
+    <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Reference Include="CSiAPIv1">
-            <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
-                23\CSiAPIv1.dll</HintPath>
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="CSiAPIv1">
+      <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
+        23\CSiAPIv1.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 
-    <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared" />
+  <Target Name="CopyDependenciesToKitfolder" AfterTargets="CopyToKitFolder"
+    Condition="'$(IsDesktopBuild)' == true">
+    <Message Text="Copying dependencies to kit folder"/>
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))"
+      Command="xcopy /Y /S &quot;$(TargetDir)PolygonMesher.dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;"/>
+  </Target>
+
+  <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared"/>
 </Project>

--- a/Objects/Converters/ConverterCSI/ConverterSAFE/ConverterSAFE.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterSAFE/ConverterSAFE.csproj
@@ -1,36 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <AssemblyName>Objects.Converter.SAFE</AssemblyName>
-        <RootNamespace>Objects.Converter.SAFE</RootNamespace>
-        <CopyToKitFolder>true</CopyToKitFolder>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Objects.Converter.SAFE</AssemblyName>
+    <RootNamespace>Objects.Converter.SAFE</RootNamespace>
+    <CopyToKitFolder>true</CopyToKitFolder>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <DefineConstants>TRACE;SAFE</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;SAFE</DefineConstants>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <DefineConstants>TRACE;SAFE</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;SAFE</DefineConstants>
+  </PropertyGroup>
 
-    <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared" />
+  <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared"/>
 
-    <ItemGroup>
-        <PackageReference Include="CSiAPIv1" Version="1.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CSiAPIv1" Version="1.0.0"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
-        <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
-        <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj"/>
+    <ProjectReference Include="..\..\..\Objects\Objects.csproj"/>
+    <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Reference Include="CSiAPIv1">
-            <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
-                23\CSiAPIv1.dll</HintPath>
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="CSiAPIv1">
+      <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
+        23\CSiAPIv1.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="CopyDependenciesToKitfolder" AfterTargets="CopyToKitFolder"
+    Condition="'$(IsDesktopBuild)' == true">
+    <Message Text="Copying dependencies to kit folder"/>
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))"
+      Command="xcopy /Y /S &quot;$(TargetDir)PolygonMesher.dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;"/>
+  </Target>
 </Project>

--- a/Objects/Converters/ConverterCSI/ConverterSAP2000/ConverterSAP2000.csproj
+++ b/Objects/Converters/ConverterCSI/ConverterSAP2000/ConverterSAP2000.csproj
@@ -1,36 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <AssemblyName>Objects.Converter.SAP2000</AssemblyName>
-        <RootNamespace>Objects.Converter.SAP2000</RootNamespace>
-        <CopyToKitFolder>true</CopyToKitFolder>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Objects.Converter.SAP2000</AssemblyName>
+    <RootNamespace>Objects.Converter.SAP2000</RootNamespace>
+    <CopyToKitFolder>true</CopyToKitFolder>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <DefineConstants>TRACE;SAP2000</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;SAP2000</DefineConstants>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <DefineConstants>TRACE;SAP2000</DefineConstants>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;SAP2000</DefineConstants>
+  </PropertyGroup>
 
-    <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared" />
+  <Import Project="..\ConverterCSIShared\ConverterCSIShared.projitems" Label="Shared"/>
 
-    <ItemGroup>
-        <PackageReference Include="CSiAPIv1" Version="1.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CSiAPIv1" Version="1.0.0"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj" />
-        <ProjectReference Include="..\..\..\Objects\Objects.csproj" />
-        <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Core\Core\Core.csproj"/>
+    <ProjectReference Include="..\..\..\Objects\Objects.csproj"/>
+    <ProjectReference Include="..\..\StructuralUtilities\PolygonMesher\PolygonMesher.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Reference Include="CSiAPIv1">
-            <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
-                23\CSiAPIv1.dll</HintPath>
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="CSiAPIv1">
+      <HintPath>..\..\..\..\..\..\..\..\..\Program Files\Computers and Structures\SAP2000
+        23\CSiAPIv1.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="CopyDependenciesToKitfolder" AfterTargets="CopyToKitFolder"
+    Condition="'$(IsDesktopBuild)' == true">
+    <Message Text="Copying dependencies to kit folder"/>
+    <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))"
+      Command="xcopy /Y /S &quot;$(TargetDir)PolygonMesher.dll&quot; &quot;$(AppData)\Speckle\Kits\Objects\&quot;"/>
+  </Target>
 </Project>


### PR DESCRIPTION
We fixed an issue with `PolygonMesher` not being included in the Kit on our ci-tools repo.

This is the equivalent fix for Debug mode. All CSI converters will now copy the PolygonMesher dependency to the Objects kit folder.