### PR TITLE
feat: check if server is using fe2

### DIFF
--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -383,6 +383,10 @@ public class ServerInfo
   public string version { get; set; }
   public string adminContact { get; set; }
   public string description { get; set; }
+  //NOTE: this field is not returned from the GQL API
+  //it is manually populated by checking against the response headers
+  //TODO: deprecate after the transition from fe1 to fe2
+  public bool frontend2 { get; set; }
 }
 
 public class StreamData

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -275,6 +276,7 @@ public static class AccountManager
         account.userInfo = userServerInfo.activeUser;
         account.serverInfo = userServerInfo.serverInfo;
         account.serverInfo.url = url;
+        account.serverInfo.frontend2 = await IsFrontend2Server(url).ConfigureAwait(false);
       }
       catch (Exception)
       {
@@ -584,6 +586,29 @@ public static class AccountManager
     catch (Exception e)
     {
       throw new SpeckleException(e.Message, e);
+    }
+  }
+
+  private static async Task<bool> IsFrontend2Server(string server)
+  {
+    try
+    {
+      using var client = Http.GetHttpProxyClient();
+      var response = await client.GetAsync(server).ConfigureAwait(false);
+
+      if (response.Headers.TryGetValues("x-speckle-frontend-2", out IEnumerable<string> values))
+      {
+        if (values.Any() && bool.Parse(values.FirstOrDefault()))
+        {
+          return true;
+        }
+      }
+
+      return false;
+    }
+    catch (Exception e)
+    {
+      return false;
     }
   }
 


### PR DESCRIPTION
Adds info needed to deliver a better UX when using DU2 & FE2:
- adds a (temporary?) `frontend2` prop to the `serverInfo` class
- checks against the response headers to see if a server/account is using frontend 2
