### PR TITLE
fix(Navisworks): Reset ConverterContext on each send. Fixes #2430

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -76,6 +76,7 @@ public partial class ConnectorBindingsNavisworks
     DisableAutoSave();
     SetupProgressViewModel();
     SetupConverter(state);
+    _navisworksConverter.SetContextDocument(_doc);
 
     _progressViewModel.CancellationToken.ThrowIfCancellationRequested();
 

--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.cs
@@ -44,11 +44,19 @@ public partial class ConverterNavisworks : ISpeckleConverter
     return new[] { VersionedAppName };
   }
 
-  /// <inheritdoc />
   public void SetContextDocument(object doc)
   {
-    Doc = (Document)doc;
-    // This sets the correct ElevationMode flag for model orientation.
+    if (doc != null && doc is not Document)
+      throw new ArgumentException("Only Navisworks Document types are supported.");
+
+    if (Doc == null && doc != null)
+      Doc = (Document)doc;
+
+    if (Doc == null && doc == null)
+      Doc = Application.ActiveDocument;
+
+    // This sets or resets the correct ElevationMode flag for model orientation.
+    // Needs to be called every time a Send is initiated to reflect the options
     SetModelOrientationMode();
     SetModelBoundingBox();
     SetTransformVector3D();


### PR DESCRIPTION
The previous code set Converter on Init and Document change did not reflect the settings change for Basepoint options.

Change to call SetConverterContext on each send. 