### PR TITLE
fix(revit): do not show the missing types dialog if the DS fallback option is set to Always

### DIFF
--- a/ConnectorRevit/ConnectorRevit/ConnectorRevit.projitems
+++ b/ConnectorRevit/ConnectorRevit/ConnectorRevit.projitems
@@ -51,7 +51,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Storage\StreamStateManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Storage\StreamStateCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeMapping\TypeMap.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)UI\ConnectorBindingsRevit .Settings.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\ConnectorBindingsRevit.Settings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\ConnectorBindingsRevit.Events.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\ConnectorBindingsRevit.Previews.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\ConnectorBindingsRevit.Receive.cs" />

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
@@ -83,18 +83,18 @@ namespace Speckle.ConnectorRevit.UI
         new ListBoxSetting
         {
           Slug = "direct-shape-strategy",
-          Name = "Convert received objects to DirectShape",
+          Name = "Fallback to DirectShape on receive",
           Icon = "Link",
           Values = new List<string> { "Always", "On Error", "Never" },
           Selection = "On Error",
-          Description = "Determines when to attempt conversion of an element into a DirectShape"
+          Description = "Determines when to fallback to DirectShape on receive.\n\nAways: all objects will be received as DirectShapes\nOn Error: only objects that fail or whose types are missing\nNever: disables the fallback behavior"
         },
         new MultiSelectBoxSetting
         {
           Slug = "disallow-join",
           Name = "Disallow Join For Elements",
           Icon = "CallSplit",
-          Description = "Determine which objects should not be allowed to join by default when receiving",
+          Description = "Determines which objects should not be allowed to join by default when receiving",
           Values = new List<string>() { ArchitecturalWalls, StructuralWalls, StructuralFraming }
         },
         new ListBoxSetting
@@ -109,10 +109,10 @@ namespace Speckle.ConnectorRevit.UI
         new MappingSetting
         {
           Slug = "receive-mappings",
-          Name = "Custom Type Mapping",
+          Name = "Missing Type Mapping",
           Icon = "LocationSearching",
           Values = mappingOptions,
-          Description = "Determine how incoming object types are mapped to object types in the host application"
+          Description = "Determines when the missing types dialog is shown\n\nNever: the dialog is never shown\nAlways: the dialog is always shown when types are missing\nFor New Types: the dialog is only shown if there are new unmapped types"
         },
       };
     }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
@@ -112,7 +112,7 @@ namespace Speckle.ConnectorRevit.UI
           Name = "Missing Type Mapping",
           Icon = "LocationSearching",
           Values = mappingOptions,
-          Description = "Determines when the missing types dialog is shown\n\nNever: the dialog is never shown\nAlways: the dialog is always shown when types are missing\nFor New Types: the dialog is only shown if there are new unmapped types"
+          Description = "Determines when the missing types dialog is shown\n\nNever: the dialog is never shown\nAlways: the dialog is always shown, useful to edit existing mappings\nFor New Types: the dialog is only shown if there are new unmapped types"
         },
       };
     }

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/MissingIncomingTypesDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/MissingIncomingTypesDialog.xaml
@@ -5,7 +5,7 @@
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   mc:Ignorable="d">
-  <Grid RowDefinitions="auto, auto, auto, auto, auto, auto">
+  <Grid RowDefinitions="auto, auto, auto, auto">
     <TextBlock
       Margin="15,15,15,0"
       Classes="Subtitle1"
@@ -14,13 +14,20 @@
 
     <TextBlock
       Grid.Row="1"
-      Margin="15"
+      Margin="15,15,15,5"
       Foreground="Gray"
-      Text="You are trying to import objects with family types that are not loaded into the project. Would you like to import family types / map incoming types to existing types in the project?"
+      Text="Some incoming types are missing, would you like to import or map them?"
+      TextWrapping="Wrap" />
+    <TextBlock
+      Grid.Row="2"
+      Margin="15,5,15,15"
+      FontStyle="Italic"
+      Foreground="Gray"
+      Text="You can change the missing types fallback behaviour and how often this dialog is displayed from the Advanced Settings."
       TextWrapping="Wrap" />
 
     <StackPanel
-      Grid.Row="5"
+      Grid.Row="3"
       Margin="15"
       HorizontalAlignment="Right"
       Orientation="Horizontal">


### PR DESCRIPTION
What the title says