### PR TITLE
feat(rhino): adds level to native conversion

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Previews.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Previews.cs
@@ -88,6 +88,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
   {
     return @object.speckle_type.Contains("Instance")
       || @object.speckle_type.Contains("View")
+      || @object.speckle_type.Contains("Level")
       || @object.speckle_type.Contains("Collection");
   }
 

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -339,16 +339,12 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
           speckleType.Contains("View") || speckleType.Contains("Level")
             ? current["name"] as string
             : current.applicationId;
-        var container = speckleType.Contains("View") || speckleType.Contains("Level") ? string.Empty : containerId;
+        var container = speckleType.Contains("View") || speckleType.Contains("Level") ? null : containerId;
         return new ApplicationObject(current.id, speckleType) { applicationId = applicationId, Container = container };
       }
 
       // skip if it is the base commit collection
       if (current is Collection && string.IsNullOrEmpty(containerId))
-        return null;
-
-      // skip if this is a dynamic object and already has been traversed
-      if (StoredObjects.ContainsKey(current.id))
         return null;
 
       // get parameters

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -173,6 +173,31 @@ public partial class ConverterRhinoGh
     return nativeObjects;
   }
 
+  // level
+  public ApplicationObject LevelToNative(Level level)
+  {
+    var appObj = new ApplicationObject(level.id, level.speckle_type) { applicationId = level.applicationId };
+
+    var commitInfo = GetCommitInfo();
+    var bakedLevelName = ReceiveMode == ReceiveMode.Create ? $"{commitInfo} - {level.name}" : $"{level.name}";
+
+    var elevation = ScaleToNative(level.elevation, level.units);
+    var plane = new RH.Plane(new RH.Point3d(0, 0, elevation), RH.Vector3d.ZAxis);
+    var res = Doc.NamedConstructionPlanes.Add(bakedLevelName, plane);
+
+    if (res == -1)
+    {
+      appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not add named construction plane to doc");
+    }
+    else
+    {
+      var namedCPlane = Doc.NamedConstructionPlanes[res];
+      appObj.Update(bakedLevelName, convertedItem: namedCPlane);
+    }
+
+    return appObj;
+  }
+
   #region CIVIL
 
   // alignment

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -461,6 +461,10 @@ public partial class ConverterRhinoGh : ISpeckleConverter
           rhinoObj = AlignmentToNative(o);
           break;
 
+        case Level o:
+          rhinoObj = LevelToNative(o);
+          break;
+
         case ModelCurve o:
           rhinoObj = CurveToNative(o.baseCurve);
           break;
@@ -665,6 +669,7 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       case View3D _:
       case Instance _:
       case Alignment _:
+      case Level _:
       case Text _:
       case Dimension _:
         return true;


### PR DESCRIPTION
## Description & motivation

Adds `LevelToNative()` conversion to rhino as `Named Construction Plane` objects. 

Part of #2872 

## Changes:

- Rhino connector and converter

## Screenshots:

Receiving Revit Sample House with two levels:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/c44c8ef6-7c50-4e83-96b8-353d95a28a73)

