### PR TITLE
fix(autocad): Fixed issue where logger was being used before setup wa…

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Speckle.Core.Logging;
 using Forms = System.Windows.Forms;
 
 #if ADVANCESTEEL2023
@@ -52,10 +53,11 @@ namespace Speckle.ConnectorAutocadCivil.Entry
         //Some dlls fail to load due to versions matching (0.10.7 vs 0.10.0)
         //the below should fix it! This affects Avalonia and Material 
         AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(OnAssemblyResolve);
-
+        
         // DUI2
-        SpeckleAutocadCommand.InitAvalonia();
         var bindings = new ConnectorBindingsAutocad();
+        Setup.Init(bindings.GetHostAppNameVersion(), bindings.GetHostAppName());
+        SpeckleAutocadCommand.InitAvalonia();
         bindings.RegisterAppEvents();
         SpeckleAutocadCommand.Bindings = bindings;
       }


### PR DESCRIPTION
During our weekly error log review, I noticed that error logs from AutoCAD were reporting as "CoreUnknown"
This is because the logger is being used before DUI calls the `Setup` function.

Like with other connectors, we have solved this by calling Setup as soon as we create the Conenctor bindings. 