### PR TITLE
fix(revit): fixes regression where 2.12 and older commits were nto being received by any sharp connector

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -131,7 +131,9 @@ namespace Objects.Converter.Revit
       }
       else
       {
-        throw new ArgumentException($"Converter.{nameof(SetContextDocument)}() was passed an object of unexpected type, {doc.GetType()}");
+        throw new ArgumentException(
+          $"Converter.{nameof(SetContextDocument)}() was passed an object of unexpected type, {doc.GetType()}"
+        );
       }
     }
 
@@ -347,7 +349,7 @@ namespace Objects.Converter.Revit
         returnObject != null
         && returnObject["renderMaterial"] == null
         && returnObject["displayValue"] == null
-        && !(returnObject is Model)
+        && !(returnObject is Collection)
       )
       {
         try

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertModel.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertModel.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Generic;
-using Autodesk.Revit.Creation;
+using System.Collections.Generic;
 using Objects.Geometry;
-using Objects.Organization;
-using Objects.Other;
 using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
 using Transform = Objects.Other.Transform;
@@ -12,7 +9,7 @@ namespace Objects.Converter.Revit
   public partial class ConverterRevit
   {
     /// <summary>
-    /// Returns a <see cref="Model"/> object containing <see cref="Objects.BuiltElements.Revit.ProjectInfo"/> and location
+    /// Returns a <see cref="Collection"/> object containing <see cref="Objects.BuiltElements.Revit.ProjectInfo"/> and location
     /// information. This is intended to be used as the root commit object when sending to Speckle.
     /// </summary>
     /// <param name="doc">the currently active document</param>
@@ -20,7 +17,7 @@ namespace Objects.Converter.Revit
     /// <returns></returns>
     public Base ModelToSpeckle(DB.Document doc, bool sendProjectInfo = true)
     {
-      var model = new Model();
+      var model = new Collection("Revit model", "model");
       // TODO: setting for whether or not to include project info
       if (sendProjectInfo)
       {
@@ -29,7 +26,7 @@ namespace Objects.Converter.Revit
         info.longitude = doc.SiteLocation.Longitude;
         info.siteName = doc.SiteLocation.PlaceName;
         info.locations = ProjectLocationsToSpeckle(doc);
-        model.info = info;
+        model["info"] = info;
       }
 
       Report.Log($"Created Model Object");
@@ -57,7 +54,12 @@ namespace Objects.Converter.Revit
         var basisX = VectorToSpeckle(revitTransform.BasisX, doc);
         var basisY = VectorToSpeckle(revitTransform.BasisY, doc);
         var basisZ = VectorToSpeckle(revitTransform.BasisZ, doc);
-        var translation = new Vector(ScaleToSpeckle(position.EastWest), ScaleToSpeckle(position.NorthSouth), ScaleToSpeckle(position.Elevation), ModelUnits);
+        var translation = new Vector(
+          ScaleToSpeckle(position.EastWest),
+          ScaleToSpeckle(position.NorthSouth),
+          ScaleToSpeckle(position.Elevation),
+          ModelUnits
+        );
         spcklLoc["transform"] = new Transform(basisX, basisY, basisZ, translation);
         spcklLoc["name"] = location.Name;
         spcklLoc["trueNorth"] = position.Angle;

--- a/Objects/Objects/Organization/Model.cs
+++ b/Objects/Objects/Organization/Model.cs
@@ -4,6 +4,11 @@ using Speckle.Core.Models;
 
 namespace Objects.Organization;
 
+#region Removed Classes (2.15)
+/*
+// The Model class was only being used by the Revit conenctor as the base commit object
+// With the new Collection class implementation, this class should be removed
+// The only property in use `ModelInfo` will be dynamically attached to the `Collection` base commit object
 /// <summary>
 /// Represents a model from an authoring application and can be used as the root commit object when sending.
 /// It contains <see cref="ModelInfo"/> and <see cref="Setting"/> objects
@@ -27,6 +32,24 @@ public class Model : Collection
   [System.Obsolete("These are not being used")]
   public List<Setting>? settings { get; set; }
 }
+
+// This class had 0 references
+public class Setting : Base
+{
+  /// <summary>
+  /// The name of the setting
+  /// </summary>
+  public string name { get; set; }
+
+  /// <summary>
+  /// The objects selected in the setting
+  /// </summary>
+  public List<Base> selection { get; set; }
+}
+
+*/
+
+#endregion
 
 /// <summary>
 /// Basic model info class to be attached to the <see cref="Model.info"/> field on a <see cref="Model"/> object.
@@ -94,17 +117,4 @@ public class BIMModelInfo : ModelInfo
   /// A list of origin locations within this model as a list of <see cref="Transform"/>s
   /// </summary>
   public List<Base> locations { get; set; }
-}
-
-public class Setting : Base
-{
-  /// <summary>
-  /// The name of the setting
-  /// </summary>
-  public string name { get; set; }
-
-  /// <summary>
-  /// The objects selected in the setting
-  /// </summary>
-  public List<Base> selection { get; set; }
 }


### PR DESCRIPTION
## Description & motivation

With the `Collection` implementation in Revit, the base commit object was changed from a `Organization.Model` class object (which uses the generic traversal) to a `Core.Model.Collection::Organization.Model` class object (which uses the `Collection` traversal). This meant that older commits prior to 2.12 where not traversed correctly on receive in any connector using the sharp traversal.

This is fixed by:
1. removing the `Model` class
2. Having Revit send with the base commit as a `Collection`, with the additional `ModelInfo` prop dynamically attached

Also deprecates the unsued `Setting` class

## Changes:

- Revit Converter
- Objects

