### PR TITLE
fix(navis): no geometry sent

### DIFF
--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.Geometry.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.Geometry.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Numerics;
+using System.DoubleNumerics;
 using Autodesk.Navisworks.Api;
 using Autodesk.Navisworks.Api.Interop.ComApi;
 using Objects.Geometry;
@@ -213,9 +213,7 @@ public class PrimitiveProcessor : InwSimplePrimitivesCB
   private static Vector3 VectorFromVertex(InwSimpleVertex v)
   {
     var arrayV = (Array)v.coord;
-    var vertexVector = new Vector3((float)arrayV.GetValue(1), (float)arrayV.GetValue(2), (float)arrayV.GetValue(3));
-
-    return vertexVector;
+    return  new Vector3((float)arrayV.GetValue(1), (float)arrayV.GetValue(2), (float)arrayV.GetValue(3));
   }
 }
 

--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.Geometry.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.Geometry.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.DoubleNumerics;
+using System.Numerics;
 using Autodesk.Navisworks.Api;
 using Autodesk.Navisworks.Api.Interop.ComApi;
 using Objects.Geometry;
@@ -213,7 +213,9 @@ public class PrimitiveProcessor : InwSimplePrimitivesCB
   private static Vector3 VectorFromVertex(InwSimpleVertex v)
   {
     var arrayV = (Array)v.coord;
-    return new Vector3((double)arrayV.GetValue(1), (double)arrayV.GetValue(2), (double)arrayV.GetValue(3));
+    var vertexVector = new Vector3((float)arrayV.GetValue(1), (float)arrayV.GetValue(2), (float)arrayV.GetValue(3));
+
+    return vertexVector;
   }
 }
 


### PR DESCRIPTION
Changes across speckle-sharp by https://github.com/specklesystems/speckle-sharp/pull/2815 broke the internal NavisToSpeckle conversion.

Casting the internal interop object directly to `double` was an invalid cast.

This PR reverts to the previous state.

Closes #2908 