### PR TITLE
fix(revit): displayable conversion now replaces existing objects on update receive

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -726,7 +726,12 @@ namespace Objects.Converter.Revit
 
     public object ConvertToNativeDisplayable(Base @base)
     {
-      return DisplayableObjectToNative(@base);
+      var nativeObject = DisplayableObjectToNative(@base);
+      if (nativeObject.Converted.Cast<Element>().ToList() is List<Element> typedList && typedList.Count >= 1)
+      {
+        receivedObjectsCache?.AddConvertedObjects(@base, typedList);
+      }
+      return nativeObject;
     }
 
     public List<Base> ConvertToSpeckle(List<object> objects) => objects.Select(ConvertToSpeckle).ToList();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -89,12 +89,13 @@ namespace Objects.Converter.Revit
     /// <exception cref="FallbackToDxfException"></exception>
     public ApplicationObject DirectShapeToNative(DirectShape speckleDs, ToNativeMeshSettingEnum fallback)
     {
-      var existingDS = GetExistingElementByApplicationId(speckleDs.applicationId ??= speckleDs.id) as DB.DirectShape;
+      // get any existing elements. This could be a DirectShape, OR another element if using fallback receive
+      var existingObj = GetExistingElementByApplicationId(speckleDs.applicationId ??= speckleDs.id);
       var appObj =
         new ApplicationObject(speckleDs.id, speckleDs.speckle_type) { applicationId = speckleDs.applicationId };
 
       // skip if element already exists in doc & receive mode is set to ignore
-      if (IsIgnore(existingDS, appObj))
+      if (IsIgnore(existingObj, appObj))
         return appObj;
 
       var converted = new List<GeometryObject>();
@@ -139,12 +140,11 @@ namespace Objects.Converter.Revit
         }
       });
 
-      if (existingDS != null)
+      if (existingObj != null && existingObj is DB.DirectShape existingDS) // if it's a directShape, just update
       {
-        // Try to update the existing Direct Shape
         existingDS.SetShape(converted);
         appObj.Update(status: ApplicationObject.State.Updated, createdId: existingDS.UniqueId,
-          convertedItem: existingDS);
+        convertedItem: existingDS);
         return appObj;
       }
 
@@ -165,6 +165,18 @@ namespace Objects.Converter.Revit
         revitDs.SetShape(converted);
         revitDs.Name = speckleDs.name;
         SetInstanceParameters(revitDs, speckleDs);
+        // delete any existing objs
+        if (existingObj != null)
+        {
+          try
+          {
+            Doc.Delete(existingObj.Id);
+          }
+          catch (Exception e)
+          {
+            appObj.Log.Add($"Could not delete existing object: {e.Message}");
+          }
+        }
         appObj.Update(status: ApplicationObject.State.Created, createdId: revitDs.UniqueId, convertedItem: revitDs);
       }
       catch (Exception ex)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDisplayableObject.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDisplayableObject.cs
@@ -30,7 +30,7 @@ public partial class ConverterRevit
       var category = GetSpeckleObjectCategory(obj);
 
       // Create a temp DirectShape and use the DirectShape conversion routine
-      var ds = new DirectShape(name, category, displayValue.ToList(), parameters?.ToList());
+      var ds = new DirectShape(name, category, displayValue.ToList(), parameters?.ToList()) { applicationId = obj.applicationId };
       return DirectShapeToNative(ds, ToNativeMeshSettingEnum.Default);
     }
     else if (obj is Other.Instance instance)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDisplayableObject.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDisplayableObject.cs
@@ -30,7 +30,10 @@ public partial class ConverterRevit
       var category = GetSpeckleObjectCategory(obj);
 
       // Create a temp DirectShape and use the DirectShape conversion routine
-      var ds = new DirectShape(name, category, displayValue.ToList(), parameters?.ToList()) { applicationId = obj.applicationId };
+      var ds = new DirectShape(name, category, displayValue.ToList(), parameters?.ToList())
+      {
+        applicationId = obj.applicationId
+      };
       return DirectShapeToNative(ds, ToNativeMeshSettingEnum.Default);
     }
     else if (obj is Other.Instance instance)


### PR DESCRIPTION
## Description & motivation

Fixes issue where we were getting duplicate objects when using the fallback to directshape setting when receiving.
This now searches for existing elements within the DS conversion not limited to DS objects, and adds a missing applicationID to created DS objects in the ConvertAsDisplayable method.

