### PR TITLE
fix(revit): better handling of built-in-categories 

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -41,6 +41,13 @@ namespace Objects.Converter.Revit
       return Enum.TryParse(builtInName, out bic);
     }
 
+    public static bool GetBuiltInCategoryFromRevitCategory(RevitFamilyCategory c, out BuiltInCategory bic)
+    {
+      var name = Enum.GetName(typeof(RevitFamilyCategory), c);
+      var builtInName = $"OST_{name}";
+      return Enum.TryParse(builtInName, out bic);
+    }
+
     /// <summary>
     /// Returns the corresponding RevitCategory enum from a specific BuiltInCategory
     /// </summary>
@@ -52,12 +59,6 @@ namespace Objects.Converter.Revit
       var name = Enum.GetName(typeof(BuiltInCategory), bic);
       var revitName = name.Split('_').Last();
       return Enum.TryParse<RevitCategory>(revitName, out c);
-    }
-
-    public static string GetBuiltInFromSchemaBuilderCategory(RevitFamilyCategory c)
-    {
-      var name = Enum.GetName(typeof(RevitFamilyCategory), c);
-      return $"OST_{name}";
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -34,10 +34,24 @@ namespace Objects.Converter.Revit
     /// </summary>
     /// <param name="c">The RevitCategory to convert</param>
     /// <returns>The name of the built-in category that corresponds to the input RevitCategory</returns>
-    public static string GetBuiltInFromSchemaBuilderCategory(RevitCategory c)
+    public static bool GetBuiltInCategoryFromRevitCategory(RevitCategory c, out BuiltInCategory bic)
     {
       var name = Enum.GetName(typeof(RevitCategory), c);
-      return $"OST_{name}";
+      var builtInName = $"OST_{name}";
+      return Enum.TryParse(builtInName, out bic);
+    }
+
+    /// <summary>
+    /// Returns the corresponding RevitCategory enum from a specific BuiltInCategory
+    /// </summary>
+    /// <param name="c"></param>
+    /// <returns></returns>
+    /// <remarks>This method should mirror <see cref="GetBuiltInCategoryFromRevitCategory"/> logic for built in categories </remarks>
+    public static bool GetRevitCategoryFromBuiltInCategory(BuiltInCategory bic, out RevitCategory c)
+    {
+      var name = Enum.GetName(typeof(BuiltInCategory), bic);
+      var revitName = name.Split('_').Last();
+      return Enum.TryParse<RevitCategory>(revitName, out c);
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -391,43 +391,6 @@ namespace Objects.Converter.Revit
       return "";
     }
 
-    private BuiltInCategory GetObjectCategory(Base @object)
-    {
-      switch (@object)
-      {
-        case BE.Beam _:
-        case BE.Brace _:
-        case BE.TeklaStructures.TeklaContourPlate _:
-          return BuiltInCategory.OST_StructuralFraming;
-        case BE.TeklaStructures.Bolts _:
-          return BuiltInCategory.OST_StructConnectionBolts;
-        case BE.TeklaStructures.Welds _:
-          return BuiltInCategory.OST_StructConnectionWelds;
-        case BE.Floor _:
-          return BuiltInCategory.OST_Floors;
-        case BE.Ceiling _:
-          return BuiltInCategory.OST_Ceilings;
-        case BE.Column _:
-          return BuiltInCategory.OST_Columns;
-        case BE.Pipe _:
-          return BuiltInCategory.OST_PipeSegments;
-        case BE.Rebar _:
-          return BuiltInCategory.OST_Rebar;
-        case BE.Topography _:
-          return BuiltInCategory.OST_Topography;
-        case BE.Wall _:
-          return BuiltInCategory.OST_Walls;
-        case BE.Roof _:
-          return BuiltInCategory.OST_Roofs;
-        case BE.Duct _:
-          return BuiltInCategory.OST_FabricationDuctwork;
-        case BE.CableTray _:
-          return BuiltInCategory.OST_CableTray;
-        default:
-          return BuiltInCategory.OST_GenericModel;
-      }
-    }
-
     private Base SwapGeometrySchemaObject(Base @object)
     {
       // schema check

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -186,8 +186,7 @@ public partial class ConverterRevit
       cat = RevitCategory.GenericModel;
 
     // Get the BuiltInCategory corresponding to the RevitCategory
-    var catName = Categories.GetBuiltInFromSchemaBuilderCategory(cat);
-    success = Enum.TryParse(catName, out DB.BuiltInCategory bic);
+    success = Categories.GetBuiltInCategoryFromRevitCategory(cat, out DB.BuiltInCategory bic);
     if (!success)
       bic = DB.BuiltInCategory.OST_GenericModel;
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -185,7 +185,7 @@ public partial class ConverterRevit
     if (!success)
       cat = RevitFamilyCategory.GenericModel;
 
-    // Get the BuiltInCategory corresponding to the RevitCategory
+    // Get the BuiltInCategory corresponding to the RevitFamilyCategory
     success = Categories.GetBuiltInCategoryFromRevitCategory(cat, out DB.BuiltInCategory bic);
     if (!success)
       bic = DB.BuiltInCategory.OST_GenericModel;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -148,25 +148,16 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      BuiltInCategory bic;
+      DB.Category cat = null;
       if ((int)speckleDs.category == -1)
         speckleDs.category = RevitCategory.GenericModel;
-      var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(speckleDs.category);
-
-      var res = BuiltInCategory.TryParse(bicName, out bic); 
-      var cat = Doc.Settings.Categories.get_Item(bic); 
+      if (Categories.GetBuiltInCategoryFromRevitCategory(speckleDs.category, out BuiltInCategory bic))
+      {
+        cat = Doc.Settings.Categories.get_Item(bic);
+      }
       if (cat is null)
       {
-        // don't know why, but sometimes the "Railings" category maps to "OST_StairsRailing" instead of "OST_Railings"
-        if (bic == BuiltInCategory.OST_Railings) 
-        {
-          cat = Doc.Settings.Categories.get_Item(BuiltInCategory.OST_StairsRailing);
-        }
-        // default to generic model as last resort
-        if (cat is null)
-        {
-          cat = Doc.Settings.Categories.get_Item(BuiltInCategory.OST_GenericModel);
-        }
+        cat = Doc.Settings.Categories.get_Item(BuiltInCategory.OST_GenericModel); // default to generic model
       }
       try
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -153,9 +153,21 @@ namespace Objects.Converter.Revit
         speckleDs.category = RevitCategory.GenericModel;
       var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(speckleDs.category);
 
-      BuiltInCategory.TryParse(bicName, out bic);
-      var cat = Doc.Settings.Categories.get_Item(bic);
-
+      var res = BuiltInCategory.TryParse(bicName, out bic); 
+      var cat = Doc.Settings.Categories.get_Item(bic); 
+      if (cat is null)
+      {
+        // don't know why, but sometimes the "Railings" category maps to "OST_StairsRailing" instead of "OST_Railings"
+        if (bic == BuiltInCategory.OST_Railings) 
+        {
+          cat = Doc.Settings.Categories.get_Item(BuiltInCategory.OST_StairsRailing);
+        }
+        // default to generic model as last resort
+        if (cat is null)
+        {
+          cat = Doc.Settings.Categories.get_Item(BuiltInCategory.OST_GenericModel);
+        }
+      }
       try
       {
         var revitDs = DB.DirectShape.CreateElement(Doc, cat.Id);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
@@ -189,18 +189,18 @@ namespace Objects.Converter.Revit
         if (freeformElement != null)
         {
           //subcategory
-          BuiltInCategory bic;
           if (!string.IsNullOrEmpty(freeformElement.subcategory))
           {
             //by default free form elements are always generic models
             //otherwise we'd need to supply base files for each category..?
-            var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(BuiltElements.Revit.RevitCategory.GenericModel);
-            BuiltInCategory.TryParse(bicName, out bic);
-            cat = famDoc.Settings.Categories.get_Item(bic);
-            if (cat.SubCategories.Contains(freeformElement.subcategory))
-              cat = cat.SubCategories.get_Item(freeformElement.subcategory);
-            else
-              cat = famDoc.Settings.Categories.NewSubcategory(cat, freeformElement.subcategory);
+            if (Categories.GetBuiltInCategoryFromRevitCategory(BuiltElements.Revit.RevitCategory.GenericModel, out BuiltInCategory bic))
+            {
+              cat = famDoc.Settings.Categories.get_Item(bic);
+              if (cat.SubCategories.Contains(freeformElement.subcategory))
+                cat = cat.SubCategories.get_Item(freeformElement.subcategory);
+              else
+                cat = famDoc.Settings.Categories.NewSubcategory(cat, freeformElement.subcategory);
+            }
           }
         }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -67,7 +67,6 @@ namespace Objects.Converter.Revit
 
         if (topRailType != null && isTopRailExactMatch)
           railingType.TopRailType = topRailType.Id;
-
       }
 
 


### PR DESCRIPTION
## Description & motivation

Fixes issues of failed railing creation due to improper sending and retrieval of built in categories for revit 2023 and 2024.

This pr mirror ths logic used by schema builder to remove "OST_" from bic internal names to find the equivalent RevitCategory, when before we were just using the category name. This was causing issues in differentiating between "OST_Railings" and "OST_StairsRailing" bics because they both had the category name of "Railing". Also seems to have fixed some issues in native railing conversion by retrieving the correct type.

## Screenshots:

![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/1fd54bd7-f11d-4090-88f5-906aaa4520bb)


Railings now received on fallback conversion:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/5f57b665-3483-483e-9f44-f61a1a735bca)


