### PR TITLE
fix(Archicad): Receive all kind of instances 

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
@@ -106,8 +106,8 @@ namespace Archicad.Converters
         while (root.parent != null)
           root = root.parent;
 
-        // transform appleid only elements in the "definition" property (not for "elements" property)
-        // root elements transform is skipped, becuase it will be added on GDL level
+        // transform appleid only elements via the "definition" property (not via "elements" property)
+        // and root elements transform is skipped, becuase it will be added on GDL level
         var currentTransform = (tc.parent.current != root.current && (tc.parent.current["transform"] is Transform) && DefaultTraversal.definitionPropAliases.Contains (tc.propName))
                                ? (Transform)(tc.parent.current["transform"])
                                : new Transform();

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
@@ -65,7 +65,7 @@ namespace Archicad.Converters
 
         // hosted elements traversals
         {
-          // #1: via the elements field of definition classes, but don't travers the elements prop of the root (they are separate elements) 
+          // #1: via the "elements" field of definition classes, but don't traverse the "elements" field of the root (it is traversed by the main element traversal) 
           if (root != @base)
             membersToTraverse.AddRange(DefaultTraversal.elementsPropAliases);
 
@@ -80,10 +80,10 @@ namespace Archicad.Converters
 
         // geometry traversals
         {
-          // #1: visiting the elements in displayValue field
+          // #1: visiting the elements in "displayValue" field
           membersToTraverse.AddRange(DefaultTraversal.displayValuePropAliases);
 
-          // #2: visiting the elements in geometry field
+          // #2: visiting the elements in "geometry" field
           membersToTraverse.AddRange(DefaultTraversal.geometryPropAliases);  // already added before
         }
 
@@ -107,7 +107,7 @@ namespace Archicad.Converters
           root = root.parent;
 
         // transform appleid only elements via the "definition" property (not via "elements" property)
-        // and root elements transform is skipped, becuase it will be added on GDL level
+        // and root elements transform is skipped, because it will be added on GDL level
         var currentTransform = (tc.parent.current != root.current && (tc.parent.current["transform"] is Transform) && DefaultTraversal.definitionPropAliases.Contains (tc.propName))
                                ? (Transform)(tc.parent.current["transform"])
                                : new Transform();


### PR DESCRIPTION
## Description & motivation

To be able to receive all kind of instances.
Found an issue during v.2.15 testing: Receiving nested hosted Revit instances results in duplicates in Archicad.

## Changes:
* hosted elements traversals: we don't traverse the "elements" field of the root BlockInstance (they will be traversed by the main element traversal) 
* transform appleid only elements via the "definition" property (not via "elements" property)
* `ArchicadDefinitionTraversal` renamed to `ArchicadGeometryCollector`


## Screenshots:

<img width="446" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/f429b1b2-94f9-4e77-9888-c435f2fa4772">


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
