### PR TITLE
bug(rhino): layer material not correctly sent

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Events.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Events.cs
@@ -17,6 +17,8 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     var streams = GetStreamsInFile();
     if (UpdateSavedStreams != null)
       UpdateSavedStreams(streams);
+
+    ClearStorage();
     //if (streams.Count > 0)
     //  SpeckleCommand.CreateOrFocusSpeckle();
   }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -178,7 +178,7 @@ public partial class ConverterRhinoGh : ISpeckleConverter
           var lId = l.GetUserString(ApplicationIdKey) ?? l.Id.ToString();
           reportObj = new ApplicationObject(l.Id.ToString(), "Layer") { applicationId = lId };
           if (l.RenderMaterial != null)
-            material = RenderMaterialToSpeckle(l.RenderMaterial.SimulateMaterial(true));
+            material = RenderMaterialToSpeckle(l.RenderMaterial);
           style = DisplayStyleToSpeckle(new ObjectAttributes(), l);
           userDictionary = l.UserDictionary;
           userStrings = l.GetUserStrings();


### PR DESCRIPTION
## Description & motivation
Fixes a bug where layer materials were not being correctly sent. Adds a new method to handle `Rhino.Render.RenderMaterial` conversion to Speckle.

## Screenshots:

Before: 
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/b41cb32c-c46f-4fd5-93c9-a8ba94cba137)


After:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/9d0f2a1d-3173-4f56-b2f6-66b534b0a152)

