### PR TITLE
Fix(Revit) : Don't show every mapped value for each receive operation

### DIFF
--- a/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
@@ -77,7 +77,7 @@ namespace ConnectorRevit.TypeMapping
       var masterTypeMap = DeserializeMapping(mappingSetting, out var previousMappingExists) ?? new TypeMap();
       var currentOperationTypeMap = new TypeMap();
 
-      var hostTypesContainer = GetHostTypesAndAddIncomingTypes(typeRetriever, currentOperationTypeMap, masterTypeMap, out var numNewTypes);
+      var hostTypesContainer = GetHostTypesAndAddIncomingTypes(currentOperationTypeMap, masterTypeMap, out var numNewTypes);
 
       if (await ShouldShowCustomMappingDialog(mappingSetting.Selection, numNewTypes).ConfigureAwait(false))
       {
@@ -198,7 +198,7 @@ namespace ConnectorRevit.TypeMapping
     /// <param name="currentTypeMap"></param>
     /// <param name="numNewTypes"></param>
     /// <returns></returns>
-    public HostTypeContainer GetHostTypesAndAddIncomingTypes(IRevitElementTypeRetriever typeRetriever, TypeMap currentTypeMap, TypeMap masterTypeMap, out int numNewTypes)
+    public HostTypeContainer GetHostTypesAndAddIncomingTypes(TypeMap currentTypeMap, TypeMap masterTypeMap, out int numNewTypes)
     {
       var hostTypes = new HostTypeContainer();
 

--- a/ConnectorRevit/ConnectorRevit/TypeMapping/TypeMap.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/TypeMap.cs
@@ -18,7 +18,7 @@ namespace ConnectorRevit.TypeMapping
     [JsonIgnore]
     private HashSet<string> baseIds = new();
 
-    public void AddIncomingType(Base @base, string incomingType, string? incomingFamily, string category, ISingleHostType initialGuess, bool overwriteExisting = false)
+    public void AddIncomingType(Base @base, string incomingType, string? incomingFamily, string category, ISingleHostType initialGuess)
     {
       if (baseIds.Contains(@base.id)) return;
       baseIds.Add(@base.id);
@@ -30,7 +30,7 @@ namespace ConnectorRevit.TypeMapping
         categoryToCategoryMap[category] = categoryMappingValues;
       }
 
-      if (!categoryMappingValues.TryGetMappingValue(incomingFamily, incomingType, out var singleValueToMap) || overwriteExisting)
+      if (!categoryMappingValues.TryGetMappingValue(incomingFamily, incomingType, out var singleValueToMap))
       {
         singleValueToMap = new RevitMappingValue(incomingType, initialGuess, incomingFamily, true);
         categoryMappingValues.AddMappingValue(singleValueToMap);

--- a/ConnectorRevit/ConnectorRevit/TypeMapping/TypeMap.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/TypeMap.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DesktopUI2.Models.TypeMappingOnReceive;
@@ -17,10 +18,8 @@ namespace ConnectorRevit.TypeMapping
     [JsonIgnore]
     private HashSet<string> baseIds = new();
 
-    public void AddIncomingType(Base @base, string incomingType, string? incomingFamily, string category, ISingleHostType initialGuess, out bool isNewType, bool overwriteExisting = false)
+    public void AddIncomingType(Base @base, string incomingType, string? incomingFamily, string category, ISingleHostType initialGuess, bool overwriteExisting = false)
     {
-      isNewType = false;
-
       if (baseIds.Contains(@base.id)) return;
       baseIds.Add(@base.id);
 
@@ -33,7 +32,6 @@ namespace ConnectorRevit.TypeMapping
 
       if (!categoryMappingValues.TryGetMappingValue(incomingFamily, incomingType, out var singleValueToMap) || overwriteExisting)
       {
-        isNewType = true;
         singleValueToMap = new RevitMappingValue(incomingType, initialGuess, incomingFamily, true);
         categoryMappingValues.AddMappingValue(singleValueToMap);
       }
@@ -77,6 +75,42 @@ namespace ConnectorRevit.TypeMapping
       }
 
       return singleValueToMap;
+    }
+
+    public void AddTypeMap(TypeMap typeMap)
+    {
+      foreach (var kvp in typeMap.categoryToCategoryMap)
+      {
+        AddAllMappingValuesInCategory(kvp.Key, kvp.Value);
+      }
+    }
+
+    private void AddAllMappingValuesInCategory(string category, SingleCategoryMap singleCategoryMap)
+    {
+      foreach (var mapping in singleCategoryMap.GetMappingValues())
+      {
+        if (mapping is not RevitMappingValue revitMappingValue)
+        {
+          throw new ArgumentException($"expected a {nameof(RevitMappingValue)}, but was passed a value of type {mapping.GetType()}");
+        }
+
+        // add empty category if it isn't already present
+        if (!categoryToCategoryMap.TryGetValue(category, out var categoryMappingValues))
+        {
+          categoryMappingValues = new SingleCategoryMap(category);
+          categoryToCategoryMap[category] = categoryMappingValues;
+        }
+
+        if (!categoryMappingValues.TryGetMappingValue(revitMappingValue.IncomingFamily, revitMappingValue.IncomingType, out var existingMappingValue))
+        {
+          categoryMappingValues.AddMappingValue(revitMappingValue);
+        }
+        else
+        {
+          existingMappingValue.InitialGuess = revitMappingValue.InitialGuess;
+          existingMappingValue.MappedHostType = revitMappingValue.MappedHostType;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Currently if you were to receive a commit and created mappings, and then receive a commit with different objects, there is a good chance that creating mappings for the new incoming objects will fail. If it doesn't fail, then it will show you every single incoming type that you have mapped before instead of only the incoming types that you are currently receiving.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- use two different TypeMaps in each receive operation. One map is a master map of every type that a user has ever created a mapping for. The second TypeMap is only for the incoming types that the user is receiving in the current operation.
- create method to add the mapped values from the current operation TypeMap to the master type map

<!---

- Item 1
- Item 2

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
