### PR TITLE
feat(revit): design options support

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -237,9 +237,6 @@ EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ConverterNavisworks", "Objects\Converters\ConverterNavisworks\ConverterNavisworks\ConverterNavisworks.shproj", "{C3232EF3-2000-44C6-A330-B94531C9CC83}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Navisworks", "Navisworks", "{B6887DDC-B9B9-4B00-95DC-1DD930A1E901}"
-	ProjectSection(SolutionItems) = preProject
-		ConnectorNavisworks\README.md = ConnectorNavisworks\README.md
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorNavisworks2023", "ConnectorNavisworks\ConnectorNavisworks2023\ConnectorNavisworks2023.csproj", "{74E39841-B2FA-494D-AC40-A6E505DE6B33}"
 EndProject

--- a/All.sln
+++ b/All.sln
@@ -339,13 +339,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterRevit2024", "Objec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorRevit2024", "ConnectorRevit\ConnectorRevit2024\ConnectorRevit2024.csproj", "{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitSharedResources2020", "ConnectorRevit\RevitSharedResources2020\RevitSharedResources2020.csproj", "{8AD2EA4F-14FB-4BB6-94CD-932630DFED9C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitSharedResources2020", "ConnectorRevit\RevitSharedResources2020\RevitSharedResources2020.csproj", "{8AD2EA4F-14FB-4BB6-94CD-932630DFED9C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitSharedResources2021", "ConnectorRevit\RevitSharedResources2021\RevitSharedResources2021.csproj", "{EA34AC83-5825-4473-A572-D5127FD33B1B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitSharedResources2021", "ConnectorRevit\RevitSharedResources2021\RevitSharedResources2021.csproj", "{EA34AC83-5825-4473-A572-D5127FD33B1B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitSharedResources2022", "ConnectorRevit\RevitSharedResources2022\RevitSharedResources2022.csproj", "{521A7D9C-637F-4965-A6E6-BA96DF99807D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitSharedResources2022", "ConnectorRevit\RevitSharedResources2022\RevitSharedResources2022.csproj", "{521A7D9C-637F-4965-A6E6-BA96DF99807D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitSharedResources2023", "ConnectorRevit\RevitSharedResources2023\RevitSharedResources2023.csproj", "{61C1304B-ED48-456B-AB90-A89066187952}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitSharedResources2023", "ConnectorRevit\RevitSharedResources2023\RevitSharedResources2023.csproj", "{61C1304B-ED48-456B-AB90-A89066187952}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RevitSharedResources", "ConnectorRevit\RevitSharedResources\RevitSharedResources.shproj", "{071F914C-F473-4FB2-9FAF-98632AFB164B}"
 EndProject
@@ -353,7 +353,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterRevitTests2022", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestGenerator", "Objects\Converters\ConverterRevit\ConverterRevitTests\TestGenerator\TestGenerator.csproj", "{6499CA05-6864-47AE-9204-B11B10C23417}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitSharedResources2024", "ConnectorRevit\RevitSharedResources2024\RevitSharedResources2024.csproj", "{C2BA8B6B-72BD-4DAB-865F-90C66083BDB2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RevitSharedResources2024", "ConnectorRevit\RevitSharedResources2024\RevitSharedResources2024.csproj", "{C2BA8B6B-72BD-4DAB-865F-90C66083BDB2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1736,6 +1736,38 @@ Global
 		{1D1B6EDA-8FD9-4758-9195-C3476DB31F4E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1D1B6EDA-8FD9-4758-9195-C3476DB31F4E}.Release|x64.ActiveCfg = Release|Any CPU
 		{1D1B6EDA-8FD9-4758-9195-C3476DB31F4E}.Release|x64.Build.0 = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|Any CPU.Build.0 = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|x64.ActiveCfg = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|x64.Build.0 = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|x64.Build.0 = Debug|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|Any CPU.Build.0 = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|x64.ActiveCfg = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|x64.Build.0 = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|x64.ActiveCfg = Release|Any CPU
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|x64.Build.0 = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|Any CPU.Build.0 = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|x64.ActiveCfg = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|x64.Build.0 = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|x64.Build.0 = Debug|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|Any CPU.Build.0 = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|x64.ActiveCfg = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|x64.Build.0 = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|x64.ActiveCfg = Release|Any CPU
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|x64.Build.0 = Release|Any CPU
 		{8AD2EA4F-14FB-4BB6-94CD-932630DFED9C}.Debug Mac|Any CPU.ActiveCfg = Debug|Any CPU
 		{8AD2EA4F-14FB-4BB6-94CD-932630DFED9C}.Debug Mac|Any CPU.Build.0 = Debug|Any CPU
 		{8AD2EA4F-14FB-4BB6-94CD-932630DFED9C}.Debug Mac|x64.ActiveCfg = Debug|Any CPU
@@ -1800,38 +1832,6 @@ Global
 		{61C1304B-ED48-456B-AB90-A89066187952}.Release|Any CPU.Build.0 = Release|Any CPU
 		{61C1304B-ED48-456B-AB90-A89066187952}.Release|x64.ActiveCfg = Release|Any CPU
 		{61C1304B-ED48-456B-AB90-A89066187952}.Release|x64.Build.0 = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|Any CPU.ActiveCfg = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|Any CPU.Build.0 = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|x64.ActiveCfg = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug Mac|x64.Build.0 = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Debug|x64.Build.0 = Debug|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|Any CPU.Build.0 = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|x64.ActiveCfg = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release Mac|x64.Build.0 = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|x64.ActiveCfg = Release|Any CPU
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64}.Release|x64.Build.0 = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|Any CPU.ActiveCfg = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|Any CPU.Build.0 = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|x64.ActiveCfg = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug Mac|x64.Build.0 = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Debug|x64.Build.0 = Debug|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|Any CPU.ActiveCfg = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|Any CPU.Build.0 = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|x64.ActiveCfg = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release Mac|x64.Build.0 = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|x64.ActiveCfg = Release|Any CPU
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3}.Release|x64.Build.0 = Release|Any CPU
 		{54E90327-5F48-468D-9349-17AACEAA0A77}.Debug Mac|Any CPU.ActiveCfg = Debug|Any CPU
 		{54E90327-5F48-468D-9349-17AACEAA0A77}.Debug Mac|Any CPU.Build.0 = Debug|Any CPU
 		{54E90327-5F48-468D-9349-17AACEAA0A77}.Debug Mac|x64.ActiveCfg = Debug|Any CPU
@@ -2017,13 +2017,13 @@ Global
 		{25F45C77-279F-4608-86D1-87345EC42CB4} = {925C0BF6-A0B1-4699-9C4B-078E01D652CC}
 		{1085F4B5-FDAD-4FF8-B144-DDDBD9454F55} = {25F45C77-279F-4608-86D1-87345EC42CB4}
 		{1D1B6EDA-8FD9-4758-9195-C3476DB31F4E} = {25F45C77-279F-4608-86D1-87345EC42CB4}
+		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64} = {925C0BF6-A0B1-4699-9C4B-078E01D652CC}
+		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3} = {42A86931-7497-4A34-B2FD-060231CD0A8F}
 		{8AD2EA4F-14FB-4BB6-94CD-932630DFED9C} = {C73C19B5-72A3-4C63-8D56-0A7E7DB46CA5}
 		{EA34AC83-5825-4473-A572-D5127FD33B1B} = {C73C19B5-72A3-4C63-8D56-0A7E7DB46CA5}
 		{521A7D9C-637F-4965-A6E6-BA96DF99807D} = {C73C19B5-72A3-4C63-8D56-0A7E7DB46CA5}
 		{61C1304B-ED48-456B-AB90-A89066187952} = {C73C19B5-72A3-4C63-8D56-0A7E7DB46CA5}
 		{071F914C-F473-4FB2-9FAF-98632AFB164B} = {C73C19B5-72A3-4C63-8D56-0A7E7DB46CA5}
-		{4C6B5FC0-37E2-442C-B647-2D6A544EFD64} = {925C0BF6-A0B1-4699-9C4B-078E01D652CC}
-		{9A1E899A-F821-4519-AAD1-0789A4E9CCB3} = {42A86931-7497-4A34-B2FD-060231CD0A8F}
 		{54E90327-5F48-468D-9349-17AACEAA0A77} = {25F45C77-279F-4608-86D1-87345EC42CB4}
 		{6499CA05-6864-47AE-9204-B11B10C23417} = {25F45C77-279F-4608-86D1-87345EC42CB4}
 		{C2BA8B6B-72BD-4DAB-865F-90C66083BDB2} = {C73C19B5-72A3-4C63-8D56-0A7E7DB46CA5}
@@ -2035,6 +2035,7 @@ Global
 		Objects\Converters\ConverterTeklaStructures\ConverterTeklaStructuresShared\ConverterTeklaStructuresShared.projitems*{02a24dd8-e0ca-4657-baa7-b033a4563709}*SharedItemsImports = 5
 		ConnectorBentley\ConnectorBentleyShared\ConnectorBentleyShared.projitems*{0420d74a-2997-4b92-844b-c3769deaa1ad}*SharedItemsImports = 5
 		Objects\Converters\ConverterTeklaStructures\ConverterTeklaStructuresShared\ConverterTeklaStructuresShared.projitems*{05f993a6-8651-4801-a732-9a30d1472eef}*SharedItemsImports = 5
+		ConnectorRevit\RevitSharedResources\RevitSharedResources.projitems*{071f914c-f473-4fb2-9faf-98632afb164b}*SharedItemsImports = 13
 		ConnectorGrasshopper\ConnectorGrasshopperShared\ConnectorGrasshopperShared.projitems*{0f1fd0c3-875f-4689-9c4a-c56e9ab31102}*SharedItemsImports = 13
 		Objects\Converters\ConverterRevit\ConverterRevitTests\ConverterRevitTestsShared\ConverterRevitTestsShared.projitems*{1085f4b5-fdad-4ff8-b144-dddbd9454f55}*SharedItemsImports = 13
 		Objects\Converters\ConverterRevit\ConverterRevitTests\ConverterRevitTestsShared\ConverterRevitTestsShared.projitems*{1d1b6eda-8fd9-4758-9195-c3476db31f4e}*SharedItemsImports = 5
@@ -2058,6 +2059,7 @@ Global
 		Objects\Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{4dbf45ee-3bce-47f4-b399-963b36a31951}*SharedItemsImports = 5
 		Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{4dbf45ee-3bce-47f4-b399-963b36a31951}*SharedItemsImports = 5
 		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{50bc1552-3e7e-4c77-ac3a-aa7c572dfe09}*SharedItemsImports = 5
+		ConnectorRevit\RevitSharedResources\RevitSharedResources.projitems*{521a7d9c-637f-4965-a6e6-ba96df99807d}*SharedItemsImports = 5
 		Objects\Converters\ConverterRevit\ConverterRevitTests\ConverterRevitTestsShared\ConverterRevitTestsShared.projitems*{54e90327-5f48-468d-9349-17aaceaa0a77}*SharedItemsImports = 5
 		ConnectorBentley\ConnectorBentleyShared\ConnectorBentleyShared.projitems*{57bf94a8-8f73-4d1a-91d2-b10cc64178b6}*SharedItemsImports = 5
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{586a5a37-93f6-427e-8df8-c10db4d6822a}*SharedItemsImports = 5
@@ -2067,6 +2069,7 @@ Global
 		Objects\Converters\ConverterNavisworks\ConverterNavisworks\ConverterNavisworksShared.projitems*{5f8e5dd7-386e-46a6-85e4-1318cbcc4ba1}*SharedItemsImports = 5
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{5fd0d810-03e9-4fd2-93e4-b1b51e5d82c5}*SharedItemsImports = 13
 		ConnectorCSI\ConnectorCSIShared\ConnectorCSIShared.projitems*{61374cd0-e774-4dcd-bfab-6356b0931283}*SharedItemsImports = 13
+		ConnectorRevit\RevitSharedResources\RevitSharedResources.projitems*{61c1304b-ed48-456b-ab90-a89066187952}*SharedItemsImports = 5
 		ConnectorTeklaStructures\ConnectorTeklaStructuresShared\ConnectorTeklaStructuresShared.projitems*{67157264-aaa5-46a8-a38b-16254b49b892}*SharedItemsImports = 5
 		Objects\Converters\ConverterDynamo\ConverterDynamoShared\ConverterDynamoShared.projitems*{67a463d3-e98b-4b16-b069-d7bbb05386a1}*SharedItemsImports = 5
 		Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{67a463d3-e98b-4b16-b069-d7bbb05386a1}*SharedItemsImports = 5
@@ -2080,6 +2083,7 @@ Global
 		ConnectorGrasshopper\ConnectorGrasshopperShared\ConnectorGrasshopperShared.projitems*{86920221-416e-4a66-a601-3418207e2401}*SharedItemsImports = 5
 		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{88a24c40-74c8-4e20-9051-6be9e6adecfd}*SharedItemsImports = 5
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{8a53b084-20d8-48f6-9591-9d53cfa74130}*SharedItemsImports = 5
+		ConnectorRevit\RevitSharedResources\RevitSharedResources.projitems*{8ad2ea4f-14fb-4bb6-94cd-932630dfed9c}*SharedItemsImports = 5
 		Objects\Converters\ConverterNavisworks\ConverterNavisworks\ConverterNavisworksShared.projitems*{8b467ff4-6a6c-4071-87a7-0dd7b9822251}*SharedItemsImports = 5
 		Objects\Converters\ConverterBentley\ConverterBentleyShared\ConverterBentleyShared.projitems*{8b50fa79-2ff0-4efa-b50f-9bf47ff3e130}*SharedItemsImports = 5
 		Objects\Converters\ConverterCSI\ConverterCSIShared\ConverterCSIShared.projitems*{907aed7a-719b-4157-8cc9-d21cb26e9243}*SharedItemsImports = 5
@@ -2104,6 +2108,7 @@ Global
 		ConnectorCSI\ConnectorCSIShared\ConnectorCSIShared.projitems*{c091e499-597d-4077-b83f-08e069091090}*SharedItemsImports = 5
 		Objects\Converters\ConverterTeklaStructures\ConverterTeklaStructuresShared\ConverterTeklaStructuresShared.projitems*{c1d53822-b11f-4772-996e-1e6d485e0702}*SharedItemsImports = 5
 		Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{c21a6553-b4ec-4ec3-b82a-c7a83cffb809}*SharedItemsImports = 5
+		ConnectorRevit\RevitSharedResources\RevitSharedResources.projitems*{c2ba8b6b-72bd-4dab-865f-90c66083bdb2}*SharedItemsImports = 5
 		Objects\Converters\ConverterNavisworks\ConverterNavisworks\ConverterNavisworksShared.projitems*{c3232ef3-2000-44c6-a330-b94531c9cc83}*SharedItemsImports = 13
 		Objects\Converters\ConverterNavisworks\ConverterNavisworks\ConverterNavisworksShared.projitems*{cafd4eac-75a8-4fc8-94e5-91cadc39f5b3}*SharedItemsImports = 5
 		Objects\Converters\ConverterRevit\ConverterRevitShared\ConverterRevitShared.projitems*{cc790553-8088-41a9-83cd-b29f7141f408}*SharedItemsImports = 5
@@ -2115,6 +2120,7 @@ Global
 		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{d9f443b5-c55b-4ad8-9c70-bc3d2be781be}*SharedItemsImports = 5
 		ConnectorNavisworks\ConnectorNavisworks\ConnectorNavisworks.Shared.projitems*{debc2174-5e31-4b6e-8680-690d75e50e2d}*SharedItemsImports = 5
 		ConnectorRevit\ConnectorRevit\ConnectorRevit.projitems*{dfdfdbb8-018b-4dcb-a012-54227abf53a7}*SharedItemsImports = 5
+		ConnectorRevit\RevitSharedResources\RevitSharedResources.projitems*{ea34ac83-5825-4473-a572-d5127fd33b1b}*SharedItemsImports = 5
 		Objects\Converters\ConverterRhinoGh\ConverterRhinoGhShared\ConverterRhinoGhShared.projitems*{ea81f83c-1485-49c8-ab05-9df2798d70ec}*SharedItemsImports = 5
 		Objects\Converters\ConverterNavisworks\ConverterNavisworks\ConverterNavisworksShared.projitems*{ec2436db-b7f4-4d78-807b-8d91d7d5165c}*SharedItemsImports = 5
 		Objects\Converters\ConverterAutocadCivil\ConverterAutocadCivilShared\ConverterAutocadCivilShared.projitems*{f03af41c-3489-4414-a887-b52d529b5a55}*SharedItemsImports = 5

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit .Settings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit .Settings.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
 using DesktopUI2.Models.Settings;
@@ -44,6 +44,7 @@ namespace Speckle.ConnectorRevit.UI
         new CheckBoxSetting {Slug = "linkedmodels-send", Name = "Send Linked Models", Icon ="Link", IsChecked= false, Description = "Include Linked Models in the selection filters when sending"},
         new CheckBoxSetting {Slug = "linkedmodels-receive", Name = "Receive Linked Models", Icon ="Link", IsChecked= false, Description = "Include Linked Models when receiving NOTE: elements from linked models will be received in the current document"},
         new CheckBoxSetting {Slug = "recieve-objects-mesh", Name = "Receive Objects as Direct Mesh", Icon = "Link", IsChecked = false, Description = "Recieve the stream as a Meshes only"},
+        new CheckBoxSetting {Slug = "include-design-options", Name = "Include Design Options", Icon ="CheckAll", IsChecked= false, Description = "Include all design options that satisfy the current selection filter"},
         new MultiSelectBoxSetting { Slug = "disallow-join", Name = "Disallow Join For Elements", Icon = "CallSplit", Description = "Determine which objects should not be allowed to join by default when receiving",
           Values = new List<string>() { ArchitecturalWalls, StructuralWalls, StructuralFraming } },
         new ListBoxSetting {Slug = "pretty-mesh", Name = "Mesh Import Method", Icon ="ChartTimelineVarient", Values = prettyMeshOptions, Selection = defaultValue, Description = "Determines the display style of imported meshes"},

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit .Settings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit .Settings.cs
@@ -44,7 +44,6 @@ namespace Speckle.ConnectorRevit.UI
         new CheckBoxSetting {Slug = "linkedmodels-send", Name = "Send Linked Models", Icon ="Link", IsChecked= false, Description = "Include Linked Models in the selection filters when sending"},
         new CheckBoxSetting {Slug = "linkedmodels-receive", Name = "Receive Linked Models", Icon ="Link", IsChecked= false, Description = "Include Linked Models when receiving NOTE: elements from linked models will be received in the current document"},
         new CheckBoxSetting {Slug = "recieve-objects-mesh", Name = "Receive Objects as Direct Mesh", Icon = "Link", IsChecked = false, Description = "Recieve the stream as a Meshes only"},
-        new CheckBoxSetting {Slug = "include-design-options", Name = "Include Design Options", Icon ="CheckAll", IsChecked= false, Description = "Include all design options that satisfy the current selection filter"},
         new MultiSelectBoxSetting { Slug = "disallow-join", Name = "Disallow Join For Elements", Icon = "CallSplit", Description = "Determine which objects should not be allowed to join by default when receiving",
           Values = new List<string>() { ArchitecturalWalls, StructuralWalls, StructuralFraming } },
         new ListBoxSetting {Slug = "pretty-mesh", Name = "Mesh Import Method", Icon ="ChartTimelineVarient", Values = prettyMeshOptions, Selection = defaultValue, Description = "Determines the display style of imported meshes"},

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Previews.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Previews.cs
@@ -160,7 +160,7 @@ namespace Speckle.ConnectorRevit.UI
       try
       {
         var converter = (ISpeckleConverter)Activator.CreateInstance(Converter.GetType());
-        var filterObjs = GetSelectionFilterObjects(converter, state.Filter);
+        var filterObjs = GetSelectionFilterObjectsWithDesignOptions(converter, state.Filter);
         foreach (var filterObj in filterObjs)
         {
           var descriptor = ConnectorRevitUtils.ObjectDescriptor(filterObj);

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
@@ -199,16 +199,14 @@ namespace Speckle.ConnectorRevit.UI
     {
       var selection = GetSelectionFilterObjects(converter, filter);
 
+      //By default, do not include design options
+      //If one is selected in Revit, also send those objects: https://speckle.community/t/revit-design-option-settings-are-ignored-in-everything-stream/3182/8
       var activeDesignOption = DesignOption.GetActiveDesignOptionId(CurrentDoc.Document);
       if (activeDesignOption != ElementId.InvalidElementId)
-      {
-        var includeAllDesignOptions = CurrentSettings?.FirstOrDefault(x => x.Slug == "include-design-options") as CheckBoxSetting;
-        if (includeAllDesignOptions == null || !includeAllDesignOptions.IsChecked)
-        {
-          selection = selection.Where(x => x.DesignOption == null || x.DesignOption.Id == activeDesignOption).ToList();
-        }
-      }
-
+        selection = selection.Where(x => x.DesignOption == null || x.DesignOption.Id == activeDesignOption).ToList(); 
+      else
+        selection = selection.Where(x => x.DesignOption == null).ToList();
+        
       return selection;
     }
 

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
@@ -199,14 +199,10 @@ namespace Speckle.ConnectorRevit.UI
     {
       var selection = GetSelectionFilterObjects(converter, filter);
 
-      //By default, do not include design options
-      //If one is selected in Revit, also send those objects: https://speckle.community/t/revit-design-option-settings-are-ignored-in-everything-stream/3182/8
-      var activeDesignOption = DesignOption.GetActiveDesignOptionId(CurrentDoc.Document);
-      if (activeDesignOption != ElementId.InvalidElementId)
-        selection = selection.Where(x => x.DesignOption == null || x.DesignOption.Id == activeDesignOption).ToList(); 
-      else
-        selection = selection.Where(x => x.DesignOption == null).ToList();
-        
+      //Only include the Main Model objects and those part of a Primary Design Option
+      //https://speckle.community/t/revit-design-option-settings-are-ignored-in-everything-stream/3182/8
+      selection = selection.Where(x => x.DesignOption == null || x.DesignOption.IsPrimary).ToList();
+
       return selection;
     }
 

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
@@ -137,7 +137,7 @@ namespace Speckle.ConnectorRevit.UI
         CurrentDoc.Document.ActiveView.Id
       ).WhereElementIsNotElementType();
       var elementIds = collector.ToElements().Select(el => el.UniqueId).ToList();
-      ;
+
 
       return elementIds;
     }
@@ -188,6 +188,30 @@ namespace Speckle.ConnectorRevit.UI
 
       return docs;
     }
+
+    /// <summary>
+    /// Given the filter in use by a stream returns the document elements that match it.
+    /// The elements returned are filtered by Design Option based on setting value
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns></returns>
+    private List<Element> GetSelectionFilterObjectsWithDesignOptions(ISpeckleConverter converter, ISelectionFilter filter)
+    {
+      var selection = GetSelectionFilterObjects(converter, filter);
+
+      var activeDesignOption = DesignOption.GetActiveDesignOptionId(CurrentDoc.Document);
+      if (activeDesignOption != ElementId.InvalidElementId)
+      {
+        var includeAllDesignOptions = CurrentSettings?.FirstOrDefault(x => x.Slug == "include-design-options") as CheckBoxSetting;
+        if (includeAllDesignOptions == null || !includeAllDesignOptions.IsChecked)
+        {
+          selection = selection.Where(x => x.DesignOption == null || x.DesignOption.Id == activeDesignOption).ToList();
+        }
+      }
+
+      return selection;
+    }
+
 
     /// <summary>
     /// Given the filter in use by a stream returns the document elements that match it.

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -48,7 +48,7 @@ namespace Speckle.ConnectorRevit.UI
       var streamId = state.StreamId;
       var client = state.Client;
 
-      var selectedObjects = GetSelectionFilterObjects(converter, state.Filter);
+      var selectedObjects = GetSelectionFilterObjectsWithDesignOptions(converter, state.Filter);
       state.SelectedObjectIds = selectedObjects.Select(x => x.UniqueId).ToList();
 
       if (!selectedObjects.Any())


### PR DESCRIPTION
Partially fixes #1546 

Adds support for design options: https://speckle.community/t/revit-design-option-settings-are-ignored-in-everything-stream/3182/8

- by default, they are excluded, and only the main model is sent
- if any design option is selected, then also all relevant elements are sent

No Design Option
![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/faf76d8a-166f-4890-84bc-5fea69432a47)

Design Option Selected
![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/97e6bfad-950d-4369-b21a-be8bb96b1bab)

