### PR TITLE
fix(Navis): Localised versions of Navis will now correctly build the commit object

### DIFF
--- a/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToSpeckle.cs
+++ b/Objects/Converters/ConverterNavisworks/ConverterNavisworks/ConverterNavisworks.ToSpeckle.cs
@@ -97,7 +97,9 @@ public partial class ConverterNavisworks
     {
       var parts = referenceOrGuid.Split(':');
       using var savedItemReference = new SavedItemReference(parts[0], parts[1]);
-      savedViewpoint = parts.Length != 2 ? null : (SavedViewpoint)Doc.ResolveReference(savedItemReference);
+      savedViewpoint = parts.Length != 2
+        ? null
+        : (SavedViewpoint)Doc.ResolveReference(savedItemReference);
     }
 
     return savedViewpoint;
@@ -332,7 +334,10 @@ public partial class ConverterNavisworks
       pathArray = @string
         .ToString()
         .Split('-')
-        .Select(x => int.TryParse(x, out var value) ? value : throw new FormatException("malformed path pseudoId"))
+        .Select(
+          x => int.TryParse(x, out var value)
+            ? value
+            : throw new FormatException("malformed path pseudoId"))
         .ToArray();
     }
     catch (FormatException)


### PR DESCRIPTION
Fixes: #2893 

## Description & motivation

Non-anglicised installations of Navisworks could not send geometry.

## Changes:

- Prior Base object type conversion was tied to a localised string "Geometry" // me == dumbass
- Changed logic to a switch on HasGeometry as a method

- Extracted CategoryToSpeckle method into a new ConvertModelItemToSpeckle method
- Added helper methods: FindCategoryProperty, GetCategoryDisplayName, CreateSpeckleObject
- Updated comments for clarity and documentation<!---

## Screenshots:

<img width="782" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/760691/d466a66f-1615-4ce4-87e9-f32ef66392de">

## Validation of changes:

I have run the application in various Latin and non-Latin language modes - all produced success.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.