### PR TITLE
fix(rhino): places objects from layers with invalid chars on correct layers

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.cs
@@ -593,7 +593,7 @@ public class ConnectorBindingsRhino : ConnectorBindings
               continue;
             }
 
-            layers.Add(layer.FullPath, layer);
+            layers.Add(path, layer);
           }
           #endregion
 

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -103,6 +103,7 @@ public static class Utils
   /// <param name="path">Full path of layer</param>
   /// <param name="MakeIfNull">Create the layer if it doesn't already exist</param>
   /// <returns>Null on failure</returns>
+  /// <remarks>Note: The created layer path may be different from the input path, due to removal of invalid chars</remarks>
   public static Layer GetLayer(this RhinoDoc doc, string path, bool MakeIfNull = false)
   {
     Layer MakeLayer(string name, Layer parentLayer = null)


### PR DESCRIPTION
## Description & motivation

Fixes an issue where created layers with modified paths due to invalid chars were not being cached correctly, so objects on those layers were being placed on the default layer

