### PR TITLE
Slab fatal crash

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
@@ -149,10 +149,11 @@ GSErrCode CreateSlab::GetElementFromObjectState (const GS::ObjectState& os,
 	// Setting side materials and edge angles
 	BMhKill ((GSHandle*) &memo.edgeTrims);
 	BMhKill ((GSHandle*) &memo.edgeIDs);
-	BMpFree (reinterpret_cast<GSPtr> (memo.sideMaterials));
 
 	memo.edgeTrims = (API_EdgeTrim**) BMAllocateHandle ((element.slab.poly.nCoords + 1) * sizeof (API_EdgeTrim), ALLOCATE_CLEAR, 0);
-	//Ignore memo side materials because of export and import do not work properly
+
+	//Ignore memo side materials because export and import do not work properly
+	//BMpFree (reinterpret_cast<GSPtr> (memo.sideMaterials));
 	//memo.sideMaterials = (API_OverriddenAttribute*) BMAllocatePtr ((element.slab.poly.nCoords + 1) * sizeof (API_OverriddenAttribute), ALLOCATE_CLEAR, 0);
 	for (Int32 k = 1; k <= element.slab.poly.nCoords; ++k) {
 		//memo.sideMaterials[k] = element.slab.sideMat;


### PR DESCRIPTION
## Description & motivation

Fix of a crash when receiving slab multiple times as parametric elements

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
