### PR TITLE
fix: Do not pack Revit TestGenerator

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitTests/TestGenerator/TestGenerator.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevitTests/TestGenerator/TestGenerator.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Any project added to `Objects` is automatically `packable` unless otherwise stated.

`TestGenerator` was left without the `IsPackable` flag set to false.