### PR TITLE
fix(Navisworks): Handles lack of One-click-send implementation causing host app to be unresponsive

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
@@ -6,11 +6,19 @@ namespace Speckle.ConnectorNavisworks.Bindings;
 
 public partial class ConnectorBindingsNavisworks
 {
+  /// <summary>
+  /// Writes the list of stream states to the file.
+  /// </summary>
+  /// <param name="streams">The list of stream states to write.</param>
   public override void WriteStreamsToFile(List<StreamState> streams)
   {
     SpeckleStreamManager.WriteStreamStateList(_doc, streams);
   }
 
+  /// <summary>
+  /// Retrieves the list of stream states from the file.
+  /// </summary>
+  /// <returns>The list of stream states.</returns>
   public override List<StreamState> GetStreamsInFile()
   {
     var streams = new List<StreamState>();
@@ -19,6 +27,10 @@ public partial class ConnectorBindingsNavisworks
     return streams;
   }
 
+  /// <summary>
+  /// Retrieves the name of the current file.
+  /// </summary>
+  /// <returns>The name of the current file.</returns>
   public override string GetFileName()
   {
     IsFileAndModelsPresent();

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using DesktopUI2.Models;
+using Sentry.Protocol;
 using Speckle.ConnectorNavisworks.Storage;
+using Application = Autodesk.Navisworks.Api.Application;
 
 namespace Speckle.ConnectorNavisworks.Bindings;
 
@@ -17,5 +20,18 @@ public partial class ConnectorBindingsNavisworks
     if (_doc != null)
       streams = SpeckleStreamManager.ReadState(_doc);
     return streams;
+  }
+
+  public override string GetFileName()
+  {
+    var activeDoc = Application.ActiveDocument;
+
+    if (activeDoc == null)
+      throw (new FileNotFoundException("No active document found."));
+
+    if (activeDoc.Models.Count == 0)
+      throw (new FileNotFoundException("No models found in active document."));
+
+    return Application.ActiveDocument.CurrentFileName ?? string.Empty;
   }
 }

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using DesktopUI2.Models;
 using Speckle.ConnectorNavisworks.Storage;
 
@@ -36,5 +37,14 @@ public partial class ConnectorBindingsNavisworks
     IsFileAndModelsPresent();
 
     return _doc?.CurrentFileName ?? string.Empty;
+  }
+
+  private static void IsFileAndModelsPresent()
+  {
+    if (_doc == null)
+      throw (new FileNotFoundException("No active document found. Cannot Send."));
+
+    if (_doc.Models.Count == 0)
+      throw (new FileNotFoundException("No models are appended. Nothing to Send."));
   }
 }

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.File.cs
@@ -1,9 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using DesktopUI2.Models;
-using Sentry.Protocol;
 using Speckle.ConnectorNavisworks.Storage;
-using Application = Autodesk.Navisworks.Api.Application;
 
 namespace Speckle.ConnectorNavisworks.Bindings;
 
@@ -24,14 +21,8 @@ public partial class ConnectorBindingsNavisworks
 
   public override string GetFileName()
   {
-    var activeDoc = Application.ActiveDocument;
+    IsFileAndModelsPresent();
 
-    if (activeDoc == null)
-      throw (new FileNotFoundException("No active document found."));
-
-    if (activeDoc.Models.Count == 0)
-      throw (new FileNotFoundException("No models found in active document."));
-
-    return Application.ActiveDocument.CurrentFileName ?? string.Empty;
+    return _doc?.CurrentFileName ?? string.Empty;
   }
 }

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using Autodesk.Navisworks.Api;
@@ -22,6 +23,13 @@ public partial class ConnectorBindingsNavisworks
 
     // Current document, models and selected elements.
     _doc = Application.ActiveDocument;
+
+    if (_doc == null)
+      throw (new FileNotFoundException("No active document found."));
+
+    if (_doc.Models.Count == 0)
+      throw (new FileNotFoundException("No models found in active document."));
+
     var appSelectedItems = _doc.CurrentSelection.SelectedItems;
 
     // Storing as a Set for consistency with the converter's handling of fragments and paths.

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using Autodesk.Navisworks.Api;
@@ -11,15 +10,6 @@ namespace Speckle.ConnectorNavisworks.Bindings;
 
 public partial class ConnectorBindingsNavisworks
 {
-  private static void IsFileAndModelsPresent()
-  {
-    if (_doc == null)
-      throw (new FileNotFoundException("No active document found."));
-
-    if (_doc.Models.Count == 0)
-      throw (new FileNotFoundException("No models found in active document."));
-  }
-
   /// <summary>
   ///   Parses list all selected Elements and their descendants that match criteria:
   ///   1. Is Selected

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Selections.cs
@@ -11,6 +11,15 @@ namespace Speckle.ConnectorNavisworks.Bindings;
 
 public partial class ConnectorBindingsNavisworks
 {
+  private static void IsFileAndModelsPresent()
+  {
+    if (_doc == null)
+      throw (new FileNotFoundException("No active document found."));
+
+    if (_doc.Models.Count == 0)
+      throw (new FileNotFoundException("No models found in active document."));
+  }
+
   /// <summary>
   ///   Parses list all selected Elements and their descendants that match criteria:
   ///   1. Is Selected
@@ -24,11 +33,7 @@ public partial class ConnectorBindingsNavisworks
     // Current document, models and selected elements.
     _doc = Application.ActiveDocument;
 
-    if (_doc == null)
-      throw (new FileNotFoundException("No active document found."));
-
-    if (_doc.Models.Count == 0)
-      throw (new FileNotFoundException("No models found in active document."));
+    IsFileAndModelsPresent();
 
     var appSelectedItems = _doc.CurrentSelection.SelectedItems;
 

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -63,7 +63,7 @@ public partial class ConnectorBindingsNavisworks
 
     // Perform the validation checks - will throw if something is wrong
     ValidateBeforeSending(state);
-    
+
     string commitId;
     var applicationProgress = Application.BeginProgress("Send to Speckle.");
     _progressBar = new ProgressInvoker(applicationProgress);
@@ -83,8 +83,6 @@ public partial class ConnectorBindingsNavisworks
         CachedConvertedElements = null;
         _cachedState = state;
         _cachedCommit = commitObject;
-
-
 
         Cursor.Current = Cursors.WaitCursor;
 
@@ -181,7 +179,7 @@ public partial class ConnectorBindingsNavisworks
     if (state.Filter == null)
       throw new InvalidOperationException("No filter provided. Nothing to Send.");
 
-    if (state.Filter.Slug == "all")
+    if (state.Filter.Slug == "all" || state.CommitMessage == "Sent everything")
       throw new InvalidOperationException("Everything Mode is not yet implemented. Send stopped.");
   }
 

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -61,6 +61,9 @@ public partial class ConnectorBindingsNavisworks
   {
     _progressViewModel = progress;
 
+    // Perform the validation checks - will throw if something is wrong
+    ValidateBeforeSending(state);
+    
     string commitId;
     var applicationProgress = Application.BeginProgress("Send to Speckle.");
     _progressBar = new ProgressInvoker(applicationProgress);
@@ -81,8 +84,7 @@ public partial class ConnectorBindingsNavisworks
         _cachedState = state;
         _cachedCommit = commitObject;
 
-        // Perform the validation checks - will throw if something is wrong
-        ValidateBeforeSending(state);
+
 
         Cursor.Current = Cursors.WaitCursor;
 

--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.cs
@@ -78,10 +78,7 @@ public partial class ConnectorBindingsNavisworks : ConnectorBindings
     return HostAppNameVersion;
   }
 
-  public override string GetFileName()
-  {
-    return Application.ActiveDocument != null ? Application.ActiveDocument.CurrentFileName : string.Empty;
-  }
+
 
   private static string GetDocPath()
   {


### PR DESCRIPTION
As reported on the forum:

https://speckle.community/t/navisworks-speckle-greys-out-after-use-and-naviswork-need-to-be-restarted/6311?u=jonathon

And it is replicable.

Two situations occur: 

1. One Click Send is enabled in the DUI even with a completely empty document with no prospect of sending anything.
    - Code now guards by throwing a `FileNotFoundException` 
2. With the file present, I am still in the defensive mode about allowing Everything mode. 
    - The code now validates ahead of the progress bar being initiated.

TODO: Consider changes to DUI2 logic on Send so that it is possible to legitimate communicate that a new Stream should not be created under the circumstances that the Connector is in control of - like a `get` only property Binding. Might hold for DUI3 (@teocomi ?)