### PR TITLE
feat(Archicad): Revit add support for Zones - Archicad side

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
@@ -17,12 +17,12 @@
 #include "Commands/GetElementBaseData.hpp"
 #include "Commands/GetObjectData.hpp"
 #include "Commands/GetSlabData.hpp"
-#include "Commands/GetRoomData.hpp"
 #include "Commands/GetRoofData.hpp"
 #include "Commands/GetShellData.hpp"
 #include "Commands/GetSkylightData.hpp"
 #include "Commands/GetProjectInfo.hpp"
 #include "Commands/GetSubElementInfo.hpp"
+#include "Commands/GetZoneData.hpp"
 #include "Commands/CreateWall.hpp"
 #include "Commands/CreateDoor.hpp"
 #include "Commands/CreateWindow.hpp"
@@ -198,12 +198,12 @@ static GSErrCode RegisterAddOnCommands ()
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetColumnData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetElementBaseData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetObjectData> ()));
-	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetRoomData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetRoofData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetShellData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetSkylightData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetSlabData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetProjectInfo> ()));
+	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetZoneData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateWall> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateDoor> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateWindow> ()));

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
@@ -59,6 +59,9 @@ GSErrCode CreateZone::GetElementFromObjectState (const GS::ObjectState& os,
 		ACAPI_ELEMENT_MASK_SET (mask, API_ZoneType, poly.nArcs);
 
 		zoneShape.SetToMemo (memo, Objects::ElementShape::MemoMainPolygon);
+		
+		element.zone.manual = true;
+		ACAPI_ELEMENT_MASK_SET (mask, API_ZoneType, manual);
 	}
 
 	if (os.Contains (Room::Height)) {
@@ -68,11 +71,15 @@ GSErrCode CreateZone::GetElementFromObjectState (const GS::ObjectState& os,
 
 	// The name and number of the zone
 	if (os.Contains (Room::Name)) {
-		os.Get (Room::Name, element.zone.roomName);
+		GS::UniString str;
+		os.Get (Room::Name, str);
+		GS::ucscpy (element.zone.roomName, str.ToUStr ());
 		ACAPI_ELEMENT_MASK_SET (mask, API_ZoneType, roomName);
 	}
 	if (os.Contains (Room::Number)) {
-		os.Get (Room::Number, element.zone.roomNoStr);
+		GS::UniString str;
+		os.Get (Room::Number, str);
+		GS::ucscpy (element.zone.roomNoStr, str.ToUStr ());
 		ACAPI_ELEMENT_MASK_SET (mask, API_ZoneType, roomNoStr);
 	}
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetZoneData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetZoneData.cpp
@@ -1,4 +1,4 @@
-﻿#include "GetRoomData.hpp"
+#include "GetZoneData.hpp"
 #include <locale>
 #include "ResourceIds.hpp"
 #include "ObjectState.hpp"
@@ -14,19 +14,19 @@ namespace AddOnCommands
 {
 
 
-GS::String GetRoomData::GetFieldName () const
+GS::String GetZoneData::GetFieldName () const
 {
 	return Zones;
 }
 
 
-API_ElemTypeID GetRoomData::GetElemTypeID () const
+API_ElemTypeID GetZoneData::GetElemTypeID () const
 {
 	return API_ZoneID;
 }
 
 
-GS::ErrCode GetRoomData::SerializeElementType (const API_Element& element,
+GS::ErrCode GetZoneData::SerializeElementType (const API_Element& element,
 	const API_ElementMemo& memo,
 	GS::ObjectState& os) const
 {
@@ -60,30 +60,39 @@ GS::ErrCode GetRoomData::SerializeElementType (const API_Element& element,
 
 	// The base point of the room
 	double level = Utility::GetStoryLevel (element.zone.head.floorInd) + element.zone.roomBaseLev;
-	os.Add (Room::BasePoint, Objects::Point3D (0, 0, level));
+	{
+		Geometry::Polygon2DData polygon;
+		Utility::ConstructPoly2DDataFromElementMemo (memo, polygon);
+		
+		const Box2DData boundingBox = polygon.boundBox;
+		GS::Array<Sector> sectors;
+		bool res = Geometry::IntersectLineWithPolygon (polygon,
+													   boundingBox.GetMidPoint(),
+													   boundingBox.GetWidth() > boundingBox.GetHeight() ? Vector2D (1.0, 0.0) : Vector2D (0.0, 1.0),
+													   &sectors);
+		
+		Geometry::FreePolygon2DData (&polygon);
+		
+		Objects::Point3D basePoint (0, 0, level);
+		if (res && sectors.GetSize() > 0) {
+			Sector sector = sectors[sectors.GetSize() / 2];
+			basePoint = Objects::Point3D (sector.GetMidPoint ().GetX (), sector.GetMidPoint ().GetY (), level);
+		}
+				
+		os.Add (Room::BasePoint, Objects::Point3D (basePoint.x, basePoint.y, basePoint.z));
+	}
 	os.Add (ElementBase::Shape, Objects::ElementShape (element.zone.poly, memo, Objects::ElementShape::MemoMainPolygon, level));
-
-	// double polyCoords [zone.poly.nCoords*3];
-	//
-	// for (Int32 point_index = 0, coord_index = 0; point_index < zone.poly.nCoords; ++point_index, coord_index+=3)
-	// {
-	//     const API_Coord coord = (*memo.coords)[point_index];
-	//     polyCoords[coord_index] = coord.x;
-	//     polyCoords[coord_index+1] = coord.y;
-	//     polyCoords[coord_index+2] = level;
-	// }
 
 	// Room Props
 	os.Add (Room::Height, element.zone.roomHeight);
 	os.Add (Room::Area, quantity.zone.area);
 	os.Add (Room::Volume, quantity.zone.volume);
 
-
 	return NoError;
 }
 
 
-GS::String GetRoomData::GetName () const
+GS::String GetZoneData::GetName () const
 {
 	return GetRoomDataCommandName;
 }

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetZoneData.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetZoneData.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef GET_ROOM_DATA_HPP
+#ifndef GET_ROOM_DATA_HPP
 #define GET_ROOM_DATA_HPP
 
 #include "GetDataCommand.hpp"
@@ -7,7 +7,7 @@
 namespace AddOnCommands {
 
 
-class GetRoomData : public GetDataCommand {
+class GetZoneData : public GetDataCommand {
 	GS::String			GetFieldName () const override;
 	API_ElemTypeID		GetElemTypeID () const override;
 	GS::ErrCode			SerializeElementType (const API_Element& elem,

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
@@ -4,6 +4,7 @@
 #include "APIEnvir.h"
 #include "ACAPinc.h"
 #include "ResourceIds.hpp"
+#include "Polygon2DData.h"
 
 #define UNUSED(x) (void)(x)
 
@@ -85,6 +86,9 @@ GS::UniString ComposeLogMessage (const Int32 resourceIndex, Args... args)
 	RSGetIndString (&errMsgFromatString, ID_LOG_MESSAGES, resourceIndex, ACAPI_GetOwnResModule ());
 	return GS::UniString::Printf (errMsgFromatString, args...);
 }
+
+// Geometry helpers
+GSErrCode ConstructPoly2DDataFromElementMemo (const API_ElementMemo& memo, Geometry::Polygon2DData& polygon2DData);
 
 }
 

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateRoom.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateRoom.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Speckle.Core.Models;
 using Speckle.Newtonsoft.Json;
-using Objects.BuiltElements.Archicad;
 
 namespace Archicad.Communication.Commands
 {
@@ -12,9 +11,9 @@ namespace Archicad.Communication.Commands
     public sealed class Parameters
     {
       [JsonProperty("zones")]
-      private IEnumerable<ArchicadRoom> Datas { get; }
+      private IEnumerable<Archicad.Room> Datas { get; }
 
-      public Parameters(IEnumerable<ArchicadRoom> datas)
+      public Parameters(IEnumerable<Archicad.Room> datas)
       {
         Datas = datas;
       }
@@ -27,9 +26,9 @@ namespace Archicad.Communication.Commands
       public IEnumerable<ApplicationObject> ApplicationObjects { get; private set; }
     }
 
-    private IEnumerable<ArchicadRoom> Datas { get; }
+    private IEnumerable<Archicad.Room> Datas { get; }
 
-    public CreateRoom(IEnumerable<ArchicadRoom> datas)
+    public CreateRoom(IEnumerable<Archicad.Room> datas)
     {
       Datas = datas;
     }

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetRoomData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetRoomData.cs
@@ -6,7 +6,7 @@ using Objects.BuiltElements.Archicad;
 
 namespace Archicad.Communication.Commands
 {
-  sealed internal class GetRoomData : ICommand<IEnumerable<ArchicadRoom>>
+  sealed internal class GetRoomData : ICommand<IEnumerable<Archicad.Room>>
   {
     [JsonObject(MemberSerialization.OptIn)]
     public sealed class Parameters
@@ -24,7 +24,7 @@ namespace Archicad.Communication.Commands
     private sealed class Result
     {
       [JsonProperty("zones")]
-      public IEnumerable<ArchicadRoom> Rooms { get; private set; }
+      public IEnumerable<Archicad.Room> Rooms { get; private set; }
     }
 
     private IEnumerable<string> ApplicationIds { get; }
@@ -34,11 +34,9 @@ namespace Archicad.Communication.Commands
       ApplicationIds = applicationIds;
     }
 
-    public async Task<IEnumerable<ArchicadRoom>> Execute()
+    public async Task<IEnumerable<Archicad.Room>> Execute()
     {
       var result = await HttpCommandExecutor.Execute<Parameters, Result>("GetRoomData", new Parameters(ApplicationIds));
-      foreach (var room in result.Rooms)
-        room.units = Units.Meters;
 
       return result.Rooms;
     }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
@@ -5,9 +5,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Archicad.Communication;
 using Archicad.Model;
+using DynamicData;
 using Objects;
+using Objects.BuiltElements;
 using Objects.BuiltElements.Archicad;
 using Objects.Geometry;
+using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
 
@@ -15,14 +18,19 @@ namespace Archicad.Converters
 {
   public sealed class Room : IConverter
   {
-    public Type Type => typeof(Objects.BuiltElements.Room);
+    public Type Type => typeof(Archicad.Room);
 
-    public async Task<List<ApplicationObject>> ConvertToArchicad(IEnumerable<TraversalContext> elements, CancellationToken token)
+    public async Task<List<ApplicationObject>> ConvertToArchicad(
+      IEnumerable<TraversalContext> elements,
+      CancellationToken token
+    )
     {
-      var rooms = new List<Objects.BuiltElements.Archicad.ArchicadRoom>();
+      var rooms = new List<Archicad.Room>();
 
       var context = Archicad.Helpers.Timer.Context.Peek;
-      using (context?.cumulativeTimer?.Begin(ConnectorArchicad.Properties.OperationNameTemplates.ConvertToNative, Type.Name))
+      using (
+        context?.cumulativeTimer?.Begin(ConnectorArchicad.Properties.OperationNameTemplates.ConvertToNative, Type.Name)
+      )
       {
         foreach (var tc in elements)
         {
@@ -30,22 +38,53 @@ namespace Archicad.Converters
 
           switch (tc.current)
           {
-            case Objects.BuiltElements.Archicad.ArchicadRoom archiRoom:
-              rooms.Add(archiRoom);
-              break;
-            case Objects.BuiltElements.Room room:
-              Objects.BuiltElements.Archicad.ArchicadRoom newRoom = new Objects.BuiltElements.Archicad.ArchicadRoom
+            case Objects.BuiltElements.Archicad.ArchicadRoom speckleRoom:
+
               {
-                id = room.id,
-                applicationId = room.applicationId,
-                shape = Utils.PolycurvesToElementShape(room.outline, room.voids),
-                name = room.name,
-                number = room.number,
-                basePoint = (room.basePoint != null) ? Utils.ScaleToNative(room.basePoint) : new Point()
-              };
+                Archicad.Room archicadRoom = new Archicad.Room
+                {
+                  // convert from Speckle to Archicad data structure
+                  // Speckle base properties
+                  id = speckleRoom.id,
+                  applicationId = speckleRoom.applicationId,
+                  // Speckle general properties
+                  name = speckleRoom.name,
+                  number = speckleRoom.number,
+                  // Archicad properties
+                  elementType = speckleRoom.elementType,
+                  classifications = speckleRoom.classifications,
+                  level = speckleRoom.archicadLevel,
+                  height = speckleRoom.height,
+                  shape = speckleRoom.shape
+                };
 
-              rooms.Add(newRoom);
+                rooms.Add(archicadRoom);
+              }
+              break;
+            case Objects.BuiltElements.Room speckleRoom:
 
+              {
+                Archicad.Room archicadRoom = new Archicad.Room
+                {
+                  // Speckle base properties
+                  id = speckleRoom.id,
+                  applicationId = speckleRoom.applicationId,
+                  // Speckle general properties
+                  name = speckleRoom.name,
+                  number = speckleRoom.number,
+                  // Archicad properties
+                  shape = Utils.PolycurvesToElementShape(speckleRoom.outline, speckleRoom.voids),
+                };
+
+                Objects.BuiltElements.Archicad.ArchicadLevel level = new Objects.BuiltElements.Archicad.ArchicadLevel();
+                level.applicationId = speckleRoom.level.applicationId;
+                level.elevation = speckleRoom.level.elevation;
+                level.name = speckleRoom.level.name;
+
+                archicadRoom.level = level;
+
+                rooms.Add(archicadRoom);
+              }
               break;
           }
         }
@@ -56,29 +95,58 @@ namespace Archicad.Converters
       return result is null ? new List<ApplicationObject>() : result.ToList();
     }
 
-    public async Task<List<Base>> ConvertToSpeckle(IEnumerable<Model.ElementModelData> elements,
-      CancellationToken token)
+    public async Task<List<Base>> ConvertToSpeckle(
+      IEnumerable<Model.ElementModelData> elements,
+      CancellationToken token
+    )
     {
       var elementModels = elements as ElementModelData[] ?? elements.ToArray();
-      IEnumerable<Objects.BuiltElements.Archicad.ArchicadRoom> data =
-        await AsyncCommandProcessor.Execute(
-          new Communication.Commands.GetRoomData(elementModels.Select(e => e.applicationId)),
-          token);
+      IEnumerable<Archicad.Room> data = await AsyncCommandProcessor.Execute(
+        new Communication.Commands.GetRoomData(elementModels.Select(e => e.applicationId)),
+        token
+      );
       if (data is null)
       {
         return new List<Base>();
       }
 
       List<Base> rooms = new List<Base>();
-      foreach (Objects.BuiltElements.Archicad.ArchicadRoom room in data)
+      foreach (Archicad.Room archicadRoom in data)
       {
-        room.displayValue =
-          Operations.ModelConverter.MeshesToSpeckle(elementModels.First(e => e.applicationId == room.applicationId)
-            .model);
-        room.outline = Utils.PolycurveToSpeckle(room.shape.contourPolyline);
-        if (room.shape.holePolylines?.Count > 0)
-          room.voids = new List<ICurve>(room.shape.holePolylines.Select(Utils.PolycurveToSpeckle));
-        rooms.Add(room);
+        Objects.BuiltElements.Archicad.ArchicadRoom speckleRoom = new Objects.BuiltElements.Archicad.ArchicadRoom();
+
+        // convert from Archicad to Speckle data structure
+        // Speckle base properties
+        speckleRoom.id = archicadRoom.id;
+        speckleRoom.applicationId = archicadRoom.applicationId;
+        speckleRoom.displayValue = Operations.ModelConverter.MeshesToSpeckle(
+          elementModels.First(e => e.applicationId == archicadRoom.applicationId).model
+        );
+        speckleRoom.units = Units.Meters;
+
+        // Archicad properties
+        speckleRoom.elementType = archicadRoom.elementType;
+        speckleRoom.classifications = archicadRoom.classifications;
+        speckleRoom.level = archicadRoom.level;
+        speckleRoom.height = archicadRoom.height;
+        speckleRoom.shape = archicadRoom.shape;
+
+        // downdgrade
+        speckleRoom.name = archicadRoom.name;
+        speckleRoom.number = archicadRoom.number;
+        speckleRoom.area = archicadRoom.area ?? .0;
+        speckleRoom.volume = archicadRoom.volume ?? .0;
+
+        ElementShape.Polyline polyLine = archicadRoom.shape.contourPolyline;
+        Polycurve polycurve = Utils.PolycurveToSpeckle(polyLine);
+        speckleRoom.outline = polycurve;
+        if (archicadRoom.shape.holePolylines?.Count > 0)
+          speckleRoom.voids = new List<ICurve>(archicadRoom.shape.holePolylines.Select(Utils.PolycurveToSpeckle));
+
+        // calculate base point
+        speckleRoom.basePoint = archicadRoom.basePoint;
+
+        rooms.Add(speckleRoom);
       }
 
       return rooms;

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
@@ -128,7 +128,7 @@ namespace Archicad.Converters
         speckleRoom.elementType = archicadRoom.elementType;
         speckleRoom.classifications = archicadRoom.classifications;
         speckleRoom.level = archicadRoom.level;
-        speckleRoom.height = archicadRoom.height;
+        speckleRoom.height = archicadRoom.height ?? .0;
         speckleRoom.shape = archicadRoom.shape;
 
         // downdgrade

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
@@ -166,8 +166,8 @@ namespace Archicad
         return Converters[typeof(Floor)];
       if (elementType.IsSubclassOf(typeof(Roof)))
         return Converters[typeof(Roof)];
-      if (elementType.IsSubclassOf(typeof(Objects.BuiltElements.Room)))
-        return Converters[typeof(Objects.BuiltElements.Room)];
+      if (elementType.IsAssignableFrom(typeof(Objects.BuiltElements.Room)))
+        return Converters[typeof(Archicad.Room)];
 
       return forReceive ? DefaultConverterForReceive : DefaultConverterForSend;
     }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementTypeProvider.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementTypeProvider.cs
@@ -6,7 +6,7 @@ using DirectShape = Objects.BuiltElements.Archicad.DirectShape;
 using Door = Objects.BuiltElements.Archicad.ArchicadDoor;
 using Floor = Objects.BuiltElements.Archicad.ArchicadFloor;
 using Roof = Objects.BuiltElements.Archicad.ArchicadRoof;
-using Room = Objects.BuiltElements.Archicad.ArchicadRoom;
+using Room = Archicad.Room;
 using Shell = Objects.BuiltElements.Archicad.ArchicadShell;
 using Wall = Objects.BuiltElements.Archicad.ArchicadWall;
 using Window = Objects.BuiltElements.Archicad.ArchicadWindow;
@@ -16,19 +16,20 @@ namespace Archicad
 {
   public static class ElementTypeProvider
   {
-    private static Dictionary<string, Type> _nameToType = new()  {
-      { "Wall", typeof(Wall) },
-      { "Slab", typeof(Floor) },
-      { "Roof", typeof(Roof) },
-      { "Shell", typeof(Shell) },
-      { "Zone", typeof(Room) },
-      { "Beam", typeof(Beam) },
-      { "Column", typeof(Column) },
-      { "Door", typeof(Door) },
-      { "Window", typeof(Window) },
-      { "Skylight", typeof(Skylight) }
-
-    };
+    private static Dictionary<string, Type> _nameToType =
+      new()
+      {
+        { "Wall", typeof(Wall) },
+        { "Slab", typeof(Floor) },
+        { "Roof", typeof(Roof) },
+        { "Shell", typeof(Shell) },
+        { "Zone", typeof(Room) },
+        { "Beam", typeof(Beam) },
+        { "Column", typeof(Column) },
+        { "Door", typeof(Door) },
+        { "Window", typeof(Window) },
+        { "Skylight", typeof(Skylight) }
+      };
 
     public static Type GetTypeByName(string name)
     {

--- a/ConnectorArchicad/ConnectorArchicad/Elements/Room.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Elements/Room.cs
@@ -1,0 +1,43 @@
+using Objects.Geometry;
+using System.Collections.Generic;
+using Objects.BuiltElements.Archicad;
+
+namespace Archicad
+{
+  public class Room
+  {
+    // Speckle-specific properties
+    // Base
+    public string? id { get; set; }
+    public string? applicationId { get; set; }
+
+    // General
+    public string? name { get; set; }
+    public string? number { get; set; }
+
+    public double? area { get; set; }
+    public double? volume { get; set; }
+
+    // Helper
+    public Point? basePoint { get; set; } // Archicad geometry kernel needed for calculation
+
+    // Archicad API properties
+    // Element base
+    public string? elementType { get; set; }
+    public List<Classification>? classifications { get; set; }
+    public ArchicadLevel? level { get; set; }
+
+    // Room
+    public double? height { get; set; }
+
+    public ElementShape? shape { get; set; }
+
+    public Room() { }
+
+    public Room(string id, string applicationId)
+    {
+      this.id = id;
+      this.applicationId = applicationId;
+    }
+  }
+}

--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -4,6 +4,7 @@ using Objects.Geometry;
 using Objects.Utils;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.BuiltElements
 {
@@ -46,7 +47,7 @@ namespace Objects.BuiltElements
 
     public string name { get; set; }
     public string number { get; set; }
-    public Level level { get; set; }
+    virtual public Level level { get; set; }
     public Point basePoint { get; set; }
     public List<ICurve> voids { get; set; } = new();
     public ICurve outline { get; set; }
@@ -70,12 +71,19 @@ namespace Objects.BuiltElements.Archicad
   public class ArchicadRoom : Room
   {
     // Element base
-    public string? /*APINullabe*/ elementType { get; set; }
-    public List<Classification>? /*APINullabe*/ classifications { get; set; }
+    public string elementType { get; set; }
+    public List<Classification> classifications { get; set; }
 
-    public ArchicadLevel? /*APINullabe*/ level { get; set; }
+    [JsonIgnore]
+    public ArchicadLevel archicadLevel { get; set; }
 
-    public double? /*APINullabe*/ height { get; set; }
+    public override Level level
+    {
+      get => archicadLevel;
+      set => archicadLevel = value as ArchicadLevel ?? throw new System.ArgumentException("Must be ArchicadLevel");
+    }
+
+    public double height { get; set; }
 
     public ElementShape shape { get; set; }
   }


### PR DESCRIPTION
## Description & motivation

Archicad side of https://github.com/specklesystems/speckle-sharp/issues/2820


## Changes:

Objects:
* `ArchicadLevel archicadLevel` virtual property added to ArchicadRoom, overriding the `level` property of the base
* `Objects.BuiltElements.Archicad.Room` is not used for the communication between the Connector and Archicad anymore (nullability has been removed from properties)

C# connector:
* a new `Archicad.Room` class has been introduced for this communication
* `RoomConverter` and HTTP commands changed accordingly

C++ add-on:
* `GetRoomData` class renamed to `GetZoneData` (AC API terminology used)
* BasePoint calculation: we cut the polygon into half with a line parallel to one of axes, get the section lines, take one from the middle, and take the midpoint of it
* ![image](https://github.com/specklesystems/speckle-sharp/assets/50739844/a5048fe5-4994-403f-9690-4d7ba5e4a9da)
* plus other fixes


## Screenshots:


<img width="453" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/9c9a1cea-e22f-44e1-b8bc-02695ed848a1">


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
