### PR TITLE
feat(rhino): nested elements layers and parameters improvements when receiving revit commits

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -207,7 +207,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
             if (state.ReceiveMode == ReceiveMode.Update)
             {
               toRemove = GetObjectsByApplicationId(previewObj.applicationId);
-              toRemove.ForEach(o => Doc.Objects.Delete(o));
+              toRemove.ForEach(o => Doc.Objects.Delete(o, false, true));
 
               if (!toRemove.Any()) // if no rhinoobjects were found, this could've been a view
               {
@@ -282,9 +282,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
       return new List<RhinoObject>();
 
     // first try to find the object by app id user string
-    var match =
-      Doc.Objects.Where(o => o.Attributes.GetUserString(ApplicationIdKey) == applicationId)?.ToList()
-      ?? new List<RhinoObject>();
+    var match = Doc.Objects.FindByUserString(ApplicationIdKey, applicationId, true).ToList();
 
     // if nothing is found, look for the geom obj by its guid directly
     if (!match.Any())

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -24,7 +24,7 @@ namespace Objects.Converter.RhinoGh;
 
 public partial class ConverterRhinoGh
 {
-  // display and render
+  // display, render, and parameters
   public RH.ObjectAttributes DisplayStyleToNative(DisplayStyle display)
   {
     var attributes = new RH.ObjectAttributes();
@@ -241,6 +241,13 @@ public partial class ConverterRhinoGh
     return renderMaterial;
   }
 
+  public Tuple<string, string> ParameterToNative(Objects.BuiltElements.Revit.Parameter parameter)
+  {
+    var name = parameter.name;
+    var val = parameter.value.ToString();
+    return new Tuple<string, string>(name, val);
+  }
+
   // hatch
   public Hatch[] HatchToNative(Other.Hatch hatch)
   {
@@ -448,7 +455,7 @@ public partial class ConverterRhinoGh
       var attribute = new RH.ObjectAttributes();
 
       // layer
-      var geoLayer = item.Key["layer"] is string s ? s : item.Value; // blocks sent from rhino will have a layer prop dynamically attached
+      var geoLayer = geo["layer"] is string s ? s : item.Value; // blocks sent from rhino will have a layer prop dynamically attached
       var layerName =
         ReceiveMode == ReceiveMode.Create ? $"{commitInfo}{RH.Layer.PathSeparator}{geoLayer}" : $"{geoLayer}";
       int index = 1;
@@ -500,7 +507,103 @@ public partial class ConverterRhinoGh
     return blockDefinition;
   }
 
-  #region block def flattening
+  // Rhino convention seems to order the origin of the vector space last instead of first
+  // This results in a transposed transformation matrix - may need to be addressed later
+  public BlockInstance BlockInstanceToSpeckle(RH.InstanceObject instance)
+  {
+    var t = instance.InstanceXform;
+    var matrix = new System.DoubleNumerics.Matrix4x4(
+      t.M00,
+      t.M01,
+      t.M02,
+      t.M03,
+      t.M10,
+      t.M11,
+      t.M12,
+      t.M13,
+      t.M20,
+      t.M21,
+      t.M22,
+      t.M23,
+      t.M30,
+      t.M31,
+      t.M32,
+      t.M33
+    );
+
+    var def = BlockDefinitionToSpeckle(instance.InstanceDefinition);
+
+    var _instance = new BlockInstance
+    {
+      transform = new Other.Transform(matrix, ModelUnits),
+      typedDefinition = def,
+      applicationId = instance.Id.ToString(),
+      units = ModelUnits
+    };
+
+    return _instance;
+  }
+
+  public ApplicationObject InstanceToNative(Instance instance, bool AppendToModelSpace = true)
+  {
+    var appObj = new ApplicationObject(instance.id, instance.speckle_type) { applicationId = instance.applicationId };
+
+    // get the definition
+    var definition = instance.definition ?? instance["@definition"] as Base ?? instance["@blockDefinition"] as Base; // some applications need to dynamically attach defs (eg sketchup)
+    if (definition == null)
+    {
+      appObj.Update(status: ApplicationObject.State.Failed, logItem: "instance did not have a definition");
+      return appObj;
+    }
+
+    // convert the definition
+    RH.InstanceDefinition instanceDef = DefinitionToNative(definition, out List<string> notes);
+    if (notes.Count > 0)
+      appObj.Update(log: notes);
+    if (instanceDef == null)
+    {
+      appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not create block definition");
+      return appObj;
+    }
+
+    // get the transform
+    var transform = TransformToNative(instance.transform);
+
+    // get any parameters
+    var parameters = instance["parameters"] as Base;
+    var attributes = new RH.ObjectAttributes();
+    if (parameters != null)
+    {
+      foreach (var member in parameters.GetMembers(DynamicBaseMemberType.Dynamic))
+      {
+        if (member.Value is Parameter parameter)
+        {
+          var convertedParameter = ParameterToNative(parameter);
+          var name = $"{convertedParameter.Item1}({member.Key})";
+          attributes.SetUserString(name, convertedParameter.Item2);
+        }
+      }
+    }
+
+    // create the instance
+    Guid instanceId = Doc.Objects.AddInstanceObject(instanceDef.Index, transform, attributes);
+
+    if (instanceId == Guid.Empty)
+    {
+      appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not add instance to doc");
+      return appObj;
+    }
+
+    var _instance = Doc.Objects.FindId(instanceId) as RH.InstanceObject;
+
+    // update appobj
+    appObj.Update(convertedItem: _instance);
+    if (AppendToModelSpace)
+      appObj.CreatedIds.Add(instanceId.ToString());
+    return appObj;
+  }
+
+  #region instance methods
 
   /// <summary>
   /// Traverses the object graph, returning objects that can be converted.
@@ -554,73 +657,6 @@ public partial class ConverterRhinoGh
   }
 
   #endregion
-
-  // Rhino convention seems to order the origin of the vector space last instead of first
-  // This results in a transposed transformation matrix - may need to be addressed later
-  public BlockInstance BlockInstanceToSpeckle(RH.InstanceObject instance)
-  {
-    var t = instance.InstanceXform;
-    var matrix = new System.DoubleNumerics.Matrix4x4(
-      t.M00, t.M01, t.M02, t.M03,
-      t.M10, t.M11, t.M12, t.M13,
-      t.M20, t.M21, t.M22, t.M23,
-      t.M30, t.M31, t.M32, t.M33);
-
-    var def = BlockDefinitionToSpeckle(instance.InstanceDefinition);
-
-    var _instance = new BlockInstance
-    {
-      transform = new Other.Transform(matrix, ModelUnits),
-      typedDefinition = def,
-      applicationId = instance.Id.ToString(),
-      units = ModelUnits
-    };
-
-    return _instance;
-  }
-
-  public ApplicationObject InstanceToNative(Instance instance, bool AppendToModelSpace = true)
-  {
-    var appObj = new ApplicationObject(instance.id, instance.speckle_type) { applicationId = instance.applicationId };
-
-    // get the definition
-    var definition = instance.definition ?? instance["@definition"] as Base ?? instance["@blockDefinition"] as Base; // some applications need to dynamically attach defs (eg sketchup)
-    if (definition == null)
-    {
-      appObj.Update(status: ApplicationObject.State.Failed, logItem: "instance did not have a definition");
-      return appObj;
-    }
-
-    // convert the definition
-    RH.InstanceDefinition instanceDef = DefinitionToNative(definition, out List<string> notes);
-    if (notes.Count > 0)
-      appObj.Update(log: notes);
-    if (instanceDef == null)
-    {
-      appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not create block definition");
-      return appObj;
-    }
-
-    // get the transform
-    var transform = TransformToNative(instance.transform);
-
-    // create the instance
-    Guid instanceId = Doc.Objects.AddInstanceObject(instanceDef.Index, transform);
-
-    if (instanceId == Guid.Empty)
-    {
-      appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not add instance to doc");
-      return appObj;
-    }
-
-    var _instance = Doc.Objects.FindId(instanceId) as RH.InstanceObject;
-
-    // update appobj
-    appObj.Update(convertedItem: _instance);
-    if (AppendToModelSpace)
-      appObj.CreatedIds.Add(instanceId.ToString());
-    return appObj;
-  }
 
   public DisplayMaterial RenderMaterialToDisplayMaterial(Other.RenderMaterial material)
   {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -508,9 +508,15 @@ public partial class ConverterRhinoGh : ISpeckleConverter
           rhinoObj = RenderMaterialToNative(o);
 #endif
           break;
+
         case Transform o:
           rhinoObj = TransformToNative(o);
           break;
+
+        case Parameter o:
+          rhinoObj = ParameterToNative(o);
+          break;
+
         default:
           if (reportObj != null)
           {
@@ -545,6 +551,7 @@ public partial class ConverterRhinoGh : ISpeckleConverter
             log: o.Log
           );
         break;
+
       default:
         if (reportObj != null)
           reportObj.Update(log: notes);


### PR DESCRIPTION
## Description & motivation

Includes the following improvements:
- When receiving commits with nested elements, the rhino connector now places those nested elements in a top-level layer named by their `category` property when previously they were placed under their host element's layer.
- Removes locked and/or hidden objects when receiving on update mode, which was previously resulting in duplicates
- Adds parameters to instances and nested instances, and uses the Parameter `name` property as part of the user string key for legibility

This is part of #2872 

## Changes:

- Rhino connector and converter


## Screenshots:

![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/50d5d024-5a25-4542-be17-a6f6496cdcd3)
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/7cc7f5ca-c4a1-406e-9e2a-623e9b1904bf)


