### PR TITLE
fix(ci): Now using fixed win/server-2019 version as august release broke our pipeline

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -504,15 +504,13 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 
   build-archicad-add-on: # build Archicad C++ add-on
     parameters:
-      e:
-        type: string
-        default: win/default
       archicadversion:
         type: string
         default: ""
     executor:
-      name: << parameters.e >>
+      name: win/server-2019
       shell: bash.exe
+      version: 2023.04.1 # Version 2023.08.01 broke this step due to missing MSVC v142 C++ build tools. Fixed to the prior working version till a fix is issued.
     steps:
       - cached-checkout
       - attach_workspace:

--- a/.circleci/scripts/connector-jobs.yml
+++ b/.circleci/scripts/connector-jobs.yml
@@ -124,13 +124,11 @@ csi:
 
 archicad:
   - build-archicad-add-on:
-      e: win/server-2019
       archicadversion: "25"
       requires:
         - get-ci-tools
       name: build-archicad-add-on-25
   - build-archicad-add-on:
-      e: win/server-2019
       archicadversion: "26"
       requires:
         - get-ci-tools


### PR DESCRIPTION
Fixes broken CI caused by 2023.08.01 update on the win/server-2019 executor. This is coming from CircleCI and there is no documentation or notification of when these types of things will happen.

For now, we've fixed the version to the one from March which seemed to include all the necessary tools. In particular:

- MSVC v142 C++ Build Tools is missing and is required by our windows build step prior to building the Archicad connector.