### PR TITLE
fix:(Navisworks): progress bar should have a maxium value of 1.0

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Other/Invokers.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Other/Invokers.cs
@@ -88,6 +88,7 @@ public sealed class ProgressInvoker : Invoker
   /// </summary>
   internal void EndSubOperation()
   {
+    Update(1.0);    
     Invoke(new Action(_progressBar.EndSubOperation));
   }
 
@@ -113,7 +114,7 @@ public sealed class ProgressInvoker : Invoker
   {
     Func<double, bool> updateProgress = _progressBar.Update;
 
-    Invoke(updateProgress, fractionDone);
+    Invoke(updateProgress, Math.Min(fractionDone, 1));
   }
 
   /// <summary>


### PR DESCRIPTION
closes: #2762 

An occasional rounding error was causing some updates to the progress bar of greater than 100% (or over 1.0). This throws an error from the host application causing a failed conversion)

Changes:
For this hotfix, the Invoker method updating the progress UI has a `Math.Max(fractiondone,1)` shield.

TODO: Will revisit this as there are three different methodologies currently used to make traversal progress reporting - should adopt a single pattern
