### PR TITLE
fix(Archicad): Room deserialisation fix

### DIFF
--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -80,7 +80,7 @@ namespace Objects.BuiltElements.Archicad
     public override Level level
     {
       get => archicadLevel;
-      set => archicadLevel = value as ArchicadLevel ?? throw new System.ArgumentException("Must be ArchicadLevel");
+      set => archicadLevel = value as ArchicadLevel ?? null;
     }
 
     public double height { get; set; }


### PR DESCRIPTION
## Description & motivation

v2.15.1 stream cannot be deserialised in case they contain Archicad Rooms.
Till that version the level property could be null, however a null check was introduced in the meantime.

## Changes:

The check has been removed.

## Screenshots:


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
