### PR TITLE
fix(Archicad): Remove unnecessary hotspots from 3D objects

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
@@ -347,7 +347,7 @@ GSErrCode LibpartImportManager::CreateLibraryPart (const ModelInfo& modelInfo,
 		BNZeroMemory (&section, sizeof (API_LibPartSection));
 		section.sectType = API_SectParamDef;
 
-		short nPars = 2;
+		short nPars = 3;
 		API_AddParType** addPars = reinterpret_cast<API_AddParType**>(BMAllocateHandle (nPars * sizeof (API_AddParType), ALLOCATE_CLEAR, 0));
 		if (addPars != nullptr) {
 			API_AddParType* pAddPar = &(*addPars)[0];
@@ -369,6 +369,12 @@ GSErrCode LibpartImportManager::CreateLibraryPart (const ModelInfo& modelInfo,
 			for (Int32 k = 0; k < pAddPar->dim1; k++)
 				for (Int32 j = 0; j < pAddPar->dim2; j++)
 					(*arrHdl)[k * pAddPar->dim2 + j] = (k == j ? 1.0 : 0.0);
+
+			pAddPar = &(*addPars)[2];
+			pAddPar->typeID = APIParT_Boolean;
+			CHTruncate ("AC_show2DHotspotsIn3D", pAddPar->name, sizeof (pAddPar->name));
+			GS::ucscpy (pAddPar->uDescname, L ("Show 2D Hotspots in 3D"));
+			pAddPar->value.real = 0;
 
 			double aa = 1.0;
 			double bb = 1.0;


### PR DESCRIPTION
## Description & motivation

There are unnecessary hotspots for object in 3D at the project zero level.

## Changes:

The parameter AC_show2DHotspotIn3D has been set to false.

Before:
<img width="699" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/f0b4dcbe-a2fc-4d9b-ae83-19c01bdfa884">

After:
<img width="659" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/402560ef-2d4d-4762-a75f-af7f8d08ba4b">


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
