### PR TITLE
fix(CSI): Fixes missing materials on receive

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSI.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSI.cs
@@ -13,6 +13,8 @@ using Speckle.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Objects.Other;
+using Objects.Structural.Materials;
 using OSG = Objects.Structural.Geometry;
 
 namespace Objects.Converter.CSI
@@ -123,6 +125,7 @@ namespace Objects.Converter.CSI
         case BuiltElements.Beam _:
         case BuiltElements.Brace _:
         case BuiltElements.Column _:
+        case StructuralMaterial _:
           return true;
       }
       ;
@@ -202,6 +205,10 @@ namespace Objects.Converter.CSI
           break;
         case Property1D o:
           Property1DToNative(o, ref appObj);
+          break;
+        case StructuralMaterial o:
+          // Material conversion does not return an app object
+          MaterialToNative(o);
           break;
         #region BuiltElements
         case BuiltElements.Beam o:

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Properties/Convert2DPropertyFloor.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Properties/Convert2DPropertyFloor.cs
@@ -14,6 +14,8 @@ namespace Objects.Converter.CSI
     public string FloorPropertyToNative(CSIProperty2D property2D)
     {
       int? success = null;
+      var materialName = MaterialToNative(property2D.material);
+
       if (property2D.deckType != Structural.CSI.Analysis.DeckType.Null)
       {
         SetDeck(property2D);
@@ -70,7 +72,7 @@ namespace Objects.Converter.CSI
               SolidSlab.name,
               eSlabType.Slab,
               shell,
-              SolidSlab.material.name,
+              materialName,
               SolidSlab.thickness
             );
             break;
@@ -81,7 +83,7 @@ namespace Objects.Converter.CSI
               slabRibbed.name,
               eSlabType.Ribbed,
               shell,
-              slabRibbed.material.name,
+              materialName,
               slabRibbed.thickness
             );
             success = Model.PropArea.SetSlabRibbed(
@@ -101,7 +103,7 @@ namespace Objects.Converter.CSI
               slabWaffled.name,
               eSlabType.Waffle,
               shell,
-              slabWaffled.material.name,
+              materialName,
               slabWaffled.thickness
             );
             success = Model.PropArea.SetSlabWaffle(

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Properties/Convert2DPropertyFloor.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Properties/Convert2DPropertyFloor.cs
@@ -68,24 +68,12 @@ namespace Objects.Converter.CSI
           case Structural.CSI.Analysis.SlabType.Slab:
             var SolidSlab = property2D;
             var shell = shellType(SolidSlab);
-            success = Model.PropArea.SetSlab(
-              SolidSlab.name,
-              eSlabType.Slab,
-              shell,
-              materialName,
-              SolidSlab.thickness
-            );
+            success = Model.PropArea.SetSlab(SolidSlab.name, eSlabType.Slab, shell, materialName, SolidSlab.thickness);
             break;
           case Structural.CSI.Analysis.SlabType.Ribbed:
             var slabRibbed = (CSIProperty2D.RibbedSlab)property2D;
             shell = shellType(slabRibbed);
-            Model.PropArea.SetSlab(
-              slabRibbed.name,
-              eSlabType.Ribbed,
-              shell,
-              materialName,
-              slabRibbed.thickness
-            );
+            Model.PropArea.SetSlab(slabRibbed.name, eSlabType.Ribbed, shell, materialName, slabRibbed.thickness);
             success = Model.PropArea.SetSlabRibbed(
               slabRibbed.name,
               slabRibbed.OverAllDepth,
@@ -99,13 +87,7 @@ namespace Objects.Converter.CSI
           case Structural.CSI.Analysis.SlabType.Waffle:
             var slabWaffled = (CSIProperty2D.WaffleSlab)property2D;
             shell = shellType(slabWaffled);
-            Model.PropArea.SetSlab(
-              slabWaffled.name,
-              eSlabType.Waffle,
-              shell,
-              materialName,
-              slabWaffled.thickness
-            );
+            Model.PropArea.SetSlab(slabWaffled.name, eSlabType.Waffle, shell, materialName, slabWaffled.thickness);
             success = Model.PropArea.SetSlabWaffle(
               slabWaffled.name,
               slabWaffled.OverAllDepth,


### PR DESCRIPTION
Structural materials where only created when being used within a `Property1D` element.

This PR enhances material support so that:
- Converter has top-level support for `StructuralMaterial` on receive. Meaning `CanConvertToNative` now returns true, and `ConvertToNative` will call `MaterialToNative`. Previously we weren't supporting this use-case
- Property2D was using the material name, but not ensuring the material existed in the model. MaterialToNative is now called and the resulting material name is used when needed.