### PR TITLE
Add support for all Archicad categories

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
@@ -14,6 +14,7 @@
 #include "Commands/GetWindowData.hpp"
 #include "Commands/GetBeamData.hpp"
 #include "Commands/GetColumnData.hpp"
+#include "Commands/GetElementBaseData.hpp"
 #include "Commands/GetObjectData.hpp"
 #include "Commands/GetSlabData.hpp"
 #include "Commands/GetRoomData.hpp"
@@ -195,6 +196,7 @@ static GSErrCode RegisterAddOnCommands ()
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetSubElementInfo> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetBeamData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetColumnData> ()));
+	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetElementBaseData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetObjectData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetRoomData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetRoofData> ()));

--- a/ConnectorArchicad/AddOn/Sources/AddOn/ClassificationImportManager.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/ClassificationImportManager.cpp
@@ -1,0 +1,83 @@
+#include "ClassificationImportManager.hpp"
+
+
+ClassificationImportManager* ClassificationImportManager::instance = nullptr;
+
+ClassificationImportManager* ClassificationImportManager::GetInstance ()
+{
+	if (nullptr == instance) {
+		instance = new ClassificationImportManager;
+	}
+	return instance;
+}
+
+
+void ClassificationImportManager::DeleteInstance ()
+{
+	if (nullptr != instance) {
+		delete instance;
+		instance = nullptr;
+	}
+}
+
+
+ClassificationImportManager::ClassificationImportManager () {}
+
+
+GSErrCode AddToCache (GS::Array<API_ClassificationItem> items, GS::HashTable<GS::UniString, API_Guid>& cache)
+{
+	for (auto& item : items) {
+		cache.Add (item.id, item.guid);
+		
+		GS::Array<API_ClassificationItem> childrenItems;
+		GSErrCode err = ACAPI_Classification_GetClassificationItemChildren (item.guid, childrenItems);
+		if (err != NoError)
+			return err;
+
+		AddToCache (childrenItems, cache);
+	}
+	
+	return NoError;
+}
+
+
+GSErrCode	ClassificationImportManager::GetItem (const GS::UniString& systemName, const GS::UniString& code, API_Guid& itemGuid)
+{
+	GS::ErrCode err = NoError;
+
+	if (!cache.ContainsKey (systemName)) {
+		API_ClassificationSystem targetSystem{};
+		{
+			GS::Array<API_ClassificationSystem> systems;
+			err = ACAPI_Classification_GetClassificationSystems (systems);
+			if (err != NoError)
+				return err;
+
+			err = Cancel;
+			for (auto& system : systems) {
+				if (system.name == systemName) {
+					targetSystem = system;
+					err = NoError;
+					break;
+				}
+			}
+			
+			if (err != NoError)
+				return err;
+		}
+
+		GS::Array<API_ClassificationItem> rootItems;
+		err = ACAPI_Classification_GetClassificationSystemRootItems (targetSystem.guid, rootItems);
+		if (err != NoError)
+			return err;
+		
+		GS::HashTable<GS::UniString, API_Guid> systemCache;
+		AddToCache (rootItems, systemCache);
+		cache.Add(systemName, systemCache);
+	}
+	
+	if (cache[systemName].Get (code, &itemGuid))
+		return NoError;
+
+	return Error;
+}

--- a/ConnectorArchicad/AddOn/Sources/AddOn/ClassificationImportManager.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/ClassificationImportManager.hpp
@@ -1,0 +1,24 @@
+#ifndef CLASSIFICATION_IMPORT_MANAGER_HPP
+#define CLASSIFICATION_IMPORT_MANAGER_HPP
+
+#include "ModelInfo.hpp"
+
+class ClassificationImportManager {
+private:
+	static ClassificationImportManager* instance;
+
+	GS::HashTable< GS::UniString, GS::HashTable<GS::UniString, API_Guid>> cache;
+
+protected:
+	ClassificationImportManager ();
+
+public:
+	ClassificationImportManager (ClassificationImportManager&) = delete;
+	void		operator=(const ClassificationImportManager&) = delete;
+	static ClassificationImportManager* GetInstance ();
+	static void					DeleteInstance ();
+
+	GSErrCode	GetItem (const GS::UniString& systemName, const GS::UniString& itemID, API_Guid& itemGuid);
+};
+
+#endif

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
@@ -58,8 +58,7 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 
 	if (os.Contains (ElementBase::Level)) {
 		GetStoryFromObjectState (os, startPoint.z, element.header.floorInd, element.beam.offset);
-	}
-	else {
+	} else {
 		Utility::SetStoryLevelAndFloor (startPoint.z, element.header.floorInd, element.beam.offset);
 	}
 	ACAPI_ELEMENT_MASK_SET (beamMask, API_Elem_Head, floorInd);
@@ -147,157 +146,157 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 		ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamType, nProfiles);
 	}
 
-	API_BeamSegmentType defaultBeamSegment;
-	if (memo.beamSegments != nullptr) {
-		defaultBeamSegment = memo.beamSegments[0];
-		memo.beamSegments = (API_BeamSegmentType*) BMAllocatePtr ((element.beam.nSegments) * sizeof (API_BeamSegmentType), ALLOCATE_CLEAR, 0);
-	} else {
-		return Error;
-	}
+		API_BeamSegmentType defaultBeamSegment;
+		if (memo.beamSegments != nullptr) {
+			defaultBeamSegment = memo.beamSegments[0];
+			memo.beamSegments = (API_BeamSegmentType*) BMAllocatePtr ((element.beam.nSegments) * sizeof (API_BeamSegmentType), ALLOCATE_CLEAR, 0);
+		} else {
+			return Error;
+		}
 
-	memoMask = APIMemoMask_BeamSegment |
-		APIMemoMask_AssemblySegmentScheme |
-		APIMemoMask_BeamHole |
-		APIMemoMask_AssemblySegmentCut;
+		memoMask = APIMemoMask_BeamSegment |
+			APIMemoMask_AssemblySegmentScheme |
+			APIMemoMask_BeamHole |
+			APIMemoMask_AssemblySegmentCut;
 
 #pragma region Segment
 	GS::ObjectState allSegments;
 	if (os.Contains (Beam::segments))
 		os.Get (Beam::segments, allSegments);
 
-	for (UInt32 idx = 0; idx < element.beam.nSegments; ++idx) {
-		GS::ObjectState currentSegment;
-		allSegments.Get (GS::String::SPrintf (AssemblySegment::SegmentName, idx + 1), currentSegment);
+		for (UInt32 idx = 0; idx < element.beam.nSegments; ++idx) {
+			GS::ObjectState currentSegment;
+			allSegments.Get (GS::String::SPrintf (AssemblySegment::SegmentName, idx + 1), currentSegment);
 
-		if (!currentSegment.IsEmpty ()) {
+			if (!currentSegment.IsEmpty ()) {
 
-			memo.beamSegments[idx] = defaultBeamSegment;
-			GS::ObjectState assemblySegment;
-			currentSegment.Get (Beam::BeamSegment::segmentData, assemblySegment);
-			Utility::CreateOneSegmentData (assemblySegment, memo.beamSegments[idx].assemblySegmentData, beamMask);
+				memo.beamSegments[idx] = defaultBeamSegment;
+				GS::ObjectState assemblySegment;
+				currentSegment.Get (Beam::BeamSegment::segmentData, assemblySegment);
+				Utility::CreateOneSegmentData (assemblySegment, memo.beamSegments[idx].assemblySegmentData, beamMask);
 
-			// The left overridden material name - in case of circle or profiled segment the left surface is the extrusion surface, but the import does not work properly in API
-			memo.beamSegments[idx].leftMaterial.overridden = false;
-			if (currentSegment.Contains (Beam::BeamSegment::LeftMaterial)) {
-				memo.beamSegments[idx].leftMaterial.overridden = true;
+				// The left overridden material name - in case of circle or profiled segment the left surface is the extrusion surface, but the import does not work properly in API
+				memo.beamSegments[idx].leftMaterial.overridden = false;
+				if (currentSegment.Contains (Beam::BeamSegment::LeftMaterial)) {
+					memo.beamSegments[idx].leftMaterial.overridden = true;
 
-				GS::UniString attrName;
-				currentSegment.Get (Beam::BeamSegment::LeftMaterial, attrName);
+					GS::UniString attrName;
+					currentSegment.Get (Beam::BeamSegment::LeftMaterial, attrName);
 
-				if (!attrName.IsEmpty ()) {
-					API_Attribute attrib;
-					BNZeroMemory (&attrib, sizeof (API_Attribute));
-					attrib.header.typeID = API_MaterialID;
-					CHCopyC (attrName.ToCStr (), attrib.header.name);
-					err = ACAPI_Attribute_Get (&attrib);
+					if (!attrName.IsEmpty ()) {
+						API_Attribute attrib;
+						BNZeroMemory (&attrib, sizeof (API_Attribute));
+						attrib.header.typeID = API_MaterialID;
+						CHCopyC (attrName.ToCStr (), attrib.header.name);
+						err = ACAPI_Attribute_Get (&attrib);
 
-					if (err == NoError) {
-						memo.beamSegments[idx].leftMaterial.attributeIndex = attrib.header.index;
-						ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, leftMaterial.attributeIndex);
+						if (err == NoError) {
+							memo.beamSegments[idx].leftMaterial.attributeIndex = attrib.header.index;
+							ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, leftMaterial.attributeIndex);
+						}
 					}
 				}
-			}
-			ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, leftMaterial.overridden);
+				ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, leftMaterial.overridden);
 
-			// The top overridden material name
-			memo.beamSegments[idx].topMaterial.overridden = false;
-			if (currentSegment.Contains (Beam::BeamSegment::TopMaterial)) {
-				memo.beamSegments[idx].topMaterial.overridden = true;
+				// The top overridden material name
+				memo.beamSegments[idx].topMaterial.overridden = false;
+				if (currentSegment.Contains (Beam::BeamSegment::TopMaterial)) {
+					memo.beamSegments[idx].topMaterial.overridden = true;
 
-				GS::UniString attrName;
-				currentSegment.Get (Beam::BeamSegment::TopMaterial, attrName);
+					GS::UniString attrName;
+					currentSegment.Get (Beam::BeamSegment::TopMaterial, attrName);
 
-				if (!attrName.IsEmpty ()) {
-					API_Attribute attrib;
-					BNZeroMemory (&attrib, sizeof (API_Attribute));
-					attrib.header.typeID = API_MaterialID;
-					CHCopyC (attrName.ToCStr (), attrib.header.name);
-					err = ACAPI_Attribute_Get (&attrib);
+					if (!attrName.IsEmpty ()) {
+						API_Attribute attrib;
+						BNZeroMemory (&attrib, sizeof (API_Attribute));
+						attrib.header.typeID = API_MaterialID;
+						CHCopyC (attrName.ToCStr (), attrib.header.name);
+						err = ACAPI_Attribute_Get (&attrib);
 
-					if (err == NoError) {
-						memo.beamSegments[idx].topMaterial.attributeIndex = attrib.header.index;
-						ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, topMaterial.attributeIndex);
+						if (err == NoError) {
+							memo.beamSegments[idx].topMaterial.attributeIndex = attrib.header.index;
+							ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, topMaterial.attributeIndex);
+						}
 					}
 				}
-			}
-			ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, topMaterial.overridden);
+				ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, topMaterial.overridden);
 
-			// The right overridden material name
-			memo.beamSegments[idx].rightMaterial.overridden = false;
-			if (currentSegment.Contains (Beam::BeamSegment::RightMaterial)) {
-				memo.beamSegments[idx].rightMaterial.overridden = true;
+				// The right overridden material name
+				memo.beamSegments[idx].rightMaterial.overridden = false;
+				if (currentSegment.Contains (Beam::BeamSegment::RightMaterial)) {
+					memo.beamSegments[idx].rightMaterial.overridden = true;
 
-				GS::UniString attrName;
-				currentSegment.Get (Beam::BeamSegment::RightMaterial, attrName);
+					GS::UniString attrName;
+					currentSegment.Get (Beam::BeamSegment::RightMaterial, attrName);
 
-				if (!attrName.IsEmpty ()) {
-					API_Attribute attrib;
-					BNZeroMemory (&attrib, sizeof (API_Attribute));
-					attrib.header.typeID = API_MaterialID;
-					CHCopyC (attrName.ToCStr (), attrib.header.name);
-					err = ACAPI_Attribute_Get (&attrib);
+					if (!attrName.IsEmpty ()) {
+						API_Attribute attrib;
+						BNZeroMemory (&attrib, sizeof (API_Attribute));
+						attrib.header.typeID = API_MaterialID;
+						CHCopyC (attrName.ToCStr (), attrib.header.name);
+						err = ACAPI_Attribute_Get (&attrib);
 
-					if (err == NoError) {
-						memo.beamSegments[idx].rightMaterial.attributeIndex = attrib.header.index;
-						ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, rightMaterial.attributeIndex);
+						if (err == NoError) {
+							memo.beamSegments[idx].rightMaterial.attributeIndex = attrib.header.index;
+							ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, rightMaterial.attributeIndex);
+						}
 					}
 				}
-			}
-			ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, rightMaterial.overridden);
+				ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, rightMaterial.overridden);
 
-			// The bottom overridden material name
-			memo.beamSegments[idx].bottomMaterial.overridden = false;
-			if (currentSegment.Contains (Beam::BeamSegment::BottomMaterial)) {
-				memo.beamSegments[idx].bottomMaterial.overridden = true;
+				// The bottom overridden material name
+				memo.beamSegments[idx].bottomMaterial.overridden = false;
+				if (currentSegment.Contains (Beam::BeamSegment::BottomMaterial)) {
+					memo.beamSegments[idx].bottomMaterial.overridden = true;
 
-				GS::UniString attrName;
-				currentSegment.Get (Beam::BeamSegment::BottomMaterial, attrName);
+					GS::UniString attrName;
+					currentSegment.Get (Beam::BeamSegment::BottomMaterial, attrName);
 
-				if (!attrName.IsEmpty ()) {
-					API_Attribute attrib;
-					BNZeroMemory (&attrib, sizeof (API_Attribute));
-					attrib.header.typeID = API_MaterialID;
-					CHCopyC (attrName.ToCStr (), attrib.header.name);
-					err = ACAPI_Attribute_Get (&attrib);
+					if (!attrName.IsEmpty ()) {
+						API_Attribute attrib;
+						BNZeroMemory (&attrib, sizeof (API_Attribute));
+						attrib.header.typeID = API_MaterialID;
+						CHCopyC (attrName.ToCStr (), attrib.header.name);
+						err = ACAPI_Attribute_Get (&attrib);
 
-					if (err == NoError) {
-						memo.beamSegments[idx].bottomMaterial.attributeIndex = attrib.header.index;
-						ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, bottomMaterial.attributeIndex);
+						if (err == NoError) {
+							memo.beamSegments[idx].bottomMaterial.attributeIndex = attrib.header.index;
+							ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, bottomMaterial.attributeIndex);
+						}
 					}
 				}
-			}
-			ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, bottomMaterial.overridden);
+				ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, bottomMaterial.overridden);
 
-			// The ends overridden material name
-			memo.beamSegments[idx].endsMaterial.overridden = false;
-			if (currentSegment.Contains (Beam::BeamSegment::EndsMaterial)) {
-				memo.beamSegments[idx].endsMaterial.overridden = true;
+				// The ends overridden material name
+				memo.beamSegments[idx].endsMaterial.overridden = false;
+				if (currentSegment.Contains (Beam::BeamSegment::EndsMaterial)) {
+					memo.beamSegments[idx].endsMaterial.overridden = true;
 
-				GS::UniString attrName;
-				currentSegment.Get (Beam::BeamSegment::EndsMaterial, attrName);
+					GS::UniString attrName;
+					currentSegment.Get (Beam::BeamSegment::EndsMaterial, attrName);
 
-				if (!attrName.IsEmpty ()) {
-					API_Attribute attrib;
-					BNZeroMemory (&attrib, sizeof (API_Attribute));
-					attrib.header.typeID = API_MaterialID;
-					CHCopyC (attrName.ToCStr (), attrib.header.name);
-					err = ACAPI_Attribute_Get (&attrib);
+					if (!attrName.IsEmpty ()) {
+						API_Attribute attrib;
+						BNZeroMemory (&attrib, sizeof (API_Attribute));
+						attrib.header.typeID = API_MaterialID;
+						CHCopyC (attrName.ToCStr (), attrib.header.name);
+						err = ACAPI_Attribute_Get (&attrib);
 
-					if (err == NoError) {
-						memo.beamSegments[idx].endsMaterial.attributeIndex = attrib.header.index;
-						ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, endsMaterial.attributeIndex);
+						if (err == NoError) {
+							memo.beamSegments[idx].endsMaterial.attributeIndex = attrib.header.index;
+							ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, endsMaterial.attributeIndex);
+						}
 					}
 				}
-			}
-			ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, endsMaterial.overridden);
+				ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, endsMaterial.overridden);
 
-			// The overridden materials are chained
-			if (currentSegment.Contains (Beam::BeamSegment::MaterialsChained)) {
-				currentSegment.Get (Beam::BeamSegment::MaterialsChained, memo.beamSegments[idx].materialsChained);
-				ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, materialsChained);
+				// The overridden materials are chained
+				if (currentSegment.Contains (Beam::BeamSegment::MaterialsChained)) {
+					currentSegment.Get (Beam::BeamSegment::MaterialsChained, memo.beamSegments[idx].materialsChained);
+					ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamSegmentType, materialsChained);
+				}
 			}
 		}
-	}
 #pragma endregion
 
 	// Scheme

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
@@ -2,6 +2,7 @@
 #include "Utility.hpp"
 #include "CreateCommand.hpp"
 #include "LibpartImportManager.hpp"
+#include "ClassificationImportManager.hpp"
 #include "APIHelper.hpp"
 #include "FieldNames.hpp"
 #include "OnExit.hpp"
@@ -63,14 +64,14 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 		db.SwitchToFloorPlan ();
 
 		for (const GS::ObjectState& objectState : objectStates) {
-			API_Element element {};
-			API_Element elementMask {};
-			API_ElementMemo memo {};
+			API_Element element{};
+			API_Element elementMask{};
+			API_ElementMemo memo{};
 			GS::UInt64 memoMask = 0;
 			API_SubElement* marker = nullptr;
 			GS::OnExit memoDisposer ([&memo, &marker] {
 				ACAPI_DisposeElemMemoHdls (&memo);
-				
+
 				if (marker != nullptr)
 					ACAPI_DisposeElemMemoHdls (&marker->memo);
 			});
@@ -80,21 +81,21 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 			GS::String speckleId;
 			{
 				objectState.Get (ElementBase::Id, speckleId);
-				
-				if (speckleId.IsEmpty())
+
+				if (speckleId.IsEmpty ())
 					err = Error;
 			}
-	
+
 			bool elementExists = false;
 			GS::Array<GS::UniString> log;
-			
+
 			if (err == NoError) {
 				bool isConverted = false;
 				API_Guid convertedArchicadId;
-				ExchangeManager::GetInstance().GetState (speckleId, isConverted, convertedArchicadId);
-				
+				ExchangeManager::GetInstance ().GetState (speckleId, isConverted, convertedArchicadId);
+
 				elementExists = isConverted && Utility::ElementExists (convertedArchicadId);
-				
+
 				{
 					// if already converted and element exists, use that
 					if (elementExists) {
@@ -107,7 +108,7 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 						element.header.guid = APIGuidFromString (applicationId.ToCStr ());
 					}
 				}
-				
+
 				err = GetElementFromObjectState (objectState, element, elementMask, memo, memoMask, &marker, *attributeManager, *libpartImportManager, log);
 				if (err == NoError) {
 					if (elementExists) {
@@ -116,6 +117,9 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 						err = CreateNewElement (element, memo, marker);
 					}
 				}
+
+				if (err == NoError)
+					err = ImportClassificationsAndProperties (objectState, element.header.guid);
 			}
 
 			GS::ObjectState applicationObject;
@@ -133,7 +137,7 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 				else
 					applicationObject.Add (ApplicationObject::Status, ApplicationObject::StateCreated);
 
-				ExchangeManager::GetInstance().UpdateState (speckleId, element.header.guid);
+				ExchangeManager::GetInstance ().UpdateState (speckleId, element.header.guid);
 			} else {
 				applicationObject.Add (ApplicationObject::Status, ApplicationObject::StateFailed);
 				applicationObject.Add (ApplicationObject::Log, log);
@@ -148,6 +152,62 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 	});
 
 	return result;
+}
+
+
+GS::ErrCode CreateCommand::ImportClassificationsAndProperties (const GS::ObjectState& os, API_Guid& elemGuid) const
+{
+	GSErrCode err = NoError;
+	GS::Array<GS::ObjectState> classifications;
+	os.Get (FieldNames::ElementBase::Classifications, classifications);
+
+	// store guids of the Archicad classification items in a set
+	GS::HashSet<API_Guid> classificationItemsInArchicad;
+	{
+		GS::Array<GS::Pair<API_Guid, API_Guid>> systemItemPairs;
+		err = ACAPI_Element_GetClassificationItems (elemGuid, systemItemPairs);
+		if (err != NoError)
+			return err;
+
+		for (auto& systemItemPair : systemItemPairs) {
+			classificationItemsInArchicad.Add (systemItemPair.second);
+		}
+	}
+
+	// store guids of the Speckle classification items in a set
+	GS::HashSet<API_Guid> classificationItemsInSpekcle;
+	{
+		GS::UniString code;
+		GS::UniString system;
+		GS::UniString name;
+		for (auto& classification : classifications) {
+			API_Guid itemGuid;
+			classification.Get (FieldNames::ElementBase::Classification::System, system);
+			classification.Get (FieldNames::ElementBase::Classification::Code, code);
+			classification.Get (FieldNames::ElementBase::Classification::Name, name); // for later usage
+
+			err = ClassificationImportManager::GetInstance ()->GetItem (system, code, itemGuid);
+			if (err != NoError)
+				return err;
+			classificationItemsInSpekcle.Add (itemGuid);
+		}
+	}
+
+	// in Archicad but not in Speckle
+	for (auto& itemGuid : classificationItemsInArchicad.Where ([&] (const API_Guid& guid) { return !classificationItemsInSpekcle.Contains(guid); })) {
+		err = ACAPI_Element_RemoveClassificationItem (elemGuid, itemGuid);
+		if (err != NoError)
+			return err;
+	}
+
+	// in Speckle but not in Archicad
+	for (auto& itemGuid : classificationItemsInSpekcle.Where ([&] (const API_Guid& guid) { return !classificationItemsInArchicad.Contains(guid); })) {
+		err = ACAPI_Element_AddClassificationItem (elemGuid, itemGuid);
+		if (err != NoError)
+			return err;
+	}
+
+	return err;
 }
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.hpp
@@ -41,6 +41,8 @@ protected:
 
 public:
 	virtual GS::ObjectState	Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+
+	GS::ErrCode				ImportClassificationsAndProperties (const GS::ObjectState& os, API_Guid& elemGuid) const;
 };
 }
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/FinishReceiveTransaction.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/FinishReceiveTransaction.cpp
@@ -1,5 +1,6 @@
 #include "FinishReceiveTransaction.hpp"
 #include "LibpartImportManager.hpp"
+#include "ClassificationImportManager.hpp"
 #include "ResourceIds.hpp"
 
 
@@ -7,6 +8,7 @@ GS::ObjectState AddOnCommands::FinishReceiveTransaction::Execute (const GS::Obje
 {
 	AttributeManager::DeleteInstance();
     LibpartImportManager::DeleteInstance ();
+	ClassificationImportManager::DeleteInstance ();
     return GS::ObjectState ();
 }
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetBeamData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetBeamData.cpp
@@ -40,8 +40,10 @@ GS::ErrCode GetBeamData::SerializeElementType (const API_Element& elem,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	// The identifier of the beam
-	os.Add (ElementBase::ApplicationId, APIGuidToString (elem.beam.head.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (elem, memo, os);
+	if (NoError != err)
+		return err;
 
 	// Positioning
 	API_StoryType story = Utility::GetStory (elem.beam.head.floorInd);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetColumnData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetColumnData.cpp
@@ -37,8 +37,10 @@ GS::ErrCode	GetColumnData::SerializeElementType (const API_Element& elem,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	// The identifier of the column
-	os.Add (ElementBase::ApplicationId, APIGuidToString (elem.column.head.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (elem, memo, os);
+	if (NoError != err)
+		return err;
 
 	// Positioning - geometry
 	API_StoryType story = Utility::GetStory (elem.column.head.floorInd);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
@@ -14,7 +14,7 @@ GS::ErrCode GetDataCommand::ExportClassificationsAndProperties (const API_Elemen
 
 	{
 		GS::UniString typeName;
-		err = Utility::GetTypeNameFromElementType(elem.header.type, typeName);
+		err = Utility::GetTypeNameFromElementType(elem.header, typeName);
 		if (err != NoError)
 			return err;
 		

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
@@ -7,10 +7,70 @@
 namespace AddOnCommands
 {
 
+	
+GS::ErrCode GetDataCommand::ExportClassificationsAndProperties (const API_Element& elem, GS::ObjectState& os) const
+{
+	GS::ErrCode err = NoError;
+
+	{
+		GS::UniString typeName;
+		err = Utility::GetTypeNameFromElementType(elem.header.type, typeName);
+		if (err != NoError)
+			return err;
+		
+		os.Add(FieldNames::ElementBase::ElementType, typeName);
+	}
+	
+	GS::Array<GS::Pair<API_Guid, API_Guid>> systemItemPairs;
+	err = ACAPI_Element_GetClassificationItems (elem.header.guid, systemItemPairs);
+	if (err != NoError)
+		return err;
+
+	const auto& classificationListAdder = os.AddList<GS::ObjectState> (FieldNames::ElementBase::Classifications);
+	for (const auto& systemItemPair : systemItemPairs) {
+		GS::ObjectState classificationOs;
+		API_ClassificationSystem system;
+		system.guid = systemItemPair.first;
+		err = ACAPI_Classification_GetClassificationSystem (system);
+		if (err != NoError)
+			break;
+
+		classificationOs.Add (FieldNames::ElementBase::Classification::System, system.name);
+		
+		API_ClassificationItem item;
+		item.guid = systemItemPair.second;
+		err = ACAPI_Classification_GetClassificationItem (item);
+		if (err != NoError)
+			break;
+
+		if (!item.id.IsEmpty())
+			classificationOs.Add (FieldNames::ElementBase::Classification::Code, item.id);
+
+		if (!item.name.IsEmpty())
+			classificationOs.Add (FieldNames::ElementBase::Classification::Name, item.name);
+
+		classificationListAdder (classificationOs);
+	}
+
+	return err;
+}
+
 
 GS::UInt64 GetDataCommand::GetMemoMask () const
 {
 	return APIMemoMask_All;
+}
+
+
+GS::ErrCode GetDataCommand::SerializeElementType(const API_Element& elem, const API_ElementMemo& /*memo*/, GS::ObjectState& os) const
+{
+	GS::ErrCode err = NoError;
+
+	os.Add(FieldNames::ElementBase::ApplicationId, APIGuidToString (elem.header.guid));
+
+	err = ExportClassificationsAndProperties (elem, os);
+
+	return err;
 }
 
 
@@ -36,10 +96,13 @@ GS::ObjectState GetDataCommand::Execute (const GS::ObjectState& parameters,
 			continue;
 		}
 
-		API_ElemTypeID elementType = Utility::GetElementType (element.header);
-		if (elementType != GetElemTypeID ())
-		{
-			continue;
+		// check for elem type
+		if (API_ZombieElemID != GetElemTypeID ()) {
+			API_ElemTypeID elementType = Utility::GetElementType (element.header);
+			if (elementType != GetElemTypeID ())
+			{
+				continue;
+			}
 		}
 
 		err = ACAPI_Element_GetMemo (guid, &memo, GetMemoMask ());

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.hpp
@@ -11,13 +11,17 @@ class GetDataCommand : public BaseCommand {
 	virtual GS::String		GetFieldName () const = 0;
 	virtual API_ElemTypeID	GetElemTypeID () const = 0;
 	virtual GS::UInt64		GetMemoMask () const;
-	virtual GS::ErrCode		SerializeElementType (const API_Element& elem,
-								const API_ElementMemo& memo,
-								GS::ObjectState& os) const = 0;
+	
+protected:
+	GS::ErrCode				ExportClassificationsAndProperties(const API_Element& elem, GS::ObjectState& os) const;
 
+	virtual GS::ErrCode		SerializeElementType (const API_Element& elem,
+												  const API_ElementMemo& memo,
+												  GS::ObjectState& os) const;
+	
 public:
 	virtual GS::ObjectState	Execute (const GS::ObjectState& parameters,
-								GS::ProcessControl& processControl) const override;
+									 GS::ProcessControl& processControl) const override;
 };
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDoorData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDoorData.cpp
@@ -26,10 +26,14 @@ API_ElemTypeID GetDoorData::GetElemTypeID () const
 
 
 GS::ErrCode	GetDoorData::SerializeElementType (const API_Element& element,
-	const API_ElementMemo& /*memo*/,
+	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	os.Add (ElementBase::ApplicationId, APIGuidToString (element.header.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
+
 	os.Add (ElementBase::ParentElementId, APIGuidToString (element.door.owner));
 
 	AddOnCommands::GetDoorWindowData<API_DoorType> (element.door, os);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementBaseData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementBaseData.cpp
@@ -1,0 +1,58 @@
+#include "GetElementBaseData.hpp"
+#include "ResourceIds.hpp"
+#include "ObjectState.hpp"
+#include "Utility.hpp"
+#include "Objects/Level.hpp"
+#include "RealNumber.h"
+#include "FieldNames.hpp"
+#include "TypeNameTables.hpp"
+
+using namespace FieldNames;
+
+
+namespace AddOnCommands
+{
+
+
+GS::String GetElementBaseData::GetFieldName () const
+{
+	return Elements;
+}
+
+
+API_ElemTypeID GetElementBaseData::GetElemTypeID () const
+{
+	return API_ZombieElemID;
+}
+
+
+GS::UInt64 GetElementBaseData::GetMemoMask () const
+{
+	return 0;
+}
+
+
+GS::ErrCode GetElementBaseData::SerializeElementType (const API_Element& elem,
+	const API_ElementMemo& memo,
+	GS::ObjectState& os) const
+{
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (elem, memo, os);
+	if (NoError != err)
+		return err;
+
+	// Positioning
+	API_StoryType story = Utility::GetStory (elem.beam.head.floorInd);
+	os.Add (ElementBase::Level, Objects::Level (story));
+
+	return NoError;
+}
+
+
+GS::String GetElementBaseData::GetName () const
+{
+	return GetElementBaseDataCommandName;
+}
+
+
+} // namespace AddOnCommands

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementBaseData.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementBaseData.hpp
@@ -1,0 +1,26 @@
+#ifndef GET_ELEMENTBASE_DATA_HPP
+#define GET_ELEMENTBASE_DATA_HPP
+
+#include "GetDataCommand.hpp"
+
+
+namespace AddOnCommands {
+
+
+class GetElementBaseData : public GetDataCommand {
+	GS::String			GetFieldName () const override;
+	API_ElemTypeID		GetElemTypeID () const override;
+	GS::UInt64			GetMemoMask () const override;
+	GS::ErrCode			SerializeElementType (const API_Element& elem,
+							const API_ElementMemo& memo,
+							GS::ObjectState& os) const override;
+
+public:
+	virtual GS::String	GetName () const override;
+};
+
+
+}
+
+
+#endif

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetObjectData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetObjectData.cpp
@@ -26,10 +26,13 @@ API_ElemTypeID GetObjectData::GetElemTypeID() const
 
 
 GS::ErrCode	GetObjectData::SerializeElementType (const API_Element& elem,
-	const API_ElementMemo& /*memo*/,
+	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	os.Add (ElementBase::ApplicationId, APIGuidToString (elem.object.head.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (elem, memo, os);
+	if (NoError != err)
+		return err;
 
 	API_StoryType story = Utility::GetStory (elem.object.head.floorInd);
 	os.Add (ElementBase::Level, Objects::Level (story));

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoofData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoofData.cpp
@@ -29,6 +29,11 @@ GS::ErrCode GetRoofData::SerializeElementType (const API_Element& element,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
+
 	// quantities
 	API_ElementQuantity quantity = {};
 	API_Quantities quantities = {};
@@ -38,12 +43,9 @@ GS::ErrCode GetRoofData::SerializeElementType (const API_Element& element,
 	ACAPI_ELEMENT_QUANTITY_MASK_SET (quantityMask, roof, volume);
 
 	quantities.elements = &quantity;
-	GSErrCode err = ACAPI_Element_GetQuantities (element.roof.head.guid, nullptr, &quantities, &quantityMask);
+	err = ACAPI_Element_GetQuantities (element.roof.head.guid, nullptr, &quantities, &quantityMask);
 	if (err != NoError)
 		return err;
-
-	// The identifier of the roof
-	os.Add (ElementBase::ApplicationId, APIGuidToString (element.roof.head.guid));
 
 	// Geometry and positioning
 	// The story of the shell

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoomData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetRoomData.cpp
@@ -30,6 +30,11 @@ GS::ErrCode GetRoomData::SerializeElementType (const API_Element& element,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
+
 	// quantities
 	API_ElementQuantity	quantity = {};
 	API_Quantities		quantities = {};
@@ -40,12 +45,10 @@ GS::ErrCode GetRoomData::SerializeElementType (const API_Element& element,
 	ACAPI_ELEMENT_QUANTITY_MASK_SET (mask, zone, volume);
 
 	quantities.elements = &quantity;
-	GSErrCode err = ACAPI_Element_GetQuantities (element.header.guid, nullptr, &quantities, &mask);
+	err = ACAPI_Element_GetQuantities (element.header.guid, nullptr, &quantities, &mask);
 	if (err != NoError)
 		return err;
 
-	// The identifier of the room
-	os.Add (ElementBase::ApplicationId, APIGuidToString (element.zone.head.guid));
 	GS::UniString roomName = element.zone.roomName;
 	GS::UniString roomNum = element.zone.roomNoStr;
 	os.Add (Room::Name, roomName);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetShellData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetShellData.cpp
@@ -30,8 +30,10 @@ GS::ErrCode	GetShellData::SerializeElementType (const API_Element& element,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	// The identifier of the shell
-	os.Add (ElementBase::ApplicationId, APIGuidToString (element.shell.head.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
 
 	// Geometry and positioning
 	// The story of the shell

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSkylightData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSkylightData.cpp
@@ -26,10 +26,14 @@ API_ElemTypeID GetSkylightData::GetElemTypeID () const
 
 
 GS::ErrCode	GetSkylightData::SerializeElementType (const API_Element& element,
-  const API_ElementMemo& /*memo*/,
+  const API_ElementMemo& memo,
   GS::ObjectState& os) const
 {
-	os.Add (ElementBase::ApplicationId, APIGuidToString (element.header.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
+
 	os.Add (ElementBase::ParentElementId, APIGuidToString (element.skylight.owner));
 
 	os.Add (Skylight::VertexID, element.skylight.vertexID);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSlabData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSlabData.cpp
@@ -28,8 +28,10 @@ GS::ErrCode GetSlabData::SerializeElementType (const API_Element& element,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	// The identifier of the slab
-	os.Add (ElementBase::ApplicationId, APIGuidToString (element.slab.head.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
 
 	// Geometry and positioning
 	// The index of the slab's floor

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetWallData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetWallData.cpp
@@ -31,10 +31,12 @@ GS::ErrCode GetWallData::SerializeElementType (const API_Element& element,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	const API_WallType wall = element.wall;
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
 
-	// The identifier of the wall
-	os.Add (ElementBase::ApplicationId, APIGuidToString (wall.head.guid));
+	const API_WallType wall = element.wall;
 
 	// Wall geometry
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetWindowData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetWindowData.cpp
@@ -26,10 +26,14 @@ API_ElemTypeID GetWindowData::GetElemTypeID () const
 
 
 GS::ErrCode	GetWindowData::SerializeElementType (const API_Element& element,
-	const API_ElementMemo& /*memo*/,
+	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
-	os.Add (ElementBase::ApplicationId, APIGuidToString (element.header.guid));
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
+
 	os.Add (ElementBase::ParentElementId, APIGuidToString (element.window.owner));
 
 	AddOnCommands::GetDoorWindowData<API_WindowType> (element.window, os);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
@@ -34,8 +34,17 @@ static const char* Level = "level";
 static const char* Shape = "shape";
 static const char* Shape1 = "shape1";
 static const char* Shape2 = "shape2";
+
+static const char* Classifications = "classifications";
+namespace Classification
+{
+static const char* System = "system";
+static const char* Code = "code"; // id is reserved for Speckle id
+static const char* Name = "name";
+}
 }
 
+static const char* Elements = "elements";
 static const char* Beams = "beams";
 static const char* Columns = "columns";
 static const char* DirectShapes = "directShapes";
@@ -728,6 +737,7 @@ static const char* Edges = "edges";
 
 namespace Level
 {
+static const char* TypeName		= "level";
 static const char* Index		= "index";
 static const char* Name			= "name";
 static const char* Elevation	= "elevation";

--- a/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
@@ -19,6 +19,7 @@
 #define GetWindowCommandName					"GetWindowData";
 #define GetBeamDataCommandName					"GetBeamData";
 #define GetColumnDataCommandName				"GetColumnData";
+#define GetElementBaseDataCommandName			"GetElementBaseData";
 #define GetObjectDataCommandName				"GetObjectData";
 #define GetSlabDataCommandName					"GetSlabData";
 #define GetRoomDataCommandName					"GetRoomData";

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
@@ -38,6 +38,7 @@ GS::ErrCode GetTypeNameFromElementType (const API_Elem_Head& header, GS::UniStri
 #ifdef ServerMainVers_2600
 	return ACAPI_Goodies_GetElemTypeName (header.type, typeName);
 #else
+	UNUSED (header);
 	typeName = "Archicad Element"; // ACAPI_Goodies_GetElemTypeName not implemented in Archicad 25
 	return NoError;
 #endif

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
@@ -33,6 +33,12 @@ API_ElemTypeID GetElementType (const API_Guid& guid)
 }
 
 
+GS::ErrCode GetTypeNameFromElementType (const API_ElemType& type, GS::UniString& typeName)
+{
+	return ACAPI_Goodies_GetElemTypeName (type, typeName);
+}
+
+
 void SetElementType (API_Elem_Head& header, const API_ElemTypeID& elementType)
 {
 #ifdef ServerMainVers_2600
@@ -251,8 +257,8 @@ GS::Array<API_Guid> GetElementSubelements (API_Element& element)
 {
 	GS::Array<API_Guid> result;
 
-	API_ElemTypeID elementType = GetElementType(element.header);
-				
+	API_ElemTypeID elementType = GetElementType (element.header);
+
 	if (elementType == API_WallID) {
 		if (element.wall.hasDoor) {
 			GS::Array<API_Guid> doors;
@@ -475,15 +481,15 @@ GSErrCode CreateAllSchemeData (const GS::ObjectState& os,
 		defaultSegmentScheme = memo->assemblySegmentSchemes[0];
 
 		switch (Utility::GetElementType (element.header)) {
-			case API_BeamID:
-				memo->assemblySegmentSchemes = (API_AssemblySegmentSchemeData*) BMAllocatePtr ((element.beam.nSchemes) * sizeof (API_AssemblySegmentSchemeData), ALLOCATE_CLEAR, 0);
-				break;
-			case API_ColumnID:
-				memo->assemblySegmentSchemes = (API_AssemblySegmentSchemeData*) BMAllocatePtr ((element.column.nSchemes) * sizeof (API_AssemblySegmentSchemeData), ALLOCATE_CLEAR, 0);
-				break;
-			default:  // In case if not beam or column
-				return Error;
-				break;
+		case API_BeamID:
+			memo->assemblySegmentSchemes = (API_AssemblySegmentSchemeData*) BMAllocatePtr ((element.beam.nSchemes) * sizeof (API_AssemblySegmentSchemeData), ALLOCATE_CLEAR, 0);
+			break;
+		case API_ColumnID:
+			memo->assemblySegmentSchemes = (API_AssemblySegmentSchemeData*) BMAllocatePtr ((element.column.nSchemes) * sizeof (API_AssemblySegmentSchemeData), ALLOCATE_CLEAR, 0);
+			break;
+		default:  // In case if not beam or column
+			return Error;
+			break;
 		}
 	} else {
 		return Error;
@@ -505,7 +511,7 @@ GSErrCode CreateAllSchemeData (const GS::ObjectState& os,
 	return err;
 }
 
-	
+
 GSErrCode GetOneCutData (const API_AssemblySegmentCutData& cutData, GS::ObjectState& out)
 {
 	out.Add (AssemblySegmentCutData::cutType, assemblySegmentCutTypeNames.Get (cutData.cutType));
@@ -564,14 +570,14 @@ GSErrCode CreateAllCutData (const GS::ObjectState& os, GS::UInt32& numberOfCuts,
 		defaultSegmentCut = memo->assemblySegmentCuts[0];
 
 		switch (GetElementType (element.header)) {
-			case API_BeamID:
-				memo->assemblySegmentCuts = (API_AssemblySegmentCutData*) BMAllocatePtr ((element.beam.nCuts) * sizeof (API_AssemblySegmentCutData), ALLOCATE_CLEAR, 0);
-				break;
-			case API_ColumnID:
-				memo->assemblySegmentCuts = (API_AssemblySegmentCutData*) BMAllocatePtr ((element.column.nCuts) * sizeof (API_AssemblySegmentCutData), ALLOCATE_CLEAR, 0);
-			default: // In case if not beam or column
-				return Error;
-				break;
+		case API_BeamID:
+			memo->assemblySegmentCuts = (API_AssemblySegmentCutData*) BMAllocatePtr ((element.beam.nCuts) * sizeof (API_AssemblySegmentCutData), ALLOCATE_CLEAR, 0);
+			break;
+		case API_ColumnID:
+			memo->assemblySegmentCuts = (API_AssemblySegmentCutData*) BMAllocatePtr ((element.column.nCuts) * sizeof (API_AssemblySegmentCutData), ALLOCATE_CLEAR, 0);
+		default: // In case if not beam or column
+			return Error;
+			break;
 		}
 
 	} else {
@@ -762,7 +768,7 @@ GSErrCode CreateOnePivotPolyEdgeData (GS::ObjectState& currentPivotPolyEdge, API
 }
 
 
-GSErrCode CreateAllPivotPolyEdgeData (GS::ObjectState& allPivotPolyEdges, GS::UInt32& numberOfPivotPolyEdges, API_ElementMemo * memo)
+GSErrCode CreateAllPivotPolyEdgeData (GS::ObjectState& allPivotPolyEdges, GS::UInt32& numberOfPivotPolyEdges, API_ElementMemo* memo)
 {
 	memo->pivotPolyEdges = (API_PivotPolyEdgeData*) BMAllocatePtr ((numberOfPivotPolyEdges + 1) * sizeof (API_PivotPolyEdgeData), ALLOCATE_CLEAR, 0);
 
@@ -944,8 +950,8 @@ GSErrCode GetCoverFillTransformation (bool coverFillOrientationComesFrom3D,
 }
 
 
-GSErrCode CreateCoverFillTransformation (const GS::ObjectState& os, 
-	bool& coverFillOrientationComesFrom3D, 
+GSErrCode CreateCoverFillTransformation (const GS::ObjectState& os,
+	bool& coverFillOrientationComesFrom3D,
 	API_CoverFillTransformationTypeID& coverFillTransformationType)
 {
 	coverFillOrientationComesFrom3D = false;
@@ -1032,7 +1038,7 @@ GSErrCode CreateTransform (const GS::ObjectState& os, API_Tranmat& transform)
 {
 	GS::ObjectState matrixOs;
 	os.Get ("matrix", matrixOs);
-	
+
 	for (GSSize idx1 = 0; idx1 < 3; ++idx1) {
 		for (GSSize idx2 = 0; idx2 < 4; ++idx2) {
 			matrixOs.Get (GS::String::SPrintf ("M%d%d", idx1 + 1, idx2 + 1), transform.tmx[idx1 * 4 + idx2]);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.cpp
@@ -33,9 +33,14 @@ API_ElemTypeID GetElementType (const API_Guid& guid)
 }
 
 
-GS::ErrCode GetTypeNameFromElementType (const API_ElemType& type, GS::UniString& typeName)
+GS::ErrCode GetTypeNameFromElementType (const API_Elem_Head& header, GS::UniString& typeName)
 {
-	return ACAPI_Goodies_GetElemTypeName (type, typeName);
+#ifdef ServerMainVers_2600
+	return ACAPI_Goodies_GetElemTypeName (header.type, typeName);
+#else
+	typeName = "Archicad Element"; // ACAPI_Goodies_GetElemTypeName not implemented in Archicad 25
+	return NoError;
+#endif
 }
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
@@ -11,7 +11,7 @@ namespace Utility {
 
 API_ElemTypeID GetElementType (const API_Elem_Head& header);
 API_ElemTypeID GetElementType (const API_Guid& guid);
-GS::ErrCode GetTypeNameFromElementType(const API_ElemType& typeId, GS::UniString& typeName);
+GS::ErrCode GetTypeNameFromElementType(const API_Elem_Head& header, GS::UniString& typeName);
 void SetElementType (API_Elem_Head& header, const API_ElemTypeID& elementType);
 
 bool ElementExists (const API_Guid& guid);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
@@ -11,6 +11,7 @@ namespace Utility {
 
 API_ElemTypeID GetElementType (const API_Elem_Head& header);
 API_ElemTypeID GetElementType (const API_Guid& guid);
+GS::ErrCode GetTypeNameFromElementType(const API_ElemType& typeId, GS::UniString& typeName);
 void SetElementType (API_Elem_Head& header, const API_ElemTypeID& elementType);
 
 bool ElementExists (const API_Guid& guid);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
@@ -5,6 +5,8 @@
 #include "ACAPinc.h"
 #include "ResourceIds.hpp"
 
+#define UNUSED(x) (void)(x)
+
 
 namespace Utility {
 

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementBaseData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementBaseData.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
+using Objects.BuiltElements.Archicad;
+
+namespace Archicad.Communication.Commands
+{
+  sealed internal class GetElementBaseData : ICommand<IEnumerable<DirectShape>>
+  {
+    [JsonObject(MemberSerialization.OptIn)]
+    public sealed class Parameters
+    {
+      [JsonProperty("applicationIds")]
+      private IEnumerable<string> ApplicationIds { get; }
+
+      public Parameters(IEnumerable<string> applicationIds)
+      {
+        ApplicationIds = applicationIds;
+      }
+    }
+
+    [JsonObject(MemberSerialization.OptIn)]
+    private sealed class Result
+    {
+      [JsonProperty("elements")]
+      public IEnumerable<DirectShape> Datas { get; private set; }
+    }
+
+    private IEnumerable<string> ApplicationIds { get; }
+
+    public GetElementBaseData(IEnumerable<string> applicationIds)
+    {
+      ApplicationIds = applicationIds;
+    }
+
+    public async Task<IEnumerable<DirectShape>> Execute()
+    {
+      Result result = await HttpCommandExecutor.Execute<Parameters, Result>(
+        "GetElementBaseData",
+        new Parameters(ApplicationIds)
+      );
+      foreach (var directShape in result.Datas)
+        directShape.units = Units.Meters;
+
+      return result.Datas;
+    }
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ConversionOptions.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ConversionOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using DesktopUI2.Models.Settings;
 using DesktopUI2.Views.Controls.StreamEditControls;

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
@@ -162,7 +162,9 @@ namespace Archicad.Converters
             applicationId = element.applicationId,
             pos = Utils.ScaleToNative(basePoint),
             transform = new Objects.Other.Transform(transform.ConvertToUnits(Units.Meters), Units.Meters),
-            modelIds = meshIdHashes
+            modelIds = meshIdHashes,
+            level = element["level"] as Objects.BuiltElements.Archicad.ArchicadLevel,
+            classifications = element["classifications"] as List<Objects.BuiltElements.Archicad.Classification>
           };
 
           archicadObjects.Add(newObject);

--- a/ConnectorArchicad/ConnectorArchicad/Elements/Object.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Elements/Object.cs
@@ -1,6 +1,5 @@
 using Objects.Geometry;
-using Objects.Structural.Materials;
-using Objects.Structural.Properties.Profiles;
+using Objects.BuiltElements.Archicad;
 using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
@@ -18,6 +17,12 @@ namespace Archicad
   {
     public string id { get; set; }
     public string applicationId { get; set; }
+
+    // Element base
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
+
+    public ArchicadLevel level { get; set; }
 
     public Point pos { get; set; }
     public Objects.Other.Transform transform { get; set; }

--- a/ConnectorArchicad/ConnectorArchicad/UI/ConnectorBinding.Settings.cs
+++ b/ConnectorArchicad/ConnectorArchicad/UI/ConnectorBinding.Settings.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using DesktopUI2.Models.Settings;
 

--- a/Objects/Objects/BuiltElements/Archicad/Classification.cs
+++ b/Objects/Objects/BuiltElements/Archicad/Classification.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+
+namespace Objects.BuiltElements.Archicad
+{
+  public class Classification : Base
+  {
+    public Classification() { }
+
+    [SchemaInfo("Classification", "A classification to set on an element", "BIM", "All")]
+    public Classification(string system, string code = null, string name = null)
+    {
+      this.system = system;
+      this.code = code;
+      this.name = name;
+    }
+
+    public string system { get; set; }
+    public string ?code { get; set; }
+    public string ?name { get; set; }
+  }
+}

--- a/Objects/Objects/BuiltElements/Archicad/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Archicad/DirectShape.cs
@@ -14,6 +14,14 @@ public class DirectShape : Base
     this.displayValue = displayValue;
   }
 
+  // Element base
+  public string elementType { get; set; }
+  public List<Classification> classifications { get; set; }
+
+  public ArchicadLevel level { get; set; }
+
+  public string units { get; set; }
+
   [DetachProperty]
   public List<Mesh> displayValue { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Archicad/Fenestration.cs
+++ b/Objects/Objects/BuiltElements/Archicad/Fenestration.cs
@@ -9,6 +9,10 @@ public class ArchicadFenestration : Base, IDisplayValue<List<Mesh>>
 {
   public string parentApplicationId { get; set; }
 
+  // Element base
+  public string elementType { get; set; }
+  public List<Classification> classifications { get; set; }
+
   public double width { get; set; }
   public double height { get; set; }
   public double subFloorThickness { get; set; }

--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Objects.Geometry;
 using Objects.Structural.Materials;
 using Objects.Structural.Properties.Profiles;
@@ -123,8 +123,13 @@ namespace Objects.BuiltElements.Archicad
     [SchemaInfo("ArchicadBeam", "Creates an Archicad beam by curve.", "Archicad", "Structure")]
     public ArchicadBeam() { }
 
-    // Positioning
+    // Element base
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
+
     public ArchicadLevel level { get; set; }
+
+    // Positioning
     public Point begC { get; set; }
     public Point endC { get; set; }
     public bool isSlanted { get; set; }

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Objects.Geometry;
 using Objects.Utils;
 using Speckle.Core.Kits;
@@ -149,8 +149,13 @@ namespace Objects.BuiltElements.Archicad
     [SchemaInfo("ArchicadColumn", "Creates an Archicad Column by curve.", "Archicad", "Structure")]
     public ArchicadColumn() { }
 
-    // Wall geometry
+    // Element base
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
+
     public ArchicadLevel level { get; set; }
+
+    // Wall geometry
     public Point origoPos { get; set; }
     public double height { get; set; }
 

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Objects.Geometry;
 using Objects.Utils;
@@ -87,8 +87,13 @@ namespace Objects.BuiltElements.Archicad
   */
   public sealed class ArchicadFloor : Floor
   {
-    // Geometry and positioning
+    // Element base
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
+
     public ArchicadLevel level { get; set; }
+
+    // Geometry and positioning
     public double? thickness { get; set; }
     public ElementShape shape { get; set; }
     public string structure { get; set; }

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -138,8 +138,13 @@ namespace Objects.BuiltElements.Archicad
       public short? showRelBelow { get; set; }
     }
 
+    // Element base
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
+
+    public ArchicadLevel level { get; set; }
+
     // Geometry and positioning
-    public Level level { get; set; }
     public double? thickness { get; set; }
     public string structure { get; set; }
     public string? compositeName { get; set; }

--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Objects.BuiltElements.Revit;
 using Objects.Geometry;
 using Objects.Utils;
@@ -69,6 +69,10 @@ namespace Objects.BuiltElements.Archicad
   */
   public class ArchicadRoom : Room
   {
+    // Element base
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
+
     public ArchicadLevel level { get; set; }
 
     public double height { get; set; }

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Objects.Geometry;
@@ -280,27 +280,24 @@ namespace Objects.BuiltElements.Archicad
     [SchemaInfo("ArchicadWall", "Creates an Archicad wall.", "Archicad", "Structure")]
     public ArchicadWall() { }
 
-    // Wall geometry
+    // Element base
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
+
     public ArchicadLevel level { get; set; }
 
+    // Wall geometry
     public double baseOffset { get; set; }
-
     public Point startPoint { get; set; }
-
     public Point endPoint { get; set; }
 
     public string structure { get; set; }
-
     public string geometryMethod { get; set; }
-
     public string wallComplexity { get; set; }
 
     public string? buildingMaterialName { get; set; }
-
     public string? compositeName { get; set; }
-
     public string? profileName { get; set; }
-
     public double? arcAngle { get; set; }
 
     public ElementShape? shape { get; set; }
@@ -308,83 +305,54 @@ namespace Objects.BuiltElements.Archicad
     public double thickness { get; set; }
 
     public double? outsideSlantAngle { get; set; }
-
     public double? insideSlantAngle { get; set; }
 
     public bool? polyWalllCornersCanChange { get; set; }
 
     // Wall and stories relation
     public double topOffset { get; set; }
-
     public short relativeTopStory { get; set; }
-
     public string referenceLineLocation { get; set; }
-
     public double? referenceLineOffset { get; set; }
-
     public double offsetFromOutside { get; set; }
-
     public int referenceLineStartIndex { get; set; }
-
     public int referenceLineEndIndex { get; set; }
-
     public bool flipped { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
     public string showOnStories { get; set; }
-
     public string displayOptionName { get; set; }
-
     public string showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces parameters
     public short? cutLinePen { get; set; }
-
     public string? cutLinetype { get; set; }
-
     public short? overrideCutFillPen { get; set; }
-
     public short? overrideCutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines parameters
     public short uncutLinePen { get; set; }
-
     public string uncutLinetype { get; set; }
-
     public short overheadLinePen { get; set; }
-
     public string overheadLinetype { get; set; }
 
     // Model - Override Surfaces
     public string? referenceMaterialName { get; set; }
-
     public int? referenceMaterialStartIndex { get; set; }
-
     public int? referenceMaterialEndIndex { get; set; }
-
     public string? oppositeMaterialName { get; set; }
-
     public int? oppositeMaterialStartIndex { get; set; }
-
     public int? oppositeMaterialEndIndex { get; set; }
-
     public string? sideMaterialName { get; set; }
-
     public bool materialsChained { get; set; }
-
     public bool inheritEndSurface { get; set; }
-
     public bool alignTexture { get; set; }
-
     public int sequence { get; set; }
 
     // Model - Log Details (log height, start with half log, surface of horizontal edges, log shape)
     public double? logHeight { get; set; }
-
     public bool? startWithHalfLog { get; set; }
-
     public string? surfaceOfHorizontalEdges { get; set; }
-
     public string? logShape { get; set; }
 
     // Model - Defines the relation of wall to zones (Zone Boundary, Reduce Zone Area Only, No Effect on Zones)


### PR DESCRIPTION
## Description & motivation

Fixes:
#2467 
#2545

## Changes:

Archicad Element type is exported as `elementType` string property.
Archicad Classification systems and items are exported and imported under the `classifications` property of the element.

During implementation the Revit pattern was taken into account, Revit category's equivalent is Archicad Element type and since Revit classifications are exported under `parameters` section (no individual tree-like data can be attached to elements), a classification tree Archicad equivalent is introduced (`Classification.cs`).

<!---

- Item 1
- Item 2

-->

## Screenshots:

<img width="457" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/93484dfe-c0fe-4e01-811e-94a7c6aadb88">

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

