### PR TITLE
fix(Archicad): Receive cancellation behaviour

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/BeamConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/BeamConverter.cs
@@ -24,6 +24,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadBeam archiBeam:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ColumnConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ColumnConverter.cs
@@ -25,6 +25,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadColumn archicadColumn:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/DirectShapeConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/DirectShapeConverter.cs
@@ -36,6 +36,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.DirectShape directShape:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/DoorConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/DoorConverter.cs
@@ -26,6 +26,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadDoor archicadDoor:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/FloorConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/FloorConverter.cs
@@ -24,6 +24,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadFloor archiFloor:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ObjectConverter.cs
@@ -156,6 +156,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           var element = tc.current;
 
           // base point

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoofConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoofConverter.cs
@@ -25,6 +25,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadRoof archiRoof:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
@@ -26,6 +26,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadRoom archiRoom:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/SkylightConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/SkylightConverter.cs
@@ -26,6 +26,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadSkylight archicadSkylight:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
@@ -26,6 +26,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadWall archiWall:

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WindowConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WindowConverter.cs
@@ -26,6 +26,8 @@ namespace Archicad.Converters
       {
         foreach (var tc in elements)
         {
+          token.ThrowIfCancellationRequested();
+
           switch (tc.current)
           {
             case Objects.BuiltElements.Archicad.ArchicadWindow archicadWindow:


### PR DESCRIPTION
## Description & motivation

Receive cancellation behaviour in Archicad connector differs from other connectors. 

## Changes:

With this fix `token.ThrowIfCancelationRequested()` is used when iteration through the elements to be converted.

Limitations:
* Currently in Archicad side multiple transactions are used, the already finished ones won't be aborted or roll-backed
* Because of this partial model could be received when cancelling the operation

## Screenshots:

<img width="314" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/3642acae-c02b-4129-aaa1-00b402e80038">

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
