### PR TITLE
fix(rvt): Send objects that have no 3d representation to Speckle

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRevitElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRevitElement.cs
@@ -37,18 +37,19 @@ namespace Objects.Converter.Revit
       speckleElement.category = revitElement.Category.Name;
 
       GetHostedElements(speckleElement, revitElement, out notes);
-      
-      var elements = (speckleElement["elements"] ?? @speckleElement["@elements"]) as List<Base>;
-      elements ??= new List<Base>();
 
-      // get the displayvalue of this revit element
-      var displayValue = GetElementDisplayValue(revitElement, new Options() { DetailLevel = ViewDetailLevel.Fine });
-      if (!displayValue.Any() && elements.Count == 0)
-      {
-        notes.Add("Not sending elements without display meshes");
-        return null;
-      }
-      speckleElement.displayValue = displayValue;
+      // get the displayValue of this revit element
+      using var options = new Options();
+      options.DetailLevel = ViewDetailLevel.Fine;
+
+      var displayValue = GetElementDisplayValue(revitElement, options);
+
+      if (!displayValue.Any())
+        notes.Add(
+          "Element does not have visible geometry. It will be sent to Speckle but won't be visible in the viewer."
+        );
+      else
+        speckleElement.displayValue = displayValue;
 
       GetAllRevitParamsAndIds(speckleElement, revitElement);
 
@@ -65,17 +66,32 @@ namespace Objects.Converter.Revit
       switch (revitType)
       {
         case FamilySymbol o:
-          var symbolType = new RevitSymbolElementType() { type = type, family = family, category = category };
+          var symbolType = new RevitSymbolElementType()
+          {
+            type = type,
+            family = family,
+            category = category
+          };
           symbolType.placementType = o.Family?.FamilyPlacementType.ToString();
           speckleType = symbolType;
           break;
         case MEPCurveType o:
-          var mepType = new RevitMepElementType() { type = type, family = family, category = category };
+          var mepType = new RevitMepElementType()
+          {
+            type = type,
+            family = family,
+            category = category
+          };
           mepType.shape = o.Shape.ToString();
           speckleType = mepType;
           break;
         default:
-          speckleType = new RevitElementType() { type = type, family = family, category = category };
+          speckleType = new RevitElementType()
+          {
+            type = type,
+            family = family,
+            category = category
+          };
           break;
       }
 


### PR DESCRIPTION
Fixes https://github.com/specklesystems/admin/issues/429

Removes the limitation for sending only objects from Revit that can be displayed.

There are cases where valid objects were not being sent:
- MEP Systems, which act as containers for all the other elements
- Unplaced rooms
- Some edge-cases for MEP families such as PipeFittings.

This does not affect any existing conversion on `ToSpeckle`, and tests on receiving it back seem to not conflict with existing conversion logic, as all of these items are being sent through as generic `RevitElement` types.