### PR TITLE
Feat(Revit) : send performance enhancement

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Entry/App.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/App.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.UI;
-using Revit.Async;
+using RevitSharedResources.Models;
 using Speckle.ConnectorRevit.UI;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
@@ -23,7 +23,7 @@ namespace Speckle.ConnectorRevit.Entry
     public Result OnStartup(UIControlledApplication application)
     {
       //Always initialize RevitTask ahead of time within Revit API context
-      RevitTask.Initialize(application);
+      APIContext.Initialize(application);
 
       UICtrlApp = application;
       UICtrlApp.ControlledApplication.ApplicationInitialized += ControlledApplication_ApplicationInitialized;

--- a/ConnectorRevit/ConnectorRevit/TypeMapping/FamilyImporter.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/FamilyImporter.cs
@@ -9,9 +9,9 @@ using Avalonia.Threading;
 using DesktopUI2.Models.TypeMappingOnReceive;
 using DesktopUI2.ViewModels;
 using DesktopUI2.Views.Windows.Dialogs;
-using Revit.Async;
 using RevitSharedResources.Extensions.SpeckleExtensions;
 using RevitSharedResources.Interfaces;
+using RevitSharedResources.Models;
 using Speckle.Core.Logging;
 using static DesktopUI2.ViewModels.ImportFamiliesDialogViewModel;
 using SHC = RevitSharedResources.Helpers.Categories;
@@ -83,7 +83,7 @@ namespace ConnectorRevit.TypeMapping
 
     private async Task ImportTypesIntoDocument(HostTypeContainer hostTypesContainer, Dictionary<string, FamilyInfo> familyInfo, ImportFamiliesDialogViewModel vm)
     {
-      await RevitTask.RunAsync(_ =>
+      await APIContext.Run(_ =>
       {
         using var t = new Transaction(document, $"Import family types");
 
@@ -151,7 +151,7 @@ namespace ConnectorRevit.TypeMapping
         string pathClone = string.Copy(path);
 
         //open family file as xml to extract all family symbols without loading all of them into the project
-        await RevitTask.RunAsync(() => document.Application.ExtractPartAtomFromFamilyFile(path, xmlPath))
+        await APIContext.Run(() => document.Application.ExtractPartAtomFromFamilyFile(path, xmlPath))
           .ConfigureAwait(false);
         var xmlDoc = new XmlDocument(); // Create an XML document object
         xmlDoc.Load(xmlPath);

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Events.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Events.cs
@@ -5,12 +5,11 @@ using System.Threading.Tasks;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Events;
 using Avalonia.Controls;
-using ConnectorRevit.Storage;
 using DesktopUI2.Models;
 using DesktopUI2.ViewModels;
 using DesktopUI2.Views;
 using DesktopUI2.Views.Windows.Dialogs;
-using Revit.Async;
+using RevitSharedResources.Models;
 using Speckle.ConnectorRevit.Entry;
 using Speckle.ConnectorRevit.Storage;
 using Speckle.Core.Kits;
@@ -26,7 +25,7 @@ namespace Speckle.ConnectorRevit.UI
     {
       try
       {
-        await RevitTask.RunAsync(
+        await APIContext.Run(
           app =>
           {
             using (Transaction t = new Transaction(CurrentDoc.Document, "Speckle Write State"))
@@ -325,7 +324,7 @@ namespace Speckle.ConnectorRevit.UI
 
         var perspView = views.FirstOrDefault(o => o.Name == "SpeckleCommentView");
 
-        await RevitTask.RunAsync(app =>
+        await APIContext.Run(app =>
         {
 
           using (var t = new Transaction(CurrentDoc.Document, $"Open Comment View"))

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Previews.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Previews.cs
@@ -13,8 +13,8 @@ using System.Threading.Tasks;
 using System.Linq;
 using ApplicationObject = Speckle.Core.Models.ApplicationObject;
 using Autodesk.Revit.DB.DirectContext3D;
-using Revit.Async;
 using RevitSharedResources.Interfaces;
+using RevitSharedResources.Models;
 
 namespace Speckle.ConnectorRevit.UI
 {
@@ -56,7 +56,7 @@ namespace Speckle.ConnectorRevit.UI
             progress.Report.Log(previewObj);
 
           IConvertedObjectsCache<Base, Element> convertedObjects = null;
-          await RevitTask.RunAsync(
+          await APIContext.Run(
             app =>
             {
               using (var t = new Transaction(CurrentDoc.Document, $"Baking stream {state.StreamId}"))

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -13,7 +13,6 @@ using DesktopUI2;
 using DesktopUI2.Models;
 using DesktopUI2.Models.Settings;
 using DesktopUI2.ViewModels;
-using Revit.Async;
 using RevitSharedResources.Interfaces;
 using RevitSharedResources.Models;
 using Serilog.Context;
@@ -94,7 +93,7 @@ namespace Speckle.ConnectorRevit.UI
       }
 #pragma warning restore CA1031 // Do not catch general exception types
 
-      var (success, exception) = await RevitTask.RunAsync(app =>
+      var (success, exception) = await APIContext.Run(_ =>
       {
         string transactionName = $"Baking stream {state.StreamId}";
         using var g = new TransactionGroup(CurrentDoc.Document, transactionName);

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -56,7 +56,7 @@ namespace Speckle.ConnectorRevit.UI
         throw new InvalidOperationException(
           "There are zero objects to send. Please use a filter, or set some via selection."
         );
-
+      converter.SetContextDocument(revitDocumentAggregateCache);
       converter.SetContextObjects(
         selectedObjects
           .Select(x => new ApplicationObject(x.UniqueId, x.GetType().ToString()) { applicationId = x.UniqueId })

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -211,10 +211,19 @@ namespace Speckle.ConnectorRevit.UI
       return false;
     }
 
-    private static void YieldToUIThread(TimeSpan delay)
+    private DateTime timerStarted = DateTime.MinValue;
+    private void YieldToUIThread(TimeSpan delay)
     {
+      var currentTime = DateTime.UtcNow;
+
+      if (currentTime.Subtract(timerStarted) < TimeSpan.FromSeconds(.15))
+      {
+        return;
+      }
+
       using CancellationTokenSource s = new(delay);
       Dispatcher.UIThread.MainLoop(s.Token);
+      timerStarted = currentTime;
     }
 
     private static Base ConvertToSpeckle(Element revitElement, ISpeckleConverter converter)

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -81,7 +81,7 @@ namespace Speckle.ConnectorRevit.UI
       var conversionProgressDict = new ConcurrentDictionary<string, int> { ["Conversion"] = 0 };
       var convertedCount = 0;
 
-      await APIContext.Run(_ =>
+      await APIContext.Run(() =>
       {
         using var _d0 = LogContext.PushProperty("converterName", converter.Name);
         using var _d1 = LogContext.PushProperty("converterAuthor", converter.Author);
@@ -144,7 +144,6 @@ namespace Speckle.ConnectorRevit.UI
 
           YieldToUIThread(TimeSpan.FromMilliseconds(1));
         }
-        return true;
       })
       .ConfigureAwait(false);
 

--- a/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
+++ b/ConnectorRevit/ConnectorRevit2020/ConnectorRevit2020.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ModPlus.Revit.API.2020" Version="1.0.0" ExcludeAssets="runtime" IncludeAssets="compile;build" PrivateAssets="all" />
-    <PackageReference Include="Revit.Async" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Core\Core.csproj" />

--- a/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
+++ b/ConnectorRevit/ConnectorRevit2021/ConnectorRevit2021.csproj
@@ -26,8 +26,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="ModPlus.Revit.API.2021" Version="1.0.0" IncludeAssets="compile;build" PrivateAssets="all"/>
-    <PackageReference Include="Revit.Async" Version="2.0.1" />
+    <PackageReference Include="ModPlus.Revit.API.2021" Version="1.0.0" IncludeAssets="compile;build" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup>

--- a/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
+++ b/ConnectorRevit/ConnectorRevit2022/ConnectorRevit2022.csproj
@@ -33,8 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Revit.Async" Version="2.0.1"/>
-    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1" IncludeAssets="compile;build" PrivateAssets="all"/>
+    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1" IncludeAssets="compile;build" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="Clean">

--- a/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
+++ b/ConnectorRevit/ConnectorRevit2023/ConnectorRevit2023.csproj
@@ -33,7 +33,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Revit.Async" Version="2.0.1" />
     <PackageReference Include="Speckle.Revit.API" Version="2023.0.0" IncludeAssets="compile;build" PrivateAssets="all" />
   </ItemGroup>
 

--- a/ConnectorRevit/ConnectorRevit2024/ConnectorRevit2024.csproj
+++ b/ConnectorRevit/ConnectorRevit2024/ConnectorRevit2024.csproj
@@ -33,7 +33,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Revit.Async" Version="2.0.1" />
     <PackageReference Include="Speckle.Revit.API" Version="2024.0.0" IncludeAssets="compile;build" PrivateAssets="all" />
   </ItemGroup>
 

--- a/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
+++ b/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
@@ -7,24 +7,26 @@ namespace RevitSharedResources.Models
 {
   public static class APIContext
   {
+    private static UIControlledApplication uiApplication;
     private static ExternalEventHandler<IExternalEventHandler, ExternalEvent> factoryExternalEventHandler;
     private static ExternalEvent factoryExternalEvent;
     public static void Initialize(UIControlledApplication application)
     {
+      uiApplication = application; 
       factoryExternalEventHandler = new(ExternalEvent.Create);
       factoryExternalEvent = ExternalEvent.Create(factoryExternalEventHandler);
     }
 
-    public static async Task<TResult> Run<TResult>(Func<UIApplication, TResult> func)
+    public static async Task<TResult> Run<TResult>(Func<UIControlledApplication, TResult> func)
     {
-      var handler = new ExternalEventHandler<UIApplication, TResult>(func);
+      var handler = new ExternalEventHandler<UIControlledApplication, TResult>(func);
       using var externalEvent = await Run(factoryExternalEventHandler, handler, factoryExternalEvent)
         .ConfigureAwait(false);
 
-      return await Run(handler, null, externalEvent).ConfigureAwait(false);
+      return await Run(handler, uiApplication, externalEvent).ConfigureAwait(false);
     }
     
-    public static async Task Run(Action<UIApplication> action)
+    public static async Task Run(Action<UIControlledApplication> action)
     {
       await Run<object>(app =>
       {

--- a/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
+++ b/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
@@ -23,6 +23,23 @@ namespace RevitSharedResources.Models
 
       return await Run(handler, null, externalEvent).ConfigureAwait(false);
     }
+    
+    public static async Task Run(Action<UIApplication> action)
+    {
+      await Run<object>(app =>
+      {
+        action(app);
+        return null;
+      }).ConfigureAwait(false);
+    }
+    public static async Task Run(Action action)
+    {
+      await Run<object>(_ =>
+      {
+        action();
+        return null;
+      }).ConfigureAwait(false);
+    }
 
     private static async Task<TResult> Run<TParameter, TResult>(
       ExternalEventHandler<TParameter, TResult> handler,

--- a/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
+++ b/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
@@ -5,12 +5,24 @@ using System.Threading;
 
 namespace RevitSharedResources.Models
 {
+  /// <summary>
+  /// This class gives access to the Revit API context from anywhere in your codebase. This is essentially a 
+  /// lite version of the Revit.Async package from Kennan Chan. Most of the functionality was taken from that code.
+  /// The main difference is that this class does not subscribe to the applicationIdling event from revit
+  /// which the docs say will impact the performance of Revit
+  /// </summary>
   public static class APIContext
   {
     private static SemaphoreSlim semaphore = new(1,1);
     private static UIControlledApplication uiApplication;
     private static ExternalEventHandler<IExternalEventHandler, ExternalEvent> factoryExternalEventHandler;
     private static ExternalEvent factoryExternalEvent;
+
+    /// <summary>
+    /// Initialize that happens in a Revit context will make an ExternalEvent and ExternalEventHandler
+    /// whose jobs are to create external events that wrap the funcs passed into the Run method.
+    /// </summary>
+    /// <param name="application"></param>
     public static void Initialize(UIControlledApplication application)
     {
       uiApplication = application; 

--- a/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
+++ b/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
@@ -7,6 +7,7 @@ namespace RevitSharedResources.Models
 {
   public static class APIContext
   {
+    private static SemaphoreSlim semaphore = new(1,1);
     private static UIControlledApplication uiApplication;
     private static ExternalEventHandler<IExternalEventHandler, ExternalEvent> factoryExternalEventHandler;
     private static ExternalEvent factoryExternalEvent;
@@ -19,11 +20,19 @@ namespace RevitSharedResources.Models
 
     public static async Task<TResult> Run<TResult>(Func<UIControlledApplication, TResult> func)
     {
-      var handler = new ExternalEventHandler<UIControlledApplication, TResult>(func);
-      using var externalEvent = await Run(factoryExternalEventHandler, handler, factoryExternalEvent)
-        .ConfigureAwait(false);
+      await semaphore.WaitAsync().ConfigureAwait(false);
+      try
+      {
+        var handler = new ExternalEventHandler<UIControlledApplication, TResult>(func);
+        using var externalEvent = await Run(factoryExternalEventHandler, handler, factoryExternalEvent)
+          .ConfigureAwait(false);
 
-      return await Run(handler, uiApplication, externalEvent).ConfigureAwait(false);
+        return await Run(handler, uiApplication, externalEvent).ConfigureAwait(false);
+      }
+      finally
+      {
+        semaphore.Release();
+      }
     }
     
     public static async Task Run(Action<UIControlledApplication> action)

--- a/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
+++ b/ConnectorRevit/RevitSharedResources/Models/APIContext.cs
@@ -1,0 +1,83 @@
+using System;
+using Autodesk.Revit.UI;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace RevitSharedResources.Models
+{
+  public static class APIContext
+  {
+    private static ExternalEventHandler<IExternalEventHandler, ExternalEvent> factoryExternalEventHandler;
+    private static ExternalEvent factoryExternalEvent;
+    public static void Initialize(UIControlledApplication application)
+    {
+      factoryExternalEventHandler = new(ExternalEvent.Create);
+      factoryExternalEvent = ExternalEvent.Create(factoryExternalEventHandler);
+    }
+
+    public static async Task<TResult> Run<TResult>(Func<UIApplication, TResult> func)
+    {
+      var handler = new ExternalEventHandler<UIApplication, TResult>(func);
+      using var externalEvent = await Run(factoryExternalEventHandler, handler, factoryExternalEvent)
+        .ConfigureAwait(false);
+
+      return await Run(handler, null, externalEvent).ConfigureAwait(false);
+    }
+
+    private static async Task<TResult> Run<TParameter, TResult>(
+      ExternalEventHandler<TParameter, TResult> handler,
+      TParameter parameter,
+      ExternalEvent externalEvent)
+    {
+      var task = handler.GetTask(parameter);
+      externalEvent.Raise();
+
+      return await task.ConfigureAwait(false);
+    }
+  }
+
+  public enum HandlerStatus
+  {
+    NotStarted,
+    Started,
+    IsCompleted,
+    IsFaulted,
+  }
+
+  internal class ExternalEventHandler<TParameter, TResult> : IExternalEventHandler
+  {
+    public TaskCompletionSource<TResult> Result { get; private set; }
+    public Task<TResult> GetTask(TParameter parameter)
+    {
+      Parameter = parameter;
+      Result = new TaskCompletionSource<TResult>();
+      return Result.Task;
+    }
+
+    private Func<TParameter, TResult> func;
+    public ExternalEventHandler(Func<TParameter, TResult> func)
+    {
+      this.func = func;
+    }
+
+    public HandlerStatus Status { get; private set; } = HandlerStatus.NotStarted;
+    public TParameter Parameter { get; private set; }
+    public void Execute(UIApplication app)
+    {
+      Status = HandlerStatus.Started;
+      try
+      {
+        var r = func(Parameter);
+        Result.SetResult(r);
+        Status = HandlerStatus.IsCompleted;
+      }
+      catch (Exception ex)
+      {
+        Status = HandlerStatus.IsFaulted;
+        Result.SetException(ex);
+      }
+    }
+
+    public string GetName() => "SpeckleRevitContextEventHandler";
+  }
+}

--- a/ConnectorRevit/RevitSharedResources/RevitSharedResources.projitems
+++ b/ConnectorRevit/RevitSharedResources/RevitSharedResources.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\IReceivedObjectIdMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\IRevitCategoryInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\IRevitElementTypeRetriever.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\APIContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\ConversionNotReadyCacheData.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -338,10 +338,11 @@ namespace Objects.Converter.Revit
     {
       exclusions ??= new();
       Dictionary<string, Parameter> paramDict = new();
-      // exclude parameters that don't have a value and those pointing to other elements as we don't support them
-      foreach (DB.Parameter param in element.Parameters)
+      using var parameters = element.Parameters;
+      foreach (DB.Parameter param in parameters)
       {
 
+        // exclude parameters that don't have a value and those pointing to other elements as we don't support them
         if (param.StorageType == StorageType.ElementId || !param.HasValue)
         {
           continue;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -158,7 +158,9 @@ namespace Objects.Converter.Revit
 
     public double ScaleToSpeckle(double value)
     {
-      return ScaleToSpeckle(value, RevitLengthTypeId);
+      return value * revitDocumentAggregateCache
+        .GetOrInitializeEmptyCacheOfType<double>(out _)
+        .GetOrAdd(RevitLengthTypeId.ToString(), () => ScaleToSpeckle(1, RevitLengthTypeId), out _);
     }
     
     public static double ScaleToSpeckle(double value, string units)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -1,4 +1,5 @@
 using Autodesk.Revit.DB;
+using RevitSharedResources.Interfaces;
 
 namespace Objects.Converter.Revit
 {
@@ -70,12 +71,22 @@ namespace Objects.Converter.Revit
     /// <returns></returns>
     public double ScaleToSpeckle(double value)
     {
-      return UnitUtils.ConvertFromInternalUnits(value, RevitLengthTypeId);
+      return ScaleToSpeckleStatic(value, RevitLengthTypeId);
+    }
+    
+    public static double ScaleToSpeckleStatic(double value, DisplayUnitType unitType)
+    {
+      return UnitUtils.ConvertFromInternalUnits(value, unitType);
+    }
+
+    public static double ScaleToSpeckle(double value, DisplayUnitType unitType, IRevitDocumentAggregateCache cache)
+    {
+      return ScaleToSpeckleStatic(value, unitType);
     }
 
     public static double ScaleToSpeckle(double value, string units)
     {
-      return UnitUtils.ConvertFromInternalUnits(value, UnitsToNative(units));
+      return ScaleToSpeckleStatic(value, UnitsToNative(units));
     }
 
     private string UnitsToSpeckle(DisplayUnitType type)
@@ -122,6 +133,10 @@ namespace Objects.Converter.Revit
           throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{units}\" is unsupported.");
       }
     }
+    private static string UnitsToNativeString(DisplayUnitType unitType)
+    {
+      return unitType.ToString();
+    }
 #else
     public string ModelUnits
     {
@@ -153,24 +168,48 @@ namespace Objects.Converter.Revit
     {
       if (string.IsNullOrEmpty(units))
         return value;
-      return UnitUtils.ConvertToInternalUnits(value, new ForgeTypeId(UnitsToNative(units)));
+      return UnitUtils.ConvertToInternalUnits(value, UnitsToNative(units));
     }
 
+    private double? defaultConversionFactor;
     public double ScaleToSpeckle(double value)
     {
-      return value * revitDocumentAggregateCache
-        .GetOrInitializeEmptyCacheOfType<double>(out _)
-        .GetOrAdd(RevitLengthTypeId.ToString(), () => ScaleToSpeckle(1, RevitLengthTypeId), out _);
+      defaultConversionFactor ??= ScaleToSpeckle(1, RevitLengthTypeId);
+      return value * defaultConversionFactor.Value;
     }
     
+    /// <summary>
+    /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="units"></param>
+    /// <returns></returns>
     public static double ScaleToSpeckle(double value, string units)
     {
-      return ScaleToSpeckle(value, new ForgeTypeId(UnitsToNative(units)));
+      return ScaleToSpeckleStatic(value, UnitsToNative(units));
     }
-
-    public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)
+    
+    /// <summary>
+    /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="forgeTypeId"></param>
+    /// <returns></returns>
+    public static double ScaleToSpeckleStatic(double value, ForgeTypeId forgeTypeId)
     {
       return UnitUtils.ConvertFromInternalUnits(value, forgeTypeId);
+    }
+
+    public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId, IRevitDocumentAggregateCache cache)
+    {
+      return value * cache
+        .GetOrInitializeEmptyCacheOfType<double>(out _)
+        .GetOrAdd(forgeTypeId.TypeId, () => UnitUtils.ConvertFromInternalUnits(1, forgeTypeId), out _);
+    }
+    
+    public double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)
+    {
+      return ScaleToSpeckle(value, forgeTypeId, revitDocumentAggregateCache);
     }
 
     //new units api introduced in 2021, bleah
@@ -190,20 +229,28 @@ namespace Objects.Converter.Revit
       throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{typeId}\" is unsupported.");
     }
 
-    public static string UnitsToNative(string units)
+    public static string UnitsToNativeString(string units)
+    {
+      return UnitsToNativeString(UnitsToNative(units));
+    }
+    public static string UnitsToNativeString(ForgeTypeId forgeTypeId)
+    {
+      return forgeTypeId.TypeId;
+    }
+    public static ForgeTypeId UnitsToNative(string units)
     {
       switch (units)
       {
         case Speckle.Core.Kits.Units.Millimeters:
-          return UnitTypeId.Millimeters.TypeId;
+          return UnitTypeId.Millimeters;
         case Speckle.Core.Kits.Units.Centimeters:
-          return UnitTypeId.Centimeters.TypeId;
+          return UnitTypeId.Centimeters;
         case Speckle.Core.Kits.Units.Meters:
-          return UnitTypeId.Meters.TypeId;
+          return UnitTypeId.Meters;
         case Speckle.Core.Kits.Units.Inches:
-          return UnitTypeId.Inches.TypeId;
+          return UnitTypeId.Inches;
         case Speckle.Core.Kits.Units.Feet:
-          return UnitTypeId.Feet.TypeId;
+          return UnitTypeId.Feet;
         default:
           throw new Speckle.Core.Logging.SpeckleException($"The Unit System \"{units}\" is unsupported.");
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitCommitObjectBuilder.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitCommitObjectBuilder.cs
@@ -169,12 +169,11 @@ public sealed class RevitCommitObjectBuilder : CommitObjectBuilder<Element>, IRe
   {
     return element switch
     {
-      CableTray o => o.MEPSystem?.Name,
-      Conduit c => c.MEPSystem?.Name,
-      Duct d => d.MEPSystem?.Name,
-      Pipe p => p.MEPSystem?.Name,
-      Wire w => w.MEPSystem?.Name,
-      _ => ConverterRevit.GetParamValue<string>(element, BuiltInParameter.RBS_SYSTEM_NAME_PARAM)
+      MEPCurve o => o.MEPSystem?.Name,
+      FamilyInstance o => o.MEPModel?.ConnectorManager?.Connectors?.Size > 0 ?
+        ConverterRevit.GetParamValue<string>(element, BuiltInParameter.RBS_SYSTEM_NAME_PARAM) :
+        null,
+      _ => null
     };
   }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.DB;
 using System;
 
 namespace Objects.Converter.Revit
@@ -77,6 +77,15 @@ namespace Objects.Converter.Revit
       return parameter.Definition.UnitType.ToString();
 #else
       return parameter.Definition.GetDataType().TypeId;
+#endif
+    }
+    
+    public static string GetUnityTypeString(this Definition definition)
+    {
+#if REVIT2020 || REVIT2021
+      return definition.UnitType.ToString();
+#else
+      return definition.GetDataType().TypeId;
 #endif
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
@@ -98,6 +98,17 @@ namespace Objects.Converter.Revit
 #endif
     }
 
+#if REVIT2020    
+    public static DisplayUnitType GetUnitTypeId(this Parameter parameter)
+    {
+      return parameter.DisplayUnitType;
+    }
+#else
+    public static ForgeTypeId GetUnitTypeId(this Parameter parameter)
+    {
+      return parameter.GetUnitTypeId();
+    }
+#endif
 
     public static bool IsCurveClosed(NurbSpline curve)
     {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitVersionHelper.cs
@@ -61,24 +61,6 @@ namespace Objects.Converter.Revit
       return UnitUtils.ConvertToInternalUnits(value, parameter.GetUnitTypeId());
 #endif
     }
-
-    public static double ConvertFromInternalUnits(double val, Parameter parameter)
-    {
-#if REVIT2020
-      return UnitUtils.ConvertFromInternalUnits(val, parameter.DisplayUnitType);
-#else
-      return UnitUtils.ConvertFromInternalUnits(val, parameter.GetUnitTypeId());
-#endif
-    }
-
-    public static string GetUnityTypeString(this Parameter parameter)
-    {
-#if REVIT2020 || REVIT2021
-      return parameter.Definition.UnitType.ToString();
-#else
-      return parameter.Definition.GetDataType().TypeId;
-#endif
-    }
     
     public static string GetUnityTypeString(this Definition definition)
     {
@@ -86,15 +68,6 @@ namespace Objects.Converter.Revit
       return definition.UnitType.ToString();
 #else
       return definition.GetDataType().TypeId;
-#endif
-    }
-
-    public static string GetDisplayUnityTypeString(this Parameter parameter)
-    {
-#if REVIT2020
-      return parameter.DisplayUnitType.ToString();
-#else
-      return parameter.GetUnitTypeId().TypeId;
 #endif
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTests2021/ConverterRevitTests2021.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTests2021/ConverterRevitTests2021.csproj
@@ -55,7 +55,6 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="ModPlus.Revit.API.2021" Version="4.0.0" />
-        <PackageReference Include="Revit.Async" Version="2.0.1" />
         <PackageReference Include="xUnitRevitUtils.2021" Version="1.0.7" />
     </ItemGroup>
     <ItemGroup>
@@ -63,8 +62,6 @@
         <ProjectReference Include="..\..\..\..\..\Core\Core\Core.csproj" />
         <ProjectReference Include="..\..\..\..\Objects\Objects.csproj" />
         <ProjectReference Include="..\..\ConverterRevit2021\ConverterRevit2021.csproj" />
-        <ProjectReference Include="..\TestGenerator\TestGenerator.csproj" 
-                          OutputItemType="Analyzer"
-                          ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\TestGenerator\TestGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 </Project>

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTests2022/ConverterRevitTests2022.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTests2022/ConverterRevitTests2022.csproj
@@ -55,7 +55,6 @@
         <PackageReference Include="coverlet.collector" Version="1.3.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Revit.Async" Version="2.0.1" />
         <PackageReference Include="xUnitRevitUtils.2022" Version="1.0.7" />
     </ItemGroup>
     <ItemGroup>
@@ -63,8 +62,6 @@
         <ProjectReference Include="..\..\..\..\..\Core\Core\Core.csproj" />
         <ProjectReference Include="..\..\..\..\Objects\Objects.csproj" />
         <ProjectReference Include="..\..\ConverterRevit2022\ConverterRevit2022.csproj" />
-        <ProjectReference Include="..\TestGenerator\TestGenerator.csproj" 
-                          OutputItemType="Analyzer" 
-                          ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\TestGenerator\TestGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 </Project>

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTests2023/ConverterRevitTests2023.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTests2023/ConverterRevitTests2023.csproj
@@ -53,7 +53,6 @@
         <PackageReference Include="coverlet.collector" Version="1.3.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Revit.Async" Version="2.0.1" />
         <PackageReference Include="xUnitRevitUtils.2023" Version="1.0.7" />
     </ItemGroup>
     <ItemGroup>
@@ -61,8 +60,6 @@
         <ProjectReference Include="..\..\..\..\..\Core\Core\Core.csproj" />
         <ProjectReference Include="..\..\..\..\Objects\Objects.csproj" />
         <ProjectReference Include="..\..\ConverterRevit2023\ConverterRevit2023.csproj" />
-        <ProjectReference Include="..\TestGenerator\TestGenerator.csproj" 
-                          OutputItemType="Analyzer" 
-                          ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\TestGenerator\TestGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 </Project>

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTestsShared/AssertUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTestsShared/AssertUtils.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Autodesk.Revit.DB;
 using Objects.Converter.Revit;
-using Revit.Async;
+using RevitSharedResources.Models;
 using Speckle.Core.Models;
 using Xunit;
 using DB = Autodesk.Revit.DB;
@@ -92,7 +92,7 @@ namespace ConverterRevitTests
     {
       ElementEqual(sourceElem, destElem);
 
-      var slopeArrow = await RevitTask.RunAsync(app => {
+      var slopeArrow = await APIContext.Run(app => {
         return ConverterRevit.GetSlopeArrow(sourceElem);
       }).ConfigureAwait(false);
 
@@ -105,7 +105,7 @@ namespace ConverterRevitTests
         var tailOffset = ConverterRevit.GetSlopeArrowTailOffset(slopeArrow, sourceElem.Document);
         _ = ConverterRevit.GetSlopeArrowHeadOffset(slopeArrow, sourceElem.Document, tailOffset, out var slope);
 
-        var newSlopeArrow = await RevitTask.RunAsync(app => {
+        var newSlopeArrow = await APIContext.Run(app => {
           return ConverterRevit.GetSlopeArrow(destElem);
         }).ConfigureAwait(false);
 
@@ -229,12 +229,12 @@ namespace ConverterRevitTests
     {
       ElementEqual(sourceElem, destElem);
 
-      var sourceValueList = await RevitTask.RunAsync(app =>
+      var sourceValueList = await APIContext.Run(app =>
       {
         return GetTextValuesFromSchedule(sourceElem);
       }).ConfigureAwait(false);
 
-      var destValueList = await RevitTask.RunAsync(app =>
+      var destValueList = await APIContext.Run(app =>
       {
         return GetTextValuesFromSchedule(destElem);
       }).ConfigureAwait(false);

--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTestsShared/SpeckleUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/ConverterRevitTestsShared/SpeckleUtils.cs
@@ -4,9 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Objects.Converter.Revit;
-using Revit.Async;
+using RevitSharedResources.Models;
 using Speckle.Core.Models;
 using Xunit;
 using xUnitRevitUtils;
@@ -21,7 +20,7 @@ namespace ConverterRevitTests
     {
       var tcs = new TaskCompletionSource<string>();
 
-      await RevitTask.RunAsync(() =>
+      await APIContext.Run(() =>
       {
         using var g = new DB.TransactionGroup(doc, transactionName);
         using var transaction = new DB.Transaction(doc, transactionName);


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- replaced RevitAsync nuget package with custom APIContext class
  - This new version does almost the same thing as the nuget package except it does not subscribe to the revit [IdlingEvent](https://www.revitapidocs.com/2023/e233027b-ba8c-0bd1-37b7-93a066efa5a3.htm)
  - This only speeds up the conversion from .5-1s. However, the idling event documentation says that subscribing to the event in a certain way (that RevitAsync is using) "can result in performance degradation for the system on which Revit is running because the CPU remains fully engaged in serving Idling events during the Revit application's downtime." So it is recommended to avoid using this event

- Throttle Send operation
  - only refresh the UI every .15 seconds. This makes a small impact on the ui refreshing and a huge impact on performance.

- Optimizations for "ParameterToSpeckle"
  - This method is taking the most time of any method that we're sending because it is called so many times. Therefore small optimizations to this method can have a large performance gain.
  -  Broke the parameter value logic out into it's own method "GetParameterValue" to avoid calling the entire ParameterToSpeckle method just to get the value of the convertedParameter
  - Started passing the cache object into the method for more perfomant unit conversions and queries

- Units to Speckle
  - started converting "1" to the desired units and then caching the result as the conversion factor. This is because Revit's "ConvertFromInternalUnits" method is fairly expensive.

<!---

- Item 1
- Item 2

-->

## Screenshots:
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/574bdd20-c9c3-4eeb-8248-35d302168b12)

A previous PR lowered the conversion time for this tower from 100s to 70s. This PR lowers the conversion time even further to ~25 seconds.

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

All unit tests still pass

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
