### PR TITLE
feat(autocadcivil): adds extension dictionaries to speckle conversions

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/Converter.AutocadCivil.Utils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
@@ -30,6 +30,7 @@ namespace Objects.Converter.AutocadCivil
     {
       return (BlockTableRecord)SymbolUtilityServices.GetBlockModelSpaceId(db).GetObject(OpenMode.ForWrite);
     }
+
     public static ObjectId Append(this BlockTableRecord owner, Entity entity)
     {
       if (!entity.IsNewObject)
@@ -38,6 +39,35 @@ namespace Objects.Converter.AutocadCivil
       var id = owner.AppendEntity(entity);
       tr.AddNewlyCreatedDBObject(entity, true);
       return id;
+    }
+
+    public static Base GetObjectExtensionDictionaryAsBase(this DBObject source)
+    {
+      if (source is null || source.ExtensionDictionary == ObjectId.Null)
+        return null;
+
+      var extensionDictionaryBase = new Base();
+      var tr = source.Database.TransactionManager.TopTransaction;
+      var extensionDictionary = tr.GetObject(source.ExtensionDictionary, OpenMode.ForRead, false) as DBDictionary;
+      foreach (var entry in extensionDictionary)
+      {
+        var xRecord = tr.GetObject(entry.Value, OpenMode.ForRead) as Xrecord; // sometimes these can be RXClass objects, in property sets
+        if (xRecord != null)
+        {
+          var entryBase = new Base();
+          foreach (var xEntry in xRecord.Data)
+          {
+            entryBase[xEntry.TypeCode.ToString()] = xEntry.Value;
+          }
+          try
+          {
+            extensionDictionaryBase[$"{entry.Key}"] = entryBase;
+          }
+          catch (Exception e) { }
+        }
+      }
+
+      return extensionDictionaryBase;
     }
   }
 
@@ -90,13 +120,16 @@ namespace Objects.Converter.AutocadCivil
       {
         handle = new Handle(Convert.ToInt64(str, 16));
       }
-      catch { return false; }
+      catch
+      {
+        return false;
+      }
       return true;
     }
 
     /// <summary>
     /// Returns, if found, the corresponding doc element.
-    /// The doc object can be null if the user deleted it. 
+    /// The doc object can be null if the user deleted it.
     /// </summary>
     /// <param name="applicationId">Id of the application that originally created the element, in autocadcivil it's the handle</param>
     /// <returns>The element, if found, otherwise null</returns>
@@ -122,10 +155,11 @@ namespace Objects.Converter.AutocadCivil
       if (res.Status == PromptStatus.None || res.Status == PromptStatus.Error)
         return ids;
 
-      // loop through all obj with an appId 
+      // loop through all obj with an appId
       foreach (var appIdObj in res.Value.GetObjectIds())
       {
-        if (appIdObj.IsErased) continue;
+        if (appIdObj.IsErased)
+          continue;
 
         // get the db object from id
         var obj = Trans.GetObject(appIdObj, OpenMode.ForRead);
@@ -184,7 +218,9 @@ namespace Objects.Converter.AutocadCivil
         if (_transform == null || _transform == new Matrix3d())
         {
           // get from settings
-          var referencePointSetting = Settings.ContainsKey("reference-point") ? Settings["reference-point"] : string.Empty;
+          var referencePointSetting = Settings.ContainsKey("reference-point")
+            ? Settings["reference-point"]
+            : string.Empty;
           _transform = GetReferencePointTransform(referencePointSetting);
         }
         return _transform;
@@ -203,8 +239,15 @@ namespace Objects.Converter.AutocadCivil
           var cs = Doc.Editor.CurrentUserCoordinateSystem.CoordinateSystem3d;
           if (cs != null)
             referencePointTransform = Matrix3d.AlignCoordinateSystem(
-                Point3d.Origin, Vector3d.XAxis, Vector3d.YAxis, Vector3d.ZAxis,
-                cs.Origin, cs.Xaxis, cs.Yaxis, cs.Zaxis);
+              Point3d.Origin,
+              Vector3d.XAxis,
+              Vector3d.YAxis,
+              Vector3d.ZAxis,
+              cs.Origin,
+              cs.Xaxis,
+              cs.Yaxis,
+              cs.Zaxis
+            );
           break;
         default: // try to see if this is a named UCS
           using (Transaction tr = Doc.Database.TransactionManager.StartTransaction())
@@ -214,8 +257,15 @@ namespace Objects.Converter.AutocadCivil
             {
               var ucsRecord = tr.GetObject(UCSTable[type], OpenMode.ForRead) as UcsTableRecord;
               referencePointTransform = Matrix3d.AlignCoordinateSystem(
-                Point3d.Origin, Vector3d.XAxis, Vector3d.YAxis, Vector3d.ZAxis,
-                ucsRecord.Origin, ucsRecord.XAxis, ucsRecord.YAxis, ucsRecord.XAxis.CrossProduct(ucsRecord.YAxis));
+                Point3d.Origin,
+                Vector3d.XAxis,
+                Vector3d.YAxis,
+                Vector3d.ZAxis,
+                ucsRecord.Origin,
+                ucsRecord.XAxis,
+                ucsRecord.YAxis,
+                ucsRecord.XAxis.CrossProduct(ucsRecord.YAxis)
+              );
             }
             tr.Commit();
           }
@@ -317,6 +367,7 @@ namespace Objects.Converter.AutocadCivil
         return _modelUnits;
       }
     }
+
     private void SetUnits(Base geom)
     {
       geom["units"] = ModelUnits;
@@ -361,6 +412,5 @@ namespace Objects.Converter.AutocadCivil
     }
 
     #endregion
-
   }
 }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Other.cs
@@ -351,7 +351,8 @@ namespace Objects.Converter.AutocadCivil
       };
 
       // add attributes
-      instance["attributes"] = attributes;
+      if (attributes.Any())
+        instance["attributes"] = attributes;
 
       return instance;
     }


### PR DESCRIPTION
## Description & motivation
As requested by a community member, this PR adds object extension dictionaries as `Base` on send. This currently only applies to `ResultBuffer` dictionary entries, but may be improved to include `RXClass` entries as well.

Tested on a file provided, resulting in this commit: [https://speckle.xyz/streams/b53a53697a/commits/9ee73de121](https://speckle.xyz/streams/b53a53697a/commits/9ee73de121
)
Closes #2673 

## Changes:

- Autocad converter

## Screenshots:

![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/e39948dd-cb00-4b10-8a54-80d14b33b1a4)

