### PR TITLE
fix(rvt): Fixes curve extraction method for Ceilings and Floors

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertCeiling.cs
@@ -15,8 +15,12 @@ namespace Objects.Converter.Revit
     private RevitCeiling CeilingToSpeckle(DB.Ceiling revitCeiling, out List<string> notes)
     {
       notes = new List<string>();
+#if REVIT2020 || REVIT2021  
       var profiles = GetProfiles(revitCeiling);
-
+#else
+      var sketch = Doc.GetElement(revitCeiling.SketchId) as Sketch;
+      var profiles = GetSketchProfiles(sketch).Cast<ICurve>().ToList();
+#endif
       var speckleCeiling = new RevitCeiling();
       speckleCeiling.type = revitCeiling.Document.GetElement(revitCeiling.GetTypeId()).Name;
       speckleCeiling.outline = profiles[0];

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertToposolid.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertToposolid.cs
@@ -62,22 +62,7 @@ namespace Objects.Converter.Revit
 
       return appObj;
     }
-    
-    private List<OG.Polycurve> GetSketchProfiles(Sketch sketch)
-    {
-      var profiles = new List<OG.Polycurve>();
-      foreach (CurveArray curves in sketch.Profile)
-      {
-        var curveLoop = CurveArrayToCurveLoop(curves);
-        profiles.Add(new OG.Polycurve
-        {
-          segments = curveLoop.Select(x => CurveToSpeckle(x, sketch.Document)).ToList()
-        });
-      }
 
-      return profiles;
-    }
-    
     private RevitToposolid ToposolidToSpeckle(Toposolid topoSolid, out List<string> notes)
     { 
       var toSpeckle = new RevitToposolid();


### PR DESCRIPTION
New curve extraction method for ceilings and floors based on extracting the drawn curve loops from the sketch. Each curve loop will become a polycurve.

This is the same behaviour that Toposolid uses.

Moved `GetSketchCurves` onto the floor file since TopoSolid file is only applied in 2024 and above.

Support for this new extraction logic only applies to >2022, so 2020 and 2021 continue to have the same issue.