### PR TITLE
Jrm/core/security analysers

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/SpeckleAutocadCommand.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/SpeckleAutocadCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -32,6 +33,7 @@ namespace Speckle.ConnectorAutocadCivil.Entry
   {
     #region Avalonia parent window
     [DllImport("user32.dll", SetLastError = true)]
+    [SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes")]
     static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr value);
     const int GWL_HWNDPARENT = -8;
     #endregion

--- a/ConnectorCSI/ConnectorCSIShared/cPlugin.cs
+++ b/ConnectorCSI/ConnectorCSIShared/cPlugin.cs
@@ -117,7 +117,7 @@ namespace SpeckleConnectorCSI
       }
       catch (Exception e)
       {
-        throw e;
+        throw;
         ISapPlugin.Finish(0);
         //return;
       }

--- a/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
+++ b/ConnectorDynamo/ConnectorDynamo/ReceiveNode/Receive.cs
@@ -455,7 +455,7 @@ namespace Speckle.ConnectorDynamo.ReceiveNode
         Warning(exceptionMessage);
         Message = exceptionMessage.Contains("don't have access") ? "Not authorised" : "Error";
         ReceiveEnabled = false;
-        throw e;
+        throw;
       }
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
@@ -203,25 +203,18 @@ public static class Utilities
 
   private static void RecurseTreeToList(List<object> parent, List<int> path, int pathIndex, List<object> objects)
   {
-    try
-    {
-      var listIndex = path[pathIndex]; //there should be a list at this index inside this parent list
+    var listIndex = path[pathIndex]; //there should be a list at this index inside this parent list
 
-      parent = EnsureHasSublistAtIndex(parent, listIndex);
-      var sublist = parent[listIndex] as List<object>;
-      //it's the last index of the path => the last sublist => add objects
-      if (pathIndex == path.Count - 1)
-      {
-        sublist.AddRange(objects);
-        return;
-      }
-
-      RecurseTreeToList(sublist, path, pathIndex + 1, objects);
-    }
-    catch (Exception ex)
+    parent = EnsureHasSublistAtIndex(parent, listIndex);
+    var sublist = parent[listIndex] as List<object>;
+    //it's the last index of the path => the last sublist => add objects
+    if (pathIndex == path.Count - 1)
     {
-      throw ex;
+      sublist.AddRange(objects);
+      return;
     }
+
+    RecurseTreeToList(sublist, path, pathIndex + 1, objects);
   }
 
   /// <summary>

--- a/ConnectorRevit/ConnectorRevit/Entry/SchedulerCommand.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/SchedulerCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
@@ -13,13 +14,14 @@ namespace Speckle.ConnectorRevit.Entry
   public class SchedulerCommand : IExternalCommand
   {
     [DllImport("user32.dll", SetLastError = true)]
+    [SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes")]
     static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr value);
+
     const int GWL_HWNDPARENT = -8;
 
     internal static UIApplication uiapp;
 
     public static ConnectorBindingsRevit Bindings { get; set; }
-
 
     public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
     {
@@ -31,11 +33,7 @@ namespace Speckle.ConnectorRevit.Entry
 
     public static void CreateOrFocusSpeckle()
     {
-
-      var scheduler = new Scheduler
-      {
-        DataContext = new SchedulerViewModel(Bindings)
-      };
+      var scheduler = new Scheduler { DataContext = new SchedulerViewModel(Bindings) };
 
       scheduler.Show();
 
@@ -45,8 +43,6 @@ namespace Speckle.ConnectorRevit.Entry
         var hwnd = scheduler.PlatformImpl.Handle.Handle;
         SetWindowLongPtr(hwnd, GWL_HWNDPARENT, parentHwnd);
       }
-
     }
   }
-
 }

--- a/ConnectorRevit/ConnectorRevit/Entry/SpeckleRevitCommand.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/SpeckleRevitCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Autodesk.Revit.Attributes;
@@ -18,42 +19,41 @@ namespace Speckle.ConnectorRevit.Entry
   [Transaction(TransactionMode.Manual)]
   public class SpeckleRevitCommand : IExternalCommand
   {
-
     public static bool UseDockablePanel = true;
 
     //window stuff
     [DllImport("user32.dll", SetLastError = true)]
+    [SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes")]
     static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr value);
+
     const int GWL_HWNDPARENT = -8;
     public static Window MainWindow { get; private set; }
     private static Avalonia.Application AvaloniaApp { get; set; }
+
     //end window stuff
 
     public static ConnectorBindingsRevit Bindings { get; set; }
 
     private static Panel _panel { get; set; }
 
-
     internal static DockablePaneId PanelId = new DockablePaneId(new Guid("{0A866FB8-8FD5-4DE8-B24B-56F4FA5B0836}"));
-
 
     public static void InitAvalonia()
     {
       BuildAvaloniaApp().SetupWithoutStarting();
     }
 
-    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<DesktopUI2.App>()
-      .UsePlatformDetect()
-      .With(new SkiaOptions { MaxGpuResourceSizeBytes = 8096000 })
-      .With(new Win32PlatformOptions { AllowEglInitialization = true, EnableMultitouch = false })
-      .LogToTrace()
-      .UseReactiveUI();
-
-
+    public static AppBuilder BuildAvaloniaApp() =>
+      AppBuilder
+        .Configure<DesktopUI2.App>()
+        .UsePlatformDetect()
+        .With(new SkiaOptions { MaxGpuResourceSizeBytes = 8096000 })
+        .With(new Win32PlatformOptions { AllowEglInitialization = true, EnableMultitouch = false })
+        .LogToTrace()
+        .UseReactiveUI();
 
     public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
     {
-
       if (UseDockablePanel)
       {
         try
@@ -69,8 +69,6 @@ namespace Speckle.ConnectorRevit.Entry
       }
       else
         CreateOrFocusSpeckle();
-
-
 
       return Result.Succeeded;
     }
@@ -95,10 +93,7 @@ namespace Speckle.ConnectorRevit.Entry
         {
           //Register dockable panel
           var viewModel = new MainViewModel(Bindings);
-          _panel = new Panel
-          {
-            DataContext = viewModel
-          };
+          _panel = new Panel { DataContext = viewModel };
           App.AppInstance.RegisterDockablePane(PanelId, "Speckle", _panel);
           _panel.Init();
         }
@@ -111,24 +106,23 @@ namespace Speckle.ConnectorRevit.Entry
           TaskDialog mainDialog = new TaskDialog("Dockable Panel Issue");
           mainDialog.MainInstruction = "Dockable Panel Issue";
           mainDialog.MainContent =
-              "Revit cannot properly register Dockable Panels when launched by double-clicking a Revit file. "
-              + "Please close and re-open Revit without launching a file OR open/create a new project to trigger the Speckle panel registration.";
-
+            "Revit cannot properly register Dockable Panels when launched by double-clicking a Revit file. "
+            + "Please close and re-open Revit without launching a file OR open/create a new project to trigger the Speckle panel registration.";
 
           // Set footer text. Footer text is usually used to link to the help document.
           mainDialog.FooterText =
-              "<a href=\"https://github.com/specklesystems/speckle-sharp/issues/1469 \">"
-              + "Click here for more info</a>";
+            "<a href=\"https://github.com/specklesystems/speckle-sharp/issues/1469 \">"
+            + "Click here for more info</a>";
 
           mainDialog.Show();
-
         }
       }
       catch (Exception ex)
       {
         SpeckleLog.Logger.Fatal(ex, "Failed to load Speckle command for host app");
         var td = new TaskDialog("Error");
-        td.MainContent = $"Oh no! Something went wrong while loading Speckle, please report it on the forum:\n{ex.Message}";
+        td.MainContent =
+          $"Oh no! Something went wrong while loading Speckle, please report it on the forum:\n{ex.Message}";
         td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Report issue on our Community Forum");
 
         TaskDialogResult tResult = td.Show();
@@ -138,30 +132,23 @@ namespace Speckle.ConnectorRevit.Entry
           Process.Start("https://speckle.community/");
         }
       }
-
     }
 
     public static void CreateOrFocusSpeckle(bool showWindow = true)
     {
       try
       {
-
         if (MainWindow == null)
         {
           var viewModel = new MainViewModel(Bindings);
-          MainWindow = new MainWindow
-          {
-            DataContext = viewModel
-          };
+          MainWindow = new MainWindow { DataContext = viewModel };
 
           //massive hack: we start the avalonia main loop and stop it immediately (since it's thread blocking)
           //to avoid an annoying error when closing revit
           var cts = new CancellationTokenSource();
           cts.CancelAfter(100);
           AvaloniaApp.Run(cts.Token);
-
         }
-
 
         if (showWindow)
         {
@@ -185,7 +172,8 @@ namespace Speckle.ConnectorRevit.Entry
       {
         SpeckleLog.Logger.Fatal(ex, "Failed to create main window");
         var td = new TaskDialog("Error");
-        td.MainContent = $"Oh no! Something went wrong while loading Speckle, please report it on the forum:\n{ex.Message}";
+        td.MainContent =
+          $"Oh no! Something went wrong while loading Speckle, please report it on the forum:\n{ex.Message}";
         td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Report issue on our Community Forum");
 
         TaskDialogResult tResult = td.Show();
@@ -201,11 +189,5 @@ namespace Speckle.ConnectorRevit.Entry
     {
       AvaloniaApp = app;
     }
-
-
-
-
-
   }
-
 }

--- a/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/MainForm.cs
+++ b/ConnectorTeklaStructures/ConnectorTeklaStructuresShared/MainForm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -21,6 +22,7 @@ namespace Speckle.ConnectorTeklaStructures
 
     //window owner call
     [DllImport("user32.dll", SetLastError = true)]
+    [SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes")]
     static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr value);
     const int GWL_HWNDPARENT = -8;
 

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -536,9 +536,7 @@ public static class AccountManager
   {
     try
     {
-      ServicePointManager.SecurityProtocol =
-        SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
-      var client = Http.GetHttpProxyClient();
+      using var client = Http.GetHttpProxyClient();
 
       var body = new
       {
@@ -566,9 +564,7 @@ public static class AccountManager
   {
     try
     {
-      ServicePointManager.SecurityProtocol =
-        SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
-      var client = Http.GetHttpProxyClient();
+      using var client = Http.GetHttpProxyClient();
 
       var body = new
       {

--- a/Core/Core/Helpers/Http.cs
+++ b/Core/Core/Helpers/Http.cs
@@ -212,6 +212,7 @@ public class SpeckleHttpClientHandler : HttpClientHandler
   public SpeckleHttpClientHandler(IEnumerable<TimeSpan>? delay = null)
   {
     _delay = delay ?? Http.DefaultDelay();
+    CheckCertificateRevocationList = true;
   }
 
   protected override async Task<HttpResponseMessage> SendAsync(

--- a/Core/Core/Logging/Setup.cs
+++ b/Core/Core/Logging/Setup.cs
@@ -63,12 +63,6 @@ public static class Setup
     //start mutex so that Manager can detect if this process is running
     mutex = new Mutex(false, "SpeckleConnector-" + hostApplication);
 
-#if !NETSTANDARD1_5_OR_GREATER
-    //needed by older .net frameworks, eg Revit 2019
-    ServicePointManager.SecurityProtocol =
-      SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
-#endif
-
     SpeckleLog.Initialize(hostApplication, versionedHostApplication);
 
     foreach (var account in AccountManager.GetAccounts())

--- a/Core/IntegrationTests/Fixtures.cs
+++ b/Core/IntegrationTests/Fixtures.cs
@@ -32,7 +32,10 @@ public static class Fixtures
     user["password"] = "12ABC3456789DEF0GHO";
     user["name"] = $"{seed.Substring(0, 5)} Name";
 
-    var httpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+    using var httpClient = new HttpClient(
+      new HttpClientHandler { AllowAutoRedirect = false, CheckCertificateRevocationList = true }
+    );
+
     httpClient.BaseAddress = new Uri(Server.url);
 
     string redirectUrl;
@@ -85,7 +88,7 @@ public static class Fixtures
       },
       serverInfo = Server
     };
-    var client = new Client(acc);
+    using var client = new Client(acc);
 
     var user1 = await client.ActiveUserGet().ConfigureAwait(false);
     acc.userInfo.id = user1.id;

--- a/DesktopUI2/AvaloniaHwndHost/UnmanagedMethods.cs
+++ b/DesktopUI2/AvaloniaHwndHost/UnmanagedMethods.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace AvaloniaHwndHost;
@@ -6,5 +7,6 @@ namespace AvaloniaHwndHost;
 internal static class UnmanagedMethods
 {
   [DllImport("user32.dll")]
+  [SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes")]
   public static extern bool SetParent(IntPtr hWnd, IntPtr hWndNewParent);
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="General Config">
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11</LangVersion>
     <!-- Code quality -->
     <EnableNetAnalyzers>true</EnableNetAnalyzers>
     <AnalysisLevel>latest-AllEnabledByDefault</AnalysisLevel>
@@ -22,8 +22,10 @@
 
     <!-- Ignore some warnings for now -->
     <NoWarn>
+      <!--XML comment-->
       CS1591;CS1573;CS1572;CS1570;CS1587;CS1574;
       CS1711;CS1734;
+      <!--Nullability-->
       CS8618;CS8602;CS8600;
       CS1998; IDE0007; CS0618;
       CA1054;
@@ -32,6 +34,30 @@
       NU1701;
       $(NoWarn)
     </NoWarn>
+    
+    <WarningsAsErrors>
+      <!--Net6 default enabled analysers-->
+      CA1416; CA1417; CA1418; CA1831; CA2013; CA2014; CA2015; CA2017;
+      CA2018; CA2200; CA2252; CA2247; CA2255; CA2256; CA2257; CA2258;
+      <!--Net7 default enabled analysers-->
+      CA1420; CA1422; CA2259; CA2260;
+      <!--Security analysers -->
+      CA2100; CA2119; CA2153; CA2300; CA2301; CA2302; CA2305;
+      CA2310; CA2311; CA2312; CA2315; CA2321; CA2322; CA2326; CA2327;
+      CA2328; CA2329; CA2330; CA2350; CA2351; CA2352; CA2353; CA2354;
+      CA2355; CA2356; CA2361; CA2362; CA3001; CA3002; CA3003; CA3004;
+      CA3006; CA3007; CA3008; CA3009; CA3010; CA3011; CA3012; CA3061;
+      CA3075; CA3076; CA3077; CA3147; CA5350; CA5351; CA5358; CA5359;
+      CA5360; CA5361; CA5362; CA5363; CA5364; CA5365; CA5366; CA5367;
+      CA5368; CA5369; CA5370; CA5371; CA5372; CA5373; CA5374; CA5375;
+      CA5376; CA5377; CA5378; CA5379; CA5380; CA5381; CA5382; CA5383;
+      CA5384; CA5385; CA5386; CA5387; CA5388; CA5389; CA5390; CA5391;
+      CA5392; CA5393; CA5395; CA5396; CA5397; CA5398; CA5399;
+      CA5400; CA5401; CA5402; CA5403; CA5404; CA5405
+      <!-- The following security anaysers are ommited for the listed reasons -->
+      <!--"CA5394: Do not use insecure randomness" - random number generators used for non cryptographic usecases-->
+      <!--"CA2109: Review visible event handlers" - threat has not existed since net4.5-->
+    </WarningsAsErrors>
 
     <!-- False if running on CI, will prevent copying of files to local folders -->
     <IsDesktopBuild Condition="'$(IsDesktopBuild)' == ''">true</IsDesktopBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,9 +47,9 @@
       CA2328; CA2329; CA2330; CA2350; CA2351; CA2352; CA2353; CA2354;
       CA2355; CA2356; CA2361; CA2362; CA3001; CA3002; CA3003; CA3004;
       CA3006; CA3007; CA3008; CA3009; CA3010; CA3011; CA3012; CA3061;
-      CA3075; CA3076; CA3077; CA3147; CA5350; CA5351; CA5358; CA5359;
+      CA3076; CA3077; CA3147; CA5350; CA5351; CA5358; CA5359;
       CA5360; CA5361; CA5362; CA5363; CA5364; CA5365; CA5366; CA5367;
-      CA5368; CA5369; CA5370; CA5371; CA5372; CA5373; CA5374; CA5375;
+      CA5368; CA5370; CA5371; CA5372; CA5373; CA5374; CA5375;
       CA5376; CA5377; CA5378; CA5379; CA5380; CA5381; CA5382; CA5383;
       CA5384; CA5385; CA5386; CA5387; CA5388; CA5389; CA5390; CA5391;
       CA5392; CA5393; CA5395; CA5396; CA5397; CA5398; CA5399;
@@ -57,6 +57,8 @@
       <!-- The following security anaysers are ommited for the listed reasons -->
       <!--"CA5394: Do not use insecure randomness" - random number generators used for non cryptographic usecases-->
       <!--"CA2109: Review visible event handlers" - threat has not existed since net4.5-->
+      <!--"CA3075: Insecure DTD Processing" - we assume loaded XML is trusted-->
+      <!--"CA5369: Use XmlReader for Deserialize" - we assume loaded XML is trusted-->
     </WarningsAsErrors>
 
     <!-- False if running on CI, will prevent copying of files to local folders -->

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -226,7 +226,7 @@ namespace Objects.Converter.AutocadCivil
               {
                 //Update report because AS object type
                 Report.UpdateReportObject(reportObj);
-                throw ex;
+                throw;
               }
 
               break;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -392,7 +392,7 @@ namespace Objects.Converter.Revit
       catch (Exception e)
       {
         if (e is Autodesk.Revit.Exceptions.ArgumentException)
-          throw e; // prob a closed, periodic curve
+          throw; // prob a closed, periodic curve
         return null;
       }
     }


### PR DESCRIPTION
Changes to editor Build Props
1. Added all default .NET7 analysers (minimal analysers) to `WarningsAsErrors` tag
2. Added all "security" category analysers to `WarningsAsErrors` tag (except a couple where I've stated a reason in build props)
3. Resolved Violations
 - Removed hardcoded TLS (we were doing this due to .net4.6.2, but I've tested with rhino 6, still works without hardcoding) 
 - Set `CheckCertificateRevocationList = true` for `SpeckleHTTPClientHandler`
 - Replaced 

Things to discuss
- I've enabled these rules globally in the Build.Props, imo this is a MUST for core, but potentially could relax for connectors?