### PR TITLE
fix(rhino): default to using speckle id when creating render materials with no name

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -133,8 +133,8 @@ public partial class ConverterRhinoGh
   public RenderMaterial RenderMaterialToNative(Other.RenderMaterial speckleMaterial)
   {
     var commitInfo = GetCommitInfo();
-    var speckleName =
-      ReceiveMode == ReceiveMode.Create ? $"{commitInfo} - {speckleMaterial.name}" : $"{speckleMaterial.name}";
+    var name = speckleMaterial.name ?? speckleMaterial.id;
+    var speckleName = ReceiveMode == ReceiveMode.Create ? $"{commitInfo} - {name}" : $"{name}";
 
     // check if the doc already has a material with speckle material name, or a previously created speckle material
     //NOTE: Looking up renderMaterials this way is slow, maybe we can create a dictionary?


### PR DESCRIPTION
## Description & motivation

Uses the speckle id of a `renderMaterial` when no name exists. This was causing many duplicate render materials on receive in rhino.

Note: this needs https://github.com/specklesystems/speckle-server/issues/1806 to be fixed for render materials in ifc uploaded commits to receive well in rhino and other connectors.

## Changes:

- Rhino converter

