### PR TITLE
hotfix(revit): sets displayValue to empty for curtain walls

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertWall.cs
@@ -205,6 +205,7 @@ namespace Objects.Converter.Revit
       }
       else
       {
+        speckleWall.displayValue = new List<Mesh>(); // avoids null value for curtain walls
         AddHostedDependentElements(
           revitWall,
           speckleWall,


### PR DESCRIPTION
## Description & motivation

Curtain walls were sending with a `null` displayValue property, resulting in their baseline being traversed in the viewer and other connectors. This sets the displayValue to empty to render the wall `displayable` during traversal.

## Changes:

- Revit converter

