### PR TITLE
feat(revit): more params

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -357,9 +357,10 @@ namespace Objects.Converter.Revit
           sp.applicationUnit = UnitsToNativeString(unitsOverride != null ? UnitsToNative(unitsOverride) : rp.GetUnitTypeId());
         }
 
-
         paramCache.Set(paramInternalName, sp);
       }
+      else
+        sp = sp.DeepCopy();
 
       sp.hasValue = rp.HasValue;
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -340,6 +340,7 @@ namespace Objects.Converter.Revit
         applicationInternalName = paramInternalName ?? GetParamInternalName(rp),
         isShared = rp.IsShared,
         isReadOnly = rp.IsReadOnly,
+        hasValue = rp.HasValue,
         isTypeParameter = isTypeParameter,
         applicationUnitType = definition.GetUnityTypeString(), //eg UT_Length
         units = GetSymbolUnit(rp),
@@ -509,14 +510,21 @@ namespace Objects.Converter.Revit
 
         var rp = revitParameterById.ContainsKey(spk.Key) ? revitParameterById[spk.Key] : revitParameterByName[spk.Key];
 
-        TrySetParam(rp, sp.value, applicationUnit: sp.applicationUnit);
+        TrySetParam(rp, sp, applicationUnit: sp.applicationUnit);
       }
     }
 
-    private void TrySetParam(DB.Parameter rp, object value, string units = "", string applicationUnit = "")
+    private void TrySetParam(DB.Parameter rp, Parameter sp, string units = "", string applicationUnit = "")
     {
       try
       {
+        if (!sp.hasValue)
+        {
+          rp.ClearValue();
+          return;
+        }
+
+        var value = sp.value;
         switch (rp.StorageType)
         {
           case StorageType.Double:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -311,7 +311,7 @@ namespace Objects.Converter.Revit
       if (rp == null || !rp.HasValue)
         return default;
 
-      var unitTypeId = unitsOverride != null ? UnitsToNative(unitsOverride).ToString() : rp.GetUnitTypeId().ToString();
+      var unitTypeId = UnitsToNativeString(unitsOverride != null ? UnitsToNative(unitsOverride) : rp.GetUnitTypeId());
 
       var value = GetParameterValue(rp, rp.Definition, unitTypeId);
       if (typeof(T) == typeof(int) && value.GetType() == typeof(bool))

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -354,7 +354,7 @@ namespace Objects.Converter.Revit
 
         if (rp.StorageType == StorageType.Double)
         {
-          sp.applicationUnit = unitsOverride != null ? UnitsToNative(unitsOverride).ToString() : rp.GetUnitTypeId().ToString();
+          sp.applicationUnit = UnitsToNativeString(unitsOverride != null ? UnitsToNative(unitsOverride) : rp.GetUnitTypeId());
         }
 
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -252,7 +252,7 @@ namespace Objects.Converter.Revit
       if (phaseDemolished != null)
         speckleElement["phaseDemolished"] = phaseDemolished.Name;
 
-      speckleElement["WorksetId"] = revitElement.WorksetId.IntegerValue;
+      speckleElement["WorksetId"] = revitElement.WorksetId.ToString();
 
       var category = revitElement.Category;
       if (category != null)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -510,21 +510,17 @@ namespace Objects.Converter.Revit
 
         var rp = revitParameterById.ContainsKey(spk.Key) ? revitParameterById[spk.Key] : revitParameterByName[spk.Key];
 
-        TrySetParam(rp, sp, applicationUnit: sp.applicationUnit);
+        if (!sp.hasValue)
+          rp.ClearValue();
+        else
+          TrySetParam(rp, sp.value, applicationUnit: sp.applicationUnit);
       }
     }
 
-    private void TrySetParam(DB.Parameter rp, Parameter sp, string units = "", string applicationUnit = "")
+    private void TrySetParam(DB.Parameter rp, object value, string units = "", string applicationUnit = "")
     {
       try
       {
-        if (!sp.hasValue)
-        {
-          rp.ClearValue();
-          return;
-        }
-
-        var value = sp.value;
         switch (rp.StorageType)
         {
           case StorageType.Double:

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -252,6 +252,8 @@ namespace Objects.Converter.Revit
       if (phaseDemolished != null)
         speckleElement["phaseDemolished"] = phaseDemolished.Name;
 
+      speckleElement["WorksetId"] = revitElement.WorksetId.IntegerValue;
+
       var category = revitElement.Category;
       if (category != null)
       {
@@ -278,12 +280,6 @@ namespace Objects.Converter.Revit
       using var parameters = element.Parameters;
       foreach (DB.Parameter param in parameters)
       {
-        // exclude parameters that don't have a value and those pointing to other elements as we don't support them
-        if (param.StorageType == StorageType.ElementId || !param.HasValue)
-        {
-          continue;
-        }
-
         var internalName = GetParamInternalName(param);
         if (paramDict.ContainsKey(internalName) || exclusions.Contains(internalName))
         {
@@ -389,13 +385,8 @@ namespace Objects.Converter.Revit
 #endif
         case StorageType.String:
           return rp.AsString();
-        // case StorageType.ElementId:
-        //   // NOTE: if this collects too much garbage, maybe we can ignore it
-        //   var id = rp.AsElementId();
-        //   var e = Doc.GetElement(id);
-        //   if (e != null && CanConvertToSpeckle(e))
-        //     sp.value = ConvertToSpeckle(e);
-        //   break;
+        case StorageType.ElementId:
+          return rp.AsElementId().ToString();
         default:
           return null;
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -97,11 +97,11 @@ namespace Objects.Converter.Revit
       if (isUGridLine.HasValue)
         @base["isUGridLine"] = isUGridLine.Value;
       if (revitFi.Room != null)
-        @base["roomId"] = revitFi.Room.Id;
+        @base["roomId"] = revitFi.Room.Id.ToString();
       if (revitFi.ToRoom != null)
-        @base["toRoomId"] = revitFi.ToRoom.Id;
+        @base["toRoomId"] = revitFi.ToRoom.Id.ToString();
       if (revitFi.FromRoom != null)
-        @base["fromRoomId"] = revitFi.FromRoom.Id;
+        @base["fromRoomId"] = revitFi.FromRoom.Id.ToString();
 
 
       return @base;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -1,24 +1,21 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.DoubleNumerics;
-
+using System.Linq;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Structure;
-using DB = Autodesk.Revit.DB;
-
-using Speckle.Core.Models;
-
-using Point = Objects.Geometry.Point;
-using RevitInstance = Objects.Other.Revit.RevitInstance;
-using RevitSymbolElementType = Objects.BuiltElements.Revit.RevitSymbolElementType;
-using Vector = Objects.Geometry.Vector;
 using Objects.BuiltElements.Revit;
+using Objects.Organization;
 using RevitSharedResources.Helpers;
 using RevitSharedResources.Helpers.Extensions;
 using Speckle.Core.Logging;
+using Speckle.Core.Models;
+using DB = Autodesk.Revit.DB;
+using Point = Objects.Geometry.Point;
+using RevitInstance = Objects.Other.Revit.RevitInstance;
+using RevitSymbolElementType = Objects.BuiltElements.Revit.RevitSymbolElementType;
 using SHC = RevitSharedResources.Helpers.Categories;
-using Objects.Organization;
+using Vector = Objects.Geometry.Vector;
 
 namespace Objects.Converter.Revit
 {
@@ -42,7 +39,7 @@ namespace Objects.Converter.Revit
       //if they are contained in 'subelements' then they have already been accounted for from a wall
       //else if they are mullions then convert them as a generic family instance but add a isUGridLine prop
       bool? isUGridLine = null;
-      if (@base == null && 
+      if (@base == null &&
         (revitFi.Category.Id.IntegerValue == (int)BuiltInCategory.OST_CurtainWallMullions
         || revitFi.Category.Id.IntegerValue == (int)BuiltInCategory.OST_CurtainWallPanels))
       {
@@ -99,6 +96,13 @@ namespace Objects.Converter.Revit
       // add additional props to base object
       if (isUGridLine.HasValue)
         @base["isUGridLine"] = isUGridLine.Value;
+      if (revitFi.Room != null)
+        @base["roomId"] = revitFi.Room.Id;
+      if (revitFi.ToRoom != null)
+        @base["toRoomId"] = revitFi.ToRoom.Id;
+      if (revitFi.FromRoom != null)
+        @base["fromRoomId"] = revitFi.FromRoom.Id;
+
 
       return @base;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -1,3 +1,4 @@
+using System;
 using Autodesk.Revit.DB;
 using RevitSharedResources.Interfaces;
 
@@ -73,15 +74,27 @@ namespace Objects.Converter.Revit
     {
       return ScaleToSpeckleStatic(value, RevitLengthTypeId);
     }
-    
+
     public static double ScaleToSpeckleStatic(double value, DisplayUnitType unitType)
     {
       return UnitUtils.ConvertFromInternalUnits(value, unitType);
     }
 
+    public static double ScaleToSpeckleStatic(double value, string unitType)
+    {
+      var displayUnitType = (DisplayUnitType)Enum.Parse(typeof(DisplayUnitType), unitType);
+      return UnitUtils.ConvertFromInternalUnits(value, displayUnitType);
+    }
+
     public static double ScaleToSpeckle(double value, DisplayUnitType unitType, IRevitDocumentAggregateCache cache)
     {
       return ScaleToSpeckleStatic(value, unitType);
+    }
+
+    public static double ScaleToSpeckle(double value, string unitType, IRevitDocumentAggregateCache cache)
+    {
+      var displayUnitType = (DisplayUnitType)Enum.Parse(typeof(DisplayUnitType), unitType);
+      return ScaleToSpeckleStatic(value, displayUnitType);
     }
 
     public static double ScaleToSpeckle(double value, string units)
@@ -177,7 +190,7 @@ namespace Objects.Converter.Revit
       defaultConversionFactor ??= ScaleToSpeckle(1, RevitLengthTypeId);
       return value * defaultConversionFactor.Value;
     }
-    
+
     /// <summary>
     /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
     /// </summary>
@@ -188,7 +201,7 @@ namespace Objects.Converter.Revit
     {
       return ScaleToSpeckleStatic(value, UnitsToNative(units));
     }
-    
+
     /// <summary>
     /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
     /// </summary>
@@ -200,13 +213,27 @@ namespace Objects.Converter.Revit
       return UnitUtils.ConvertFromInternalUnits(value, forgeTypeId);
     }
 
+    public static double ScaleToSpeckleStatic(double value, string typeId)
+    {
+      var forgeTypeId = new ForgeTypeId(typeId);
+      return UnitUtils.ConvertFromInternalUnits(value, forgeTypeId);
+    }
+
+    public static double ScaleToSpeckle(double value, string typeId, IRevitDocumentAggregateCache cache)
+    {
+      var forgeTypeId = new ForgeTypeId(typeId);
+      return value * cache
+        .GetOrInitializeEmptyCacheOfType<double>(out _)
+        .GetOrAdd(forgeTypeId.TypeId, () => UnitUtils.ConvertFromInternalUnits(1, forgeTypeId), out _);
+    }
+
     public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId, IRevitDocumentAggregateCache cache)
     {
       return value * cache
         .GetOrInitializeEmptyCacheOfType<double>(out _)
         .GetOrAdd(forgeTypeId.TypeId, () => UnitUtils.ConvertFromInternalUnits(1, forgeTypeId), out _);
     }
-    
+
     public double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)
     {
       return ScaleToSpeckle(value, forgeTypeId, revitDocumentAggregateCache);

--- a/Objects/Objects/BuiltElements/Revit/Parameter.cs
+++ b/Objects/Objects/BuiltElements/Revit/Parameter.cs
@@ -37,10 +37,14 @@ public class Parameter : Base
 
   public bool isReadOnly { get; set; } = false;
 
+  //setting this to true explicitely as it was added in 2.16 and it will otherwise 
+  //prevent previously sent parameters to receive correctly
+  public bool hasValue { get; set; } = true;
+
   /// <summary>
   /// True = Type Parameter, False = Instance Parameter
   /// </summary>
   public bool isTypeParameter { get; set; } = false;
-  
+
   public string units { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Revit/Parameter.cs
+++ b/Objects/Objects/BuiltElements/Revit/Parameter.cs
@@ -47,4 +47,22 @@ public class Parameter : Base
   public bool isTypeParameter { get; set; } = false;
 
   public string units { get; set; }
+
+  public Parameter DeepCopy()
+  {
+    return new Parameter
+    {
+      name = this.name,
+      //value = this.value,
+      applicationUnitType = this.applicationId,
+      applicationUnit = this.applicationUnit,
+      applicationInternalName = this.applicationInternalName,
+      isShared = this.isShared,
+      isReadOnly = this.isReadOnly,
+      //hasValue = this.hasValue,
+      units = this.units,
+      isTypeParameter = this.isTypeParameter
+
+    };
+  }
 }


### PR DESCRIPTION
Adding more parameters when sending to Speckle:

- `roomId`: for family instances (https://speckle.community/t/include-room-property-on-familyinstance-conversion/6741/)
- `roomFromId`: for doors and windows
- `roomToId`: for doors and windows
- `worksetId`: for anything that has it
- all the `parameters` type `ElementId` as strings (which were previously excluded) https://speckle.community/t/model-parameters-strategy/6158/13
- all of the `parameters`  with value `null` (which were previously excluded)

@connorivy would appreciate it if you could quickly benchmark if adding these extra `parameters` might affect send performance.