### PR TITLE
bug(rhino): clear cache on document open event

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Events.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Events.cs
@@ -17,6 +17,8 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     var streams = GetStreamsInFile();
     if (UpdateSavedStreams != null)
       UpdateSavedStreams(streams);
+
+    ClearStorage();
     //if (streams.Count > 0)
     //  SpeckleCommand.CreateOrFocusSpeckle();
   }


### PR DESCRIPTION
## Description & motivation
Previously, the `Preview` list was not being cleared in a document open event, which resulted in unexpected behaviors when receiving the same commit in a new document after receiving it already.
This clears the cache anytime the document open event is triggered.

## Screenshots:

Before
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/ea1f3350-2a64-4c1c-a530-700e7a7e8f7b)

After
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/758be458-2872-4a53-ab60-d6b75ec2c55b)


