### PR TITLE
fix(Navisworks): Division by zero errors on small models. Fixes #2665

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -154,7 +154,7 @@ public partial class ConnectorBindingsNavisworks
     var conversions = new Dictionary<Element, Tuple<Constants.ConversionState, Base>>();
 
     var totalObjects = modelItemsToConvert.Count;
-    var objectIncrement = 1 / (double)totalObjects;
+    var objectIncrement = 1 / Math.Max((double)totalObjects, 1);
     var objectInterval = Math.Max(totalObjects / 100, 1);
 
     for (int index = 0; index < modelItemsToConvert.Count; index++)
@@ -478,7 +478,7 @@ public partial class ConnectorBindingsNavisworks
       .ToDictionary(c => c.Key, c => c.Value);
 
     int convertedCount = 0;
-    var conversionIncrement = 1.0 / conversions.Count;
+    var conversionIncrement = conversions.Count != 0 ? 1.0 / conversions.Count : 0.0;
     var conversionInterval = Math.Max(conversions.Count / 100, 1);
 
     for (var i = 0; i < conversions.Count; i++)

--- a/ConnectorNavisworks/ConnectorNavisworks/Other/SelectionBuilder.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Other/SelectionBuilder.cs
@@ -69,7 +69,7 @@ public class SelectionHandler
     // Selections are modelItem pseudo-ids.
     var selection = _filter.Selection;
     var count = selection.Count;
-    var progressIncrement = 1.0 / count;
+    var progressIncrement = 1.0 / count != 0 ? count : 1.0;
 
     // Begin the progress sub-operation for getting objects from selection
     ProgressBar.BeginSubOperation(0.1, "Rolling up the sleeves... Time to handpick your favorite data items!");
@@ -299,7 +299,7 @@ public class SelectionHandler
   /// <param name="totalDescendants">The total number of descendants.</param>
   private void TraverseDescendants(ModelItem startNode, int totalDescendants)
   {
-    var descendantInterval = totalDescendants / 100;
+    var descendantInterval = Math.Max(totalDescendants / 100.0, 1);
     var validDescendants = new HashSet<ModelItem>();
 
     Stack<ModelItem> stack = new();
@@ -352,7 +352,7 @@ public class SelectionHandler
     double fractionOfRemainingTime = 0
   )
   {
-    var increment = 1.0 / totalCount;
+    var increment = 1.0 / totalCount != 0 ? 1.0 / totalCount : 1.0;
     var updateInterval = Math.Max(totalCount / 100, 1);
     ProgressBar.BeginSubOperation(fractionOfRemainingTime, operationName);
     ProgressBar.Update(0);


### PR DESCRIPTION
Fixes #2665.

The code changes prevent division by zero errors in three different files. The changes ensure that the progress bar is updated correctly even when there are no items to process or fewer than the anticipated interval, resulting in a more accurate representation of progress.

Code changes wrap the interval assignment to a default value where the total is less than the default interval chunk. For increment values, the divisor is zero-checked.

This is an alternative to checking on the Progress update loop. However, that would be more DRY.