### PR TITLE
fix(revit): do not show the missing types dialog if the DS fallback option is set to Always

### DIFF
--- a/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
@@ -74,7 +74,9 @@ namespace ConnectorRevit.TypeMapping
     {
       // Get Settings for recieve on mapping 
       if (mapOnReceiveSetting is not MappingSetting mappingSetting
-        || mappingSetting.Selection == ConnectorBindingsRevit.noMapping)
+        || mappingSetting.Selection == ConnectorBindingsRevit.noMapping
+        //skip mappings dialog always when DS fallback is set to always
+        || directShapeStrategySetting.Selection == ConnectorBindingsRevit.DsFallbackAways)
       {
         return;
       }
@@ -84,7 +86,7 @@ namespace ConnectorRevit.TypeMapping
 
       var hostTypesContainer = GetHostTypesAndAddIncomingTypes(currentOperationTypeMap, masterTypeMap, out var numNewTypes);
 
-      if (await ShouldShowCustomMappingDialog(mappingSetting.Selection, directShapeStrategySetting.Selection, numNewTypes).ConfigureAwait(false))
+      if (await ShouldShowCustomMappingDialog(mappingSetting.Selection, numNewTypes).ConfigureAwait(false))
       {
         // show custom mapping dialog if the settings correspond to what is being received
         await ShowCustomMappingDialog(currentOperationTypeMap, hostTypesContainer, numNewTypes).ConfigureAwait(false);
@@ -108,16 +110,13 @@ namespace ConnectorRevit.TypeMapping
       Analytics.TrackEvent(Analytics.Events.DUIAction, new Dictionary<string, object> { { "name", "Type Map" }, { "method", "Mappings Set" } });
     }
 
-    private async Task<bool> ShouldShowCustomMappingDialog(string listBoxSelection, string directShapeStartegySelection, int numNewTypes)
+    private async Task<bool> ShouldShowCustomMappingDialog(string listBoxSelection, int numNewTypes)
     {
-      //skip mappings dialog always when DS fallback is set to always
-      if (directShapeStartegySelection == ConnectorBindingsRevit.DsFallbackAways)
-        return false;
       if (listBoxSelection == ConnectorBindingsRevit.everyReceive)
+      {
         return true;
-      else if (listBoxSelection == ConnectorBindingsRevit.forNewTypes && numNewTypes > 0)
-        return true;
-      else if (listBoxSelection == null
+      }
+      else if (listBoxSelection == ConnectorBindingsRevit.forNewTypes
         && numNewTypes > 0
         && await ShowMissingIncomingTypesDialog().ConfigureAwait(false)
       )

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -91,7 +91,7 @@ namespace Speckle.ConnectorRevit.UI
           CurrentDoc.Document
         );
         await elementTypeMapper
-          .Map(state.Settings.FirstOrDefault(x => x.Slug == "receive-mappings"))
+          .Map(state.Settings.FirstOrDefault(x => x.Slug == "receive-mappings"), state.Settings.FirstOrDefault(x => x.Slug == DsFallbackSlug))
           .ConfigureAwait(false);
       }
       catch (Exception ex)

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
@@ -118,7 +118,7 @@ namespace Speckle.ConnectorRevit.UI
           Icon = "LocationSearching",
           Values = mappingOptions,
           Selection = forNewTypes,
-          Description = "Determines when the missing types dialog is shown\n\nNever: the dialog is never shown\nAlways: the dialog is always shown, useful to edit existing mappings\nFor New Types: the dialog is only shown if there are new unmapped types"
+          Description = "Determines when the missing types dialog is shown\n\nNever: the dialog is never shown\nAlways: the dialog is always shown, useful to edit existing mappings\nFor New Types: the dialog is only shown if there are new unmapped types\n\nNOTE: no dialog is shown if Fallback to DirectShape is set to Always"
         },
       };
     }

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Settings.cs
@@ -24,6 +24,11 @@ namespace Speckle.ConnectorRevit.UI
     public const string everyReceive = "Always";
     public const string forNewTypes = "For New Types";
 
+    public const string DsFallbackSlug = "direct-shape-strategy";
+    public const string DsFallbackOnError = "On Error";
+    public const string DsFallbackAways = "Always";
+    public const string DsFallbackNever = "Never";
+
     public override List<ISetting> GetSettings()
     {
       List<string> referencePoints = new List<string>() { InternalOrigin };
@@ -82,11 +87,11 @@ namespace Speckle.ConnectorRevit.UI
         // },
         new ListBoxSetting
         {
-          Slug = "direct-shape-strategy",
+          Slug = DsFallbackSlug,
           Name = "Fallback to DirectShape on receive",
           Icon = "Link",
-          Values = new List<string> { "Always", "On Error", "Never" },
-          Selection = "On Error",
+          Values = new List<string> { DsFallbackAways, DsFallbackOnError, DsFallbackNever },
+          Selection = DsFallbackOnError,
           Description = "Determines when to fallback to DirectShape on receive.\n\nAways: all objects will be received as DirectShapes\nOn Error: only objects that fail or whose types are missing\nNever: disables the fallback behavior"
         },
         new MultiSelectBoxSetting
@@ -112,6 +117,7 @@ namespace Speckle.ConnectorRevit.UI
           Name = "Missing Type Mapping",
           Icon = "LocationSearching",
           Values = mappingOptions,
+          Selection = forNewTypes,
           Description = "Determines when the missing types dialog is shown\n\nNever: the dialog is never shown\nAlways: the dialog is always shown, useful to edit existing mappings\nFor New Types: the dialog is only shown if there are new unmapped types"
         },
       };


### PR DESCRIPTION
What the title says