### PR TITLE
chore(core): Make client functions consistent with cancellation token position

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponent.cs
@@ -91,7 +91,7 @@ public class ReceiveComponent : SelectKitAsyncComponentBase
 
             // Get last commit from the branch
             var b = ApiClient
-              .BranchGet(BaseWorker.CancellationToken, StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1)
+              .BranchGet(StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1, BaseWorker.CancellationToken)
               .Result;
 
             // Compare commit id's. If they don't match, notify user or fetch data if in auto mode
@@ -619,7 +619,7 @@ public class ReceiveComponentWorker : WorkerInstance
       case StreamWrapperType.Commit:
         try
         {
-          myCommit = await client.CommitGet(CancellationToken, InputWrapper.StreamId, InputWrapper.CommitId);
+          myCommit = await client.CommitGet(InputWrapper.StreamId, InputWrapper.CommitId, CancellationToken);
           return myCommit;
         }
         catch (Exception e)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.ReceiveComponentSync.cs
@@ -84,7 +84,7 @@ public class ReceiveSync : SelectKitTaskCapableComponentBase<Base>
 
             // Get last commit from the branch
             var b = ApiClient
-              .BranchGet(source.Token, StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1)
+              .BranchGet(StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1, source.Token)
               .Result;
 
             // Compare commit id's. If they don't match, notify user or fetch data if in auto mode

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponent.cs
@@ -542,7 +542,7 @@ public class SendComponentWorker : WorkerInstance
               if (prevCommit != null)
                 commitCreateInput.parents = new List<string> { prevCommit.CommitId };
 
-              var commitId = await client.CommitCreate(CancellationToken, commitCreateInput);
+              var commitId = await client.CommitCreate(commitCreateInput, CancellationToken);
 
               var wrapper = new StreamWrapper(
                 $"{client.Account.serverInfo.url}/streams/{((ServerTransport)transport).StreamId}/commits/{commitId}?u={client.Account.userInfo.id}"

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponentSync.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.SendComponentSync.cs
@@ -425,7 +425,7 @@ public class SendComponentSync : GH_SpeckleTaskCapableComponent<List<StreamWrapp
               if (prevCommit != null)
                 commitCreateInput.parents = new List<string> { prevCommit.CommitId };
 
-              var commitId = await client.CommitCreate(source.Token, commitCreateInput);
+              var commitId = await client.CommitCreate(commitCreateInput, source.Token);
 
               var wrapper = new StreamWrapper(
                 $"{client.Account.serverInfo.url}/streams/{((ServerTransport)transport).StreamId}/commits/{commitId}?u={client.Account.userInfo.id}"

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Deprecated/Operations.VariableInputSendComponent.cs
@@ -616,7 +616,7 @@ public class VariableInputSendComponentWorker : WorkerInstance
               if (prevCommit != null)
                 commitCreateInput.parents = new List<string> { prevCommit.CommitId };
 
-              var commitId = await client.CommitCreate(CancellationToken, commitCreateInput);
+              var commitId = await client.CommitCreate(commitCreateInput, CancellationToken);
 
               var wrapper = new StreamWrapper(
                 $"{client.Account.serverInfo.url}/streams/{((ServerTransport)transport).StreamId}/commits/{commitId}?u={client.Account.userInfo.id}"

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
@@ -58,7 +58,7 @@ public class SyncReceiveComponent : SelectKitTaskCapableComponentBase<Base>
 
             // Get last commit from the branch
             var b = ApiClient
-              .BranchGet(CancelToken, StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1)
+              .BranchGet(StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1, CancelToken)
               .Result;
 
             // Compare commit id's. If they don't match, notify user or fetch data if in auto mode

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncSendComponent.cs
@@ -290,7 +290,7 @@ public class SyncSendComponent : SelectKitTaskCapableComponentBase<List<StreamWr
               if (prevCommit != null)
                 commitCreateInput.parents = new List<string> { prevCommit.CommitId };
 
-              var commitId = await client.CommitCreate(CancelToken, commitCreateInput);
+              var commitId = await client.CommitCreate(commitCreateInput, CancelToken);
 
               var wrapper = new StreamWrapper(
                 $"{client.Account.serverInfo.url}/streams/{((ServerTransport)transport).StreamId}/commits/{commitId}?u={client.Account.userInfo.id}"

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -128,7 +128,7 @@ public class VariableInputReceiveComponent : SelectKitAsyncComponentBase, IGH_Va
 
             // Get last commit from the branch
             var b = ApiClient
-              .BranchGet(BaseWorker.CancellationToken, StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1)
+              .BranchGet(StreamWrapper.StreamId, StreamWrapper.BranchName ?? "main", 1, BaseWorker.CancellationToken)
               .Result;
 
             // Compare commit id's. If they don't match, notify user or fetch data if in auto mode
@@ -740,7 +740,7 @@ public class VariableInputReceiveComponentWorker : WorkerInstance
       case StreamWrapperType.Commit:
         try
         {
-          myCommit = await client.CommitGet(CancellationToken, InputWrapper.StreamId, InputWrapper.CommitId);
+          myCommit = await client.CommitGet(InputWrapper.StreamId, InputWrapper.CommitId, CancellationToken);
           if (myCommit == null)
             OnFail(
               GH_RuntimeMessageLevel.Warning,
@@ -758,7 +758,7 @@ public class VariableInputReceiveComponentWorker : WorkerInstance
         return myCommit;
       case StreamWrapperType.Stream:
       case StreamWrapperType.Undefined:
-        var mb = await client.BranchGet(CancellationToken, InputWrapper.StreamId, "main", 1);
+        var mb = await client.BranchGet(InputWrapper.StreamId, "main", 1, CancellationToken);
         if (mb.commits.totalCount == 0)
           // TODO: Warn that we're not pulling from the main branch
           OnFail(
@@ -768,7 +768,7 @@ public class VariableInputReceiveComponentWorker : WorkerInstance
         else
           return mb.commits.items[0];
 
-        var cms = await client.StreamGetCommits(CancellationToken, InputWrapper.StreamId, 1);
+        var cms = await client.StreamGetCommits(InputWrapper.StreamId, 1, CancellationToken);
         if (cms.Count == 0)
         {
           OnFail(GH_RuntimeMessageLevel.Warning, "This stream has no commits.");
@@ -777,7 +777,7 @@ public class VariableInputReceiveComponentWorker : WorkerInstance
 
         return cms[0];
       case StreamWrapperType.Branch:
-        var br = await client.BranchGet(CancellationToken, InputWrapper.StreamId, InputWrapper.BranchName, 1);
+        var br = await client.BranchGet(InputWrapper.StreamId, InputWrapper.BranchName, 1, CancellationToken);
         if (br == null)
         {
           OnFail(

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
@@ -652,7 +652,7 @@ public class NewVariableInputSendComponentWorker : WorkerInstance
               if (prevCommit != null)
                 commitCreateInput.parents = new List<string> { prevCommit.CommitId };
 
-              var commitId = await client.CommitCreate(CancellationToken, commitCreateInput);
+              var commitId = await client.CommitCreate(commitCreateInput, CancellationToken);
 
               var wrapper = new StreamWrapper(
                 $"{client.Account.serverInfo.url}/streams/{((ServerTransport)transport).StreamId}/commits/{commitId}?u={client.Account.userInfo.id}"

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamCreateComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamCreateComponentV2.cs
@@ -108,7 +108,7 @@ public class StreamCreateComponentV2 : GH_SpeckleTaskCapableComponent<StreamWrap
 
     var client = new Client(account);
 
-    var streamId = client.StreamCreate(CancelToken, new StreamCreateInput { isPublic = false }).Result;
+    var streamId = client.StreamCreate(new StreamCreateInput { isPublic = false }, CancelToken).Result;
     var sw = new StreamWrapper(streamId, account.userInfo.id, account.serverInfo.url);
     sw.SetAccount(account);
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
@@ -90,7 +90,7 @@ public class StreamListComponentV2 : GH_SpeckleTaskCapableComponent<List<StreamW
   {
     var client = new Client(account);
     var res = client
-      .StreamsGet(CancelToken, limit)
+      .StreamsGet(limit, CancelToken)
       .Result.Select(stream => new StreamWrapper(stream.id, account.userInfo.id, account.serverInfo.url))
       .ToList();
     return Task.FromResult(res);

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ActivityOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ActivityOperations.cs
@@ -13,7 +13,7 @@ public partial class Client
   /// <summary>
   /// Gets the activity of a stream
   /// </summary>
-  /// <param name="streamId">Id of the stream to get the activity from</param>
+  /// <param name="id">Id of the stream to get the activity from</param>
   /// <param name="after">Only show activity after this DateTime</param>
   /// <param name="before">Only show activity before this DateTime</param>
   /// <param name="cursor">Time to filter the activity with</param>
@@ -22,12 +22,12 @@ public partial class Client
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   public async Task<List<ActivityItem>> StreamGetActivity(
-    string streamId,
+    string id,
     DateTime? after = null,
     DateTime? before = null,
     DateTime? cursor = null,
     string actionType = "",
-    int limit = 10,
+    int limit = 25,
     CancellationToken cancellationToken = default
   )
   {
@@ -54,7 +54,7 @@ public partial class Client
                     }",
       Variables = new
       {
-        streamId,
+        id,
         limit,
         actionType,
         after,

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ActivityOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ActivityOperations.cs
@@ -19,39 +19,16 @@ public partial class Client
   /// <param name="cursor">Time to filter the activity with</param>
   /// <param name="actionType">Time to filter the activity with</param>
   /// <param name="limit">Max number of activity items to get</param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public Task<List<ActivityItem>> StreamGetActivity(
+  public async Task<List<ActivityItem>> StreamGetActivity(
     string streamId,
     DateTime? after = null,
     DateTime? before = null,
     DateTime? cursor = null,
     string actionType = "",
-    int limit = 10
-  )
-  {
-    return StreamGetActivity(CancellationToken.None, streamId, after, before, cursor, actionType, limit);
-  }
-
-  /// <summary>
-  /// Gets the activity of a stream
-  /// </summary>
-  /// <param name="cancellationToken"></param>
-  /// <param name="id">Id of the stream to get the activity from</param>
-  /// <param name="after">Only show activity after this DateTime</param>
-  /// <param name="before">Only show activity before this DateTime</param>
-  /// <param name="cursor">Time to filter the activity with</param>
-  /// <param name="actionType">Time to filter the activity with</param>
-  /// <param name="limit">Max number of commits to get</param>
-  /// <returns></returns>
-  /// <exception cref="Exception"></exception>
-  public async Task<List<ActivityItem>> StreamGetActivity(
-    CancellationToken cancellationToken,
-    string id,
-    DateTime? after = null,
-    DateTime? before = null,
-    DateTime? cursor = null,
-    string actionType = "",
-    int limit = 25
+    int limit = 10,
+    CancellationToken cancellationToken = default
   )
   {
     var request = new GraphQLRequest
@@ -77,7 +54,7 @@ public partial class Client
                     }",
       Variables = new
       {
-        id,
+        streamId,
         limit,
         actionType,
         after,

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.BranchOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.BranchOperations.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,26 +15,13 @@ public partial class Client
   /// <param name="streamId">Id of the stream to get the branches from</param>
   /// <param name="branchesLimit">Max number of branches to retrieve</param>
   /// <param name="commitsLimit">Max number of commits to retrieve</param>
-  /// <returns></returns>
-  public Task<List<Branch>> StreamGetBranches(string streamId, int branchesLimit = 10, int commitsLimit = 10)
-  {
-    return StreamGetBranches(CancellationToken.None, streamId, branchesLimit, commitsLimit);
-  }
-
-  /// <summary>
-  /// Get branches from a given stream
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamId">Id of the stream to get the branches from</param>
-  /// <param name="branchesLimit">Max number of branches to retrieve</param>
-  /// <param name="commitsLimit">Max number of commits to retrieve</param>
   /// <returns></returns>
-  /// <exception cref="Exception"></exception>
   public async Task<List<Branch>> StreamGetBranches(
-    CancellationToken cancellationToken,
     string streamId,
     int branchesLimit = 10,
-    int commitsLimit = 10
+    int commitsLimit = 10,
+    CancellationToken cancellationToken = default
   )
   {
     var request = new GraphQLRequest
@@ -77,18 +63,9 @@ public partial class Client
   /// Creates a branch on a stream.
   /// </summary>
   /// <param name="branchInput"></param>
-  /// <returns>The stream's id.</returns>
-  public Task<string> BranchCreate(BranchCreateInput branchInput)
-  {
-    return BranchCreate(CancellationToken.None, branchInput);
-  }
-
-  /// <summary>
-  /// Creates a branch on a stream.
-  /// </summary>
-  /// <param name="branchInput"></param>
+  /// <param name="cancellationToken"></param>
   /// <returns>The branch id.</returns>
-  public async Task<string> BranchCreate(CancellationToken cancellationToken, BranchCreateInput branchInput)
+  public async Task<string> BranchCreate(BranchCreateInput branchInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -105,24 +82,13 @@ public partial class Client
   /// </summary>
   /// <param name="streamId">Id of the stream to get the branch from</param>
   /// <param name="branchName">Name of the branch to get</param>
-  /// <returns></returns>
-  public Task<Branch> BranchGet(string streamId, string branchName, int commitsLimit = 10)
-  {
-    return BranchGet(CancellationToken.None, streamId, branchName, commitsLimit);
-  }
-
-  /// <summary>
-  /// Gets a given branch from a stream.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamId">Id of the stream to get the branch from</param>
-  /// <param name="branchName">Name of the branch to get</param>
-  /// <returns></returns>
+  /// <returns>The requested branch</returns>
   public async Task<Branch> BranchGet(
-    CancellationToken cancellationToken,
     string streamId,
     string branchName,
-    int commitsLimit = 10
+    int commitsLimit = 10,
+    CancellationToken cancellationToken = default
   )
   {
     var request = new GraphQLRequest
@@ -165,17 +131,7 @@ public partial class Client
   /// </summary>
   /// <param name="branchInput"></param>
   /// <returns>The stream's id.</returns>
-  public Task<bool> BranchUpdate(BranchUpdateInput branchInput)
-  {
-    return BranchUpdate(CancellationToken.None, branchInput);
-  }
-
-  /// <summary>
-  /// Updates a branch.
-  /// </summary>
-  /// <param name="branchInput"></param>
-  /// <returns>The stream's id.</returns>
-  public async Task<bool> BranchUpdate(CancellationToken cancellationToken, BranchUpdateInput branchInput)
+  public async Task<bool> BranchUpdate(BranchUpdateInput branchInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -191,18 +147,9 @@ public partial class Client
   /// Deletes a stream.
   /// </summary>
   /// <param name="branchInput"></param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public Task<bool> BranchDelete(BranchDeleteInput branchInput)
-  {
-    return BranchDelete(CancellationToken.None, branchInput);
-  }
-
-  /// <summary>
-  /// Deletes a stream.
-  /// </summary>
-  /// <param name="branchInput"></param>
-  /// <returns></returns>
-  public async Task<bool> BranchDelete(CancellationToken cancellationToken, BranchDeleteInput branchInput)
+  public async Task<bool> BranchDelete(BranchDeleteInput branchInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.CommentOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.CommentOperations.cs
@@ -3,7 +3,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
-using Speckle.Core.Logging;
 
 namespace Speckle.Core.Api;
 
@@ -15,26 +14,13 @@ public partial class Client
   /// <param name="streamId">Id of the stream to get the comments from</param>
   /// <param name="limit">The number of comments to get</param>
   /// <param name="cursor">Time to filter the comments with</param>
-  /// <returns></returns>
-  public Task<Comments> StreamGetComments(string streamId, int limit = 25, string? cursor = null)
-  {
-    return StreamGetComments(CancellationToken.None, streamId, limit, cursor);
-  }
-
-  /// <summary>
-  ///  Gets the comments on a Stream
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamId">Id of the stream to get the comments from</param>
-  /// <param name="limit">The number of comments to get</param>
-  /// <param name="cursor">Time to filter the comments with</param>
   /// <returns></returns>
-  /// <exception cref="SpeckleException"></exception>
   public async Task<Comments> StreamGetComments(
-    CancellationToken cancellationToken,
     string streamId,
     int limit = 25,
-    string? cursor = null
+    string? cursor = null,
+    CancellationToken cancellationToken = default
   )
   {
     var request = new GraphQLRequest
@@ -88,25 +74,17 @@ public partial class Client
   }
 
   /// <summary>
-  ///  Gets the screenshot of a Comment
+  /// Gets the screenshot of a Comment
   /// </summary>
   /// <param name="id">Id of the comment</param>
   /// <param name="streamId">Id of the stream to get the comment from</param>
-  /// <returns></returns>
-  public Task<string> StreamGetCommentScreenshot(string id, string streamId)
-  {
-    return StreamGetCommentScreenshot(CancellationToken.None, id, streamId);
-  }
-
-  /// <summary>
-  ///  Gets the screenshot of a Comment
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="id">Id of the comment</param>
-  /// <param name="streamId">Id of the stream to get the comment from</param>
   /// <returns></returns>
-  /// <exception cref="SpeckleException"></exception>
-  public async Task<string> StreamGetCommentScreenshot(CancellationToken cancellationToken, string id, string streamId)
+  public async Task<string> StreamGetCommentScreenshot(
+    string id,
+    string streamId,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.CommitOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.CommitOperations.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,20 +14,9 @@ public partial class Client
   /// </summary>
   /// <param name="streamId">Id of the stream to get the commit from</param>
   /// <param name="commitId">Id of the commit to get</param>
-  /// <returns></returns>
-  public Task<Commit> CommitGet(string streamId, string commitId)
-  {
-    return CommitGet(CancellationToken.None, streamId, commitId);
-  }
-
-  /// <summary>
-  /// Gets a given commit from a stream.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamId">Id of the stream to get the commit from</param>
-  /// <param name="commitId">Id of the commit to get</param>
   /// <returns></returns>
-  public async Task<Commit> CommitGet(CancellationToken cancellationToken, string streamId, string commitId)
+  public async Task<Commit> CommitGet(string streamId, string commitId, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -60,21 +48,13 @@ public partial class Client
   /// </summary>
   /// <param name="streamId">Id of the stream to get the commits from</param>
   /// <param name="limit">Max number of commits to get</param>
-  /// <returns></returns>
-  public Task<List<Commit>> StreamGetCommits(string streamId, int limit = 10)
-  {
-    return StreamGetCommits(CancellationToken.None, streamId, limit);
-  }
-
-  /// <summary>
-  /// Gets the latest commits from a stream
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamId">Id of the stream to get the commits from</param>
-  /// <param name="limit">Max number of commits to get</param>
-  /// <returns></returns>
-  /// <exception cref="Exception"></exception>
-  public async Task<List<Commit>> StreamGetCommits(CancellationToken cancellationToken, string streamId, int limit = 10)
+  /// <returns>The requested commits</returns>
+  public async Task<List<Commit>> StreamGetCommits(
+    string streamId,
+    int limit = 10,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {
@@ -110,14 +90,7 @@ public partial class Client
   /// </summary>
   /// <param name="commitInput"></param>
   /// <returns>The commit id.</returns>
-  public Task<string> CommitCreate(CommitCreateInput commitInput)
-  {
-    return CommitCreate(CancellationToken.None, commitInput);
-  }
-
-  /// <inheritdoc cref="CommitCreate(CommitCreateInput)"/>
-  /// <param name="cancellationToken"></param>
-  public async Task<string> CommitCreate(CancellationToken cancellationToken, CommitCreateInput commitInput)
+  public async Task<string> CommitCreate(CommitCreateInput commitInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -133,18 +106,9 @@ public partial class Client
   /// Updates a commit.
   /// </summary>
   /// <param name="commitInput"></param>
+  /// <param name="cancellationToken"></param>
   /// <returns>The stream's id.</returns>
-  public Task<bool> CommitUpdate(CommitUpdateInput commitInput)
-  {
-    return CommitUpdate(CancellationToken.None, commitInput);
-  }
-
-  /// <summary>
-  /// Updates a commit.
-  /// </summary>
-  /// <param name="commitInput"></param>
-  /// <returns>The stream's id.</returns>
-  public async Task<bool> CommitUpdate(CancellationToken cancellationToken, CommitUpdateInput commitInput)
+  public async Task<bool> CommitUpdate(CommitUpdateInput commitInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -160,18 +124,9 @@ public partial class Client
   /// Deletes a commit.
   /// </summary>
   /// <param name="commitInput"></param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public Task<bool> CommitDelete(CommitDeleteInput commitInput)
-  {
-    return CommitDelete(CancellationToken.None, commitInput);
-  }
-
-  /// <summary>
-  /// Deletes a commit.
-  /// </summary>
-  /// <param name="commitInput"></param>
-  /// <returns></returns>
-  public async Task<bool> CommitDelete(CancellationToken cancellationToken, CommitDeleteInput commitInput)
+  public async Task<bool> CommitDelete(CommitDeleteInput commitInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -188,15 +143,12 @@ public partial class Client
   /// </summary>
   /// <remarks>Used for read receipts</remarks>
   /// <param name="commitReceivedInput"></param>
-  /// <returns></returns>
-  public Task<bool> CommitReceived(CommitReceivedInput commitReceivedInput)
-  {
-    return CommitReceived(CancellationToken.None, commitReceivedInput);
-  }
-
-  /// <inheritdoc cref="CommitReceived(CommitReceivedInput)"/>
   /// <param name="cancellationToken"></param>
-  public async Task<bool> CommitReceived(CancellationToken cancellationToken, CommitReceivedInput commitReceivedInput)
+  /// <returns></returns>
+  public async Task<bool> CommitReceived(
+    CommitReceivedInput commitReceivedInput,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ObjectOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ObjectOperations.cs
@@ -9,24 +9,17 @@ namespace Speckle.Core.Api;
 public partial class Client
 {
   /// <summary>
-  /// Gets a given object from a stream.
+  /// Gets data about the requested Speckle object from a stream.
   /// </summary>
   /// <param name="streamId">Id of the stream to get the object from</param>
   /// <param name="objectId">Id of the object to get</param>
-  /// <returns></returns>
-  public Task<SpeckleObject> ObjectGet(string streamId, string objectId)
-  {
-    return ObjectGet(CancellationToken.None, streamId, objectId);
-  }
-
-  /// <summary>
-  /// Gets a given object from a stream.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamId">Id of the stream to get the object from</param>
-  /// <param name="objectId">Id of the object to get</param>
   /// <returns></returns>
-  public async Task<SpeckleObject> ObjectGet(CancellationToken cancellationToken, string streamId, string objectId)
+  public async Task<SpeckleObject> ObjectGet(
+    string streamId,
+    string objectId,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {
@@ -53,20 +46,13 @@ public partial class Client
   /// </summary>
   /// <param name="streamId"></param>
   /// <param name="objectId"></param>
-  /// <returns></returns>
-  public Task<SpeckleObject> ObjectCountGet(string streamId, string objectId)
-  {
-    return ObjectCountGet(CancellationToken.None, streamId, objectId);
-  }
-
-  /// <summary>
-  /// Gets a given object from a stream.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamId"></param>
-  /// <param name="objectId"></param>
   /// <returns></returns>
-  public async Task<SpeckleObject> ObjectCountGet(CancellationToken cancellationToken, string streamId, string objectId)
+  public async Task<SpeckleObject> ObjectCountGet(
+    string streamId,
+    string objectId,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ObsoleteOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ObsoleteOperations.cs
@@ -1,0 +1,270 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL;
+using Speckle.Core.Logging;
+
+namespace Speckle.Core.Api;
+
+[SuppressMessage("Design", "CA1068:CancellationToken parameters must come last")]
+public partial class Client
+{
+  #region Depreated Invites
+
+  /// <summary>
+  /// Checks if Speckle Server version is at least v2.6.4 meaning stream invites are supported.
+  /// </summary>
+  /// <param name="cancellationToken"></param>
+  /// <returns>true if invites are supported</returns>
+  /// <exception cref="SpeckleException">if Speckle Server version is less than v2.6.4</exception>
+  [Obsolete("We're not supporting 2.6.4 version any more", true)]
+  public async Task<bool> _CheckStreamInvitesSupported(CancellationToken cancellationToken = default)
+  {
+    var version = ServerVersion ?? await GetServerVersion(cancellationToken).ConfigureAwait(false);
+    if (version < new System.Version("2.6.4"))
+      throw new SpeckleException("Stream invites are only supported as of Speckle Server v2.6.4.");
+    return true;
+  }
+  #endregion
+
+  #region Stream Grant Permission
+
+  /// <summary>
+  /// Grants permissions to a user on a given stream.
+  /// </summary>
+  /// <param name="permissionInput"></param>
+  /// <returns></returns>
+  [Obsolete("Please use the `StreamUpdatePermission` method", true)]
+  public Task<bool> StreamGrantPermission(StreamPermissionInput permissionInput)
+  {
+    return StreamGrantPermission(CancellationToken.None, permissionInput);
+  }
+
+  /// <summary>
+  /// Grants permissions to a user on a given stream.
+  /// </summary>
+  /// <param name="cancellationToken"></param>
+  /// <param name="permissionInput"></param>
+  /// <returns></returns>
+  [Obsolete("Please use the `StreamUpdatePermission` method", true)]
+  public async Task<bool> StreamGrantPermission(
+    CancellationToken cancellationToken,
+    StreamPermissionInput permissionInput
+  )
+  {
+    var request = new GraphQLRequest
+    {
+      Query =
+        @"
+          mutation streamGrantPermission($permissionParams: StreamGrantPermissionInput!) {
+            streamGrantPermission(permissionParams:$permissionParams)
+          }",
+      Variables = new { permissionParams = permissionInput }
+    };
+
+    var res = await ExecuteGraphQLRequest<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
+    return (bool)res["streamGrantPermission"];
+  }
+
+  #endregion
+
+  #region Cancellation token as last param
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<List<ActivityItem>> StreamGetActivity(
+    CancellationToken cancellationToken,
+    string id,
+    DateTime? after = null,
+    DateTime? before = null,
+    DateTime? cursor = null,
+    string actionType = "",
+    int limit = 25
+  )
+  {
+    return StreamGetActivity(id, after, before, cursor, actionType, limit, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<List<Branch>> StreamGetBranches(
+    CancellationToken cancellationToken,
+    string streamId,
+    int branchesLimit = 10,
+    int commitsLimit = 10
+  )
+  {
+    return StreamGetBranches(streamId, branchesLimit, commitsLimit, CancellationToken.None);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<string> BranchCreate(CancellationToken cancellationToken, BranchCreateInput branchInput)
+  {
+    return BranchCreate(branchInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<Branch> BranchGet(
+    CancellationToken cancellationToken,
+    string streamId,
+    string branchName,
+    int commitsLimit = 10
+  )
+  {
+    return BranchGet(streamId, branchName, commitsLimit, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> BranchUpdate(CancellationToken cancellationToken, BranchUpdateInput branchInput)
+  {
+    return BranchUpdate(branchInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> BranchDelete(CancellationToken cancellationToken, BranchDeleteInput branchInput)
+  {
+    return BranchDelete(branchInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<Comments> StreamGetComments(
+    CancellationToken cancellationToken,
+    string streamId,
+    int limit = 25,
+    string? cursor = null
+  )
+  {
+    return StreamGetComments(streamId, limit, cursor, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<string> StreamGetCommentScreenshot(CancellationToken cancellationToken, string id, string streamId)
+  {
+    return StreamGetCommentScreenshot(id, streamId, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<Commit> CommitGet(CancellationToken cancellationToken, string streamId, string commitId)
+  {
+    return CommitGet(streamId, commitId, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<List<Commit>> StreamGetCommits(CancellationToken cancellationToken, string streamId, int limit = 10)
+  {
+    return StreamGetCommits(streamId, limit, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<string> CommitCreate(CancellationToken cancellationToken, CommitCreateInput commitInput)
+  {
+    return CommitCreate(commitInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> CommitUpdate(CancellationToken cancellationToken, CommitUpdateInput commitInput)
+  {
+    return CommitUpdate(commitInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> CommitDelete(CancellationToken cancellationToken, CommitDeleteInput commitInput)
+  {
+    return CommitDelete(commitInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> CommitReceived(CancellationToken cancellationToken, CommitReceivedInput commitReceivedInput)
+  {
+    return CommitReceived(commitReceivedInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<SpeckleObject> ObjectGet(CancellationToken cancellationToken, string streamId, string objectId)
+  {
+    return ObjectGet(streamId, objectId, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<SpeckleObject> ObjectCountGet(CancellationToken cancellationToken, string streamId, string objectId)
+  {
+    return ObjectCountGet(streamId, objectId, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<Stream> StreamGet(CancellationToken cancellationToken, string id, int branchesLimit = 10)
+  {
+    return StreamGet(id, branchesLimit, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<List<Stream>> StreamsGet(CancellationToken cancellationToken, int limit = 10)
+  {
+    return StreamsGet(limit, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<List<Stream>> FavoriteStreamsGet(CancellationToken cancellationToken, int limit = 10)
+  {
+    return FavoriteStreamsGet(limit, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<List<Stream>> StreamSearch(CancellationToken cancellationToken, string query, int limit = 10)
+  {
+    return StreamSearch(query, limit, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<string> StreamCreate(CancellationToken cancellationToken, StreamCreateInput streamInput)
+  {
+    return StreamCreate(streamInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> StreamUpdate(CancellationToken cancellationToken, StreamUpdateInput streamInput)
+  {
+    return StreamUpdate(streamInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> StreamDelete(CancellationToken cancellationToken, string id)
+  {
+    return StreamDelete(id, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> StreamRevokePermission(
+    CancellationToken cancellationToken,
+    StreamRevokePermissionInput permissionInput
+  )
+  {
+    return StreamRevokePermission(permissionInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<Stream> StreamGetPendingCollaborators(CancellationToken cancellationToken, string id)
+  {
+    return StreamGetPendingCollaborators(id, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<bool> StreamInviteCreate(CancellationToken cancellationToken, StreamInviteCreateInput inviteCreateInput)
+  {
+    return StreamInviteCreate(inviteCreateInput, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<LimitedUser?> OtherUserGet(CancellationToken cancellationToken, string id)
+  {
+    return OtherUserGet(id, cancellationToken);
+  }
+
+  [Obsolete("Use overload with cancellation token parameter last")]
+  public Task<List<LimitedUser>> UserSearch(CancellationToken cancellationToken, string query, int limit = 10)
+  {
+    return UserSearch(query, limit, cancellationToken);
+  }
+  #endregion
+}

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ServerOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.ServerOperations.cs
@@ -16,7 +16,6 @@ public partial class Client
   /// <param name="cancellationToken">[Optional] defaults to an empty cancellation token</param>
   /// <returns><see cref="Version"/> object excluding any strings (eg "2.7.2-alpha.6995" becomes "2.7.2.6995")</returns>
   /// <exception cref="SpeckleException"></exception>
-  ///
   public async Task<System.Version> GetServerVersion(CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.StreamOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.StreamOperations.cs
@@ -9,11 +9,11 @@ namespace Speckle.Core.Api;
 
 public partial class Client
 {
-
   /// <summary>
-  /// Cheks if a stream exists by id.
+  /// Checks if a stream exists by id.
   /// </summary>
   /// <param name="id">Id of the stream to get</param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
   public async Task<bool> IsStreamAccessible(string id, CancellationToken cancellationToken = default)
   {
@@ -41,30 +41,17 @@ public partial class Client
     {
       return false;
     }
-
-  }
-
-
-  /// <summary>
-  /// Gets a stream by id including basic branch info (id, name, description, and total commit count).
-  /// For detailed commit and branch info, use StreamGetCommits and StreamGetBranches respectively.
-  /// </summary>
-  /// <param name="id">Id of the stream to get</param>
-  /// <param name="branchesLimit">Max number of branches to retrieve</param>
-  /// <returns></returns>
-  public Task<Stream> StreamGet(string id, int branchesLimit = 10)
-  {
-    return StreamGet(CancellationToken.None, id, branchesLimit);
   }
 
   /// <summary>
   /// Gets a stream by id including basic branch info (id, name, description, and total commit count).
-  /// For detailed commit and branch info, use StreamGetCommits and StreamGetBranches respectively.
+  /// For detailed commit and branch info, use <see cref="StreamGetCommits"/> and <see cref="StreamGetBranches"/> respectively.
   /// </summary>
   /// <param name="id">Id of the stream to get</param>
   /// <param name="branchesLimit">Max number of branches to retrieve</param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public async Task<Stream> StreamGet(CancellationToken cancellationToken, string id, int branchesLimit = 10)
+  public async Task<Stream> StreamGet(string id, int branchesLimit = 10, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -110,18 +97,9 @@ public partial class Client
   /// Gets all streams for the current user
   /// </summary>
   /// <param name="limit">Max number of streams to return</param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public Task<List<Stream>> StreamsGet(int limit = 10)
-  {
-    return StreamsGet(CancellationToken.None, limit);
-  }
-
-  /// <summary>
-  /// Gets all streams for the current user
-  /// </summary>
-  /// <param name="limit">Max number of streams to return</param>
-  /// <returns></returns>
-  public async Task<List<Stream>> StreamsGet(CancellationToken cancellationToken, int limit = 10)
+  public async Task<List<Stream>> StreamsGet(int limit = 10, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -172,17 +150,13 @@ public partial class Client
     return res.activeUser.streams.items;
   }
 
-  public Task<List<Stream>> FavoriteStreamsGet(int limit = 10)
-  {
-    return FavoriteStreamsGet(CancellationToken.None, limit);
-  }
-
   /// <summary>
   /// Gets all favorite streams for the current user
   /// </summary>
   /// <param name="limit">Max number of streams to return</param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public async Task<List<Stream>> FavoriteStreamsGet(CancellationToken cancellationToken, int limit = 10)
+  public async Task<List<Stream>> FavoriteStreamsGet(int limit = 10, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -234,19 +208,13 @@ public partial class Client
   /// </summary>
   /// <param name="query">String query to search for</param>
   /// <param name="limit">Max number of streams to return</param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public Task<List<Stream>> StreamSearch(string query, int limit = 10)
-  {
-    return StreamSearch(CancellationToken.None, query, limit);
-  }
-
-  /// <summary>
-  /// Searches the user's streams by name, description, and ID
-  /// </summary>
-  /// <param name="query">String query to search for</param>
-  /// <param name="limit">Max number of streams to return</param>
-  /// <returns></returns>
-  public async Task<List<Stream>> StreamSearch(CancellationToken cancellationToken, string query, int limit = 10)
+  public async Task<List<Stream>> StreamSearch(
+    string query,
+    int limit = 10,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {
@@ -276,7 +244,7 @@ public partial class Client
       Variables = new { query, limit }
     };
 
-    var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false);
+    var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false); //WARN: Why do we do this?
     return (await ExecuteGraphQLRequest<StreamsData>(request, cancellationToken).ConfigureAwait(false)).streams.items;
   }
 
@@ -284,18 +252,9 @@ public partial class Client
   /// Creates a stream.
   /// </summary>
   /// <param name="streamInput"></param>
+  /// <param name="cancellationToken"></param>
   /// <returns>The stream's id.</returns>
-  public Task<string> StreamCreate(StreamCreateInput streamInput)
-  {
-    return StreamCreate(CancellationToken.None, streamInput);
-  }
-
-  /// <summary>
-  /// Creates a stream.
-  /// </summary>
-  /// <param name="streamInput"></param>
-  /// <returns>The stream's id.</returns>
-  public async Task<string> StreamCreate(CancellationToken cancellationToken, StreamCreateInput streamInput)
+  public async Task<string> StreamCreate(StreamCreateInput streamInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -310,19 +269,9 @@ public partial class Client
   /// Updates a stream.
   /// </summary>
   /// <param name="streamInput">Note: the id field needs to be a valid stream id.</param>
-  /// <returns>The stream's id.</returns>
-  public Task<bool> StreamUpdate(StreamUpdateInput streamInput)
-  {
-    return StreamUpdate(CancellationToken.None, streamInput);
-  }
-
-  /// <summary>
-  /// Updates a stream.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="streamInput">Note: the id field needs to be a valid stream id.</param>
   /// <returns>The stream's id.</returns>
-  public async Task<bool> StreamUpdate(CancellationToken cancellationToken, StreamUpdateInput streamInput)
+  public async Task<bool> StreamUpdate(StreamUpdateInput streamInput, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -339,19 +288,9 @@ public partial class Client
   /// Deletes a stream.
   /// </summary>
   /// <param name="id">Id of the stream to be deleted</param>
-  /// <returns></returns>
-  public Task<bool> StreamDelete(string id)
-  {
-    return StreamDelete(CancellationToken.None, id);
-  }
-
-  /// <summary>
-  /// Deletes a stream.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="id">Id of the stream to be deleted</param>
   /// <returns></returns>
-  public async Task<bool> StreamDelete(CancellationToken cancellationToken, string id)
+  public async Task<bool> StreamDelete(string id, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -363,61 +302,14 @@ public partial class Client
   }
 
   /// <summary>
-  /// Grants permissions to a user on a given stream.
-  /// </summary>
-  /// <param name="permissionInput"></param>
-  /// <returns></returns>
-  [Obsolete("Please use the `StreamUpdatePermission` method", true)]
-  public Task<bool> StreamGrantPermission(StreamPermissionInput permissionInput)
-  {
-    return StreamGrantPermission(CancellationToken.None, permissionInput);
-  }
-
-  /// <summary>
-  /// Grants permissions to a user on a given stream.
-  /// </summary>
-  /// <param name="cancellationToken"></param>
-  /// <param name="permissionInput"></param>
-  /// <returns></returns>
-  [Obsolete("Please use the `StreamUpdatePermission` method", true)]
-  public async Task<bool> StreamGrantPermission(
-    CancellationToken cancellationToken,
-    StreamPermissionInput permissionInput
-  )
-  {
-    var request = new GraphQLRequest
-    {
-      Query =
-        @"
-          mutation streamGrantPermission($permissionParams: StreamGrantPermissionInput!) {
-            streamGrantPermission(permissionParams:$permissionParams)
-          }",
-      Variables = new { permissionParams = permissionInput }
-    };
-
-    var res = await ExecuteGraphQLRequest<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
-    return (bool)res["streamGrantPermission"];
-  }
-
-  /// <summary>
   /// Revokes permissions of a user on a given stream.
   /// </summary>
   /// <param name="permissionInput"></param>
-  /// <returns></returns>
-  public Task<bool> StreamRevokePermission(StreamRevokePermissionInput permissionInput)
-  {
-    return StreamRevokePermission(CancellationToken.None, permissionInput);
-  }
-
-  /// <summary>
-  /// Revokes permissions of a user on a given stream.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="permissionInput"></param>
   /// <returns></returns>
   public async Task<bool> StreamRevokePermission(
-    CancellationToken cancellationToken,
-    StreamRevokePermissionInput permissionInput
+    StreamRevokePermissionInput permissionInput,
+    CancellationToken cancellationToken = default
   )
   {
     var request = new GraphQLRequest
@@ -463,21 +355,13 @@ public partial class Client
   /// Gets the pending collaborators of a stream by id.
   /// Requires the user to be an owner of the stream.
   /// </summary>
-  /// <param name="id">Id of the stream to get</param>
+  /// <param name="streamId"></param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public Task<Stream> StreamGetPendingCollaborators(string id)
-  {
-    return StreamGetPendingCollaborators(CancellationToken.None, id);
-  }
-
-  /// <summary>
-  /// Gets the pending collaborators of a stream by id.
-  /// Requires the user to be an owner of the stream.
-  /// </summary>
-  /// <param name="id">Id of the stream to get</param>
-  /// <param name="branchesLimit">Max number of branches to retrieve</param>
-  /// <returns></returns>
-  public async Task<Stream> StreamGetPendingCollaborators(CancellationToken cancellationToken, string id)
+  public async Task<Stream> StreamGetPendingCollaborators(
+    string streamId,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {
@@ -496,31 +380,21 @@ public partial class Client
                         }
                       }
                     }",
-      Variables = new { id }
+      Variables = new { streamId }
     };
-    var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false);
+    var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false); //WARN: Why do we do this?
     return (await ExecuteGraphQLRequest<StreamData>(request, cancellationToken).ConfigureAwait(false)).stream;
   }
 
   /// <summary>
   /// Sends an email invite to join a stream and assigns them a collaborator role.
   /// </summary>
-  /// <param name="streamCreateInput"></param>
-  /// <returns></returns>
-  public Task<bool> StreamInviteCreate(StreamInviteCreateInput streamCreateInput)
-  {
-    return StreamInviteCreate(CancellationToken.None, streamCreateInput);
-  }
-
-  /// <summary>
-  /// Sends an email invite to join a stream and assigns them a collaborator role.
-  /// </summary>
-  /// <param name="cancellationToken"></param>
   /// <param name="inviteCreateInput"></param>
+  /// <param name="cancellationToken"></param>
   /// <returns></returns>
   public async Task<bool> StreamInviteCreate(
-    CancellationToken cancellationToken,
-    StreamInviteCreateInput inviteCreateInput
+    StreamInviteCreateInput inviteCreateInput,
+    CancellationToken cancellationToken = default
   )
   {
     if ((inviteCreateInput.email == null) & (inviteCreateInput.userId == null))
@@ -564,21 +438,6 @@ public partial class Client
 
     var res = await ExecuteGraphQLRequest<Dictionary<string, object>>(request, cancellationToken).ConfigureAwait(false);
     return (bool)res["streamInviteCancel"];
-  }
-
-  /// <summary>
-  /// Checks if Speckle Server version is at least v2.6.4 meaning stream invites are supported.
-  /// </summary>
-  /// <param name="cancellationToken"></param>
-  /// <returns>true if invites are supported</returns>
-  /// <exception cref="SpeckleException">if Speckle Server version is less than v2.6.4</exception>
-  [Obsolete("We're not supporting 2.6.4 version any more", true)]
-  public async Task<bool> _CheckStreamInvitesSupported(CancellationToken cancellationToken = default)
-  {
-    var version = ServerVersion ?? await GetServerVersion(cancellationToken).ConfigureAwait(false);
-    if (version < new System.Version("2.6.4"))
-      throw new SpeckleException("Stream invites are only supported as of Speckle Server v2.6.4.");
-    return true;
   }
 
   /// <summary>

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.UserOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.UserOperations.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
-using Speckle.Core.Logging;
 
 namespace Speckle.Core.Api;
 
@@ -12,19 +11,9 @@ public partial class Client
   /// <summary>
   /// Gets the currently active user profile.
   /// </summary>
-  /// <returns></returns>
-  public Task<User> ActiveUserGet()
-  {
-    return ActiveUserGet(CancellationToken.None);
-  }
-
-  /// <summary>
-  /// Gets the currently active user profile.
-  /// </summary>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  /// <exception cref="SpeckleException"></exception>
-  public async Task<User> ActiveUserGet(CancellationToken cancellationToken)
+  public async Task<User> ActiveUserGet(CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -50,20 +39,9 @@ public partial class Client
   /// Get another user's profile by its user id.
   /// </summary>
   /// <param name="id">Id of the user you are looking for</param>
-  /// <returns></returns>
-  public Task<LimitedUser?> OtherUserGet(string id)
-  {
-    return OtherUserGet(CancellationToken.None, id);
-  }
-
-  /// <summary>
-  /// Get another user's profile by its user id.
-  /// </summary>
   /// <param name="cancellationToken"></param>
-  /// <param name="id">Id of the user you are looking for</param>
   /// <returns></returns>
-  /// <exception cref="SpeckleException"></exception>
-  public async Task<LimitedUser?> OtherUserGet(CancellationToken cancellationToken, string id)
+  public async Task<LimitedUser?> OtherUserGet(string userId, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -79,7 +57,7 @@ public partial class Client
                         role,
                       }
                     }",
-      Variables = new { id }
+      Variables = new { userId }
     };
     return (await ExecuteGraphQLRequest<LimitedUserData>(request, cancellationToken).ConfigureAwait(false)).otherUser;
   }
@@ -90,18 +68,11 @@ public partial class Client
   /// <param name="query">String to search for. Must be at least 3 characters</param>
   /// <param name="limit">Max number of users to return</param>
   /// <returns></returns>
-  public Task<List<LimitedUser>> UserSearch(string query, int limit = 10)
-  {
-    return UserSearch(CancellationToken.None, query, limit);
-  }
-
-  /// <summary>
-  /// Searches for a user on the server.
-  /// </summary>
-  /// <param name="query">String to search for. Must be at least 3 characters</param>
-  /// <param name="limit">Max number of users to return</param>
-  /// <returns></returns>
-  public async Task<List<LimitedUser>> UserSearch(CancellationToken cancellationToken, string query, int limit = 10)
+  public async Task<List<LimitedUser>> UserSearch(
+    string query,
+    int limit = 10,
+    CancellationToken cancellationToken = default
+  )
   {
     var request = new GraphQLRequest
     {

--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.UserOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.UserOperations.cs
@@ -41,7 +41,7 @@ public partial class Client
   /// <param name="id">Id of the user you are looking for</param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public async Task<LimitedUser?> OtherUserGet(string userId, CancellationToken cancellationToken = default)
+  public async Task<LimitedUser?> OtherUserGet(string id, CancellationToken cancellationToken = default)
   {
     var request = new GraphQLRequest
     {
@@ -57,7 +57,7 @@ public partial class Client
                         role,
                       }
                     }",
-      Variables = new { userId }
+      Variables = new { id }
     };
     return (await ExecuteGraphQLRequest<LimitedUserData>(request, cancellationToken).ConfigureAwait(false)).otherUser;
   }

--- a/Core/Core/Api/GraphQL/Client.cs
+++ b/Core/Core/Api/GraphQL/Client.cs
@@ -75,7 +75,7 @@ public partial class Client : IDisposable
 
   public string ApiToken => Account.token;
 
-  public System.Version ServerVersion { get; set; }
+  public System.Version? ServerVersion { get; set; }
 
   [JsonIgnore]
   public Account Account { get; set; }

--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -122,17 +122,17 @@ public class Stream
   public Branches branches { get; set; }
 
   /// <summary>
-  /// Set only in the case that you've requested this through <see cref="Client.BranchGet(System.Threading.CancellationToken, string, string, int)"/>.
+  /// Set only in the case that you've requested this through <see cref="Client.BranchGet(string, string, int, System.Threading.CancellationToken)"/>.
   /// </summary>
   public Branch branch { get; set; }
 
   /// <summary>
-  /// Set only in the case that you've requested this through <see cref="Client.CommitGet(System.Threading.CancellationToken, string, string)"/>.
+  /// Set only in the case that you've requested this through <see cref="Client.CommitGet(string, string, System.Threading.CancellationToken)"/>.
   /// </summary>
   public Commit commit { get; set; }
 
   /// <summary>
-  /// Set only in the case that you've requested this through <see cref="Client.StreamGetCommits(System.Threading.CancellationToken, string, int)"/>
+  /// Set only in the case that you've requested this through <see cref="Client.StreamGetCommits(string, int, System.Threading.CancellationToken)"/>
   /// </summary>
   public Commits commits { get; set; }
 

--- a/DesktopUI2/DesktopUI2/ConnectorHelpers.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorHelpers.cs
@@ -74,8 +74,6 @@ public static class ConnectorHelpers
     return commitObject;
   }
 
-
-
   /// <param name="cancellationToken">Progress cancellation token</param>
   /// <param name="state">Current Stream card state (does not mutate)</param>
   /// <returns>Requested Commit</returns>
@@ -91,13 +89,13 @@ public static class ConnectorHelpers
       if (state.CommitId == LatestCommitString) //if "latest", always make sure we get the latest commit
       {
         var res = await state.Client
-          .BranchGet(cancellationToken, state.StreamId, state.BranchName, 1)
+          .BranchGet(state.StreamId, state.BranchName, 1, cancellationToken)
           .ConfigureAwait(false);
         commit = res.commits.items.First();
       }
       else
       {
-        var res = await state.Client.CommitGet(cancellationToken, state.StreamId, state.CommitId).ConfigureAwait(false);
+        var res = await state.Client.CommitGet(state.StreamId, state.CommitId, cancellationToken).ConfigureAwait(false);
         commit = res;
       }
     }
@@ -118,7 +116,7 @@ public static class ConnectorHelpers
   }
 
   /// <summary>
-  /// Try catch wrapper around <see cref="Client.CommitReceived(CancellationToken, CommitReceivedInput)"/> with logging
+  /// Try catch wrapper around <see cref="Client.CommitReceived(CommitReceivedInput, CancellationToken)"/> with logging
   /// </summary>
   public static async Task TryCommitReceived(
     Client client,
@@ -128,7 +126,7 @@ public static class ConnectorHelpers
   {
     try
     {
-      await client.CommitReceived(cancellationToken, commitReceivedInput).ConfigureAwait(false);
+      await client.CommitReceived(commitReceivedInput, cancellationToken).ConfigureAwait(false);
     }
     catch (SpeckleException ex)
     {
@@ -159,9 +157,9 @@ public static class ConnectorHelpers
 
   //TODO: should this just be how `CommitCreate` id implemented?
   /// <summary>
-  /// Wrapper around <see cref="Client.CommitCreate(CancellationToken, CommitCreateInput)"/> with Error handling.
+  /// Wrapper around <see cref="Client.CommitCreate(CommitCreateInput, CancellationToken)"/> with Error handling.
   /// </summary>
-  /// <inheritdoc cref="Client.CommitCreate(CancellationToken, CommitCreateInput)"/>
+  /// <inheritdoc cref="Client.CommitCreate(CommitCreateInput, CancellationToken)"/>
   /// <exception cref="OperationCanceledException"></exception>
   /// <exception cref="SpeckleException">All other exceptions</exception>
   public static async Task<string> CreateCommit(
@@ -172,7 +170,7 @@ public static class ConnectorHelpers
   {
     try
     {
-      var commitId = await client.CommitCreate(cancellationToken, commitInput).ConfigureAwait(false);
+      var commitId = await client.CommitCreate(commitInput, cancellationToken).ConfigureAwait(false);
       return commitId;
     }
     catch (OperationCanceledException)
@@ -199,9 +197,9 @@ public static class ConnectorHelpers
     //Treat all operation errors as fatal
     throw new SpeckleException($"Failed to send objects to server - {error}", ex);
   }
-  
+
   #region deprecated members
-  
+
   [Obsolete("Use overload that has cancellation token last", true)]
   public static async Task TryCommitReceived(
     CancellationToken cancellationToken,
@@ -211,13 +209,13 @@ public static class ConnectorHelpers
   {
     await TryCommitReceived(client, commitReceivedInput, cancellationToken).ConfigureAwait(false);
   }
-  
+
   [Obsolete("Use overload that has cancellation token last", true)]
   public static async Task<Commit> GetCommitFromState(CancellationToken cancellationToken, StreamState state)
   {
     return await GetCommitFromState(state, cancellationToken).ConfigureAwait(false);
   }
-  
+
   [Obsolete("Use overload that has cancellation token last", true)]
   public static async Task TryCommitReceived(
     CancellationToken cancellationToken,
@@ -228,7 +226,7 @@ public static class ConnectorHelpers
   {
     await TryCommitReceived(state, commit, sourceApplication, cancellationToken).ConfigureAwait(false);
   }
-  
+
   [Obsolete("Use overload that has cancellation token last", true)]
   public static async Task<string> CreateCommit(
     CancellationToken cancellationToken,

--- a/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
@@ -181,10 +181,10 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
           {
             if (SelectedFilter == Filter.favorite)
               result = await account.Client
-                .FavoriteStreamsGet(StreamGetCancelTokenSource.Token, 25)
+                .FavoriteStreamsGet(25, StreamGetCancelTokenSource.Token)
                 .ConfigureAwait(true);
             else
-              result = await account.Client.StreamsGet(StreamGetCancelTokenSource.Token, 25).ConfigureAwait(true);
+              result = await account.Client.StreamsGet(25, StreamGetCancelTokenSource.Token).ConfigureAwait(true);
           }
           //SEARCH
           else
@@ -193,7 +193,7 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
             if (SelectedFilter == Filter.favorite)
               SelectedFilter = Filter.all;
             result = await account.Client
-              .StreamSearch(StreamGetCancelTokenSource.Token, SearchQuery, 25)
+              .StreamSearch(SearchQuery, 25, StreamGetCancelTokenSource.Token)
               .ConfigureAwait(true);
           }
 

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
@@ -58,11 +58,11 @@ public class StreamSelectorViewModel : ReactiveObject
 
         //NO SEARCH
         if (string.IsNullOrEmpty(SearchQuery))
-          result = await account.Client.StreamsGet(StreamGetCancelTokenSource.Token, 25).ConfigureAwait(true);
+          result = await account.Client.StreamsGet(25, StreamGetCancelTokenSource.Token).ConfigureAwait(true);
         //SEARCH
         else
           result = await account.Client
-            .StreamSearch(StreamGetCancelTokenSource.Token, SearchQuery, 25)
+            .StreamSearch(SearchQuery, 25, StreamGetCancelTokenSource.Token)
             .ConfigureAwait(true);
 
         if (StreamGetCancelTokenSource.IsCancellationRequested)


### PR DESCRIPTION
This PR updates the `Client` functions to accept an optional `CancellationToken` parameter in the last position in the method signature.

This follows the C# convention defined by [CA1068: CancellationToken parameters must come last](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1068)
Following this convention improves the DX by 
- reducing the complexity of `Client` (by reducing overloads)
- using a cancellation structure developers are more familiar with
- using a cancellation structure consistent with other functions in Core
- Enables proper use of [`CA2016: Forward the CancellationToken parameter to methods that take one`](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2016)
- And for us, we have fewer warnings in core, and in the long run fewer lines of code to manage.

This PR contains no breaking changes.

The current `Obsolete` functions generate warnings for user code.
A few releases down the line these can be made `error: true` before being removed entirely another few releases down the line.