### PR TITLE
fix(Revit): Corrects Affine and Offset Unit Conversions. Closes #2878

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -5,7 +5,6 @@ namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
-
     private string _modelUnits;
 
 #if REVIT2020
@@ -172,12 +171,13 @@ namespace Objects.Converter.Revit
     }
 
     private double? defaultConversionFactor;
+
     public double ScaleToSpeckle(double value)
     {
       defaultConversionFactor ??= ScaleToSpeckle(1, RevitLengthTypeId);
       return value * defaultConversionFactor.Value;
     }
-    
+
     /// <summary>
     /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
     /// </summary>
@@ -188,7 +188,7 @@ namespace Objects.Converter.Revit
     {
       return ScaleToSpeckleStatic(value, UnitsToNative(units));
     }
-    
+
     /// <summary>
     /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
     /// </summary>
@@ -202,11 +202,13 @@ namespace Objects.Converter.Revit
 
     public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId, IRevitDocumentAggregateCache cache)
     {
-      return value * cache
+      var cacheKey = $"{value}_{forgeTypeId.TypeId}";
+
+      return cache
         .GetOrInitializeEmptyCacheOfType<double>(out _)
-        .GetOrAdd(forgeTypeId.TypeId, () => UnitUtils.ConvertFromInternalUnits(1, forgeTypeId), out _);
+        .GetOrAdd(cacheKey, () => UnitUtils.ConvertFromInternalUnits(value, forgeTypeId), out _);
     }
-    
+
     public double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)
     {
       return ScaleToSpeckle(value, forgeTypeId, revitDocumentAggregateCache);
@@ -233,10 +235,12 @@ namespace Objects.Converter.Revit
     {
       return UnitsToNativeString(UnitsToNative(units));
     }
+
     public static string UnitsToNativeString(ForgeTypeId forgeTypeId)
     {
       return forgeTypeId.TypeId;
     }
+
     public static ForgeTypeId UnitsToNative(string units)
     {
       switch (units)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -202,7 +202,7 @@ namespace Objects.Converter.Revit
 
     public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId, IRevitDocumentAggregateCache cache)
     {
-      var cacheKey = $"{value}_{forgeTypeId.TypeId}";
+      var cacheKey = $"{forgeTypeId.TypeId}_{value}";
 
       return cache
         .GetOrInitializeEmptyCacheOfType<double>(out _)


### PR DESCRIPTION
## Description & motivation

Closes #2878 

## Changes:

- Units.cs changes the cached index for Parameter Conversions to type-value from type

The Conversion is performed for all new type:value combinations as not all conversions are scale factored.

Nominally this is less efficient than keying by typeId alone, but my crude benchmarking suggests no real effect.

## Validation of changes:

Comparison of UI values with values within Speckle

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.