### PR TITLE
fix(revit): type mapping null reference

### DIFF
--- a/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
@@ -162,7 +162,7 @@ namespace ConnectorRevit.TypeMapping
       {
         try
         {
-          familyImporter ??= new FamilyImporter(document, revitCategoriesExposer, typeRetriever);
+          familyImporter ??= new FamilyImporter(document, revitCategoriesExposer, typeRetriever, revitDocumentAggregateCache);
           await familyImporter.ImportFamilyTypes(hostTypesContainer).ConfigureAwait(false);
         }
         catch (SpeckleException ex)

--- a/ConnectorRevit/ConnectorRevit/TypeMapping/FamilyImporter.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/FamilyImporter.cs
@@ -25,11 +25,12 @@ namespace ConnectorRevit.TypeMapping
     private readonly IRevitElementTypeRetriever typeRetriever;
     private readonly IRevitDocumentAggregateCache revitDocumentAggregateCache;
 
-    public FamilyImporter(Document document, IAllRevitCategoriesExposer revitCategoriesExposer, IRevitElementTypeRetriever typeRetriever)
+    public FamilyImporter(Document document, IAllRevitCategoriesExposer revitCategoriesExposer, IRevitElementTypeRetriever typeRetriever, IRevitDocumentAggregateCache revitDocumentAggregateCache)
     {
       this.document = document;
       this.revitCategoriesExposer = revitCategoriesExposer;
       this.typeRetriever = typeRetriever;
+      this.revitDocumentAggregateCache = revitDocumentAggregateCache;
     }
 
     /// <summary>


### PR DESCRIPTION
As reported here: https://www.notion.so/speckle/ImportTypes-Failed-ba359f3d6c8a43ccb0027f5ecce5591e?pvs=4

The `revitDocumentAggregateCache` was never initialized or passed to the `FamilyImporter` class, this caused a null reference exception. Not sure how this was working before or how it broke?
