### PR TITLE
break(objects): adds new convert to native displayable bindings

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Converters/ConverterArchicad.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ConverterArchicad.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Archicad;
@@ -50,12 +50,16 @@ namespace Objects.Converter.Archicad
       return null;
     }
 
+    public object ConvertToNativeDisplayable(Base @object)
+    {
+      throw new NotImplementedException();
+    }
+
     public List<object> ConvertToNative(List<Base> objects) => objects.Select(ConvertToNative).ToList();
 
     public bool CanConvertToNativeImplemented(Base @object)
     {
-      return @object
-        switch
+      return @object switch
       {
         // Speckle BIM elements
         Objects.BuiltElements.Beam _ => true,
@@ -82,15 +86,14 @@ namespace Objects.Converter.Archicad
         // Speckle geomtries
         Objects.Geometry.Mesh _ => true,
         Objects.Geometry.Brep _ => true,
- 
+
         _ => false
       };
     }
 
     public bool CanConvertToNativeNotImplemented(Base @object)
     {
-      return @object
-        switch
+      return @object switch
       {
         // Project info
         Objects.Organization.ModelInfo _ => true,
@@ -102,6 +105,11 @@ namespace Objects.Converter.Archicad
     public bool CanConvertToNative(Base @object)
     {
       return CanConvertToNativeImplemented(@object) || CanConvertToNativeNotImplemented(@object);
+    }
+
+    public bool CanConvertToNativeDisplayable(Base @object)
+    {
+      return false;
     }
 
     /// <summary>
@@ -116,9 +124,7 @@ namespace Objects.Converter.Archicad
     /// </summary>
     public List<ApplicationObject> PreviousContextObjects { get; set; } = new List<ApplicationObject>();
 
-    public void SetContextDocument(object doc)
-    {
-    }
+    public void SetContextDocument(object doc) { }
 
     public void SetContextObjects(List<ApplicationObject> objects) => ContextObjects = objects;
 
@@ -150,9 +156,7 @@ namespace Objects.Converter.Archicad
 
     public void SetPreviousContextObjects(List<ApplicationObject> objects) => PreviousContextObjects = objects;
 
-    public void SetConverterSettings(object settings)
-    {
-    }
+    public void SetConverterSettings(object settings) { }
 
     public ConverterArchicad(ConversionOptions conversionOptions)
     {

--- a/Core/Core/Kits/ISpeckleConverter.cs
+++ b/Core/Core/Kits/ISpeckleConverter.cs
@@ -81,12 +81,13 @@ public interface ISpeckleConverter
 
   /// <summary>
   /// Checks to verify if a given object is: 1) displayable and  2) can be supported for conversion to the native application.
-  /// An object is considered "displayable" if it has a 'displayValue' property (defined in it's class or dynamically attached to it, detached or not).
+  /// An object is considered "displayable" if it has a 'displayValue' property (defined in its class or dynamically attached to it, detached or not).
   /// </summary>
   /// <remarks>
   /// An object may return "True" for both <see cref="CanConvertToNative"/> and <see cref="CanConvertToNativeDisplayable"/>
   /// In this case, deciding which to use is dependent on each connector developer.
   /// Preferably, <see cref="CanConvertToNativeDisplayable"/> should be used as a fallback to the <see cref="CanConvertToNative"/> logic.
+  /// Objects found in the 'displayValue' property are assumed to be universally convertible by all converters and the viewer, but are not guaranteed to be so.
   /// </remarks>
   /// <param name="object">Speckle object to convert</param>
   /// <returns>True if the object is "displayable" and the converter supports native conversion of the given speckle object in particular.</returns>

--- a/Core/Core/Kits/ISpeckleConverter.cs
+++ b/Core/Core/Kits/ISpeckleConverter.cs
@@ -56,10 +56,20 @@ public interface ISpeckleConverter
   public List<object> ConvertToNative(List<Base> objects);
 
   /// <summary>
-  /// Converts a Speckle object to a native displayable one
+  /// Converts a given speckle objects as a generic native object.
+  /// This should assume <see cref="CanConvertToNativeDisplayable"/> has been called and returned True,
+  /// or call it within this method's implementation to ensure non-displayable objects are gracefully handled.
   /// </summary>
+  /// <remarks>
+  /// This method should not try to convert an object to it's native representation (i.e Speckle Wall -> Wall),
+  /// but rather use the 'displayValue' of that wall to create a geometrically correct representation of that object
+  /// in the native application.
+  /// An object may be able to be converted both with <see cref="ConvertToNative(Speckle.Core.Models.Base)"/> and <see cref="ConvertToNativeDisplayable"/>.
+  /// In this case, deciding which to use is dependent on each connector developer.
+  /// Preferably, <see cref="ConvertToNativeDisplayable"/> should be used as a fallback to the <see cref="ConvertToNative(Speckle.Core.Models.Base)"/> logic.
+  /// </remarks>
   /// <param name="object">Speckle object to convert</param>
-  /// <returns></returns>
+  /// <returns>The native object that resulted after converting the input <paramref name="object"/></returns>
   public object ConvertToNativeDisplayable(Base @object);
 
   /// <summary>
@@ -70,10 +80,16 @@ public interface ISpeckleConverter
   public bool CanConvertToNative(Base @object);
 
   /// <summary>
-  /// Checks if it can convert a Speckle object to a native displayable one
+  /// Checks to verify if a given object is: 1) displayable and  2) can be supported for conversion to the native application.
+  /// An object is considered "displayable" if it has a 'displayValue' property (defined in it's class or dynamically attached to it, detached or not).
   /// </summary>
+  /// <remarks>
+  /// An object may return "True" for both <see cref="CanConvertToNative"/> and <see cref="CanConvertToNativeDisplayable"/>
+  /// In this case, deciding which to use is dependent on each connector developer.
+  /// Preferably, <see cref="CanConvertToNativeDisplayable"/> should be used as a fallback to the <see cref="CanConvertToNative"/> logic.
+  /// </remarks>
   /// <param name="object">Speckle object to convert</param>
-  /// <returns></returns>
+  /// <returns>True if the object is "displayable" and the converter supports native conversion of the given speckle object in particular.</returns>
   public bool CanConvertToNativeDisplayable(Base @object);
 
   /// <summary>

--- a/Core/Core/Kits/ISpeckleConverter.cs
+++ b/Core/Core/Kits/ISpeckleConverter.cs
@@ -56,11 +56,25 @@ public interface ISpeckleConverter
   public List<object> ConvertToNative(List<Base> objects);
 
   /// <summary>
+  /// Converts a Speckle object to a native displayable one
+  /// </summary>
+  /// <param name="object">Speckle object to convert</param>
+  /// <returns></returns>
+  public object ConvertToNativeDisplayable(Base @object);
+
+  /// <summary>
   /// Checks if it can convert a Speckle object to a native one
   /// </summary>
   /// <param name="object">Speckle object to convert</param>
   /// <returns></returns>
   public bool CanConvertToNative(Base @object);
+
+  /// <summary>
+  /// Checks if it can convert a Speckle object to a native displayable one
+  /// </summary>
+  /// <param name="object">Speckle object to convert</param>
+  /// <returns></returns>
+  public bool CanConvertToNativeDisplayable(Base @object);
 
   /// <summary>
   /// Returns a list of applications serviced by this converter

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -428,6 +428,11 @@ namespace Objects.Converter.AutocadCivil
       return acadObj;
     }
 
+    public object ConvertToNativeDisplayable(Base @object)
+    {
+      throw new NotImplementedException();
+    }
+
     public List<object> ConvertToNative(List<Base> objects)
     {
       return objects.Select(x => ConvertToNative(x)).ToList();
@@ -533,6 +538,11 @@ namespace Objects.Converter.AutocadCivil
         default:
           return false;
       }
+    }
+
+    public bool CanConvertToNativeDisplayable(Base @object)
+    {
+      return false;
     }
   }
 }

--- a/Objects/Converters/ConverterBentley/ConverterBentleyShared/ConverterBentley.cs
+++ b/Objects/Converters/ConverterBentley/ConverterBentleyShared/ConverterBentley.cs
@@ -1,4 +1,4 @@
-﻿using Bentley.DgnPlatformNET;
+using Bentley.DgnPlatformNET;
 using Bentley.DgnPlatformNET.DgnEC;
 using Bentley.DgnPlatformNET.Elements;
 using Bentley.EC.Persistence.Query;
@@ -62,7 +62,9 @@ namespace Objects.Converter.Bentley
     public string Name => nameof(ConverterBentley);
     public string Author => "Arup";
     public string WebsiteOrEmail => "https://www.arup.com";
+
     public IEnumerable<string> GetServicedApplications() => new string[] { BentleyAppName };
+
     public ProgressReport Report { get; private set; } = new ProgressReport();
     public HashSet<Exception> ConversionErrors { get; private set; } = new HashSet<Exception>();
     public Session Session { get; private set; }
@@ -74,8 +76,11 @@ namespace Objects.Converter.Bentley
 #endif
     public double UoR { get; private set; }
     public List<ApplicationObject> ContextObjects { get; set; } = new List<ApplicationObject>();
+
     public void SetContextObjects(List<ApplicationObject> objects) => ContextObjects = objects;
+
     public void SetPreviousContextObjects(List<ApplicationObject> objects) => throw new NotImplementedException();
+
     public void SetConverterSettings(object settings)
     {
       throw new NotImplementedException("This converter does not have any settings.");
@@ -321,6 +326,11 @@ namespace Objects.Converter.Bentley
       }
     }
 
+    public object ConvertToNativeDisplayable(Base @object)
+    {
+      throw new NotImplementedException();
+    }
+
     public List<object> ConvertToNative(List<Base> objects)
     {
       return objects.Select(x => ConvertToNative(x)).ToList();
@@ -390,6 +400,11 @@ namespace Objects.Converter.Bentley
         default:
           return false;
       }
+    }
+
+    public bool CanConvertToNativeDisplayable(Base @object)
+    {
+      return false;
     }
   }
 }

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSI.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSI.cs
@@ -45,6 +45,7 @@ namespace Objects.Converter.CSI
     public Model SpeckleModel { get; set; }
 
     public ReceiveMode ReceiveMode { get; set; }
+
     /// <summary>
     /// <para>To know which objects are already in the model. These are *mostly* elements that are in the model before the receive operation starts, but certain names will be added for objects that may be referenced by other elements such as load patterns and load cases.</para>
     /// <para> The keys are typically GUIDS and the values are exclusively names. It is easier to retrieve names, and names are typically used by the api, however GUIDS are more stable and can't be changed in the user interface. Some items (again load patterns and load combinations) don't have GUIDs so those just store the name value twice. </para>
@@ -63,8 +64,11 @@ namespace Objects.Converter.CSI
     /// </summary>
     public List<ApplicationObject> PreviousContextObjects { get; set; } = new List<ApplicationObject>();
     public Dictionary<string, string> Settings { get; private set; } = new Dictionary<string, string>();
+
     public void SetContextObjects(List<ApplicationObject> objects) => ContextObjects = objects;
+
     public void SetPreviousContextObjects(List<ApplicationObject> objects) => PreviousContextObjects = objects;
+
     public void SetContextDocument(object doc)
     {
       Model = (cSapModel)doc;
@@ -77,7 +81,7 @@ namespace Objects.Converter.CSI
         throw new Exception("operation setting was not set before calling converter.SetContextDocument");
 
       if (Settings["operation"] == "receive")
-      { 
+      {
         ExistingObjectGuids = GetAllGuids(Model);
         // TODO: make sure we are setting the load patterns before we import load combinations
       }
@@ -88,6 +92,7 @@ namespace Objects.Converter.CSI
       else
         throw new Exception("operation setting was not set to \"send\" or \"receive\"");
     }
+
     public void SetConverterSettings(object settings)
     {
       Settings = settings as Dictionary<string, string>;
@@ -117,7 +122,13 @@ namespace Objects.Converter.CSI
         case BuiltElements.Brace _:
         case BuiltElements.Column _:
           return true;
-      };
+      }
+      ;
+      return false;
+    }
+
+    public bool CanConvertToNativeDisplayable(Base @object)
+    {
       return false;
     }
 
@@ -202,16 +213,24 @@ namespace Objects.Converter.CSI
           break;
         #endregion
         default:
-          appObj.Update(status: ApplicationObject.State.Skipped, logItem: $"Skipped not supported type: {@object.GetType()}");
+          appObj.Update(
+            status: ApplicationObject.State.Skipped,
+            logItem: $"Skipped not supported type: {@object.GetType()}"
+          );
           break;
       }
 
-      // log 
+      // log
       var reportObj = Report.ReportObjects.ContainsKey(@object.id) ? Report.ReportObjects[@object.id] : null;
       if (reportObj != null && notes.Count > 0)
         reportObj.Update(log: notes);
 
       return appObj;
+    }
+
+    public object ConvertToNativeDisplayable(Base @object)
+    {
+      throw new NotImplementedException();
     }
 
     public List<object> ConvertToNative(List<Base> objects)
@@ -334,64 +353,64 @@ namespace Objects.Converter.CSI
           returnObject = LoadPatternToSpeckle(name);
           Report.Log($"Created Loading Pattern");
           break;
-          //case "ColumnResults":
-          //    returnObject = FrameResultSet1dToSpeckle(name);
-          //    break;
-          //case "BeamResults":
-          //    returnObject = FrameResultSet1dToSpeckle(name);
-          //    break;
-          //case "BraceResults":
-          //    returnObject = FrameResultSet1dToSpeckle(name);
-          //    break;
-          //case "PierResults":
-          //    returnObject = PierResultSet1dToSpeckle(name);
-          //    break;
-          //case "SpandrelResults":
-          //    returnObject = SpandrelResultSet1dToSpeckle(name);
-          //    break;
-          //case "GridSys":
-          //    returnObject = GridSysToSpeckle(name);
-          //    break;
-          //case "Combo":
-          //    returnObject = ComboToSpeckle(name);
-          //    break;
-          //case "DesignSteel":
-          //    returnObject = DesignSteelToSpeckle(name);
-          //    break;
-          //case "DeisgnConcrete":
-          //    returnObject = DesignConcreteToSpeckle(name);
-          //    break;
-          //case "Story":
-          //    returnObject = StoryToSpeckle(name);
-          //    break;
-          //case "Diaphragm":
-          //    returnObject = DiaphragmToSpeckle(name);
-          //    break;
-          //case "PierLabel":
-          //    returnObject = PierLabelToSpeckle(name);
-          //    break;
-          //case "PropAreaSpring":
-          //    returnObject = PropAreaSpringToSpeckle(name);
-          //    break;
-          //case "PropLineSpring":
-          //    returnObject = PropLineSpringToSpeckle(name);
-          //    break;
-          //case "PropPointSpring":
-          //    returnObject = PropPointSpringToSpeckle(name);
-          //    break;
-          //case "SpandrelLabel":
-          //    returnObject = SpandrelLabelToSpeckle(name);
-          //    break;
-          //case "PropTendon":
-          //    returnObject = PropTendonToSpeckle(name);
-          //    break;
-          //case "PropLink":
-          //    returnObject = PropLinkToSpeckle(name);
-          //    break;
-          //default:
-          //    ConversionErrors.Add(new SpeckleException($"Skipping not supported type: {type}"));
-          //    returnObject = null;
-          //    break;
+        //case "ColumnResults":
+        //    returnObject = FrameResultSet1dToSpeckle(name);
+        //    break;
+        //case "BeamResults":
+        //    returnObject = FrameResultSet1dToSpeckle(name);
+        //    break;
+        //case "BraceResults":
+        //    returnObject = FrameResultSet1dToSpeckle(name);
+        //    break;
+        //case "PierResults":
+        //    returnObject = PierResultSet1dToSpeckle(name);
+        //    break;
+        //case "SpandrelResults":
+        //    returnObject = SpandrelResultSet1dToSpeckle(name);
+        //    break;
+        //case "GridSys":
+        //    returnObject = GridSysToSpeckle(name);
+        //    break;
+        //case "Combo":
+        //    returnObject = ComboToSpeckle(name);
+        //    break;
+        //case "DesignSteel":
+        //    returnObject = DesignSteelToSpeckle(name);
+        //    break;
+        //case "DeisgnConcrete":
+        //    returnObject = DesignConcreteToSpeckle(name);
+        //    break;
+        //case "Story":
+        //    returnObject = StoryToSpeckle(name);
+        //    break;
+        //case "Diaphragm":
+        //    returnObject = DiaphragmToSpeckle(name);
+        //    break;
+        //case "PierLabel":
+        //    returnObject = PierLabelToSpeckle(name);
+        //    break;
+        //case "PropAreaSpring":
+        //    returnObject = PropAreaSpringToSpeckle(name);
+        //    break;
+        //case "PropLineSpring":
+        //    returnObject = PropLineSpringToSpeckle(name);
+        //    break;
+        //case "PropPointSpring":
+        //    returnObject = PropPointSpringToSpeckle(name);
+        //    break;
+        //case "SpandrelLabel":
+        //    returnObject = SpandrelLabelToSpeckle(name);
+        //    break;
+        //case "PropTendon":
+        //    returnObject = PropTendonToSpeckle(name);
+        //    break;
+        //case "PropLink":
+        //    returnObject = PropLinkToSpeckle(name);
+        //    break;
+        //default:
+        //    ConversionErrors.Add(new SpeckleException($"Skipping not supported type: {type}"));
+        //    returnObject = null;
+        //    break;
       }
 
       // send the object out with the same appId that it came in with for updating purposes

--- a/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.cs
+++ b/Objects/Converters/ConverterDynamo/ConverterDynamoShared/ConverterDynamo.cs
@@ -1,4 +1,4 @@
-﻿#if REVIT
+#if REVIT
 using Autodesk.Revit.DB;
 using RD = Revit.Elements; //Dynamo for Revit nodes
 using Objects.Converter.Revit;
@@ -27,7 +27,6 @@ namespace Objects.Converter.Dynamo
 {
   public partial class ConverterDynamo : ISpeckleConverter
   {
-
 #if REVIT2023
     public static string AppName = HostApplications.Dynamo.GetVersion(HostAppVersion.vRevit2023);
 #elif REVIT2022
@@ -186,6 +185,11 @@ namespace Objects.Converter.Dynamo
       }
     }
 
+    public object ConvertToNativeDisplayable(Base @object)
+    {
+      throw new NotImplementedException();
+    }
+
     public List<Base> ConvertToSpeckle(List<object> objects)
     {
       return objects.Select(x => ConvertToSpeckle(x)).ToList();
@@ -193,7 +197,8 @@ namespace Objects.Converter.Dynamo
 
     public List<object> ConvertToNative(List<Base> objects)
     {
-      return objects.Select(x => ConvertToNative(x)).ToList(); ;
+      return objects.Select(x => ConvertToNative(x)).ToList();
+      ;
     }
 
     public bool CanConvertToSpeckle(object @object)
@@ -257,12 +262,16 @@ namespace Objects.Converter.Dynamo
       }
     }
 
+    public bool CanConvertToNativeDisplayable(Base @object)
+    {
+      return false;
+    }
+
     public void SetContextDocument(object doc)
     {
 #if REVIT
       Doc = (Document)doc;
 #endif
     }
-
   }
 }

--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToNative.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToNative.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Speckle.Core.Models;
 
@@ -9,9 +9,14 @@ public partial class ConverterNavisworks
 {
   /// Methods included to satisfy the ISpeckleConverter requirements
   /// No actual receiving exists
-  /// 
+  ///
   /// <inheritdoc />
   public object ConvertToNative(Base @object)
+  {
+    throw new NotImplementedException();
+  }
+
+  public object ConvertToNativeDisplayable(Base @object)
   {
     throw new NotImplementedException();
   }
@@ -24,6 +29,11 @@ public partial class ConverterNavisworks
 
   /// <inheritdoc />
   public bool CanConvertToNative(Base @object)
+  {
+    throw new NotImplementedException();
+  }
+
+  public bool CanConvertToNativeDisplayable(Base @object)
   {
     throw new NotImplementedException();
   }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -472,7 +472,7 @@ namespace Objects.Converter.Revit
           receivedObjectsCache.AddConvertedObjects(@base, new List<Element> { element });
           break;
       }
-      
+
       return nativeObject;
     }
 
@@ -717,6 +717,11 @@ namespace Objects.Converter.Revit
       }
     }
 
+    public object ConvertToNativeDisplayable(Base @object)
+    {
+      throw new NotImplementedException();
+    }
+
     public List<Base> ConvertToSpeckle(List<object> objects) => objects.Select(ConvertToSpeckle).ToList();
 
     public List<object> ConvertToNative(List<Base> objects) => objects.Select(ConvertToNative).ToList();
@@ -847,6 +852,11 @@ namespace Objects.Converter.Revit
         Organization.DataTable _ => true,
         _ => false,
       };
+    }
+
+    public bool CanConvertToNativeDisplayable(Base @object)
+    {
+      return false;
     }
   }
 }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -556,6 +556,11 @@ public partial class ConverterRhinoGh : ISpeckleConverter
     return rhinoObj;
   }
 
+  public object ConvertToNativeDisplayable(Base @object)
+  {
+    throw new NotImplementedException();
+  }
+
   public List<object> ConvertToNative(List<Base> objects)
   {
     return objects.Select(x => ConvertToNative(x)).ToList();
@@ -668,5 +673,10 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       default:
         return false;
     }
+  }
+
+  public bool CanConvertToNativeDisplayable(Base @object)
+  {
+    return false;
   }
 }

--- a/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/ConverterTeklaStructures.cs
+++ b/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/ConverterTeklaStructures.cs
@@ -11,7 +11,6 @@ using Tekla.Structures.Model;
 using BE = Objects.BuiltElements;
 using GE = Objects.Geometry;
 
-
 namespace Objects.Converter.TeklaStructures
 {
   public partial class ConverterTeklaStructures : ISpeckleConverter
@@ -45,6 +44,7 @@ namespace Objects.Converter.TeklaStructures
     {
       Model = (Model)doc;
     }
+
     /// <summary>
     /// <para>To know which other objects are being converted, in order to sort relationships between them.
     /// For example, elements that have children use this to determine whether they should send their children out or not.</para>
@@ -94,8 +94,14 @@ namespace Objects.Converter.TeklaStructures
         //    return true;
         default:
           return false;
-          //_ => (@object as ModelObject).IsElementSupported()
-      };
+        //_ => (@object as ModelObject).IsElementSupported()
+      }
+      ;
+    }
+
+    public bool CanConvertToNativeDisplayable(Base @object)
+    {
+      return false;
     }
 
     public bool CanConvertToSpeckle(object @object)
@@ -123,8 +129,9 @@ namespace Objects.Converter.TeklaStructures
           return true;
         default:
           return false;
-          //_ => (@object as ModelObject).IsElementSupported()
-      };
+        //_ => (@object as ModelObject).IsElementSupported()
+      }
+      ;
     }
 
     public object ConvertToNative(Base @object)
@@ -143,7 +150,8 @@ namespace Objects.Converter.TeklaStructures
           {
             foreach (var displayAlias in DefaultTraversal.displayValuePropAliases)
             {
-              if (@base[displayAlias] is not List<GE.Mesh> meshes) continue;
+              if (@base[displayAlias] is not List<GE.Mesh> meshes)
+                continue;
 
               MeshToNative(@base, meshes);
             }
@@ -179,11 +187,15 @@ namespace Objects.Converter.TeklaStructures
       }
     }
 
+    public object ConvertToNativeDisplayable(Base @object)
+    {
+      throw new NotImplementedException();
+    }
+
     public List<object> ConvertToNative(List<Base> objects) => objects.Select(ConvertToNative).ToList();
 
     public Base ConvertToSpeckle(object @object)
     {
-
       Base returnObject = null;
       switch (@object)
       {
@@ -228,10 +240,11 @@ namespace Objects.Converter.TeklaStructures
           Report.Log($"Created Fitting");
           break;
         default:
-          ConversionErrors.Add(new Exception($"Skipping not supported type: {@object.GetType()}{GetElemInfo(@object)}"));
+          ConversionErrors.Add(
+            new Exception($"Skipping not supported type: {@object.GetType()}{GetElemInfo(@object)}")
+          );
           returnObject = null;
           break;
-
       }
       return returnObject;
     }


### PR DESCRIPTION
## Description & motivation

> **THIS IS A BREAKING CHANGE**

Adds new `ConvertToNativeDisplayable()` and `CanConvertToNativeDisplayable()` bindings to our `ISpeckleConverter` interface.
These bindings are a prerequisite to pr #2841 and part of #2777 

## Changes:

Converters

## Checklist:

- [ ] ⚠️This breaking change should be communicated to our dev users and community contributed connectors.

