### PR TITLE
fix(revit): instance display mesh fix once and for all🤞

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -793,8 +793,7 @@ namespace Objects.Converter.Revit
         var meshes = GetElementDisplayValue(
           instance,
           new Options() { DetailLevel = ViewDetailLevel.Fine },
-          true,
-          instance.HasModifiedGeometry()
+          true
         );
         symbol.displayValue = meshes;
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -41,9 +41,13 @@ namespace Objects.Converter.Revit
       //if they are contained in 'subelements' then they have already been accounted for from a wall
       //else if they are mullions then convert them as a generic family instance but add a isUGridLine prop
       bool? isUGridLine = null;
-      if (@base == null && 
-        (revitFi.Category.Id.IntegerValue == (int)BuiltInCategory.OST_CurtainWallMullions
-        || revitFi.Category.Id.IntegerValue == (int)BuiltInCategory.OST_CurtainWallPanels))
+      if (
+        @base == null
+        && (
+          revitFi.Category.Id.IntegerValue == (int)BuiltInCategory.OST_CurtainWallMullions
+          || revitFi.Category.Id.IntegerValue == (int)BuiltInCategory.OST_CurtainWallPanels
+        )
+      )
       {
         if (SubelementIds.Contains(revitFi.Id))
           return null;
@@ -790,11 +794,7 @@ namespace Objects.Converter.Revit
       // get the displayvalue of the family symbol
       try
       {
-        var meshes = GetElementDisplayValue(
-          instance,
-          new Options() { DetailLevel = ViewDetailLevel.Fine },
-          true
-        );
+        var meshes = GetElementDisplayValue(instance, new Options() { DetailLevel = ViewDetailLevel.Fine }, true);
         symbol.displayValue = meshes;
       }
       catch (Exception e)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -44,11 +44,7 @@ namespace Objects.Converter.Revit
       {
         foreach (var id in g.GetMemberIds())
         {
-          var groupMeshes = GetElementDisplayValue(
-            element.Document.GetElement(id),
-            options,
-            isConvertedAsInstance
-          );
+          var groupMeshes = GetElementDisplayValue(element.Document.GetElement(id), options, isConvertedAsInstance);
           displayMeshes.AddRange(groupMeshes);
         }
         return displayMeshes;
@@ -103,12 +99,10 @@ namespace Objects.Converter.Revit
               }
               break;
             case GeometryInstance instance:
-              var instanceGeo =
-                !isConvertedAsInstance // this seems counter-intuitive, but in order to retrieve the fully modified instance geo, we need to get the instance geo and then untransform it
-                  ? instance.GetSymbolGeometry() // this is not reliable for retrieving definition meshes
-                  : instance.GetInstanceGeometry(); 
-              inverseTransform =
-                isConvertedAsInstance ? instance.Transform.Inverse : null;
+              var instanceGeo = !isConvertedAsInstance // this seems counter-intuitive, but in order to retrieve the fully modified instance geo, we need to get the instance geo and then untransform it
+                ? instance.GetSymbolGeometry() // this is not reliable for retrieving definition meshes
+                : instance.GetInstanceGeometry();
+              inverseTransform = isConvertedAsInstance ? instance.Transform.Inverse : null;
               SortGeometry(instanceGeo, inverseTransform);
               break;
             case GeometryElement element:


### PR DESCRIPTION
## Description & motivation

Community-provided test file on the 2.15 announcement in the forum showed that some instances (with `.HasModifiedGeometry() = false` ) still have incorrect display value meshes on send.

This fix will always retreive the instance geometry rather than the symbol geometry when converting definitions, and then untransform the instance geomtry - hopefully this will be the most reliable approach to accurate display meshes + transforms.

## To-do before merge:

- [ ] test as many user-provided revit files as possible, especially those with previously out of place instances

## Screenshots:
Before:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/80674488-bff3-443e-afb2-362134f23509)

After:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/53cddd31-5ab6-4334-b46d-38bbe022483a)


## Validation of changes:

Tested on Revit2023 & 2024:
- face based instances
- simple wall
- rool wall floor hosted instances
- sample architectural model
- sample structural model

