### PR TITLE
fix(revit): skips category assignment when category already exists on send

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -251,10 +251,11 @@ namespace Objects.Converter.Revit
 
       speckleElement["worksetId"] = revitElement.WorksetId.ToString();
 
+      // assign the category *if* it hasn't already been assigned (eg, DirectShape conversion should already have assigned the category).
       // for the category, we should be mirroring how we handle parsing of built-in-categories for revit 2023/2024
       // this is because different built-in-categories may have the same name, eg "OST_Railings" and "OST_StairsRailing" both have a Category name of "Railing"
       var category = revitElement.Category;
-      if (category is not null)
+      if (category is null)
       {
         var categoryName = revitElement.Category.Name;
 #if !(REVIT2020 || REVIT2021 || REVIT2022)
@@ -345,29 +346,32 @@ namespace Objects.Converter.Revit
       // TODO : could add some generic getOrAdd overloads to avoid creating closures
       var paramData = revitDocumentAggregateCache
         .GetOrInitializeEmptyCacheOfType<ParameterToSpeckleData>(out _)
-        .GetOrAdd(paramInternalName, () =>
-        {
-          var definition = rp.Definition;
-          var newParamData = new ParameterToSpeckleData()
+        .GetOrAdd(
+          paramInternalName,
+          () =>
           {
-            Definition = definition,
-            InternalName = paramInternalName,
-            IsReadOnly = rp.IsReadOnly,
-            IsShared = rp.IsShared,
-            IsTypeParameter = isTypeParameter,
-            Name = definition.Name,
-            UnitType = definition.GetUnityTypeString(),
-          };
-          if (rp.StorageType == StorageType.Double)
-          {
-            unitTypeId = rp.GetUnitTypeId();
-            newParamData.UnitsSymbol = GetSymbolUnit(rp, definition, unitTypeId);
-            newParamData.ApplicationUnits = unitsOverride != null
-              ? UnitsToNative(unitsOverride).ToUniqueString()
-              : unitTypeId.ToUniqueString();
-          }
-          return newParamData;
-        }, out _);
+            var definition = rp.Definition;
+            var newParamData = new ParameterToSpeckleData()
+            {
+              Definition = definition,
+              InternalName = paramInternalName,
+              IsReadOnly = rp.IsReadOnly,
+              IsShared = rp.IsShared,
+              IsTypeParameter = isTypeParameter,
+              Name = definition.Name,
+              UnitType = definition.GetUnityTypeString(),
+            };
+            if (rp.StorageType == StorageType.Double)
+            {
+              unitTypeId = rp.GetUnitTypeId();
+              newParamData.UnitsSymbol = GetSymbolUnit(rp, definition, unitTypeId);
+              newParamData.ApplicationUnits =
+                unitsOverride != null ? UnitsToNative(unitsOverride).ToUniqueString() : unitTypeId.ToUniqueString();
+            }
+            return newParamData;
+          },
+          out _
+        );
 
       return paramData.GetParameterObjectWithValue(rp.GetValue(paramData.Definition, unitTypeId));
     }
@@ -382,9 +386,7 @@ namespace Objects.Converter.Revit
     /// <param name="cache"></param>
     /// <param name="forgeTypeId"></param>
     /// <returns></returns>
-    public string GetSymbolUnit(
-      DB.Parameter parameter,
-      DB.Definition definition,
+    public string GetSymbolUnit(DB.Parameter parameter, DB.Definition definition,
 #if REVIT2020
       DisplayUnitType unitTypeId
 #else
@@ -619,7 +621,7 @@ namespace Objects.Converter.Revit
 
       var cachedIds = PreviouslyReceivedObjectIds?.GetCreatedIdsFromConvertedId(applicationId);
       // TODO: we may not want just the first one
-      return  cachedIds == null ? null : Doc.GetElement(cachedIds.First());
+      return cachedIds == null ? null : Doc.GetElement(cachedIds.First());
     }
 
     public IEnumerable<DB.Element?> GetExistingElementsByApplicationId(string applicationId)
@@ -628,7 +630,8 @@ namespace Objects.Converter.Revit
         yield break;
 
       var cachedIds = PreviouslyReceivedObjectIds?.GetCreatedIdsFromConvertedId(applicationId);
-      if (cachedIds == null) yield break;
+      if (cachedIds == null)
+        yield break;
       foreach (var id in cachedIds)
         yield return Doc.GetElement(id);
     }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -255,7 +255,8 @@ namespace Objects.Converter.Revit
       // for the category, we should be mirroring how we handle parsing of built-in-categories for revit 2023/2024
       // this is because different built-in-categories may have the same name, eg "OST_Railings" and "OST_StairsRailing" both have a Category name of "Railing"
       var category = revitElement.Category;
-      if (category is null)
+      var speckleCategory = speckleElement["category"];
+      if (speckleCategory is null && category is not null)
       {
         var categoryName = revitElement.Category.Name;
 #if !(REVIT2020 || REVIT2021 || REVIT2022)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -259,7 +259,7 @@ namespace Objects.Converter.Revit
         var categoryName = category.Name;
         switch (speckleElement["category"])
         {
-          case RevitCategory c: // DirectShape as of 2.16 is the only class with `category` prop of type `RevitCategory`
+          case RevitCategory: // DirectShape as of 2.16 is the only class with `category` prop of type `RevitCategory`
             speckleElement["category"] = Categories.GetSchemaBuilderCategoryFromBuiltIn(categoryName);
             break;
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -255,8 +255,7 @@ namespace Objects.Converter.Revit
       // WARN: DirectShapes have a `category` prop of type `RevitCategory` (enum), NOT `string`. This is the only exception as of 2.16.
       // If the null check is removed, the DirectShape case needs to be handled.
       var category = revitElement.Category;
-      var speckleCategory = speckleElement["category"];
-      if (speckleCategory is null && category is not null)
+      if (speckleElement["category"] is null && category is not null)
       {
         var categoryName = category.Name;
         // we should use RevitCategory values for BuiltInCategory strings where possible (revit 2023+)


### PR DESCRIPTION
## Description & motivation

Revit tests for `DirectShapes` were failing as reported by @connorivy : 
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/c75d82a7-5325-4642-b18d-c7bd13cc14e0)

Turns out this was due `DirectShape` having a `category` prop of type `RevitCategory` and not `string` (which is the case for all other revit built elements). This case check was removed in [https://github.com/specklesystems/speckle-sharp/commit/5dc407faaa0cc2a8be30afb65ab59f92e51de307](https://github.com/specklesystems/speckle-sharp/commit/5dc407faaa0cc2a8be30afb65ab59f92e51de307) with the intent of skipping category assignment if a category value already exists, assuming all missing categories would be of type `string`. Pr #2910 subsequently missed the null check and caused DS tests to fail.

Pr adds a type case check back in to make explicit the different types of `category` prop we can expect in our object model, which should also catch the case DirectShapes are being created with no `category` prop assigned


