### PR TITLE
fix(Archicad): Parametric receive fixes

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
@@ -146,6 +146,12 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 		ACAPI_ELEMENT_MASK_SET (beamMask, API_BeamType, nProfiles);
 	}
 
+#pragma region Segment
+	GS::ObjectState allSegments;
+	if (os.Contains (Beam::segments))
+		os.Get (Beam::segments, allSegments);
+
+	if (!allSegments.IsEmpty ()) {
 		API_BeamSegmentType defaultBeamSegment;
 		if (memo.beamSegments != nullptr) {
 			defaultBeamSegment = memo.beamSegments[0];
@@ -158,11 +164,6 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 			APIMemoMask_AssemblySegmentScheme |
 			APIMemoMask_BeamHole |
 			APIMemoMask_AssemblySegmentCut;
-
-#pragma region Segment
-	GS::ObjectState allSegments;
-	if (os.Contains (Beam::segments))
-		os.Get (Beam::segments, allSegments);
 
 		for (UInt32 idx = 0; idx < element.beam.nSegments; ++idx) {
 			GS::ObjectState currentSegment;
@@ -297,6 +298,7 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 				}
 			}
 		}
+	}
 #pragma endregion
 
 	// Scheme

--- a/ConnectorArchicad/ConnectorArchicad/UI/ConnectorBinding.Settings.cs
+++ b/ConnectorArchicad/ConnectorArchicad/UI/ConnectorBinding.Settings.cs
@@ -10,7 +10,7 @@ namespace Archicad.Launcher
     {
       return new List<ISetting>
       {
-        new CheckBoxSetting {Slug = "receive - parametric", Name = "Receive parametric elements", Icon = "Link", IsChecked = true, Description = "Receive parametric elements where applicable"},
+        new CheckBoxSetting {Slug = "receive - parametric", Name = "Receive parametric elements", Icon = "Link", IsChecked = false, Description = "Receive parametric elements where applicable"},
       };
     }
   }

--- a/Objects/Objects/BuiltElements/Archicad/Fenestration.cs
+++ b/Objects/Objects/BuiltElements/Archicad/Fenestration.cs
@@ -10,36 +10,36 @@ public class ArchicadFenestration : Base, IDisplayValue<List<Mesh>>
   public string parentApplicationId { get; set; }
 
   // Element base
-  public string elementType { get; set; }
-  public List<Classification> classifications { get; set; }
+  public string? /*APINullabe*/ elementType { get; set; }
+  public List<Classification>? /*APINullabe*/ classifications { get; set; }
 
-  public double width { get; set; }
-  public double height { get; set; }
-  public double subFloorThickness { get; set; }
-  public bool reflected { get; set; }
-  public bool oSide { get; set; }
-  public bool refSide { get; set; }
+  public double? /*APINullabe*/ width { get; set; }
+  public double? /*APINullabe*/ height { get; set; }
+  public double? /*APINullabe*/ subFloorThickness { get; set; }
+  public bool? /*APINullabe*/ reflected { get; set; }
+  public bool? /*APINullabe*/ oSide { get; set; }
+  public bool? /*APINullabe*/ refSide { get; set; }
   public string? verticalLinkTypeName { get; set; }
   public short? verticalLinkStoryIndex { get; set; }
   public bool? wallCutUsing { get; set; }
-  public short pen { get; set; }
-  public string lineTypeName { get; set; }
-  public string buildingMaterial { get; set; }
-  public string sectFill { get; set; }
-  public short sectFillPen { get; set; }
-  public short sectBackgroundPen { get; set; }
-  public short sectContPen { get; set; }
-  public string cutLineType { get; set; }
-  public string aboveViewLineType { get; set; }
-  public short aboveViewLinePen { get; set; }
-  public short belowViewLinePen { get; set; }
-  public string belowViewLineType { get; set; }
-  public bool useObjectPens { get; set; }
-  public bool useObjLinetypes { get; set; }
-  public bool useObjMaterials { get; set; }
-  public bool useObjSectAttrs { get; set; }
-  public string libraryPart { get; set; }
-  public string displayOptionName { get; set; }
+  public short? /*APINullabe*/ pen { get; set; }
+  public string? /*APINullabe*/ lineTypeName { get; set; }
+  public string? /*APINullabe*/ buildingMaterial { get; set; }
+  public string? /*APINullabe*/ sectFill { get; set; }
+  public short? /*APINullabe*/ sectFillPen { get; set; }
+  public short? /*APINullabe*/ sectBackgroundPen { get; set; }
+  public short? /*APINullabe*/ sectContPen { get; set; }
+  public string? /*APINullabe*/ cutLineType { get; set; }
+  public string? /*APINullabe*/ aboveViewLineType { get; set; }
+  public short? /*APINullabe*/ aboveViewLinePen { get; set; }
+  public short? /*APINullabe*/ belowViewLinePen { get; set; }
+  public string? /*APINullabe*/ belowViewLineType { get; set; }
+  public bool? /*APINullabe*/ useObjectPens { get; set; }
+  public bool? /*APINullabe*/ useObjLinetypes { get; set; }
+  public bool? /*APINullabe*/ useObjMaterials { get; set; }
+  public bool? /*APINullabe*/ useObjSectAttrs { get; set; }
+  public string? /*APINullabe*/ libraryPart { get; set; }
+  public string? /*APINullabe*/ displayOptionName { get; set; }
 
   [DetachProperty]
   public List<Mesh> displayValue { get; set; }
@@ -47,16 +47,16 @@ public class ArchicadFenestration : Base, IDisplayValue<List<Mesh>>
 
 public class ArchicadDoorWindowBase : ArchicadFenestration
 {
-  public double revealDepthFromSide { get; set; }
-  public double jambDepthHead { get; set; }
-  public double jambDepth { get; set; }
-  public double jambDepth2 { get; set; }
-  public double objLoc { get; set; }
-  public double lower { get; set; }
-  public string directionType { get; set; }
+  public double? /*APINullabe*/ revealDepthFromSide { get; set; }
+  public double? /*APINullabe*/ jambDepthHead { get; set; }
+  public double? /*APINullabe*/ jambDepth { get; set; }
+  public double? /*APINullabe*/ jambDepth2 { get; set; }
+  public double? /*APINullabe*/ objLoc { get; set; }
+  public double? /*APINullabe*/ lower { get; set; }
+  public string? /*APINullabe*/ directionType { get; set; }
 
-  public Point startPoint { get; set; }
-  public Point dirVector { get; set; }
+  public Point? /*APINullabe*/ startPoint { get; set; }
+  public Point? /*APINullabe*/ dirVector { get; set; }
 }
 
 public sealed class ArchicadDoor : ArchicadDoorWindowBase
@@ -69,11 +69,11 @@ public sealed class ArchicadWindow : ArchicadDoorWindowBase
 
 public sealed class ArchicadSkylight : ArchicadFenestration
 {
-  public UInt32 vertexID { get; set; }
-  public string skylightFixMode { get; set; }
-  public string skylightAnchor { get; set; }
-  public Point anchorPosition { get; set; }
-  public double anchorLevel { get; set; }
-  public double azimuthAngle { get; set; }
-  public double elevationAngle { get; set; }
+  public UInt32? /*APINullabe*/ vertexID { get; set; }
+  public string? /*APINullabe*/ skylightFixMode { get; set; }
+  public string? /*APINullabe*/ skylightAnchor { get; set; }
+  public Point? /*APINullabe*/ anchorPosition { get; set; }
+  public double? /*APINullabe*/ anchorLevel { get; set; }
+  public double? /*APINullabe*/ azimuthAngle { get; set; }
+  public double? /*APINullabe*/ elevationAngle { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -124,35 +124,35 @@ namespace Objects.BuiltElements.Archicad
     public ArchicadBeam() { }
 
     // Element base
-    public string elementType { get; set; }
-    public List<Classification> classifications { get; set; }
+    public string? /*APINullabe*/ elementType { get; set; }
+    public List<Classification>? /*APINullabe*/ classifications { get; set; }
 
-    public ArchicadLevel level { get; set; }
+    public ArchicadLevel? /*APINullabe*/ level { get; set; }
 
     // Positioning
     public Point begC { get; set; }
     public Point endC { get; set; }
-    public bool isSlanted { get; set; }
-    public double slantAngle { get; set; }
-    public string beamShape { get; set; }
-    public int sequence { get; set; }
-    public double curveAngle { get; set; }
-    public double verticalCurveHeight { get; set; }
-    public bool isFlipped { get; set; }
+    public bool? /*APINullabe*/ isSlanted { get; set; }
+    public double? /*APINullabe*/ slantAngle { get; set; }
+    public string? /*APINullabe*/ beamShape { get; set; }
+    public int? /*APINullabe*/ sequence { get; set; }
+    public double? /*APINullabe*/ curveAngle { get; set; }
+    public double? /*APINullabe*/ verticalCurveHeight { get; set; }
+    public bool? /*APINullabe*/ isFlipped { get; set; }
 
     // End Cuts
-    public uint nCuts { get; set; }
+    public uint? /*APINullabe*/ nCuts { get; set; }
     public Dictionary<string, AssemblySegmentCut>? Cuts { get; set; }
 
     // Reference Axis
-    public short anchorPoint { get; set; }
+    public short? /*APINullabe*/ anchorPoint { get; set; }
     public double? offset { get; set; }
     public double? profileAngle { get; set; }
 
     // Segment
-    public uint nSegments { get; set; }
-    public uint nProfiles { get; set; }
-    public Dictionary<string, BeamSegment> segments { get; set; }
+    public uint? /*APINullabe*/ nSegments { get; set; }
+    public uint? /*APINullabe*/ nProfiles { get; set; }
+    public Dictionary<string, BeamSegment>? /*APINullabe*/ segments { get; set; }
 
     // Scheme
     public uint? nSchemes { get; set; }
@@ -162,11 +162,11 @@ namespace Objects.BuiltElements.Archicad
     public Dictionary<string, Hole>? Holes { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string showOnStories { get; set; }
-    public string displayOptionName { get; set; }
-    public string uncutProjectionMode { get; set; }
-    public string overheadProjectionMode { get; set; }
-    public string showProjectionName { get; set; }
+    public string? /*APINullabe*/ showOnStories { get; set; }
+    public string? /*APINullabe*/ displayOptionName { get; set; }
+    public string? /*APINullabe*/ uncutProjectionMode { get; set; }
+    public string? /*APINullabe*/ overheadProjectionMode { get; set; }
+    public string? /*APINullabe*/ showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces
     public short? cutContourLinePen { get; set; }
@@ -175,21 +175,21 @@ namespace Objects.BuiltElements.Archicad
     public short? overrideCutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines
-    public string showOutline { get; set; }
-    public short uncutLinePen { get; set; }
-    public string uncutLinetype { get; set; }
-    public short overheadLinePen { get; set; }
-    public string overheadLinetype { get; set; }
-    public short hiddenLinePen { get; set; }
-    public string hiddenLinetype { get; set; }
+    public string? /*APINullabe*/ showOutline { get; set; }
+    public short? /*APINullabe*/ uncutLinePen { get; set; }
+    public string? /*APINullabe*/ uncutLinetype { get; set; }
+    public short? /*APINullabe*/ overheadLinePen { get; set; }
+    public string? /*APINullabe*/ overheadLinetype { get; set; }
+    public short? /*APINullabe*/ hiddenLinePen { get; set; }
+    public string? /*APINullabe*/ hiddenLinetype { get; set; }
 
     // Floor Plan and Section - Symbol
-    public string showReferenceAxis { get; set; }
-    public short referencePen { get; set; }
-    public string referenceLinetype { get; set; }
+    public string? /*APINullabe*/ showReferenceAxis { get; set; }
+    public short? /*APINullabe*/ referencePen { get; set; }
+    public string? /*APINullabe*/ referenceLinetype { get; set; }
 
     // Floor Plan and Section - Cover Fills
-    public bool useCoverFill { get; set; }
+    public bool? /*APINullabe*/ useCoverFill { get; set; }
     public bool? useCoverFillFromSurface { get; set; }
     public short? coverFillForegroundPen { get; set; }
     public short? coverFillBackgroundPen { get; set; }

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -150,53 +150,53 @@ namespace Objects.BuiltElements.Archicad
     public ArchicadColumn() { }
 
     // Element base
-    public string elementType { get; set; }
-    public List<Classification> classifications { get; set; }
+    public string? /*APINullabe*/ elementType { get; set; }
+    public List<Classification>? /*APINullabe*/ classifications { get; set; }
 
-    public ArchicadLevel level { get; set; }
+    public ArchicadLevel? /*APINullabe*/ level { get; set; }
 
     // Wall geometry
     public Point origoPos { get; set; }
     public double height { get; set; }
 
     // Positioning - story relation
-    public double bottomOffset { get; set; }
-    public double topOffset { get; set; }
-    public short relativeTopStory { get; set; }
+    public double? /*APINullabe*/ bottomOffset { get; set; }
+    public double? /*APINullabe*/ topOffset { get; set; }
+    public short? /*APINullabe*/ relativeTopStory { get; set; }
 
     // Positioning - slanted column
-    public bool isSlanted { get; set; }
-    public double slantAngle { get; set; }
-    public double slantDirectionAngle { get; set; }
-    public bool isFlipped { get; set; }
+    public bool? /*APINullabe*/ isSlanted { get; set; }
+    public double? /*APINullabe*/ slantAngle { get; set; }
+    public double? /*APINullabe*/ slantDirectionAngle { get; set; }
+    public bool? /*APINullabe*/ isFlipped { get; set; }
 
     // Positioning - wrapping
-    public bool wrapping { get; set; }
+    public bool? /*APINullabe*/ wrapping { get; set; }
 
     // Positioning - Defines the relation of column to zones (Zone Boundary, Reduce Zone Area Only, No Effect on Zones)
-    public string columnRelationToZoneName { get; set; }
+    public string? /*APINullabe*/ columnRelationToZoneName { get; set; }
 
     // End Cuts
-    public uint nCuts { get; set; }
-    public Dictionary<string, AssemblySegmentCut> Cuts { get; set; }
+    public uint? /*APINullabe*/ nCuts { get; set; }
+    public Dictionary<string, AssemblySegmentCut>? /*APINullabe*/ Cuts { get; set; }
 
     // Reference Axis
     public short? coreAnchor { get; set; }
     public double? axisRotationAngle { get; set; }
 
     // Segment
-    public uint nSegments { get; set; }
-    public uint nProfiles { get; set; }
-    public Dictionary<string, ColumnSegment> segments { get; set; }
+    public uint? /*APINullabe*/ nSegments { get; set; }
+    public uint? /*APINullabe*/ nProfiles { get; set; }
+    public Dictionary<string, ColumnSegment>? /*APINullabe*/ segments { get; set; }
 
     // Scheme
     public uint? nSchemes { get; set; }
     public Dictionary<string, AssemblySegmentScheme>? Schemes { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string showOnStories { get; set; }
-    public string displayOptionName { get; set; }
-    public string showProjectionName { get; set; }
+    public string? /*APINullabe*/ showOnStories { get; set; }
+    public string? /*APINullabe*/ displayOptionName { get; set; }
+    public string? /*APINullabe*/ showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces
     public short? corePen { get; set; }
@@ -207,21 +207,21 @@ namespace Objects.BuiltElements.Archicad
     public short? overrideCutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines
-    public short uncutLinePen { get; set; }
-    public string uncutLinetype { get; set; }
-    public short overheadLinePen { get; set; }
-    public string overheadLinetype { get; set; }
-    public short hiddenLinePen { get; set; }
-    public string hiddenLinetype { get; set; }
+    public short? /*APINullabe*/ uncutLinePen { get; set; }
+    public string? /*APINullabe*/ uncutLinetype { get; set; }
+    public short? /*APINullabe*/ overheadLinePen { get; set; }
+    public string? /*APINullabe*/ overheadLinetype { get; set; }
+    public short? /*APINullabe*/ hiddenLinePen { get; set; }
+    public string? /*APINullabe*/ hiddenLinetype { get; set; }
 
     // Floor Plan and Section - Floor Plan Symbol
-    public string coreSymbolTypeName { get; set; }
-    public double coreSymbolPar1 { get; set; }
-    public double coreSymbolPar2 { get; set; }
-    public short coreSymbolPen { get; set; }
+    public string? /*APINullabe*/ coreSymbolTypeName { get; set; }
+    public double? /*APINullabe*/ coreSymbolPar1 { get; set; }
+    public double? /*APINullabe*/ coreSymbolPar2 { get; set; }
+    public short? /*APINullabe*/ coreSymbolPen { get; set; }
 
     // Floor Plan and Section - Cover Fills
-    public bool useCoverFill { get; set; }
+    public bool? /*APINullabe*/ useCoverFill { get; set; }
     public bool? useCoverFillFromSurface { get; set; }
     public short? coverFillForegroundPen { get; set; }
     public short? coverFillBackgroundPen { get; set; }

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -88,25 +88,25 @@ namespace Objects.BuiltElements.Archicad
   public sealed class ArchicadFloor : Floor
   {
     // Element base
-    public string elementType { get; set; }
-    public List<Classification> classifications { get; set; }
+    public string? /*APINullabe*/ elementType { get; set; }
+    public List<Classification>? /*APINullabe*/ classifications { get; set; }
 
-    public ArchicadLevel level { get; set; }
+    public ArchicadLevel? /*APINullabe*/ level { get; set; }
 
     // Geometry and positioning
     public double? thickness { get; set; }
     public ElementShape shape { get; set; }
-    public string structure { get; set; }
+    public string? /*APINullabe*/ structure { get; set; }
     public string? compositeName { get; set; }
     public string? buildingMaterialName { get; set; }
-    public string referencePlaneLocation { get; set; }
+    public string? /*APINullabe*/ referencePlaneLocation { get; set; }
 
     // EdgeTrims
     public string? edgeAngleType { get; set; }
     public double? edgeAngle { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string showOnStories { get; set; }
+    public string? /*APINullabe*/ showOnStories { get; set; }
     public Visibility? visibilityCont { get; set; }
     public Visibility? visibilityFill { get; set; }
 

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -139,14 +139,14 @@ namespace Objects.BuiltElements.Archicad
     }
 
     // Element base
-    public string elementType { get; set; }
-    public List<Classification> classifications { get; set; }
+    public string? /*APINullabe*/ elementType { get; set; }
+    public List<Classification>? /*APINullabe*/ classifications { get; set; }
 
-    public ArchicadLevel level { get; set; }
+    public ArchicadLevel? /*APINullabe*/ level { get; set; }
 
     // Geometry and positioning
     public double? thickness { get; set; }
-    public string structure { get; set; }
+    public string? /*APINullabe*/ structure { get; set; }
     public string? compositeName { get; set; }
     public string? buildingMaterialName { get; set; }
 
@@ -155,26 +155,26 @@ namespace Objects.BuiltElements.Archicad
     public double? edgeAngle { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string showOnStories { get; set; }
+    public string? /*APINullabe*/ showOnStories { get; set; }
     public Visibility? visibilityCont { get; set; }
     public Visibility? visibilityFill { get; set; }
-    public string displayOptionName { get; set; }
-    public string showProjectionName { get; set; }
+    public string? /*APINullabe*/ displayOptionName { get; set; }
+    public string? /*APINullabe*/ showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces
-    public short sectContPen { get; set; }
-    public string sectContLtype { get; set; }
+    public short? /*APINullabe*/ sectContPen { get; set; }
+    public string? /*APINullabe*/ sectContLtype { get; set; }
     public short? cutFillPen { get; set; }
     public short? cutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines
-    public short contourPen { get; set; }
-    public string contourLineType { get; set; }
-    public short overheadLinePen { get; set; }
-    public string overheadLinetype { get; set; }
+    public short? /*APINullabe*/ contourPen { get; set; }
+    public string? /*APINullabe*/ contourLineType { get; set; }
+    public short? /*APINullabe*/ overheadLinePen { get; set; }
+    public string? /*APINullabe*/ overheadLinetype { get; set; }
 
     // Floor Plan and Section - Cover Fills
-    public bool useFloorFill { get; set; }
+    public bool? /*APINullabe*/ useFloorFill { get; set; }
     public short? floorFillPen { get; set; }
     public short? floorFillBGPen { get; set; }
     public string? floorFillName { get; set; }
@@ -194,7 +194,7 @@ namespace Objects.BuiltElements.Archicad
     public string? sideMat { get; set; }
     public string? botMat { get; set; }
     public bool? materialsChained { get; set; }
-    public string trimmingBodyName { get; set; }
+    public string? /*APINullabe*/ trimmingBodyName { get; set; }
   }
 
   /*
@@ -237,9 +237,9 @@ namespace Objects.BuiltElements.Archicad
     public ElementShape shape { get; set; }
     public BaseLine? baseLine { get; set; }
     public bool? posSign { get; set; }
-    public ElementShape pivotPolygon { get; set; }
+    public ElementShape? /*APINullabe*/ pivotPolygon { get; set; }
     public short? levelNum { get; set; }
-    public Dictionary<string, RoofLevel> levels { get; set; }
+    public Dictionary<string, RoofLevel>? /*APINullabe*/ levels { get; set; }
     public Dictionary<string, PivotPolyEdge>? roofPivotPolyEdges { get; set; }
   }
 
@@ -267,13 +267,13 @@ namespace Objects.BuiltElements.Archicad
     }
 
     // Geometry and positioning
-    public string shellClassName { get; set; }
-    public Transform basePlane { get; set; }
-    public bool flipped { get; set; }
-    public bool hasContour { get; set; }
-    public int numHoles { get; set; }
+    public string? /*APINullabe*/ shellClassName { get; set; }
+    public Transform? /*APINullabe*/ basePlane { get; set; }
+    public bool? /*APINullabe*/ flipped { get; set; }
+    public bool? /*APINullabe*/ hasContour { get; set; }
+    public int? /*APINullabe*/ numHoles { get; set; }
     public Dictionary<string, ShellContourData>? shellContours { get; set; }
-    public string defaultEdgeType { get; set; }
+    public string? /*APINullabe*/ defaultEdgeType { get; set; }
 
     public double? slantAngle { get; set; }
     public double? revolutionAngle { get; set; }
@@ -283,11 +283,11 @@ namespace Objects.BuiltElements.Archicad
     public double? begPlaneTilt { get; set; }
     public double? endPlaneTilt { get; set; }
     public ElementShape shape { get; set; }
-    public ElementShape shape1 { get; set; }
-    public ElementShape shape2 { get; set; }
-    public Transform axisBase { get; set; }
-    public Transform plane1 { get; set; }
-    public Transform plane2 { get; set; }
+    public ElementShape? /*APINullabe*/ shape1 { get; set; }
+    public ElementShape? /*APINullabe*/ shape2 { get; set; }
+    public Transform? /*APINullabe*/ axisBase { get; set; }
+    public Transform? /*APINullabe*/ plane1 { get; set; }
+    public Transform? /*APINullabe*/ plane2 { get; set; }
     public Point? begC { get; set; }
     public double? begAngle { get; set; }
     public Vector? extrusionVector { get; set; }

--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -70,12 +70,12 @@ namespace Objects.BuiltElements.Archicad
   public class ArchicadRoom : Room
   {
     // Element base
-    public string elementType { get; set; }
-    public List<Classification> classifications { get; set; }
+    public string? /*APINullabe*/ elementType { get; set; }
+    public List<Classification>? /*APINullabe*/ classifications { get; set; }
 
-    public ArchicadLevel level { get; set; }
+    public ArchicadLevel? /*APINullabe*/ level { get; set; }
 
-    public double height { get; set; }
+    public double? /*APINullabe*/ height { get; set; }
 
     public ElementShape shape { get; set; }
   }

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -281,19 +281,19 @@ namespace Objects.BuiltElements.Archicad
     public ArchicadWall() { }
 
     // Element base
-    public string elementType { get; set; }
-    public List<Classification> classifications { get; set; }
+    public string? /*APINullabe*/ elementType { get; set; }
+    public List<Classification>? /*APINullabe*/ classifications { get; set; }
 
-    public ArchicadLevel level { get; set; }
+    public ArchicadLevel? /*APINullabe*/ level { get; set; }
 
     // Wall geometry
-    public double baseOffset { get; set; }
+    public double? /*APINullabe*/ baseOffset { get; set; }
     public Point startPoint { get; set; }
     public Point endPoint { get; set; }
 
-    public string structure { get; set; }
-    public string geometryMethod { get; set; }
-    public string wallComplexity { get; set; }
+    public string? /*APINullabe*/ structure { get; set; }
+    public string? /*APINullabe*/ geometryMethod { get; set; }
+    public string? /*APINullabe*/ wallComplexity { get; set; }
 
     public string? buildingMaterialName { get; set; }
     public string? compositeName { get; set; }
@@ -302,7 +302,7 @@ namespace Objects.BuiltElements.Archicad
 
     public ElementShape? shape { get; set; }
 
-    public double thickness { get; set; }
+    public double? /*APINullabe*/ thickness { get; set; }
 
     public double? outsideSlantAngle { get; set; }
     public double? insideSlantAngle { get; set; }
@@ -310,19 +310,19 @@ namespace Objects.BuiltElements.Archicad
     public bool? polyWalllCornersCanChange { get; set; }
 
     // Wall and stories relation
-    public double topOffset { get; set; }
-    public short relativeTopStory { get; set; }
-    public string referenceLineLocation { get; set; }
+    public double? /*APINullabe*/ topOffset { get; set; }
+    public short? /*APINullabe*/ relativeTopStory { get; set; }
+    public string? /*APINullabe*/ referenceLineLocation { get; set; }
     public double? referenceLineOffset { get; set; }
-    public double offsetFromOutside { get; set; }
-    public int referenceLineStartIndex { get; set; }
-    public int referenceLineEndIndex { get; set; }
+    public double? /*APINullabe*/ offsetFromOutside { get; set; }
+    public int? /*APINullabe*/ referenceLineStartIndex { get; set; }
+    public int? /*APINullabe*/ referenceLineEndIndex { get; set; }
     public bool flipped { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string showOnStories { get; set; }
-    public string displayOptionName { get; set; }
-    public string showProjectionName { get; set; }
+    public string? /*APINullabe*/ showOnStories { get; set; }
+    public string? /*APINullabe*/ displayOptionName { get; set; }
+    public string? /*APINullabe*/ showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces parameters
     public short? cutLinePen { get; set; }
@@ -331,10 +331,10 @@ namespace Objects.BuiltElements.Archicad
     public short? overrideCutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines parameters
-    public short uncutLinePen { get; set; }
-    public string uncutLinetype { get; set; }
-    public short overheadLinePen { get; set; }
-    public string overheadLinetype { get; set; }
+    public short? /*APINullabe*/ uncutLinePen { get; set; }
+    public string? /*APINullabe*/ uncutLinetype { get; set; }
+    public short? /*APINullabe*/ overheadLinePen { get; set; }
+    public string? /*APINullabe*/ overheadLinetype { get; set; }
 
     // Model - Override Surfaces
     public string? referenceMaterialName { get; set; }
@@ -344,10 +344,10 @@ namespace Objects.BuiltElements.Archicad
     public int? oppositeMaterialStartIndex { get; set; }
     public int? oppositeMaterialEndIndex { get; set; }
     public string? sideMaterialName { get; set; }
-    public bool materialsChained { get; set; }
-    public bool inheritEndSurface { get; set; }
-    public bool alignTexture { get; set; }
-    public int sequence { get; set; }
+    public bool? /*APINullabe*/ materialsChained { get; set; }
+    public bool? /*APINullabe*/ inheritEndSurface { get; set; }
+    public bool? /*APINullabe*/ alignTexture { get; set; }
+    public int? /*APINullabe*/ sequence { get; set; }
 
     // Model - Log Details (log height, start with half log, surface of horizontal edges, log shape)
     public double? logHeight { get; set; }
@@ -356,11 +356,11 @@ namespace Objects.BuiltElements.Archicad
     public string? logShape { get; set; }
 
     // Model - Defines the relation of wall to zones (Zone Boundary, Reduce Zone Area Only, No Effect on Zones)
-    public string wallRelationToZoneName { get; set; }
+    public string? /*APINullabe*/ wallRelationToZoneName { get; set; }
 
     // Does it have any embedded object?
-    public bool hasDoor { get; set; }
+    public bool? /*APINullabe*/ hasDoor { get; set; }
 
-    public bool hasWindow { get; set; }
+    public bool? /*APINullabe*/ hasWindow { get; set; }
   }
 }


### PR DESCRIPTION
## Description & motivation

Fixes:
 * 😡 Revit → Archicad - Fatal crash receiving whole Revit models
 * 😢 Revit → Archicad zero thickness walls and no openings 

The cause of both issues above is with optional props in the common schema (see [#2342]).

## Changes:

Optional flags are introduced for properties in the common schema with the tag /*APINullable*/, which means the field can be null in the Archicad API calls, but not in the Speckle common schema. This might not be the ideal solution for #2342.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
