### PR TITLE
feat(autocad/rhino): adds gridline to native conversion

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Previews.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Previews.cs
@@ -89,6 +89,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     return @object.speckle_type.Contains("Instance")
       || @object.speckle_type.Contains("View")
       || @object.speckle_type.Contains("Level")
+      || @object.speckle_type.Contains("GridLine")
       || @object.speckle_type.Contains("Collection");
   }
 

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -596,7 +596,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     if (obj[UserDictionary] is Base userDictionary)
       ParseDictionaryToArchivable(attributes.UserDictionary, userDictionary);
 
-    var name = obj["name"] as string;
+    var name = obj["name"] as string ?? obj["label"] as string; // gridlines have a "label" prop instead of name?
     if (name != null)
       attributes.Name = name;
   }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -1,5 +1,6 @@
 using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
+using Objects.BuiltElements;
 using Objects.Other;
 using Objects.Structural.Properties.Profiles;
 using Speckle.Core.Kits;
@@ -395,6 +396,10 @@ namespace Objects.Converter.AutocadCivil
           acadObj = CurveToNativeDB(o.baseCurve);
           break;
 
+        case GridLine o:
+          acadObj = CurveToNativeDB(o.baseLine);
+          break;
+
         default:
           if (reportObj != null)
           {
@@ -491,7 +496,7 @@ namespace Objects.Converter.AutocadCivil
 #if ADVANCESTEEL
                 return CanConvertASToSpeckle(o);
 #else
-                return false;
+              return false;
 #endif
             }
           }
@@ -524,7 +529,6 @@ namespace Objects.Converter.AutocadCivil
         case Polyline _:
         case Polycurve _:
         case Curve _:
-        //case Brep _:
         case Mesh _:
 
         case Dimension _:
@@ -535,6 +539,7 @@ namespace Objects.Converter.AutocadCivil
 
         case Alignment _:
         case ModelCurve _:
+        case GridLine _:
           return true;
 
         default:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.BuiltElements.cs
@@ -221,7 +221,7 @@ public partial class ConverterRhinoGh
     }
     // get linetype
     ObjectAttributes atts = null;
-    if (gridline[@"displayStyle"] as DisplayStyle == null)
+    if (gridline["@displayStyle"] as DisplayStyle == null)
     {
       var linetypeIndex = Doc.Linetypes.Find("Dashed");
       if (linetypeIndex >= 0)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -457,6 +457,10 @@ public partial class ConverterRhinoGh : ISpeckleConverter
           rhinoObj = SurfaceToNative(o);
           break;
 
+        case GridLine o:
+          rhinoObj = CurveToNative(o.baseLine);
+          break;
+
         case Alignment o:
           rhinoObj = AlignmentToNative(o);
           break;
@@ -674,13 +678,13 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       case DirectShape _:
       case View3D _:
       case Instance _:
+      case GridLine _:
       case Alignment _:
       case Level _:
       case Text _:
       case Dimension _:
       case Collection c when !c.collectionType.ToLower().Contains("model"):
         return true;
-
 #endif
 
       default:

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -458,7 +458,7 @@ public partial class ConverterRhinoGh : ISpeckleConverter
           break;
 
         case GridLine o:
-          rhinoObj = CurveToNative(o.baseLine);
+          rhinoObj = GridlineToNative(o);
           break;
 
         case Alignment o:


### PR DESCRIPTION
## Description & motivation

Adds conversions for `Gridline`s as `Curve`s. 
In Rhino, the gridline `label` property is added as the curve `name` as well as two `TextDot`s at the curve start and end. The curve uses a default dashed linetype if no `DisplayStyle` is found.
In AutoCAD, the curve is added with a default dashed linetype if no `DisplayStyle`. The label isn't created in Autocad.

Note: in order for display styles to be accurately represented, gridlines should be sent with a `DisplayStyle` property from Revit and other applications.

## Changes:

- Autocad connector and converter
- Rhino connector and converter

## Screenshots:

Rhino
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/754ed34f-96be-4a52-aaee-e3f93c56b48b)

Autocad
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/4804f20f-5543-4fc5-9942-a1a5fadc718b)

