### PR TITLE
Fix(Revit) : using wrong collector for views

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Selection.cs
@@ -444,7 +444,7 @@ namespace Speckle.ConnectorRevit.UI
         foreach (var doc in allDocs)
         {
           using var docCollector = new FilteredElementCollector(doc, view.Id);
-          selection.AddRange(collector
+          selection.AddRange(docCollector
             .WhereElementIsNotElementType()
             .WhereElementIsViewIndependent()
             //.Where(x => x.IsPhysicalElement())


### PR DESCRIPTION
## Changes:

- use collector for elements and add that to the selection. Don't use the collector for views

<!---

- Item 1
- Item 2

-->
