### PR TITLE
fix(revit): allows converter to skip nested elements on receive

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -222,8 +222,9 @@ namespace Speckle.ConnectorRevit.UI
         // traverse each element member and convert
         foreach (var obj in GraphTraversal.TraverseMember(nestedElements))
         {
-          // create the application object and log to reports
-          var nestedAppObj = Preview.Where(o => o.OriginalId == obj.id)?.FirstOrDefault();
+          // first try to retrieve this object from the preview and the converter report
+          // create if none exist
+          var nestedAppObj = Preview.Where(o => o.OriginalId == obj.id)?.FirstOrDefault()??converter.Report.ReportObjects[obj.id];
           if (nestedAppObj == null)
           {
             nestedAppObj = new ApplicationObject(obj.id, ConnectorRevitUtils.SimplifySpeckleType(obj.speckle_type))
@@ -234,6 +235,10 @@ namespace Speckle.ConnectorRevit.UI
             progress.Report.Log(nestedAppObj);
             converter.Report.Log(nestedAppObj);
           }
+
+          //check status, skip if necessary
+          if (nestedAppObj.Status == ApplicationObject.State.Skipped)
+            continue;
 
           // convert
           var converted = ConvertObject(nestedAppObj, obj, receiveDirectMesh, converter, progress, transactionManager);

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -238,8 +238,11 @@ namespace Speckle.ConnectorRevit.UI
             converter.Report.Log(nestedAppObj);
           }
 
-          //check status, skip if necessary
-          if (nestedAppObj.Status == ApplicationObject.State.Skipped)
+          //check status, skip if this appobject is anything other than unknown or failed state
+          if (
+            nestedAppObj.Status != ApplicationObject.State.Unknown
+            || nestedAppObj.Status != ApplicationObject.State.Failed
+          )
             continue;
 
           // convert

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -224,7 +224,9 @@ namespace Speckle.ConnectorRevit.UI
         {
           // first try to retrieve this object from the preview and the converter report
           // create if none exist
-          var nestedAppObj = Preview.Where(o => o.OriginalId == obj.id)?.FirstOrDefault()??converter.Report.ReportObjects[obj.id];
+          var nestedAppObj = converter.Report.ReportObjects.ContainsKey(obj.id)
+            ? converter.Report.ReportObjects[obj.id]
+            : Preview.Where(o => o.OriginalId == obj.id)?.FirstOrDefault();
           if (nestedAppObj == null)
           {
             nestedAppObj = new ApplicationObject(obj.id, ConnectorRevitUtils.SimplifySpeckleType(obj.speckle_type))

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -241,7 +241,7 @@ namespace Speckle.ConnectorRevit.UI
           //check status, skip if this appobject is anything other than unknown or failed state
           if (
             nestedAppObj.Status != ApplicationObject.State.Unknown
-            || nestedAppObj.Status != ApplicationObject.State.Failed
+            && nestedAppObj.Status != ApplicationObject.State.Failed
           )
             continue;
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -38,21 +38,21 @@ namespace Objects.Converter.Revit
       if (nestedElements == null)
         return;
 
-      bool toSkip = skipCategories is null;
       foreach (var obj in GraphTraversal.TraverseMember(nestedElements))
       {
+        bool toSkip = skipCategories is null;
         if (!toSkip)
         {
           var category = obj["category"] as string;
           if (!string.IsNullOrEmpty(category))
             toSkip = skipCategories.Contains(category);
         }
-        
+
         if (toSkip) // create the application object with status = skipped and log to reports
         {
           var nestedAppObj = Report.ReportObjects.TryGetValue(obj.id, out ApplicationObject value)
-           ? value
-           : new ApplicationObject(obj.id, obj.speckle_type);
+            ? value
+            : new ApplicationObject(obj.id, obj.speckle_type);
           nestedAppObj.Status = ApplicationObject.State.Skipped;
           Report.Log(nestedAppObj);
         }
@@ -320,29 +320,32 @@ namespace Objects.Converter.Revit
       // TODO : could add some generic getOrAdd overloads to avoid creating closures
       var paramData = revitDocumentAggregateCache
         .GetOrInitializeEmptyCacheOfType<ParameterToSpeckleData>(out _)
-        .GetOrAdd(paramInternalName, () =>
-        {
-          var definition = rp.Definition;
-          var newParamData = new ParameterToSpeckleData()
+        .GetOrAdd(
+          paramInternalName,
+          () =>
           {
-            Definition = definition,
-            InternalName = paramInternalName,
-            IsReadOnly = rp.IsReadOnly,
-            IsShared = rp.IsShared,
-            IsTypeParameter = isTypeParameter,
-            Name = definition.Name,
-            UnitType = definition.GetUnityTypeString(),
-          };
-          if (rp.StorageType == StorageType.Double)
-          {
-            unitTypeId = rp.GetUnitTypeId();
-            newParamData.UnitsSymbol = GetSymbolUnit(rp, definition, unitTypeId);
-            newParamData.ApplicationUnits = unitsOverride != null
-              ? UnitsToNative(unitsOverride).ToUniqueString()
-              : unitTypeId.ToUniqueString();
-          }
-          return newParamData;
-        }, out _);
+            var definition = rp.Definition;
+            var newParamData = new ParameterToSpeckleData()
+            {
+              Definition = definition,
+              InternalName = paramInternalName,
+              IsReadOnly = rp.IsReadOnly,
+              IsShared = rp.IsShared,
+              IsTypeParameter = isTypeParameter,
+              Name = definition.Name,
+              UnitType = definition.GetUnityTypeString(),
+            };
+            if (rp.StorageType == StorageType.Double)
+            {
+              unitTypeId = rp.GetUnitTypeId();
+              newParamData.UnitsSymbol = GetSymbolUnit(rp, definition, unitTypeId);
+              newParamData.ApplicationUnits =
+                unitsOverride != null ? UnitsToNative(unitsOverride).ToUniqueString() : unitTypeId.ToUniqueString();
+            }
+            return newParamData;
+          },
+          out _
+        );
 
       return paramData.GetParameterObjectWithValue(rp.GetValue(paramData.Definition, unitTypeId));
     }
@@ -357,9 +360,7 @@ namespace Objects.Converter.Revit
     /// <param name="cache"></param>
     /// <param name="forgeTypeId"></param>
     /// <returns></returns>
-    public string GetSymbolUnit(
-      DB.Parameter parameter,
-      DB.Definition definition,
+    public string GetSymbolUnit(DB.Parameter parameter, DB.Definition definition,
 #if REVIT2020
       DisplayUnitType unitTypeId
 #else
@@ -620,7 +621,7 @@ namespace Objects.Converter.Revit
 
       var cachedIds = PreviouslyReceivedObjectIds?.GetCreatedIdsFromConvertedId(applicationId);
       // TODO: we may not want just the first one
-      return  cachedIds == null ? null : Doc.GetElement(cachedIds.First());
+      return cachedIds == null ? null : Doc.GetElement(cachedIds.First());
     }
 
     public IEnumerable<DB.Element?> GetExistingElementsByApplicationId(string applicationId)
@@ -629,7 +630,8 @@ namespace Objects.Converter.Revit
         yield break;
 
       var cachedIds = PreviouslyReceivedObjectIds?.GetCreatedIdsFromConvertedId(applicationId);
-      if (cachedIds == null) yield break;
+      if (cachedIds == null)
+        yield break;
       foreach (var id in cachedIds)
         yield return Doc.GetElement(id);
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -166,7 +166,7 @@ namespace Objects.Converter.Revit
       appObj.Update(status: state, createdId: revitWall.UniqueId, convertedItem: revitWall);
 
       SetWallVoids(revitWall, speckleWall);
-      
+
       return appObj;
     }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -150,7 +150,7 @@ namespace Objects.Converter.Revit
         TrySetParam(revitWall, BuiltInParameter.WALL_TOP_OFFSET, spklRevitWall.topOffset, speckleWall.units);
 
         if (revitWall.CurtainGrid is CurtainGrid)
-          SkipNestedElementsOnReceive(spklRevitWall); // handles and skips curtain wall elements for the connector
+          SkipNestedElementsOnReceive(spklRevitWall, new List<string> { "Curtain Wall Mullions", "Curtain Panel" }); // handles and skips curtain wall elements for the connector
       }
       else
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -150,7 +150,7 @@ namespace Objects.Converter.Revit
         TrySetParam(revitWall, BuiltInParameter.WALL_TOP_OFFSET, spklRevitWall.topOffset, speckleWall.units);
 
         if (revitWall.CurtainGrid is CurtainGrid)
-          SkipNestedElementsOnReceive(spklRevitWall, new List<string> { "Curtain Wall Mullions", "Curtain Panel" }); // handles and skips curtain wall elements for the connector
+          SkipNestedElementsOnReceive(spklRevitWall, new List<string> { "Curtain Wall Mullions", "Curtain Panels" }); // handles and skips curtain wall elements for the connector
       }
       else
       {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -148,6 +148,9 @@ namespace Objects.Converter.Revit
 
         TrySetParam(revitWall, BuiltInParameter.WALL_BASE_OFFSET, spklRevitWall.baseOffset, speckleWall.units);
         TrySetParam(revitWall, BuiltInParameter.WALL_TOP_OFFSET, spklRevitWall.topOffset, speckleWall.units);
+
+        if (revitWall.CurtainGrid is CurtainGrid)
+          SkipNestedElementsOnReceive(spklRevitWall); // handles and skips curtain wall elements for the connector
       }
       else
       {
@@ -163,7 +166,7 @@ namespace Objects.Converter.Revit
       appObj.Update(status: state, createdId: revitWall.UniqueId, convertedItem: revitWall);
 
       SetWallVoids(revitWall, speckleWall);
-      //appObj = SetHostedElements(speckleWall, revitWall, appObj);
+      
       return appObj;
     }
 


### PR DESCRIPTION
> ⚠️ **WARNING**
> This PR and #2915 fix the same issue in different ways. Only one of them should be merged

## Description & motivation
In the case of receiving curtain walls, where the parent wall (1) is convertible and (2) has panel and mullion objects inside the `elements` property that **should not** be created, we needed a way to skip the conversion of these elements in the connector.

This implementation includes:
- A new `SkipNestedElementsOnReceive()` method in the converter that creates `ApplicationObject` with status = `skipped` in the converter report
- An extra line in the connector checking for `ApplicationObject` status before sending an object to the converter
- Removes two methods for Hosted elements in the converter utils that didn't have any references

This seems to work without receiving any duplicates when receiving on regular update mode, as well as on the always use direct shape setting.
