### PR TITLE
fix(Archicad): Receive cancellation handling improvement

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
@@ -228,7 +228,11 @@ API_AddonType __ACDLL_CALL CheckEnvironment (API_EnvirParams* envir)
 	RSGetIndString (&envir->addOnInfo.name, AddOnInfoID, AddOnNameID, ACAPI_GetOwnResModule ());
 	RSGetIndString (&envir->addOnInfo.description, AddOnInfoID, AddOnDescriptionID, ACAPI_GetOwnResModule ());
 
+#ifdef DEBUG
+	return APIAddon_Preload;
+#else
 	return APIAddon_Normal;
+#endif
 }
 
 

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManagerReceive.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManagerReceive.cs
@@ -87,35 +87,21 @@ namespace Archicad
 
     public async Task<bool> ConvertToNative(StreamState state, Base commitObject, ProgressViewModel progress)
     {
-      try
-      {
-        ConversionOptions conversionOptions = new ConversionOptions(state.Settings);
+      ConversionOptions conversionOptions = new ConversionOptions(state.Settings);
 
-        Objects.Converter.Archicad.ConverterArchicad converter = new Objects.Converter.Archicad.ConverterArchicad(
-          conversionOptions
-        );
-        List<TraversalContext> flattenObjects = FlattenCommitObject(commitObject, converter);
+      Objects.Converter.Archicad.ConverterArchicad converter = new Objects.Converter.Archicad.ConverterArchicad(
+        conversionOptions
+      );
+      List<TraversalContext> flattenObjects = FlattenCommitObject(commitObject, converter);
 
-        converter.SetContextObjects(flattenObjects);
+      converter.SetContextObjects(flattenObjects);
 
-        foreach (var applicationObject in converter.ContextObjects)
-          progress.Report.Log(applicationObject);
+      foreach (var applicationObject in converter.ContextObjects)
+        progress.Report.Log(applicationObject);
 
-        converter.ReceiveMode = state.ReceiveMode;
+      converter.ReceiveMode = state.ReceiveMode;
 
-        return await ConvertReceivedObjects(flattenObjects, converter, progress);
-      }
-      catch (Exception ex)
-      {
-        SpeckleLog.Logger.Error("Conversion to native failed.");
-
-        string message = $"Fatal Error: {ex.Message}";
-        if (ex is OperationCanceledException)
-          message = "Receive cancelled";
-        progress.Report.LogOperationError(new Exception($"{message} - Partial model could be received.", ex));
-
-        return false;
-      }
+      return await ConvertReceivedObjects(flattenObjects, converter, progress);
     }
 
     private List<TraversalContext> FlattenCommitObject(


### PR DESCRIPTION
## Description & motivation

Receive process cancellation fix:
* warning bubble shows correct text
* no error entries created in the log


## Changes:

1. All exceptions are rethrown the base ReceiveStream function
2. `progress.Report.LogOperationError` of cancelation removed from `ConvertToNative`, because it is not shows on the DUI Report page in case of any kind of exceptions
3. `SpeckleLog.Logger.Error` not created if cancelled (despite of Revit, which should be fixed also)


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
