### PR TITLE
feat(objects): only load converters matching the version of the Objects dll

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Entry/App.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/App.cs
@@ -8,6 +8,7 @@ using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.UI;
 using Revit.Async;
 using Speckle.ConnectorRevit.UI;
+using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 
 namespace Speckle.ConnectorRevit.Entry
@@ -96,7 +97,7 @@ namespace Speckle.ConnectorRevit.Entry
     private void ControlledApplication_ApplicationInitialized(object sender, Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs e)
     {
       try
-      {        
+      {
         // We need to hook into the AssemblyResolve event before doing anything else
         // or we'll run into unresolved issues loading dependencies
         AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(OnAssemblyResolve);
@@ -121,9 +122,17 @@ namespace Speckle.ConnectorRevit.Entry
       catch (Exception ex)
       {
         SpeckleLog.Logger.Fatal(ex, "Failed to load Speckle app");
-        var td = new TaskDialog("Could not load Speckle");
-        td.MainContent = $"Oh no! Something went wrong while loading Speckle, please report it on the forum:\n{ex.Message}";
-        td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Report issue on our Community Forum");
+        var td = new TaskDialog("Error loading Speckle");
+        if (ex is KitException)
+        {
+          td.MainContent = ex.Message;
+        }
+        else
+        {
+          td.MainContent = $"Oh no! Something went wrong while loading Speckle, please report it on the forum:\n\n{ex.Message}";
+        }
+
+        td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Ask for help on our Community Forum");
 
         TaskDialogResult tResult = td.Show();
 


### PR DESCRIPTION
If a user has installed connectors of different versions (eg Revit 2.14 and Navis 2.15) there is a risk of conflicts between their respective different versions of Objects.dll and converters dlls.

This PR forces the Objects Kit to only load converters that have a matching Major and Minor version numbers, and in Revit shows the following popup box:

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/a41483cc-768e-42fb-9578-ff5a25b23e7c)

Currently this was handled as a UI warning in Manager but it is not enough and has led to [user frustration](https://speckle.community/t/system-typeload-exception-revit-export/6328):

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/ea99d1f2-487b-4f1d-9dc0-55c5d28ff094)

Another fix to be eventually carried out is to have Core only load DLLsin the kits folder in reflection mode when checking for kits.

