### PR TITLE
Fix: Curtain walls components as nested elements

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -195,21 +195,7 @@ namespace Objects.Converter.Revit
       }
       else
       {
-        // curtain walls have two meshes, one for panels and one for mullions
-        // adding mullions as sub-elements so they can be correctly displayed in viewers etc
-        var (panelsMesh, mullionsMesh) = GetCurtainWallDisplayMesh(revitWall);
         speckleWall["renderMaterial"] = new Other.RenderMaterial() { opacity = 0.2, diffuse = System.Drawing.Color.AliceBlue.ToArgb() };
-        speckleWall.displayValue = panelsMesh;
-
-        var elements = new List<Base>();
-        if (mullionsMesh.Count > 0) //Only add mullions object if they have meshes 
-        {
-          elements.Add(new Base
-          {
-            ["@displayValue"] = mullionsMesh
-          });
-        }
-        speckleWall.elements = elements;
       }
 
       GetAllRevitParamsAndIds(speckleWall, revitWall, new List<string>


### PR DESCRIPTION


## Description & motivation

#1938 describes an issue with curtain walls. #2471 relates to the same problem.


## Changes:

- The adjustment creates individual instances for each component. THese components are now located in the `elements` of the `Wall`. The wall itself does no longer have a geometry.

## Screenshots:


<p float="left">
  <img height="400" alt="before" src="https://github.com/specklesystems/speckle-sharp/assets/86473259/5a0b21fb-2616-43dd-90fa-8a47469b4428">
  <img height="400" alt="After" src="https://github.com/specklesystems/speckle-sharp/assets/86473259/7033ed6d-6e42-4f2d-acb1-f4c02782b4d1">
</p>
Before (left) and after (right)

Each element has its own geometry now incl. the material quantities.
![image](https://github.com/specklesystems/speckle-sharp/assets/86473259/123d17fe-e7b9-41a3-9e40-dff865876058)

## Validation of changes:

The changes have been tested with the following stream:

https://speckle.xyz/streams/e9ed27e22b

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

