### PR TITLE
Fix(Revit) : fix units that don't scale linearly

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -378,7 +378,7 @@ namespace Objects.Converter.Revit
             unitTypeId = UnitsToNative(unitsOverride);
           }
           unitType = UnitsToNativeString(unitTypeId);
-          return cache != null ? ScaleToSpeckle(val, unitTypeId, cache) : ScaleToSpeckleStatic(val, unitTypeId);
+          return ScaleToSpeckle(val, unitTypeId);
         case StorageType.Integer:
           var intVal = rp.AsInteger();
           return definition.IsBool() ? Convert.ToBoolean(intVal) : intVal;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Extensions/ForgeTypeIdExtensions.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Extensions/ForgeTypeIdExtensions.cs
@@ -1,5 +1,6 @@
 #nullable enable
 #if !REVIT2020
+using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
 using DB = Autodesk.Revit.DB;
@@ -24,18 +25,20 @@ namespace ConverterRevitShared.Extensions
     }
     public static string ToUniqueString(this ForgeTypeId forgeTypeId)
     {
-      return forgeTypeId.TypeId.ToString();
+      return forgeTypeId.TypeId;
     }
+    private readonly static HashSet<string> lengthTypes = new()
+    {
+      UnitTypeId.Millimeters.ToUniqueString(),
+      UnitTypeId.Centimeters.ToUniqueString(),
+      UnitTypeId.Meters.ToUniqueString(),
+      UnitTypeId.Inches.ToUniqueString(),
+      UnitTypeId.Feet.ToUniqueString(),
+      UnitTypeId.FeetFractionalInches.ToUniqueString(),
+    };
     public static bool IsLengthType(this ForgeTypeId forgeTypeId)
     {
-      if (
-        forgeTypeId == UnitTypeId.Millimeters
-        || forgeTypeId == UnitTypeId.Centimeters
-        || forgeTypeId == UnitTypeId.Meters
-        || forgeTypeId == UnitTypeId.Inches
-        || forgeTypeId == UnitTypeId.Feet
-        || forgeTypeId == UnitTypeId.FeetFractionalInches
-      )
+      if (lengthTypes.Contains(forgeTypeId.ToUniqueString()))
       {
         return true;
       }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Extensions/ForgeTypeIdExtensions.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Extensions/ForgeTypeIdExtensions.cs
@@ -26,6 +26,21 @@ namespace ConverterRevitShared.Extensions
     {
       return forgeTypeId.TypeId.ToString();
     }
+    public static bool IsLengthType(this ForgeTypeId forgeTypeId)
+    {
+      if (
+        forgeTypeId == UnitTypeId.Millimeters
+        || forgeTypeId == UnitTypeId.Centimeters
+        || forgeTypeId == UnitTypeId.Meters
+        || forgeTypeId == UnitTypeId.Inches
+        || forgeTypeId == UnitTypeId.Feet
+        || forgeTypeId == UnitTypeId.FeetFractionalInches
+      )
+      {
+        return true;
+      }
+      return false;
+    }
   }
 }
 #endif

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Extensions/ForgeTypeIdExtensions.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Extensions/ForgeTypeIdExtensions.cs
@@ -1,6 +1,5 @@
 #nullable enable
 #if !REVIT2020
-using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
 using DB = Autodesk.Revit.DB;
@@ -26,23 +25,6 @@ namespace ConverterRevitShared.Extensions
     public static string ToUniqueString(this ForgeTypeId forgeTypeId)
     {
       return forgeTypeId.TypeId;
-    }
-    private readonly static HashSet<string> lengthTypes = new()
-    {
-      UnitTypeId.Millimeters.ToUniqueString(),
-      UnitTypeId.Centimeters.ToUniqueString(),
-      UnitTypeId.Meters.ToUniqueString(),
-      UnitTypeId.Inches.ToUniqueString(),
-      UnitTypeId.Feet.ToUniqueString(),
-      UnitTypeId.FeetFractionalInches.ToUniqueString(),
-    };
-    public static bool IsLengthType(this ForgeTypeId forgeTypeId)
-    {
-      if (lengthTypes.Contains(forgeTypeId.ToUniqueString()))
-      {
-        return true;
-      }
-      return false;
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -1,4 +1,5 @@
 using Autodesk.Revit.DB;
+using ConverterRevitShared.Extensions;
 using RevitSharedResources.Interfaces;
 
 namespace Objects.Converter.Revit
@@ -202,9 +203,16 @@ namespace Objects.Converter.Revit
 
     public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId, IRevitDocumentAggregateCache cache)
     {
-      return value * cache
-        .GetOrInitializeEmptyCacheOfType<double>(out _)
-        .GetOrAdd(forgeTypeId.TypeId, () => UnitUtils.ConvertFromInternalUnits(1, forgeTypeId), out _);
+      if (forgeTypeId.IsLengthType())
+      {
+        return value * cache
+          .GetOrInitializeEmptyCacheOfType<double>(out _)
+          .GetOrAdd(forgeTypeId.TypeId, () => UnitUtils.ConvertFromInternalUnits(1, forgeTypeId), out _);
+      }
+      else
+      {
+        return UnitUtils.ConvertFromInternalUnits(value, forgeTypeId);
+      }
     }
     
     public double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -72,22 +72,22 @@ namespace Objects.Converter.Revit
     /// <returns></returns>
     public double ScaleToSpeckle(double value)
     {
-      return ScaleToSpeckleStatic(value, RevitLengthTypeId);
+      return ScaleToSpeckle(value, RevitLengthTypeId);
     }
     
-    public static double ScaleToSpeckleStatic(double value, DisplayUnitType unitType)
+    public static double ScaleToSpeckle(double value, DisplayUnitType unitType)
     {
       return UnitUtils.ConvertFromInternalUnits(value, unitType);
     }
 
     public static double ScaleToSpeckle(double value, DisplayUnitType unitType, IRevitDocumentAggregateCache cache)
     {
-      return ScaleToSpeckleStatic(value, unitType);
+      return ScaleToSpeckle(value, unitType);
     }
 
     public static double ScaleToSpeckle(double value, string units)
     {
-      return ScaleToSpeckleStatic(value, UnitsToNative(units));
+      return ScaleToSpeckle(value, UnitsToNative(units));
     }
 
     private string UnitsToSpeckle(DisplayUnitType type)
@@ -179,49 +179,17 @@ namespace Objects.Converter.Revit
       return value * defaultConversionFactor.Value;
     }
     
-    /// <summary>
-    /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
-    /// </summary>
-    /// <param name="value"></param>
-    /// <param name="units"></param>
-    /// <returns></returns>
     public static double ScaleToSpeckle(double value, string units)
     {
-      return ScaleToSpeckleStatic(value, UnitsToNative(units));
+      return ScaleToSpeckle(value, UnitsToNative(units));
     }
     
-    /// <summary>
-    /// this method does not take advantage of any caching. Prefer other implementations of ScaleToSpeckle
-    /// </summary>
-    /// <param name="value"></param>
-    /// <param name="forgeTypeId"></param>
-    /// <returns></returns>
-    public static double ScaleToSpeckleStatic(double value, ForgeTypeId forgeTypeId)
+    public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)
     {
+      // our current profiling shows that the method "ConvertFromInternalUnits" is a huge bottleneck
+      // in the ScaleToSpeckle(double) method, but not here. This is because the former method is called
+      // roughly 12 times more often than this function
       return UnitUtils.ConvertFromInternalUnits(value, forgeTypeId);
-    }
-
-    public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId, IRevitDocumentAggregateCache cache)
-    {
-      if (forgeTypeId.IsLengthType())
-      {
-        return value * cache
-          .GetOrInitializeEmptyCacheOfType<double>(out _)
-          .GetOrAdd(forgeTypeId.TypeId, () => UnitUtils.ConvertFromInternalUnits(1, forgeTypeId), out _);
-      }
-      else
-      {
-        var cacheKey = $"{forgeTypeId.TypeId}_{value}";
-
-        return cache
-          .GetOrInitializeEmptyCacheOfType<double>(out _)
-          .GetOrAdd(cacheKey, () => UnitUtils.ConvertFromInternalUnits(value, forgeTypeId), out _);
-      }
-    }
-    
-    public double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)
-    {
-      return ScaleToSpeckle(value, forgeTypeId, revitDocumentAggregateCache);
     }
 
     //new units api introduced in 2021, bleah

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -211,7 +211,11 @@ namespace Objects.Converter.Revit
       }
       else
       {
-        return UnitUtils.ConvertFromInternalUnits(value, forgeTypeId);
+        var cacheKey = $"{forgeTypeId.TypeId}_{value}";
+
+        return cache
+          .GetOrInitializeEmptyCacheOfType<double>(out _)
+          .GetOrAdd(cacheKey, () => UnitUtils.ConvertFromInternalUnits(value, forgeTypeId), out _);
       }
     }
     


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

See description here https://github.com/specklesystems/speckle-sharp/pull/2879 for problem.

Benchmarking the above solution led to finding a very slight slow down. On small models it is unnoticable. Here are some average results that I found from benchmarking the solution in the above PR (this cached value solution) and this solution (the type check solution)

Cached value solution : ~ 57.7s
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/a09dac11-a58c-4e98-b23a-683090e298c3)

Type check solution : ~ 55.3s
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/1fe66353-23c8-4cab-917a-f5812d72a7f7)

It is interesting to me that the recorded time difference between these two functions is ~ 100 ms (or maybe ticks?), but the time difference of the send operations was consistantly ~2s. This may be because of the extra heap allocations and garbage collections, but that is just my guess. The difference is small enough that I wondered if this PR is really necessay, but it's an easy implementation so why not? I also figure that we can eventual add more unit types that scale linearly which would improve the performance even more.

EDIT:
Turns out caching the revit convertFromInternal method IN THIS LOCATION is not saving much time for us at all, so we're just reverting back to using the Revit method.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- check if units are length type
  - if so, use previous method
  - if not, use new method that caches each individual value

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
