### PR TITLE
feat(revit): send builtInCategories

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/AllRevitCategories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/AllRevitCategories.cs
@@ -148,7 +148,9 @@ namespace Objects.Converter.Revit
       if (unformattedCatName.StartsWith("OST"))
       {
         if (!Enum.TryParse(unformattedCatName, out bic))
+        {
           return null;
+        }
         formattedName = unformattedCatName.Replace("OST_", "");
       }
       // pre 2.16 we're passing the "category" string

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/AllRevitCategories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/AllRevitCategories.cs
@@ -143,11 +143,13 @@ namespace Objects.Converter.Revit
     private IRevitCategoryInfo? GetCategoryInfoForObjectWithExactName(string unformattedCatName)
     {
       var bic = BuiltInCategory.INVALID;
+      string formattedName = "";
       // 2.16 onwards we're passing the "builtInCategory" string
       if (unformattedCatName.StartsWith("OST"))
       {
         if (!Enum.TryParse(unformattedCatName, out bic))
           return null;
+        formattedName = unformattedCatName.Replace("OST_", "");
       }
       // pre 2.16 we're passing the "category" string
       else
@@ -159,10 +161,8 @@ namespace Objects.Converter.Revit
         if (revitCat == null) return null;
 
         bic = Categories.GetBuiltInCategory(revitCat);
+        formattedName = CategoryNameFormatted(unformattedCatName);
       }
-
-
-      var formattedName = CategoryNameFormatted(unformattedCatName);
 
       return revitDocumentAggregateCache
         .GetOrInitializeWithDefaultFactory<IRevitCategoryInfo>()

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -34,31 +34,16 @@ namespace Objects.Converter.Revit
     /// </summary>
     /// <param name="c">The RevitCategory to convert</param>
     /// <returns>The name of the built-in category that corresponds to the input RevitCategory</returns>
-    public static bool GetBuiltInCategoryFromRevitCategory(RevitCategory c, out BuiltInCategory bic)
+    public static string GetBuiltInFromSchemaBuilderCategory(RevitCategory c)
     {
       var name = Enum.GetName(typeof(RevitCategory), c);
-      var builtInName = $"OST_{name}";
-      return Enum.TryParse(builtInName, out bic);
+      return $"OST_{name}";
     }
 
-    public static bool GetBuiltInCategoryFromRevitCategory(RevitFamilyCategory c, out BuiltInCategory bic)
+    public static string GetBuiltInFromSchemaBuilderCategory(RevitFamilyCategory c)
     {
       var name = Enum.GetName(typeof(RevitFamilyCategory), c);
-      var builtInName = $"OST_{name}";
-      return Enum.TryParse(builtInName, out bic);
-    }
-
-    /// <summary>
-    /// Returns the corresponding RevitCategory enum from a specific BuiltInCategory
-    /// </summary>
-    /// <param name="c"></param>
-    /// <returns></returns>
-    /// <remarks>This method should mirror <see cref="GetBuiltInCategoryFromRevitCategory"/> logic for built in categories </remarks>
-    public static bool GetRevitCategoryFromBuiltInCategory(BuiltInCategory bic, out RevitCategory c)
-    {
-      var name = Enum.GetName(typeof(BuiltInCategory), bic);
-      var revitName = name.Split('_').Last();
-      return Enum.TryParse<RevitCategory>(revitName, out c);
+      return $"OST_{name}";
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Categories.cs
@@ -45,5 +45,14 @@ namespace Objects.Converter.Revit
       var name = Enum.GetName(typeof(RevitFamilyCategory), c);
       return $"OST_{name}";
     }
+
+    public static BuiltInCategory GetBuiltInCategory(Category category)
+    {
+#if REVIT2020 || REVIT2021 || REVIT2022
+      return (BuiltInCategory)category.Id.IntegerValue;
+#else
+      return category.BuiltInCategory;
+#endif
+    }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -67,7 +67,12 @@ namespace Objects.Converter.Revit
         var elementId = element.Id;
         if (!hostedElementIds.Contains(elementId))
         {
-          extraProps["speckleHost"] = new Base() { applicationId = host.UniqueId, ["category"] = host.Category.Name };
+          extraProps["speckleHost"] = new Base()
+          {
+            applicationId = host.UniqueId,
+            ["category"] = host.Category.Name,
+            ["builtInCategory"] = Categories.GetBuiltInCategory(host.Category)
+          };
         }
         else
           return false;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -251,21 +251,16 @@ namespace Objects.Converter.Revit
 
       speckleElement["worksetId"] = revitElement.WorksetId.ToString();
 
+
       // assign the category if it is null
       // WARN: DirectShapes have a `category` prop of type `RevitCategory` (enum), NOT `string`. This is the only exception as of 2.16.
       // If the null check is removed, the DirectShape case needs to be handled.
       var category = revitElement.Category;
       if (speckleElement["category"] is null && category is not null)
       {
-        var categoryName = category.Name;
-        // we should use RevitCategory values for BuiltInCategory strings where possible (revit 2023+)
-        // different BuiltInCategory may have the same name, eg "OST_Railings" and "OST_StairsRailing" both have a Category name of "Railing"
-#if !(REVIT2020 || REVIT2021 || REVIT2022)
-        if (Categories.GetRevitCategoryFromBuiltInCategory(category.BuiltInCategory, out RevitCategory c))
-          categoryName = c.ToString();
-#endif
-        speckleElement["category"] = categoryName;
+        speckleElement["category"] = category.Name;
       }
+
 
       //NOTE: adds the quantities of all materials to an element
       var qs = MaterialQuantitiesToSpeckle(revitElement, speckleElement["units"] as string);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -67,7 +67,7 @@ namespace Objects.Converter.Revit
         var elementId = element.Id;
         if (!hostedElementIds.Contains(elementId))
         {
-          extraProps["speckleHost"] = new Base() { applicationId = host.UniqueId, ["category"] = host.Category.Name, };
+          extraProps["speckleHost"] = new Base() { applicationId = host.UniqueId, ["category"] = host.Category.Name };
         }
         else
           return false;
@@ -254,12 +254,18 @@ namespace Objects.Converter.Revit
 
       // assign the category if it is null
       // WARN: DirectShapes have a `category` prop of type `RevitCategory` (enum), NOT `string`. This is the only exception as of 2.16.
+      // In all other cases this should be the display value string (localized name) of the catogory
       // If the null check is removed, the DirectShape case needs to be handled.
       var category = revitElement.Category;
       if (speckleElement["category"] is null && category is not null)
       {
         speckleElement["category"] = category.Name;
       }
+      // from 2.16 onward we're also passing the full BuiltInCategory for better handling on receive
+      //TODO: move this to a typed property, define full list of categories in Objects
+      BuiltInCategory builtInCategory = Categories.GetBuiltInCategory(category);
+      speckleElement["builtInCategory"] = builtInCategory.ToString();
+
 
 
       //NOTE: adds the quantities of all materials to an element

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertBlock.cs
@@ -185,8 +185,9 @@ public partial class ConverterRevit
     if (!success)
       cat = RevitFamilyCategory.GenericModel;
 
-    // Get the BuiltInCategory corresponding to the RevitFamilyCategory
-    success = Categories.GetBuiltInCategoryFromRevitCategory(cat, out DB.BuiltInCategory bic);
+    // Get the BuiltInCategory corresponding to the RevitCategory
+    var catName = Categories.GetBuiltInFromSchemaBuilderCategory(cat);
+    success = Enum.TryParse(catName, out DB.BuiltInCategory bic);
     if (!success)
       bic = DB.BuiltInCategory.OST_GenericModel;
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -46,12 +46,13 @@ namespace Objects.Converter.Revit
       }
     }
 
-    public ApplicationObject TryDirectShapeToNative(Brep brep, ToNativeMeshSettingEnum fallbackSetting,  RevitCategory cat = RevitCategory.GenericModel)
+    public ApplicationObject TryDirectShapeToNative(Brep brep, ToNativeMeshSettingEnum fallbackSetting, RevitCategory cat = RevitCategory.GenericModel)
     {
       DirectShape ds = new(
         $"Brep {brep.applicationId ?? brep.id}",
         cat,
-        new List<Base> { brep }) { applicationId = brep.applicationId, id = brep.id };
+        new List<Base> { brep })
+      { applicationId = brep.applicationId, id = brep.id };
       return TryDirectShapeToNative(ds, fallbackSetting);
     }
 
@@ -60,10 +61,11 @@ namespace Objects.Converter.Revit
       DirectShape ds = new(
         $"Mesh {mesh.applicationId ?? mesh.id}",
         cat,
-        new List<Base> { mesh }) { applicationId = mesh.applicationId, id = mesh.id };
+        new List<Base> { mesh })
+      { applicationId = mesh.applicationId, id = mesh.id };
       return TryDirectShapeToNative(ds, fallbackSetting);
     }
-    
+
     public ApplicationObject TryDirectShapeToNative(ApplicationObject appObj, List<Mesh> meshes, ToNativeMeshSettingEnum fallbackSetting, RevitCategory cat = RevitCategory.GenericModel)
     {
       if (meshes.Count == 0)
@@ -75,11 +77,12 @@ namespace Objects.Converter.Revit
       var ds = new DirectShape(
         $"{appObj.Descriptor.Split(':').LastOrDefault() ?? "Meshes"} {appObj.applicationId}",
         cat,
-        meshes.Cast<Base>().ToList()) { applicationId = appObj.applicationId, id = appObj.OriginalId };
-      
+        meshes.Cast<Base>().ToList())
+      { applicationId = appObj.applicationId, id = appObj.OriginalId };
+
       return TryDirectShapeToNative(ds, fallbackSetting);
     }
-    
+
     /// <summary>
     /// The default DirectShape conversion method. Will return a Revit DirectShape with the containing geometry.
     /// </summary>
@@ -148,12 +151,19 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      BuiltInCategory bic;
-      if ((int)speckleDs.category == -1)
-        speckleDs.category = RevitCategory.GenericModel;
-      var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(speckleDs.category);
+      //from 2.16 onwards use the builtInCategory field for direct shape fallback
+      BuiltInCategory bic = BuiltInCategory.OST_GenericModel;
+      if (!BuiltInCategory.TryParse(speckleDs["builtInCategory"] as string, out bic))
+      {
+        //pre 2.16 or coming from grasshopper, using the enum
+        //TODO: move away from enum logic
+        if ((int)speckleDs.category != -1)
+        {
+          var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(speckleDs.category);
+          _ = BuiltInCategory.TryParse(bicName, out bic);
+        }
+      }
 
-      BuiltInCategory.TryParse(bicName, out bic);
       var cat = Doc.Settings.Categories.get_Item(bic);
 
       try

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDirectShape.cs
@@ -148,17 +148,14 @@ namespace Objects.Converter.Revit
         return appObj;
       }
 
-      DB.Category cat = null;
+      BuiltInCategory bic;
       if ((int)speckleDs.category == -1)
         speckleDs.category = RevitCategory.GenericModel;
-      if (Categories.GetBuiltInCategoryFromRevitCategory(speckleDs.category, out BuiltInCategory bic))
-      {
-        cat = Doc.Settings.Categories.get_Item(bic);
-      }
-      if (cat is null)
-      {
-        cat = Doc.Settings.Categories.get_Item(BuiltInCategory.OST_GenericModel); // default to generic model
-      }
+      var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(speckleDs.category);
+
+      BuiltInCategory.TryParse(bicName, out bic);
+      var cat = Doc.Settings.Categories.get_Item(bic);
+
       try
       {
         var revitDs = DB.DirectShape.CreateElement(Doc, cat.Id);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDisplayableObject.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDisplayableObject.cs
@@ -27,7 +27,7 @@ public partial class ConverterRevit
       var displayValue = obj.TryGetDisplayValue() ?? throw new Exception("Display value was empty or null");
 
       var parameters = obj.TryGetParameters<Parameter>();
-      var category = GetSpeckleObjectCategory(obj);
+      var category = GetSpeckleObjectBuiltInCategory(obj);
 
       // Create a temp DirectShape and use the DirectShape conversion routine
       var ds = new DirectShape(name, category, displayValue.ToList(), parameters?.ToList())
@@ -43,10 +43,10 @@ public partial class ConverterRevit
       var displayValue = instance.GetTransformedGeometry().Cast<Base>();
 
       var parameters = obj.TryGetParameters<Parameter>();
-      var category = GetSpeckleObjectCategory(obj);
+      var builtInCategory = GetSpeckleObjectBuiltInCategory(obj);
 
       // Create a temp DirectShape and use the DirectShape conversion routine
-      var ds = new DirectShape(name, category, displayValue.ToList(), parameters?.ToList());
+      var ds = new DirectShape(name, builtInCategory, displayValue.ToList(), parameters?.ToList());
       return DirectShapeToNative(ds, ToNativeMeshSettingEnum.Default);
     }
     else
@@ -55,45 +55,50 @@ public partial class ConverterRevit
     }
   }
 
-  public RevitCategory GetSpeckleObjectCategory(Base @object)
+  public string GetSpeckleObjectBuiltInCategory(Base @object)
   {
-    if (Enum.TryParse<RevitCategory>(@object["category"] as string, out RevitCategory category))
-      return category;
-    else
+    //from 2.16 onwards we're passing the BuiltInCategory on every object
+    if (@object["builtInCategory"] is not null)
+      return @object["builtInCategory"] as string;
+
+    if (RevitCategory.TryParse(@object["category"] as string, out RevitCategory category))
     {
-      switch (@object)
-      {
-        case BE.Beam _:
-        case BE.Brace _:
-        case BE.TeklaStructures.TeklaContourPlate _:
-          return RevitCategory.StructuralFraming;
-        case BE.TeklaStructures.Bolts _:
-          return RevitCategory.StructConnectionBolts;
-        case BE.TeklaStructures.Welds _:
-          return RevitCategory.StructConnectionWelds;
-        case BE.Floor _:
-          return RevitCategory.Floors;
-        case BE.Ceiling _:
-          return RevitCategory.Ceilings;
-        case BE.Column _:
-          return RevitCategory.Columns;
-        case BE.Pipe _:
-          return RevitCategory.PipeSegments;
-        case BE.Rebar _:
-          return RevitCategory.Rebar;
-        case BE.Topography _:
-          return RevitCategory.Topography;
-        case BE.Wall _:
-          return RevitCategory.Walls;
-        case BE.Roof _:
-          return RevitCategory.Roofs;
-        case BE.Duct _:
-          return RevitCategory.DuctSystem;
-        case BE.CableTray _:
-          return RevitCategory.CableTray;
-        default:
-          return RevitCategory.GenericModel;
-      }
+      return Categories.GetBuiltInFromSchemaBuilderCategory(category);
+    }
+
+    switch (@object)
+    {
+      case BE.Beam _:
+      case BE.Brace _:
+      case BE.TeklaStructures.TeklaContourPlate _:
+        return BuiltInCategory.OST_StructuralFraming.ToString();
+      case BE.TeklaStructures.Bolts _:
+        return BuiltInCategory.OST_StructConnectionBolts.ToString();
+      case BE.TeklaStructures.Welds _:
+        return BuiltInCategory.OST_StructConnectionWelds.ToString();
+      case BE.Floor _:
+        return BuiltInCategory.OST_Floors.ToString();
+      case BE.Ceiling _:
+        return BuiltInCategory.OST_Ceilings.ToString();
+      case BE.Column _:
+        return BuiltInCategory.OST_Columns.ToString();
+      case BE.Pipe _:
+        return BuiltInCategory.OST_PipeSegments.ToString();
+      case BE.Rebar _:
+        return BuiltInCategory.OST_Rebar.ToString();
+      case BE.Topography _:
+        return BuiltInCategory.OST_Topography.ToString();
+      case BE.Wall _:
+        return BuiltInCategory.OST_Walls.ToString();
+      case BE.Roof _:
+        return BuiltInCategory.OST_Roofs.ToString();
+      case BE.Duct _:
+        return BuiltInCategory.OST_DuctSystem.ToString();
+      case BE.CableTray _:
+        return BuiltInCategory.OST_CableTray.ToString();
+      default:
+        return BuiltInCategory.OST_GenericModel.ToString();
+
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
@@ -189,13 +189,12 @@ namespace Objects.Converter.Revit
         if (freeformElement != null)
         {
           //subcategory
-          BuiltInCategory bic;
+
           if (!string.IsNullOrEmpty(freeformElement.subcategory))
           {
             //by default free form elements are always generic models
             //otherwise we'd need to supply base files for each category..?
-            var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(BuiltElements.Revit.RevitCategory.GenericModel);
-            BuiltInCategory.TryParse(bicName, out bic);
+            BuiltInCategory bic = BuiltInCategory.OST_GenericModel;
             cat = famDoc.Settings.Categories.get_Item(bic);
             if (cat.SubCategories.Contains(freeformElement.subcategory))
             {

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
@@ -189,18 +189,18 @@ namespace Objects.Converter.Revit
         if (freeformElement != null)
         {
           //subcategory
+          BuiltInCategory bic;
           if (!string.IsNullOrEmpty(freeformElement.subcategory))
           {
             //by default free form elements are always generic models
             //otherwise we'd need to supply base files for each category..?
-            if (Categories.GetBuiltInCategoryFromRevitCategory(BuiltElements.Revit.RevitCategory.GenericModel, out BuiltInCategory bic))
-            {
-              cat = famDoc.Settings.Categories.get_Item(bic);
-              if (cat.SubCategories.Contains(freeformElement.subcategory))
-                cat = cat.SubCategories.get_Item(freeformElement.subcategory);
-              else
-                cat = famDoc.Settings.Categories.NewSubcategory(cat, freeformElement.subcategory);
-            }
+            var bicName = Categories.GetBuiltInFromSchemaBuilderCategory(BuiltElements.Revit.RevitCategory.GenericModel);
+            BuiltInCategory.TryParse(bicName, out bic);
+            cat = famDoc.Settings.Categories.get_Item(bic);
+            if (cat.SubCategories.Contains(freeformElement.subcategory))
+              cat = cat.SubCategories.get_Item(freeformElement.subcategory);
+            else
+              cat = famDoc.Settings.Categories.NewSubcategory(cat, freeformElement.subcategory);
           }
         }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRailing.cs
@@ -67,6 +67,7 @@ namespace Objects.Converter.Revit
 
         if (topRailType != null && isTopRailExactMatch)
           railingType.TopRailType = topRailType.Id;
+
       }
 
 

--- a/Objects/Objects/BuiltElements/Revit/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Revit/DirectShape.cs
@@ -31,6 +31,16 @@ public class DirectShape : Base, IDisplayValue<List<Base>>
     this.parameters = parameters.ToBase();
   }
 
+  // moving away from using the RevitCategory Enum
+  public DirectShape(string name, string builtInCategory, List<Base> baseGeometries, List<Parameter> parameters = null)
+  {
+    this.name = name;
+    this.baseGeometries = baseGeometries.FindAll(IsValidObject);
+    this.parameters = parameters.ToBase();
+    //TODO: move to typed property alongside all other revit elements
+    this["builtInCategory"] = builtInCategory;
+  }
+
   public string name { get; set; }
   public RevitCategory category { get; set; }
   public Base parameters { get; set; }


### PR DESCRIPTION
Reverts: https://github.com/specklesystems/speckle-sharp/pull/2910
Changes the logic to use the BuiltInCategory instead of the `RevitCategory` enum, because more reliable:
- adds a `builtInCategory` prop to every element coming out of Revit
- when falling back to DirectShape first checks if there is a `builtInCategory` prop and uses that, and if not uses the old `RevitCategory` enum

Internal notes: https://www.notion.so/speckle/2-16-Category-Mis-Alignment-8d5a51e672fc4314883eab3af2f02b2d#8ca51ecef5c148ae8cdb48f1b58e4c53

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/75c50558-c261-4495-aa31-261f70dd9071)


### Tests
- send from the sample revit model
- receive in a new doc with direct shape fallback logic set to Always
- railings are received correctly

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/779a2b91-9242-4f88-a84a-e07390499a60)

### TODO
in the future we should:
- get rid of the `RevitCategory` enum entirely
- better align the collections names and element category names

