### PR TITLE
chore(core): use product version

### DIFF
--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -181,6 +181,7 @@ public static class Analytics
     {
       try
       {
+        var executingAssembly = Assembly.GetExecutingAssembly();
         var properties = new Dictionary<string, object>
         {
           { "distinct_id", hashedEmail },
@@ -188,7 +189,7 @@ public static class Analytics
           { "token", MixpanelToken },
           { "hostApp", Setup.HostApplication },
           { "hostAppVersion", Setup.VersionedHostApplication },
-          { "core_version", FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion},
+          { "core_version", FileVersionInfo.GetVersionInfo(executingAssembly.Location).ProductVersion ?? executingAssembly.GetName().Version.ToString()},
           { "$os", GetOs() }
         };
 

--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -173,7 +174,7 @@ public static class Analytics
 
 #if DEBUG
     //only track in prod
-    return;
+    //return;
 #endif
 
     Task.Run(() =>
@@ -187,7 +188,7 @@ public static class Analytics
           { "token", MixpanelToken },
           { "hostApp", Setup.HostApplication },
           { "hostAppVersion", Setup.VersionedHostApplication },
-          { "core_version", Assembly.GetExecutingAssembly().GetName().Version.ToString() },
+          { "core_version", FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion},
           { "$os", GetOs() }
         };
 

--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -174,7 +174,7 @@ public static class Analytics
 
 #if DEBUG
     //only track in prod
-    //return;
+    return;
 #endif
 
     Task.Run(() =>


### PR DESCRIPTION
A quick change to use the dll product version instead of the file version for better analytics.

Cc @paloknapo 

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/39f558aa-dca2-4a1c-8574-c498134b7837)