### PR TITLE
fix(rvt): Modified revit traversal to prevent traversing displayable objects

### DIFF
--- a/Core/Core/Models/GraphTraversal/DefaultTraversal.cs
+++ b/Core/Core/Models/GraphTraversal/DefaultTraversal.cs
@@ -40,14 +40,13 @@ public static class DefaultTraversal
   /// <returns></returns>
   public static GraphTraversal CreateRevitTraversalFunc(ISpeckleConverter converter)
   {
-    var convertableRule = TraversalRule.NewTraversalRule().When(converter.CanConvertToNative).ContinueTraversing(None);
-
-    var displayValueRule = TraversalRule
+    var convertableRule = TraversalRule
       .NewTraversalRule()
+      .When(converter.CanConvertToNative)
       .When(HasDisplayValue)
-      .ContinueTraversing(_ => displayValueAndElementsPropAliases);
+      .ContinueTraversing(None);
 
-    return new GraphTraversal(convertableRule, displayValueRule, IgnoreResultsRule, DefaultRule);
+    return new GraphTraversal(convertableRule, IgnoreResultsRule, DefaultRule);
   }
 
   /// <summary>


### PR DESCRIPTION
Revit Traversal is still traversing all elements inside a `displayValue` list, even when we're already considering the parent object to be "displayable", and hence, convertible too.

This leads to duplicated objects when receiving "purely displayable objects" (ones that we can't directly convert), as the traversal will return the parent and all it's children.

Changes in this PR modify the Revit traversal so that it also stops traversing when an object is displayable (Navis objects are always purely displayable)

This could be related to some of the other instance duplication issues we've been encountering.

Kudos to @JR-Morgan for the quick session on traversal details.

