### PR TITLE
fix(revit): Category not assigned to Blocks>NewFamily

### DIFF
--- a/DesktopUI2/DesktopUI2/ViewModels/MappingTool/Schemas.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/MappingTool/Schemas.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Runtime.Serialization;
 using Objects.BuiltElements;
 using Objects.BuiltElements.Revit;
-using Objects.Other;
 using Objects.BuiltElements.Revit.RevitRoof;
+using Objects.Other;
 using ReactiveUI;
 using Speckle.Core.Api;
 using Speckle.Newtonsoft.Json;
@@ -441,12 +441,12 @@ public class BlockDefinitionViewModel : Schema
 {
   private List<string> _categories;
 
-  private string _selectedCategory = RevitCategory.GenericModel.ToString();
+  private string _selectedCategory = RevitFamilyCategory.GenericModel.ToString();
 
   public BlockDefinitionViewModel()
   {
-    Categories = Enum.GetValues(typeof(RevitCategory))
-      .Cast<RevitCategory>()
+    Categories = Enum.GetValues(typeof(RevitFamilyCategory))
+      .Cast<RevitFamilyCategory>()
       .Select(x => x.ToString())
       .OrderBy(x => x)
       .ToList();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -39,5 +39,11 @@ namespace Objects.Converter.Revit
       var name = Enum.GetName(typeof(RevitCategory), c);
       return $"OST_{name}";
     }
+
+    public static string GetBuiltInFromSchemaBuilderCategory(RevitFamilyCategory c)
+    {
+      var name = Enum.GetName(typeof(RevitFamilyCategory), c);
+      return $"OST_{name}";
+    }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -181,9 +181,9 @@ public partial class ConverterRevit
   private static void AssignCategoryToFamilyDoc(DB.Document famDoc, string? categoryName)
   {
     // Get the RevitCategory from a string value
-    var success = Enum.TryParse(categoryName, out RevitCategory cat);
+    var success = Enum.TryParse(categoryName, out RevitFamilyCategory cat);
     if (!success)
-      cat = RevitCategory.GenericModel;
+      cat = RevitFamilyCategory.GenericModel;
 
     // Get the BuiltInCategory corresponding to the RevitCategory
     var catName = Categories.GetBuiltInFromSchemaBuilderCategory(cat);
@@ -205,7 +205,7 @@ public partial class ConverterRevit
     }
     catch (Exception e)
     {
-      SpeckleLog.Logger.Warning(e, "Document category could not be modified");
+      SpeckleLog.Logger.Error(e, "Document category could not be modified");
       t.RollBack();
     }
   }

--- a/Objects/Objects/BuiltElements/Revit/Enums.cs
+++ b/Objects/Objects/BuiltElements/Revit/Enums.cs
@@ -117,6 +117,61 @@ public enum RevitCategory
   Railings = 110
 }
 
+/// <summary>
+/// FamilyDocuments can only be assigned these categories
+/// This is a subset of the list above which was manually retrieved from Revit's UI
+/// </summary>
+public enum RevitFamilyCategory
+{
+  AudioVisualDevices = 9,
+  CableTrayFitting = 16,
+  Casework = 19,
+  Columns = 21,
+  CommunicationDevices = 22,
+  ConduitFitting = 23,
+  DataDevices = 30,
+  Doors = 32,
+  DuctAccessory = 33,
+  DuctFitting = 34,
+  ElectricalEquipment = 38,
+  ElectricalFixtures = 39,
+  Entourage = 40,
+  FireAlarmDevices = 42,
+  FireProtection = 43,
+  FoodServiceEquipment = 45,
+  Furniture = 46,
+  FurnitureSystems = 47,
+  GenericModel = 49,
+  Hardscape = 51,
+  LightingDevices = 52,
+  LightingFixtures = 53,
+  Mass = 55,
+  MechanicalEquipment = 56,
+  MedicalEquipment = 57,
+  NurseCallDevices = 58,
+  Parking = 59,
+  PipeAccessory = 68,
+  PipeFitting = 69,
+  Planting = 74,
+  PlumbingFixtures = 76,
+  Roads = 80,
+  SecurityDevices = 82,
+  Signage = 84,
+  Site = 85,
+  SpecialityEquipment = 86,
+  Sprinklers = 87,
+  StructuralFramingSystem = 89,
+  StructuralColumns = 90,
+  StructConnections = 91,
+  StructuralFoundation = 93,
+  StructuralFraming = 94,
+  StructuralStiffener = 97,
+  TemporaryStructure = 100,
+  VerticalCirculation = 103,
+  Windows = 109,
+  Railings = 110
+}
+
 public enum LocationLine
 {
   Centerline,


### PR DESCRIPTION
Fixes #2905  

It turns out the list of catagories that can be used for new family creation is a subset of the BuiltIn ones.
See dialog below. I created a list that matches the one in the Revit UI (manually, as I could not find anything on this in the API) and used that for the Block > New Family Mapper objects:

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/8bf43632-e906-4ddd-a426-6881798aada2)
