### PR TITLE
fix(Navisworks): Civil3D Models failing as geometries containing embedded primitives

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Bindings/ConnectorNavisworksBindings.Send.cs
@@ -310,7 +310,7 @@ public partial class ConnectorBindingsNavisworks
     if (commitObject.elements.Count == 0)
     {
       _settingsHandler.RestoreAutoSave();
-      throw new SpeckleException("All Geometry objects in the selection are hidden. Send stopped.");
+      throw new SpeckleException("All Geometry objects in the selection are hidden or cannot be converted. Send stopped.");
     }
 
     _progressViewModel.Report.Merge(_navisworksConverter.Report);

--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToSpeckle.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToSpeckle.cs
@@ -314,7 +314,8 @@ public partial class ConverterNavisworks
     if (!item.HasGeometry || item.Children.Any())
       return true;
 
-    const PrimitiveTypes allowedTypes = PrimitiveTypes.Lines | PrimitiveTypes.Triangles | PrimitiveTypes.SnapPoints;
+    const PrimitiveTypes allowedTypes =
+      PrimitiveTypes.Lines | PrimitiveTypes.Triangles | PrimitiveTypes.SnapPoints | PrimitiveTypes.Text;
 
     var primitives = item.Geometry.PrimitiveTypes;
     var primitiveTypeSupported = (primitives & allowedTypes) == primitives;


### PR DESCRIPTION
As Text Primitives are in fact decimated into lines, the addition of a Text Primitive was inconsequential.

TODO: Processing Text Primitives to the underlying text content may be possible and omitting the geometric 