### PR TITLE
fix(rhino): various bugs when receiving

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -37,7 +37,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     converter.ReceiveMode = state.ReceiveMode;
 
     // set converter settings
-    bool settingsChanged = CurrentSettings == state.Settings ? false : true;
+    bool settingsChanged = CurrentSettings != state.Settings;
     CurrentSettings = state.Settings;
     var settings = GetSettingsDict(CurrentSettings);
     converter.SetConverterSettings(settings);

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -335,7 +335,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
       ApplicationObject NewAppObj()
       {
         var speckleType = current.speckle_type
-          .Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries)
+          .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)
           .LastOrDefault();
 
         return new ApplicationObject(current.id, speckleType)

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -37,6 +37,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     converter.ReceiveMode = state.ReceiveMode;
 
     // set converter settings
+    bool settingsChanged = CurrentSettings == state.Settings ? false : true;
     CurrentSettings = state.Settings;
     var settings = GetSettingsDict(CurrentSettings);
     converter.SetConverterSettings(settings);
@@ -44,7 +45,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     Commit commit = await ConnectorHelpers.GetCommitFromState(state, progress.CancellationToken);
     state.LastCommit = commit;
 
-    if (SelectedReceiveCommit != commit.id)
+    if (SelectedReceiveCommit != commit.id || settingsChanged) // clear storage if receiving a new commit, or if settings have changed!!
     {
       ClearStorage();
       SelectedReceiveCommit = commit.id;
@@ -69,7 +70,6 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
         () =>
         {
           RhinoDoc.ActiveDoc.Notes += "%%%" + commitLayerName; // give converter a way to access commit layer info
-
           // create preview objects if they don't already exist
           if (Preview.Count == 0)
           {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -17,6 +17,14 @@ namespace Objects.Converter.RhinoGh;
 
 public partial class ConverterRhinoGh
 {
+  // parameters
+  public Tuple<string, string> ParameterToNative(RV.Parameter parameter)
+  {
+    var name = parameter.name;
+    var val = parameter.value?.ToString() ?? string.Empty;
+    return new Tuple<string, string>(name, val);
+  }
+
   // views
   public View3D ViewToSpeckle(ViewInfo view)
   {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -24,7 +24,7 @@ namespace Objects.Converter.RhinoGh;
 
 public partial class ConverterRhinoGh
 {
-  // display, render, and parameters
+  // display, render
   public RH.ObjectAttributes DisplayStyleToNative(DisplayStyle display)
   {
     var attributes = new RH.ObjectAttributes();
@@ -239,13 +239,6 @@ public partial class ConverterRhinoGh
 #endif
 
     return renderMaterial;
-  }
-
-  public Tuple<string, string> ParameterToNative(Objects.BuiltElements.Revit.Parameter parameter)
-  {
-    var name = parameter.name;
-    var val = parameter.value.ToString();
-    return new Tuple<string, string>(name, val);
   }
 
   // hatch

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -670,7 +670,6 @@ public partial class ConverterRhinoGh : ISpeckleConverter
 #else
       // This types are not supported in GH!
       case Pointcloud _:
-      case Collection _:
       case ModelCurve _:
       case DirectShape _:
       case View3D _:
@@ -679,7 +678,9 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       case Level _:
       case Text _:
       case Dimension _:
+      case Collection c when !c.collectionType.ToLower().Contains("model"):
         return true;
+
 #endif
 
       default:


### PR DESCRIPTION
## Description & motivation

Fixes the following issues during receiving:
- Revit parameters with null values are now being handled correctly: previously this was throwing a null exception and preventing receives
- Receiving on a different mesh setting now updates all objects properly: previously, when re-receiving the same commit with a different mesh setting, the previously converted mesh objects were not being re-converted
- Now traverses and receives `Views` and `Levels` on revit commits without any geometry, by treating all `model` type collections as not convertible

## Changes:

rhino connector


