### PR TITLE
fix(Archicad): build readme update

### DIFF
--- a/ConnectorArchicad/README.md
+++ b/ConnectorArchicad/README.md
@@ -44,7 +44,7 @@ You can start ArchiCAD in demo mode with the following commands:
 
 ### Adding the Connector to ArchiCAD
 
-You will now need to manually add the add-on from Add-On Manager (Option menu) in Archicad. Under "Edit List of Available Add-Ons" press th "Add.." button and browse for the .apx file at `./AddOn/Build/Debug`.
+You will now need to manually add the add-on from Add-On Manager (Option menu) in Archicad. Under "Edit List of Available Add-Ons" press the "Add.." button and browse for the .apx file at `./AddOn/Build/Debug`.
 
 ### Launching the Connector
 

--- a/ConnectorArchicad/README.md
+++ b/ConnectorArchicad/README.md
@@ -27,24 +27,6 @@ Open the Speckle Connector solution file `Addon/Build/Speckle Connector.sln` in 
 
 Next, open `speckle-sharp/ConnectorArchicad/ConnectorArchicad.sln` and build that entire solution.
 
-### Adding the Connector to ArchiCAD
-
-You will now need to manually move the build files for both of the projects you've just built into the ArchiCAD `Add-Ons` directory. On Windows, you will find this directory at:
-
-    C:\Program Files\GRAPHISOFT\ARCHICAD 25\Add-Ons
-
-First, head to the ArchiCAD `Add-Ons` directory specified above and create a new folder called `ConnectorArchicad`
-
-![image](https://user-images.githubusercontent.com/7717434/149930481-deedabbf-bf99-49ca-9758-88c4c092c9df.png)
-
-Now, we'll move our `Speckle Connector` build files. Open your build files at `./AddOn/Build/Debug` and copy the whole contents of the folder into the `ConnectorArchicad` folder you just created at `C:\Program Files\GRAPHISOFT\ARCHICAD 25\Add-Ons\ConnectorArchicad`. You'll also create another new folder called `ConnectorArchicad` inside this folder.
-
-![image](https://user-images.githubusercontent.com/7717434/149930098-4fc73382-955e-42e9-bba9-a048630f49ec.png)
-
-Next, we'll add out `ConnectorArchicad` build files. Open up your build files at `./speckle-sharp/ConnectorArchicad/bin/Debug/net6.0`. Copy the entire contents of this folder to the second `ConnectorArchicad` folder you just created at `C:\Program Files\GRAPHISOFT\ARCHICAD 25\Add-Ons\ConnectorArchicad\ConnectorArchicad`
-
-![image](https://user-images.githubusercontent.com/7717434/149930127-c7ec8de0-89be-4dfc-9943-940b55913a0d.png)
-
 ### Starting ArchiCAD in Demo Mode
 
 As the connector is currently unsigned, you can only run it in demo mode.
@@ -59,6 +41,10 @@ You can start ArchiCAD in demo mode with the following commands:
 **MacOS:**
 
     ARCHICAD\ 25.app/Contents/MacOS/ARCHICAD -demo
+
+### Adding the Connector to ArchiCAD
+
+You will now need to manually add the add-on from Add-On Manager (Option menu) in Archicad. Under "Edit List of Available Add-Ons" press th "Add.." button and browse for the .apx file at `./AddOn/Build/Debug`.
 
 ### Launching the Connector
 


### PR DESCRIPTION
## Description & motivation

Users potentially could create `ConnectorArchicad` folder under `C:\Program Files\GRAPHISOFT\ARCHICAD 26\Add-Ons`  based on this readme especially in case of previous installer problems. Instead of copying build files, they should load the add-ons via Add-On Manager. Installer will remove this folder in https://github.com/specklesystems/speckle-sharp-ci-tools/issues/97. Readme updated accordingly.

