### PR TITLE
fix(DUI): Wording alignment between web and dui. Improved semantics.

### DIFF
--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
@@ -9,11 +9,11 @@
   <UserControl.Styles>
 
     <Style Selector="ToggleSwitch[IsChecked=true]">
-      <Setter Property="Content" Value="Public stream" />
+      <Setter Property="Content" Value=" Link Shareable" />
     </Style>
 
     <Style Selector="ToggleSwitch[IsChecked=false]">
-      <Setter Property="Content" Value="Private stream" />
+      <Setter Property="Content" Value=" Private" />
     </Style>
 
 
@@ -73,9 +73,8 @@
     <ToggleSwitch
       Name="isPublic"
       Grid.Row="4"
-      Margin="15" />
-
-
+      Margin="15"/>
+    
     <StackPanel
       Grid.Row="5"
       Margin="15"


### PR DESCRIPTION
Closes #2900

### Motivation:
Improved semantics to aid the acceptance of Speckle in privacy/security interested organisations and individuals.

### Changes:

- Change the text for ToggleSwitch when IsChecked is true to "Link Shareable"
- Change the text for ToggleSwitch when IsChecked is false to "Private"

- increased padding between control and label text

<img width="230" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/760691/e877904e-7fc5-45a6-9052-74100ccce9b9">
