### PR TITLE
Fix(Revit) : add curtain panel class with ToNative implementation to avoid converting as displayable object

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -634,6 +634,9 @@ namespace Objects.Converter.Revit
         case BE.Topography o:
           return TopographyToNative(o);
 
+        case BER.RevitCurtainWallPanel o:
+          return PanelToNative(o);
+
         case BER.RevitProfileWall o:
           return ProfileWallToNative(o);
 
@@ -836,6 +839,7 @@ namespace Objects.Converter.Revit
         BERC.SpaceSeparationLine _ => true,
         BE.Roof _ => true,
         BE.Topography _ => true,
+        BER.RevitCurtainWallPanel _ => true,
         BER.RevitFaceWall _ => true,
         BER.RevitProfileWall _ => true,
         BE.Wall _ => true,

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevitShared.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertMEPFamilyInstance.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertNetwork.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertPolygonElement.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertRebar.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Partial Classes\ConvertBrace.cs" />

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFamilyInstance.cs
@@ -82,6 +82,12 @@ namespace Objects.Converter.Revit
         @base = MEPFamilyInstanceToSpeckle(revitFi);
       }
 
+      // curtain panels
+      if (revitFi is DB.Panel panel)
+      {
+        @base = PanelToSpeckle(panel);
+      }
+
       // elements
       var baseGeometry = LocationToSpeckle(revitFi);
       var basePoint = baseGeometry as Point;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPanel.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPanel.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Objects.BuiltElements.Revit;
+using Speckle.Core.Models;
+using DB = Autodesk.Revit.DB;
+
+namespace Objects.Converter.Revit
+{
+  public partial class ConverterRevit
+  {
+    public ApplicationObject PanelToNative(RevitCurtainWallPanel specklePanel)
+    {
+      return new ApplicationObject(specklePanel.id, specklePanel.speckle_type)
+      {
+        Status = ApplicationObject.State.Skipped,
+        Log = new List<string>() { "Revit does not support receive standalone curtain panels " }
+      };
+    }
+
+    public RevitCurtainWallPanel PanelToSpeckle(DB.Panel revitPanel)
+    {
+      RevitCurtainWallPanel panel = new();
+      return (RevitCurtainWallPanel)RevitElementToSpeckle(revitPanel, out _, panel);
+    }
+  }
+}

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRevitElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRevitElement.cs
@@ -12,12 +12,12 @@ namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
-    public RevitElement RevitElementToSpeckle(Element revitElement, out List<string> notes)
+    public RevitElement RevitElementToSpeckle(Element revitElement, out List<string> notes, RevitElement speckleElement = null)
     {
       notes = new List<string>();
       var symbol = revitElement.Document.GetElement(revitElement.GetTypeId()) as FamilySymbol;
 
-      RevitElement speckleElement = new RevitElement();
+      speckleElement ??= new RevitElement();
       if (symbol != null)
       {
         speckleElement.family = symbol.FamilyName;

--- a/Objects/Objects/BuiltElements/Revit/RevitCurtainWallPanel.cs
+++ b/Objects/Objects/BuiltElements/Revit/RevitCurtainWallPanel.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Objects.BuiltElements.Revit
+{
+  public class RevitCurtainWallPanel : RevitElement
+  {
+  }
+}


### PR DESCRIPTION
> ⚠️ **WARNING**
> This PR and #2912 fix the same issue in different ways. Only one of them should be merged

In the case of receiving curtain walls, where the parent wall (1) is convertible and (2) has panel and mullion objects inside the elements property that should not be created, we needed a way to skip the conversion of these elements in the connector.

This implementation includes:

- a new RevitCurtainWallPanel object that is just a RevitElement
- implements PanelToNative which just skips converting to native