### PR TITLE
Hotfix(Revit) : fix incorrect instance assumptions

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -793,7 +793,8 @@ namespace Objects.Converter.Revit
         var meshes = GetElementDisplayValue(
           instance,
           new Options() { DetailLevel = ViewDetailLevel.Fine },
-          true
+          true,
+          parentTransform
         );
         symbol.displayValue = meshes;
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -76,8 +76,6 @@ namespace Objects.Converter.Revit
       var meshes = new List<DB.Mesh>();
 
       SortGeometry(element, solids, meshes, geom, transform?.Inverse);
-      //if (isConvertedAsInstance) SortInstanceGeometry(element, solids, meshes, geom);
-      //else SortGeometry(element.Document, solids, meshes, geom);
 
       // convert meshes and solids
       displayMeshes.AddRange(ConvertMeshesByRenderMaterial(meshes, element.Document, isConvertedAsInstance));

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertMeshUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Autodesk.Revit.DB;
 using Speckle.Core.Logging;
 using DB = Autodesk.Revit.DB;
@@ -35,7 +34,8 @@ namespace Objects.Converter.Revit
     public List<Mesh> GetElementDisplayValue(
       DB.Element element,
       Options options = null,
-      bool isConvertedAsInstance = false
+      bool isConvertedAsInstance = false,
+      DB.Transform transform = null
     )
     {
       var displayMeshes = new List<Mesh>();
@@ -75,14 +75,45 @@ namespace Objects.Converter.Revit
       var solids = new List<Solid>();
       var meshes = new List<DB.Mesh>();
 
-      if (isConvertedAsInstance) SortInstanceGeometry(element, solids, meshes, geom);
-      else SortGeometry(element.Document, solids, meshes, geom);
+      SortGeometry(element, solids, meshes, geom, transform?.Inverse);
+      //if (isConvertedAsInstance) SortInstanceGeometry(element, solids, meshes, geom);
+      //else SortGeometry(element.Document, solids, meshes, geom);
 
       // convert meshes and solids
       displayMeshes.AddRange(ConvertMeshesByRenderMaterial(meshes, element.Document, isConvertedAsInstance));
       displayMeshes.AddRange(ConvertSolidsByRenderMaterial(solids, element.Document, isConvertedAsInstance));
 
       return displayMeshes;
+    }
+
+    private static void LogInstanceMeshRetrievalWarnings(
+      Element element, 
+      int topLevelSolidsCount, 
+      int topLevelMeshesCount, 
+      int topLevelGeomElementCount, 
+      int topLevelGeomInstanceCount, 
+      bool hasSymbolGeom
+    )
+    {
+      if (hasSymbolGeom)
+      {
+        if (topLevelSolidsCount > 0)
+        {
+          SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} has valid symbol geometry and {numSolids} top level solids. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId, topLevelSolidsCount);
+        }
+        if (topLevelMeshesCount > 0)
+        {
+          SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} has valid symbol geometry and {numMeshes} top level meshes. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId, topLevelMeshesCount);
+        }
+        if (topLevelGeomElementCount > 0)
+        {
+          SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} has valid symbol geometry and {numGeomElements} top level geometry elements. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId, topLevelGeomElementCount);
+        }
+      }
+      else if (topLevelSolidsCount == 0 && topLevelMeshesCount == 0)
+      {
+        SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} does not have valid symbol geometry and does not have any top-level solids or meshes. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId);
+      }
     }
 
     /// <summary>
@@ -100,11 +131,12 @@ namespace Objects.Converter.Revit
     /// <param name="solids"></param>
     /// <param name="meshes"></param>
     /// <param name="geom"></param>
-    void SortInstanceGeometry(
+    void SortGeometry(
       Element element,
       List<Solid> solids,
       List<DB.Mesh> meshes,
-      GeometryElement geom
+      GeometryElement geom,
+      Transform inverseTransform = null
     )
     {
       var topLevelSolidsCount = 0;
@@ -112,139 +144,75 @@ namespace Objects.Converter.Revit
       var topLevelGeomElementCount = 0;
       var topLevelGeomInstanceCount = 0;
       var hasSymbolGeom = false;
-      foreach (GeometryObject geomObj in geom)
-      {
-        switch (geomObj)
-        {
-          case Solid:
-            topLevelSolidsCount++;
-            break;
-          case DB.Mesh:
-            topLevelMeshesCount++;
-            break;
-          case GeometryElement:
-            topLevelGeomElementCount++;
-            break;
-          case GeometryInstance instance:
-            topLevelGeomInstanceCount++;
-            var symbolGeo = instance.GetSymbolGeometry();
 
-            if (!SymbolGeometryContainsGeometryData(symbolGeo))
-            {
-              SortGeometry(element.Document, solids, meshes, geom, instance.Transform.Inverse);
-            }
-            else
-            {
-              hasSymbolGeom = true;
-              SortGeometry(element.Document, solids, meshes, symbolGeo);
-            }
-            break;
-        }
-      }
-
-      LogInstanceMeshRetrievalWarnings(
-        element, 
-        topLevelSolidsCount, 
-        topLevelMeshesCount, 
-        topLevelGeomElementCount, 
-        topLevelGeomInstanceCount, 
-        hasSymbolGeom);
-    }
-
-    private bool SymbolGeometryContainsGeometryData(GeometryElement geometryElement)
-    {
-      foreach (var geomObj in geometryElement)
-      {
-        switch (geomObj)
-        {
-          case Solid:
-            return true;
-          case DB.Mesh:
-            return true;
-          case GeometryElement el:
-            return SymbolGeometryContainsGeometryData(el);
-          case GeometryInstance instance:
-            return SymbolGeometryContainsGeometryData(instance.GetSymbolGeometry());
-        }
-      }
-      return false;
-    }
-
-    private static void LogInstanceMeshRetrievalWarnings(
-      Element element, 
-      int topLevelSolidsCount, 
-      int topLevelMeshesCount, 
-      int topLevelGeomElementCount, 
-      int topLevelGeomInstanceCount, 
-      bool hasSymbolGeom
-    )
-    {
-      if (topLevelGeomInstanceCount == 0)
-      {
-        SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} did not have any top level geometry instances. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId);
-      }
-      else if (hasSymbolGeom)
-      {
-        if (topLevelSolidsCount > 0)
-        {
-          SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} has valid symbol geometry and {numSolids} top level solids. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId, topLevelSolidsCount);
-        }
-        if (topLevelMeshesCount > 0)
-        {
-          SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} has valid symbol geometry and {numMeshes} top level meshes. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId, topLevelMeshesCount);
-        }
-        if (topLevelGeomElementCount > 0)
-        {
-          SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} has valid symbol geometry and {numGeomElements} top level geometry elements. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId, topLevelGeomElementCount);
-        }
-      }
-      else
-      {
-        if (topLevelSolidsCount == 0 && topLevelMeshesCount == 0)
-        {
-          SpeckleLog.Logger.Warning("Element of type {elementType} with uniqueId {uniqueId} does not have valid symbol geometry and does not have any top-level solids or meshes. See comment on method SortInstanceGeometry for link to RevitAPI docs that leads us to believe this shouldn't happen", element.GetType(), element.UniqueId);
-        }
-      }
-    }
-
-    void SortGeometry(
-      Document doc,
-      List<Solid> solids,
-      List<DB.Mesh> meshes,
-      GeometryElement geom,
-      Transform inverseTransform = null
-    )
-    {
       foreach (GeometryObject geomObj in geom)
       {
         switch (geomObj)
         {
           case Solid solid:
             // skip invalid solid
-            if (solid.Faces.Size == 0 || Math.Abs(solid.SurfaceArea) == 0) continue;
-            if (IsSkippableGraphicStyle(solid.GraphicsStyleId, doc)) continue;
+            if (solid.Faces.Size == 0
+              || Math.Abs(solid.SurfaceArea) == 0
+              || IsSkippableGraphicStyle(solid.GraphicsStyleId, element.Document)) 
+            {
+              continue;
+            }
 
             if (inverseTransform != null)
+            {
+              topLevelSolidsCount++;
               solid = SolidUtils.CreateTransformed(solid, inverseTransform);
+            }
 
             solids.Add(solid);
             break;
           case DB.Mesh mesh:
-            if (IsSkippableGraphicStyle(mesh.GraphicsStyleId, doc)) continue;
+            if (IsSkippableGraphicStyle(mesh.GraphicsStyleId, element.Document)) continue;
 
             if (inverseTransform != null)
+            {
+              topLevelMeshesCount++;
               mesh = mesh.get_Transformed(inverseTransform);
+            }
 
             meshes.Add(mesh);
             break;
           case GeometryInstance instance:
-            var instanceGeo = instance.GetInstanceGeometry();
-            SortGeometry(doc, solids, meshes, instanceGeo, inverseTransform);
+            GeometryElement geomElement;
+            if (inverseTransform != null)
+            {
+              topLevelGeomInstanceCount++;
+              hasSymbolGeom = true;
+              geomElement = instance.GetSymbolGeometry();
+            }
+            else
+            {
+              geomElement = instance.GetInstanceGeometry();
+            }
+
+            // element transforms should not be carried down into nested geometryInstances.
+            // Nested geomInstances should have their geom retreived with GetInstanceGeom, not GetSymbolGeom
+            SortGeometry(element, solids, meshes, geomElement);
             break;
-          case GeometryElement element:
-            SortGeometry(doc, solids, meshes, element, inverseTransform);
+          case GeometryElement geometryElement:
+            if (inverseTransform != null)
+            {
+              topLevelGeomElementCount++;
+            }
+            SortGeometry(element, solids, meshes, geometryElement);
             break;
         }
+      }
+
+      if (inverseTransform != null)
+      {
+        LogInstanceMeshRetrievalWarnings(
+          element,
+          topLevelSolidsCount,
+          topLevelMeshesCount,
+          topLevelGeomElementCount,
+          topLevelGeomInstanceCount,
+          hasSymbolGeom);
       }
     }
 


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Found an incorrect assumption that we were making about geometryElements in Revit.
Conduit fittings are missing because we were depending on the fitting's geometryElement to have a top-level geometryInstance, but they don't so the mesh is being ignored
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/3b2633b3-3d0d-4e29-9040-ded73390c996)

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

SortGeometry made sense to be recombined into a single recursive method

Previous flow for instances (flow for non-instances is the same)
1. Get geometry element for element
2. Search the top-level of the geometryElement until a GeometryInstance is found
3. Check if geometry instance actually contained geometry or not
  3a. If yes, then retrieve Symbol geometry from geometry instance and SortGeometry without applying any transforms
  3b. If no, then pass original geometry element to the SortGeometry function which will apply an inverse transform to all of the solid objects that it finds

This flow made the following assumption: the top-level geometry element of a family instance will definitely contain a geometryInstance object. This is almost always true but not always. Sometimes you may only have top-level solids and no geometry instance. If that is the case, we want to treat the element as if it had an empty geometry instance (the 3b. route in the above procedure)

New flow
1. Get geometry element for element
2. Loop through top-level of geometryElement converting all solids and meshes by the provided inverse transform
3. If a geometry element is encountered, then try getting the symbol geometry and continue the recursive conversion. However, do not pass down the transform because all nested geometry instances should be treated as already transformed. This is unchanged behavior 

A remaining assumption that we are making is that geometryElements will not contain meaningful top-level solids and a meaningful symbolGeometry. If this were to be true, then either the top level solids would be incorrectly transformed, or they would be fine. We are still logging to see if this ever happens.

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

Previous:
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/d052e041-a7f7-4dc0-be25-64b272b09092)

New:
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/1fb97144-3c93-4a50-80ce-03121bf37ed0)

Nested geometryInstances still send fine
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/41d369f1-c3c7-4687-a3b3-7e2685373c18)

Other instance files that have given us issues in the past also send fine
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/e0744aa7-7879-44ce-af4d-8cf9aa0d7894)


<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
