### PR TITLE
fix(rhino): mapping constraints on polylines and facewalls

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/MappingBindingsRhino.cs
@@ -117,9 +117,9 @@ public class MappingBindingsRhino : MappingsBindings
               result.Add(new RevitDefaultPipeViewModel());
               result.Add(new RevitDefaultDuctViewModel());
             }
-            else if (c.IsPlanar())
+            else if (c.IsPlanar() && !c.IsPolyline())
             {
-              // If the curve is non-linear, but is planar, it can still be a beam.
+              // If the curve is non-linear, but is planar and is not a polyline, it can still be a beam.
               result.Add(new RevitDefaultBeamViewModel());
               result.Add(new RevitBeamViewModel());
             }

--- a/DesktopUI2/DesktopUI2/ViewModels/MappingTool/MappingsViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/MappingTool/MappingsViewModel.cs
@@ -356,7 +356,7 @@ public class MappingsViewModel : ViewModelBase, IScreen, IDialogHost
               break;
 
             case RevitFaceWallViewModel o:
-              var faceWallFamilies = AvailableRevitTypes.Where(x => x.category == "Walls").ToList();
+              var faceWallFamilies = AvailableRevitTypes.Where(x => x.family == "Basic Wall").ToList();
               if (!faceWallFamilies.Any() || !AvailableRevitLevels.Any())
                 break;
               var faceWallFamiliesViewModels = faceWallFamilies


### PR DESCRIPTION
## Description & motivation
Removes beam assignment from polylines, and constrains facewall assignment to basic wall types only.