### PR TITLE
core: hotfix for sqlite transport swallowing exception when failing t…

### DIFF
--- a/Core/Core/Transports/Exceptions.cs
+++ b/Core/Core/Transports/Exceptions.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+using System;
+
+namespace Speckle.Core.Transports;
+
+public class TransportException : Exception
+{
+  public ITransport? Transport { get; }
+
+  public TransportException(ITransport? transport, string? message, Exception? innerException = null)
+    : base(message, innerException)
+  {
+    Transport = transport;
+  }
+
+  public TransportException() { }
+
+  public TransportException(string message) : base(message) { }
+
+  public TransportException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/Core/Core/Transports/SQLite.cs
+++ b/Core/Core/Transports/SQLite.cs
@@ -48,7 +48,7 @@ public class SQLiteTransport : IDisposable, ICloneable, ITransport, IBlobCapable
     }
     catch (Exception ex)
     {
-      throw new Exception($"Cound not create {dir}", ex);
+      throw new TransportException(this, $"Cound not create {dir}", ex);
     }
 
     RootPath = Path.Combine(basePath, applicationName, $"{scope}.db");
@@ -66,9 +66,9 @@ public class SQLiteTransport : IDisposable, ICloneable, ITransport, IBlobCapable
       };
       WriteTimer.Elapsed += WriteTimerElapsed;
     }
-    catch (Exception e)
+    catch (Exception ex)
     {
-      OnErrorAction?.Invoke(TransportName, e);
+      throw new TransportException(this, "Failed to initialize DB connection", ex);
     }
   }
 


### PR DESCRIPTION
This PR contains a small subset of the changes already merged in `dev` for 2.16 regarding transport exception handling - https://github.com/specklesystems/speckle-sharp/pull/2700

The problem with the SQLite transport, is if it fails to initialize a connection to the DB, it "calls" OnErrorAction. However, there is no way for OnErrorAction to be assigned, since this is performed in the constructor.

So in effect, this is a silent swallow of any exceptions that occur when initializing a connection to the DB.

This leaves the transport in an invalid state such that calls to its members will fail with no-descript error messages.

This PR replaces the false call to OnErrorAction with a throw - as per the changes already made in dev. This way callers are aware of their failed sqlite connection