### PR TITLE
fix(core): AccountManager.GetUserInfo was still using old user query

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ServerAccount.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ServerAccount.cs
@@ -89,12 +89,12 @@ public class ServerAccountComponent : GH_SpeckleTaskCapableComponent<Account>
       }
 
       var task = Task.Run(
-        () =>
+        async () =>
         {
           var acc = new Account();
           acc.token = token;
-          acc.serverInfo = AccountManager.GetServerInfo($"{url.Scheme}://{url.Host}").Result;
-          acc.userInfo = acc.Validate().Result;
+          acc.serverInfo = await AccountManager.GetServerInfo($"{url.Scheme}://{url.Host}").ConfigureAwait(false);
+          acc.userInfo = await acc.Validate().ConfigureAwait(false);
           return acc;
         },
         CancelToken

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -71,24 +71,7 @@ public class Account : IEquatable<Account>
 
   public async Task<UserInfo> Validate()
   {
-    using var httpClient = Http.GetHttpProxyClient();
-
-    httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
-
-    using var gqlClient = new GraphQLHttpClient(
-      new GraphQLHttpClientOptions { EndPoint = new Uri(new Uri(serverInfo.url), "/graphql") },
-      new NewtonsoftJsonSerializer(),
-      httpClient
-    );
-
-    var request = new GraphQLRequest { Query = @" query { activeUser { name email id company } }" };
-
-    var response = await gqlClient.SendQueryAsync<UserInfoResponse>(request).ConfigureAwait(false);
-
-    if (response.Errors != null)
-      return null;
-
-    return response.Data.user;
+    return await AccountManager.GetUserInfo(token, serverInfo.url).ConfigureAwait(false);
   }
 
   public override string ToString()

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -77,12 +77,12 @@ public static class AccountManager
 
     var request = new GraphQLRequest { Query = @" query { activeUser { name email id company } }" };
 
-    var response = await gqlClient.SendQueryAsync<UserInfoResponse>(request).ConfigureAwait(false);
+    var response = await gqlClient.SendQueryAsync<ActiveUserResponse>(request).ConfigureAwait(false);
 
     if (response.Errors != null)
       return null;
 
-    return response.Data.user;
+    return response.Data.activeUser;
   }
 
   /// <summary>

--- a/Core/Core/Credentials/Responses.cs
+++ b/Core/Core/Credentials/Responses.cs
@@ -1,3 +1,4 @@
+using System;
 using Speckle.Core.Api;
 
 namespace Speckle.Core.Credentials;
@@ -8,9 +9,15 @@ public class UserServerInfoResponse
   public ServerInfo serverInfo { get; set; }
 }
 
+[Obsolete("Use activeUser query and ActiveUserResponse instead", true)]
 public class UserInfoResponse
 {
   public UserInfo user { get; set; }
+}
+
+public class ActiveUserResponse
+{
+  public UserInfo activeUser { get; set; }
 }
 
 public class UserInfo


### PR DESCRIPTION
Fixes issue reported in the forum, where Account.ToString would throw because it would be missing the `User` information after validation.

This was caused by the fact that, even though the queries were updated to use `activeUser` a while back, **the responses were not**

