### PR TITLE
fix(rvt): Changes some conversions to be skipped instead of failed

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -250,7 +250,9 @@ namespace Speckle.ConnectorRevit.UI
       Base conversionResult = converter.ConvertToSpeckle(revitElement);
 
       if (conversionResult == null)
-        throw new SpeckleException($"Conversion of {revitElement.UniqueId} (ToSpeckle) returned null");
+        throw new SpeckleException(
+          $"Conversion of {revitElement.GetType().Name} with id {revitElement.Id} (ToSpeckle) returned null"
+        );
 
       return conversionResult;
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
 using Objects.BuiltElements.Revit;
 using Objects.GIS;
 using Objects.Organization;
@@ -274,8 +275,9 @@ namespace Objects.Converter.Revit
           break;
         //these should be handled by curtain walls
         case DB.CurtainGridLine _:
-          returnObject = null;
-          break;
+          throw new ConversionSkippedException(
+            "Curtain Grid Lines are handled as part of the parent CurtainWall conversion"
+          );
         case DB.Architecture.BuildingPad o:
           returnObject = BuildingPadToSpeckle(o);
           break;
@@ -284,10 +286,11 @@ namespace Objects.Converter.Revit
           break;
         //these are handled by Stairs
         case DB.Architecture.StairsRun _:
-          returnObject = null;
-          break;
+          throw new ConversionSkippedException($"{nameof(StairsRun)} are handled by the {nameof(Stairs)} conversion");
         case DB.Architecture.StairsLanding _:
-          returnObject = null;
+          throw new ConversionSkippedException(
+            $"{nameof(StairsLanding)} are handled by the {nameof(Stairs)} conversion"
+          );
           break;
         case DB.Architecture.Railing o:
           returnObject = RailingToSpeckle(o);
@@ -296,8 +299,7 @@ namespace Objects.Converter.Revit
           returnObject = TopRailToSpeckle(o);
           break;
         case DB.Architecture.HandRail _:
-          returnObject = null;
-          break;
+          throw new ConversionSkippedException($"{nameof(HandRail)} are handled by the {nameof(Railing)} conversion");
         case DB.Structure.Rebar o:
           returnObject = RebarToSpeckle(o);
           break;
@@ -352,8 +354,7 @@ namespace Objects.Converter.Revit
             returnObject = RevitElementToSpeckle(el, out notes);
             break;
           }
-          returnObject = null;
-          break;
+          throw new NotSupportedException($"Conversion of {@object.GetType().Name} is not supported.");
       }
 
       // NOTE: Only try generic method assignment if there is no existing render material from conversions;
@@ -707,7 +708,6 @@ namespace Objects.Converter.Revit
         // gis
         case PolygonElement o:
           return PolygonElementToNative(o);
-
 
         //hacky but the current comments camera is not a Base object
         //used only from DUI and not for normal geometry conversion

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Autodesk.Revit.DB;
+using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
 using View = Objects.BuiltElements.View;
@@ -55,7 +56,7 @@ namespace Objects.Converter.Revit
       {
         // some views have null origin, not sure why, but for now we just ignore them and don't bother the user
         if (rv3d.Origin == null)
-          return null;
+          throw new ConversionSkippedException($"Views with no origin are not supported");
 
         // get orientation
         var forward = rv3d.GetSavedOrientation().ForwardDirection; // this is unit vector


### PR DESCRIPTION
Some specific conversions returned null, which in turn resulted in a "failed" report item, when the behaviour was actually expected.