### PR TITLE
feat (Revit, Archicad): Support grids between Revit and Archicad

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
@@ -15,6 +15,7 @@
 #include "Commands/GetBeamData.hpp"
 #include "Commands/GetColumnData.hpp"
 #include "Commands/GetElementBaseData.hpp"
+#include "Commands/GetGridElementData.hpp"
 #include "Commands/GetObjectData.hpp"
 #include "Commands/GetSlabData.hpp"
 #include "Commands/GetRoofData.hpp"
@@ -28,6 +29,7 @@
 #include "Commands/CreateWindow.hpp"
 #include "Commands/CreateBeam.hpp"
 #include "Commands/CreateColumn.hpp"
+#include "Commands/CreateGridElement.hpp"
 #include "Commands/CreateObject.hpp"
 #include "Commands/CreateRoof.hpp"
 #include "Commands/CreateSkylight.hpp"
@@ -197,6 +199,7 @@ static GSErrCode RegisterAddOnCommands ()
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetBeamData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetColumnData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetElementBaseData> ()));
+	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetGridElementData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetObjectData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetRoofData> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::GetShellData> ()));
@@ -208,6 +211,7 @@ static GSErrCode RegisterAddOnCommands ()
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateDoor> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateWindow> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateBeam> ()));
+	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateGridElement> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateColumn> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateObject> ()));
 	CHECKERROR (ACAPI_Install_AddOnCommandHandler (NewOwned<AddOnCommands::CreateRoof> ()));

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
@@ -663,6 +663,7 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 	return NoError;
 }
 
+
 GS::String CreateBeam::GetName () const
 {
 	return CreateBeamCommandName;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.cpp
@@ -80,6 +80,13 @@ GSErrCode CreateGridElement::GetElementFromObjectState (const GS::ObjectState& o
 		length = beginToEnd.GetLength ();
 
 	} else {
+		
+		// reflected
+		if (arcAngle < 0.0) {
+			arcAngle *= -1.0;
+			element.object.reflected = true;
+			ACAPI_ELEMENT_MASK_SET (elementMask, API_ObjectType, reflected);
+		}
 		// circle position
 		GenArc arc = GenArc::CreateCircleArc (Point2D(begin.x,begin.y), Point2D(end.x, end.y), arcAngle);
 		Point2D origo = arc.GetOrigo ();

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.cpp
@@ -104,6 +104,8 @@ GSErrCode CreateGridElement::GetElementFromObjectState (const GS::ObjectState& o
 			GS::ucscpy (parameter.value.uStr, markerText.ToUStr ().Get ());
 		} else if (CHCompareCStrings (parameter.name, "AC_LineVisibility_i", CS_CaseSensitive) == 0) {
 			parameter.value.real = (int)1;
+		} else if (CHCompareCStrings (parameter.name, "AC_StaggerDist", CS_CaseSensitive) == 0) {
+			parameter.value.real = .0;
 		} else if (CHCompareCStrings (parameter.name, "AC_Type_i", CS_CaseSensitive) == 0) {
 			if (isArc) {
 				parameter.value.real = (int)2;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.cpp
@@ -1,0 +1,141 @@
+#include "CreateGridElement.hpp"
+#include "ResourceIds.hpp"
+#include "ObjectState.hpp"
+#include "APIHelper.hpp"
+#include "Utility.hpp"
+#include "Objects/Level.hpp"
+#include "Objects/Point.hpp"
+#include "FieldNames.hpp"
+#include "GenArc2DData.h"
+using namespace FieldNames;
+
+namespace AddOnCommands {
+
+
+GS::String CreateGridElement::GetFieldName () const
+{
+	return FieldNames::GridElements;
+}
+
+
+GS::UniString CreateGridElement::GetUndoableCommandName () const
+{
+	return "CreateSpeckleGridElement";
+}
+
+
+GSErrCode CreateGridElement::GetElementFromObjectState (const GS::ObjectState& os,
+	API_Element& element,
+	API_Element& elementMask,
+	API_ElementMemo& memo,
+	GS::UInt64& memoMask,
+	API_SubElement** /*marker*/,
+	AttributeManager& /*attributeManager*/,
+	LibpartImportManager& /*libpartImportManager*/,
+	GS::Array<GS::UniString>& log) const
+{
+	GSErrCode err = NoError;
+
+	Utility::SetElementType (element.header, API_ElemType (API_ObjectID, APIVarId_GridElement));
+
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
+	if (err != NoError)
+		return err;
+
+	Objects::Point3D begin, end;
+	GS::UniString markerText;
+	bool isArc = false;
+	double length = .0;
+	double radius = .0;
+	double arcAngle = .0;
+
+	if (os.Contains (GridElement::begin) && os.Contains (GridElement::end)) {
+		os.Get (GridElement::begin, begin);
+		os.Get (GridElement::end, end);
+	}
+
+	if (os.Contains (GridElement::markerText)) {
+		os.Get (GridElement::markerText, markerText);
+	}
+
+	if (os.Contains (GridElement::isArc)) {
+		os.Get (GridElement::isArc, isArc);
+	}
+
+	if (os.Contains (GridElement::arcAngle)) {
+		os.Get (GridElement::arcAngle, arcAngle);
+	}
+
+	if (!isArc) {
+		// position
+		element.object.pos = begin.ToAPI_Coord ();
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_ObjectType, pos);
+
+		// angle
+		Vector2D beginToEnd (end.x - begin.x, end.y - begin.y);
+		element.object.angle = beginToEnd.CalcAngleToReference (Vector2D (1.0, 0));
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_ObjectType, angle);
+
+		// length
+		length = beginToEnd.GetLength ();
+
+	} else {
+		// circle position
+		GenArc arc = GenArc::CreateCircleArc (Point2D(begin.x,begin.y), Point2D(end.x, end.y), arcAngle);
+		Point2D origo = arc.GetOrigo ();
+		element.object.pos.x = origo.GetX ();
+		element.object.pos.y = origo.GetY ();
+
+		// angle
+		Vector2D posToBegin (begin.x - origo.GetX (), begin.y - origo.GetY ());
+		element.object.angle = posToBegin.CalcAngleToReference (Vector2D (1.0, 0));
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_ObjectType, angle);
+
+		// radius
+		radius = posToBegin.GetLength ();
+	}
+
+	GSSize addParCount = BMGetHandleSize (reinterpret_cast<GSHandle>(memo.params)) / sizeof (API_AddParType);
+	
+	for (Int32 i = 0; i < addParCount; ++i) {
+		API_AddParType& parameter = (*memo.params)[i];
+		
+		if (CHCompareCStrings (parameter.name, "AC_MarkerText_1", CS_CaseSensitive) == 0) {
+			GS::ucscpy (parameter.value.uStr, markerText.ToUStr ().Get ());
+		} else if (CHCompareCStrings (parameter.name, "AC_LineVisibility_i", CS_CaseSensitive) == 0) {
+			parameter.value.real = (int)1;
+		} else if (CHCompareCStrings (parameter.name, "AC_Type_i", CS_CaseSensitive) == 0) {
+			if (isArc) {
+				parameter.value.real = (int)2;
+			} else {
+				parameter.value.real = (int)1;
+			}
+		} else if (CHCompareCStrings (parameter.name, "AC_Length", CS_CaseSensitive) == 0) {
+			if (!isArc) {
+				parameter.value.real = length;
+			}
+		} else if (CHCompareCStrings (parameter.name, "AC_Angle", CS_CaseSensitive) == 0) {
+			if (isArc) {
+				parameter.value.real = arcAngle;
+			}
+		} else if (CHCompareCStrings (parameter.name, "AC_Radius", CS_CaseSensitive) == 0) {
+			if (isArc) {
+				parameter.value.real = radius;
+			}
+		}
+	}
+
+	memoMask = APIMemoMask_AddPars;
+
+	return NoError;
+}
+
+
+GS::String CreateGridElement::GetName () const
+{
+	return CreateGridElementCommandName;
+}
+
+
+}
+ // namespace AddOnCommands

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateGridElement.hpp
@@ -1,0 +1,32 @@
+#ifndef CREATE_GRIDELEMENT_HPP
+#define CREATE_GRIDELEMENT_HPP
+
+#include "CreateCommand.hpp"
+
+
+namespace AddOnCommands {
+
+
+class CreateGridElement : public CreateCommand {
+	GS::String			GetFieldName () const override;
+	GS::UniString		GetUndoableCommandName () const override;
+
+	GSErrCode			GetElementFromObjectState (const GS::ObjectState& os,
+							API_Element& element,
+							API_Element& elementMask,
+							API_ElementMemo& memo,
+							GS::UInt64& memoMask,
+							API_SubElement** marker,
+							AttributeManager& attributeManager,
+							LibpartImportManager& libpartImportManager,
+							GS::Array<GS::UniString>& log) const override;
+
+public:
+	virtual GS::String	GetName () const override;
+};
+
+
+}
+
+
+#endif

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpeningBase.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpeningBase.cpp
@@ -54,7 +54,7 @@ bool CreateOpeningBase::CheckEnvironment (const GS::ObjectState& os, API_Element
 		return false;
 
 	// Set its parent
-	API_ElemTypeID elementType = Utility::GetElementType (elem.header);
+	API_ElemTypeID elementType = Utility::GetElementType (elem.header).typeID;
 	if (elementType == API_DoorID) {
 		element.door.owner = parentArchicadId;
 	} else if (elementType == API_WindowID) {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
@@ -26,30 +26,32 @@ GS::ErrCode GetDataCommand::ExportClassificationsAndProperties (const API_Elemen
 	if (err != NoError)
 		return err;
 
-	const auto& classificationListAdder = os.AddList<GS::ObjectState> (FieldNames::ElementBase::Classifications);
-	for (const auto& systemItemPair : systemItemPairs) {
-		GS::ObjectState classificationOs;
-		API_ClassificationSystem system;
-		system.guid = systemItemPair.first;
-		err = ACAPI_Classification_GetClassificationSystem (system);
-		if (err != NoError)
-			break;
+	if (systemItemPairs.GetSize () != 0) {
+		const auto& classificationListAdder = os.AddList<GS::ObjectState> (FieldNames::ElementBase::Classifications);
+		for (const auto& systemItemPair : systemItemPairs) {
+			GS::ObjectState classificationOs;
+			API_ClassificationSystem system;
+			system.guid = systemItemPair.first;
+			err = ACAPI_Classification_GetClassificationSystem (system);
+			if (err != NoError)
+				break;
 
-		classificationOs.Add (FieldNames::ElementBase::Classification::System, system.name);
-		
-		API_ClassificationItem item;
-		item.guid = systemItemPair.second;
-		err = ACAPI_Classification_GetClassificationItem (item);
-		if (err != NoError)
-			break;
+			classificationOs.Add (FieldNames::ElementBase::Classification::System, system.name);
 
-		if (!item.id.IsEmpty())
-			classificationOs.Add (FieldNames::ElementBase::Classification::Code, item.id);
+			API_ClassificationItem item;
+			item.guid = systemItemPair.second;
+			err = ACAPI_Classification_GetClassificationItem (item);
+			if (err != NoError)
+				break;
 
-		if (!item.name.IsEmpty())
-			classificationOs.Add (FieldNames::ElementBase::Classification::Name, item.name);
+			if (!item.id.IsEmpty ())
+				classificationOs.Add (FieldNames::ElementBase::Classification::Code, item.id);
 
-		classificationListAdder (classificationOs);
+			if (!item.name.IsEmpty ())
+				classificationOs.Add (FieldNames::ElementBase::Classification::Name, item.name);
+
+			classificationListAdder (classificationOs);
+		}
 	}
 
 	return err;
@@ -98,7 +100,7 @@ GS::ObjectState GetDataCommand::Execute (const GS::ObjectState& parameters,
 
 		// check for elem type
 		if (API_ZombieElemID != GetElemTypeID ()) {
-			API_ElemTypeID elementType = Utility::GetElementType (element.header);
+			API_ElemTypeID elementType = Utility::GetElementType (element.header).typeID;
 			if (elementType != GetElemTypeID ())
 			{
 				continue;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementTypes.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementTypes.cpp
@@ -26,8 +26,8 @@ GS::ObjectState GetElementTypes::Execute (const GS::ObjectState& parameters, GS:
 	const auto& listAdder = result.AddList<GS::ObjectState> (ElementBase::ElementTypes);
 	for (const GS::UniString& id : ids) {
 		API_Guid guid = APIGuidFromString (id.ToCStr ());
-		API_ElemTypeID elementTypeId = Utility::GetElementType (guid);
-		GS::UniString elemType = elementNames.Get (elementTypeId);
+		API_ElemType elementType = Utility::GetElementType (guid);
+		GS::UniString elemType = elementNames.Get (elementType);
 		GS::ObjectState listElem{ElementBase::ApplicationId, id, ElementBase::ElementType, elemType};
 		listAdder (listElem);
 	}

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
@@ -74,6 +74,7 @@ GS::ErrCode	GetGridElementData::SerializeElementType (const API_Element& element
 	}
 
 	{
+		// mirror
 		if (element.object.reflected) {
 			Geometry::Transformation2D rotationMirrorY = Geometry::Transformation2D::CreateMirrorY ();
 			beginVector = rotationMirrorY.Apply (beginVector);
@@ -82,10 +83,12 @@ GS::ErrCode	GetGridElementData::SerializeElementType (const API_Element& element
 			arcAngle *= -1;
 		}
 
+		// rotation
 		Geometry::Transformation2D rotationGlobal = Geometry::Transformation2D::CreateOrigoRotation (angle);
 		beginVector = rotationGlobal.Apply (beginVector);
 		endVector = rotationGlobal.Apply (endVector);
 		
+		// offset
 		Geometry::Transformation2D transformationGlobal = Geometry::Transformation2D::CreateTranslation (Vector2D (element.object.pos.x, element.object.pos.y));
 		Point2D beginPoint = transformationGlobal.Apply (Point2D (beginVector));
 		Point2D endPoint = transformationGlobal.Apply (Point2D (endVector));

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
@@ -1,0 +1,114 @@
+#include "GetGridElementData.hpp"
+#include "ResourceIds.hpp"
+#include "ObjectState.hpp"
+#include "Utility.hpp"
+#include "Objects/Level.hpp"
+#include "Objects/Point.hpp"
+#include "RealNumber.h"
+#include "FieldNames.hpp"
+#include "TypeNameTables.hpp"
+using namespace FieldNames;
+
+
+namespace AddOnCommands {
+
+
+GS::String GetGridElementData::GetFieldName () const
+{
+	return GridElements;
+}
+
+
+API_ElemTypeID GetGridElementData::GetElemTypeID () const
+{
+	return API_ObjectID;
+}
+
+
+GS::ErrCode	GetGridElementData::SerializeElementType (const API_Element& element,
+	const API_ElementMemo& memo,
+	GS::ObjectState& os) const
+{
+	GS::ErrCode err = NoError;
+	err = GetDataCommand::SerializeElementType (element, memo, os);
+	if (NoError != err)
+		return err;
+
+	GS::UniString markerText;
+	double angle = element.object.angle;
+	double length = .0;
+	int type = 0;
+	double arcAngle = .0;
+	double radius = .0;
+
+	{
+		GSSize addParCount = BMGetHandleSize (reinterpret_cast<GSHandle>(memo.params)) / sizeof (API_AddParType);
+		
+		for (Int32 i = 0; i < addParCount; ++i) {
+			API_AddParType& parameter = (*memo.params)[i];
+			if (CHCompareCStrings (parameter.name, "AC_Length", CS_CaseSensitive) == 0) {
+				length = parameter.value.real;
+			} else if (CHCompareCStrings (parameter.name, "AC_MarkerText_1", CS_CaseSensitive) == 0) {
+				markerText = parameter.value.uStr;
+			} else if (CHCompareCStrings (parameter.name, "AC_Type_i", CS_CaseSensitive) == 0) {
+				type = (int)parameter.value.real;
+			} else if (CHCompareCStrings (parameter.name, "AC_Angle", CS_CaseSensitive) == 0) {
+				arcAngle = parameter.value.real;
+			} else if (CHCompareCStrings (parameter.name, "AC_Radius", CS_CaseSensitive) == 0) {
+				radius = parameter.value.real;
+			}
+		}
+	}
+
+	bool isArc = (type == 2);
+
+	Vector2D beginVector, endVector;
+	if (!isArc) {
+		beginVector = Vector2D (.0, .0);
+		endVector = Vector2D (length, .0);
+	} else {
+		beginVector = Vector2D (radius, .0);
+		Geometry::Transformation2D rotationEnd = Geometry::Transformation2D::CreateOrigoRotation (arcAngle);
+
+		endVector = rotationEnd.Apply (beginVector);
+	}
+
+	{
+		if (element.object.reflected) {
+			Geometry::Transformation2D rotationMirrorY = Geometry::Transformation2D::CreateMirrorY ();
+			beginVector = rotationMirrorY.Apply (beginVector);
+			endVector = rotationMirrorY.Apply (endVector);
+
+			Geometry::Transformation2D rotationMirrorX = Geometry::Transformation2D::CreateMirrorX ();
+			beginVector = rotationMirrorX.Apply (beginVector);
+			endVector = rotationMirrorX.Apply (endVector);
+		}
+
+		Geometry::Transformation2D rotationGlobal = Geometry::Transformation2D::CreateOrigoRotation (angle);
+		beginVector = rotationGlobal.Apply (beginVector);
+		endVector = rotationGlobal.Apply (endVector);
+		
+		Geometry::Transformation2D transformationGlobal = Geometry::Transformation2D::CreateTranslation (Vector2D (element.object.pos.x, element.object.pos.y));
+		Point2D beginPoint = transformationGlobal.Apply (Point2D (beginVector));
+		Point2D endPoint = transformationGlobal.Apply (Point2D (endVector));
+		
+		double z = Utility::GetStoryLevel (element.object.head.floorInd) + element.object.level;
+		os.Add (GridElement::begin, Objects::Point3D (beginPoint.x, beginPoint.y, z));
+		os.Add (GridElement::end, Objects::Point3D (endPoint.x, endPoint.y, z));
+	}
+
+	os.Add (GridElement::markerText, markerText);
+	os.Add (GridElement::isArc, isArc);
+	os.Add (GridElement::arcAngle, arcAngle);
+
+	return NoError;
+}
+
+
+GS::String GetGridElementData::GetName () const
+{
+	return GetGridElementCommandName;
+}
+
+
+} // namespace AddOnCommands

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
@@ -78,10 +78,6 @@ GS::ErrCode	GetGridElementData::SerializeElementType (const API_Element& element
 			Geometry::Transformation2D rotationMirrorY = Geometry::Transformation2D::CreateMirrorY ();
 			beginVector = rotationMirrorY.Apply (beginVector);
 			endVector = rotationMirrorY.Apply (endVector);
-
-			Geometry::Transformation2D rotationMirrorX = Geometry::Transformation2D::CreateMirrorX ();
-			beginVector = rotationMirrorX.Apply (beginVector);
-			endVector = rotationMirrorX.Apply (endVector);
 		}
 
 		Geometry::Transformation2D rotationGlobal = Geometry::Transformation2D::CreateOrigoRotation (angle);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.cpp
@@ -78,6 +78,8 @@ GS::ErrCode	GetGridElementData::SerializeElementType (const API_Element& element
 			Geometry::Transformation2D rotationMirrorY = Geometry::Transformation2D::CreateMirrorY ();
 			beginVector = rotationMirrorY.Apply (beginVector);
 			endVector = rotationMirrorY.Apply (endVector);
+			
+			arcAngle *= -1;
 		}
 
 		Geometry::Transformation2D rotationGlobal = Geometry::Transformation2D::CreateOrigoRotation (angle);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetGridElementData.hpp
@@ -1,0 +1,24 @@
+#ifndef GET_GRID_DATA_HPP
+#define GET_GRID_DATA_HPP
+
+#include "GetDataCommand.hpp"
+
+namespace AddOnCommands {
+
+
+class GetGridElementData : public GetDataCommand {
+	GS::String			GetFieldName () const override;
+	API_ElemTypeID		GetElemTypeID () const override;
+	GS::ErrCode			SerializeElementType (const API_Element& elem,
+							const API_ElementMemo& memo,
+							GS::ObjectState& os) const override;
+
+public:
+	virtual GS::String	GetName () const override;
+};
+
+
+}
+
+
+#endif

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetModelForElements.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetModelForElements.cpp
@@ -82,7 +82,7 @@ static void GetModelInfoForElement (const Modeler::Elem& elem,
 			modelInfo.AddEdge (ModelInfo::EdgeId (edge.vert1 + vetrexOffset, edge.vert2 + vetrexOffset), ModelInfo::EdgeData (ModelInfo::VisibleEdge, edge.pgon1, edge.pgon2));
 		}
 
-		// polygon
+		// polygons
 		CollectPolygonsFromBody (body, attributes, vetrexOffset, modelInfo);
 	}
 }

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetModelForElements.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetModelForElements.cpp
@@ -70,11 +70,19 @@ static void GetModelInfoForElement (const Modeler::Elem& elem,
 	for (const auto& body : elem.TessellatedBodies ()) {
 		UInt32 vetrexOffset = modelInfo.GetVertices ().GetSize ();
 
+		// vertices
 		for (UInt32 vertexIdx = 0; vertexIdx < body.GetVertexCount (); ++vertexIdx) {
 			const auto coord = body.GetVertexPoint (vertexIdx, transformation);
 			modelInfo.AddVertex (ModelInfo::Vertex (coord.x, coord.y, coord.z));
 		}
 
+		// edges
+		for (ULong edgeIdx = 0; edgeIdx < body.GetEdgeCount (); ++edgeIdx) {
+			const EDGE& edge = body.GetConstEdge (edgeIdx);
+			modelInfo.AddEdge (ModelInfo::EdgeId (edge.vert1 + vetrexOffset, edge.vert2 + vetrexOffset), ModelInfo::EdgeData (ModelInfo::VisibleEdge, edge.pgon1, edge.pgon2));
+		}
+
+		// polygon
 		CollectPolygonsFromBody (body, attributes, vetrexOffset, modelInfo);
 	}
 }
@@ -178,7 +186,7 @@ static GS::Array<API_Guid> CheckForSubelements (const API_Guid& applicationId)
 		return GS::Array<API_Guid> ();
 	}
 
-	switch (Utility::GetElementType (header)) {
+	switch (Utility::GetElementType (header).typeID) {
 		case API_CurtainWallID:					return GetCurtainWallSubElements (applicationId);
 		case API_StairID:						return GetStairSubElements (applicationId);
 		case API_RailingID:						return GetRailingSubElements (applicationId);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetOpeningBaseData.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetOpeningBaseData.hpp
@@ -50,7 +50,7 @@ GSErrCode GetOpeningBaseData (const T& element, GS::ObjectState& os)
 	os.Add (OpeningBase::oSide, element.openingBase.oSide);
 	os.Add (OpeningBase::refSide, element.openingBase.refSide);
 
-	API_ElemTypeID elementType = Utility::GetElementType (element.head);
+	API_ElemTypeID elementType = Utility::GetElementType (element.head).typeID;
 	
 	// Vertical Link type and story index
 	if (elementType == API_WindowID || elementType == API_DoorID) {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSubElementInfo.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSubElementInfo.cpp
@@ -38,8 +38,8 @@ GS::ObjectState GetSubElementInfo::Execute (const GS::ObjectState& parameters, G
 			API_Guid currentGuid = elementGuids.Get (i);
 
 			GS::UniString guid = APIGuidToString (currentGuid);
-			API_ElemTypeID elementTypeId = Utility::GetElementType (currentGuid);
-			GS::UniString elemType = elementNames.Get (elementTypeId);
+			API_ElemType elementType = Utility::GetElementType (currentGuid);
+			GS::UniString elemType = elementNames.Get (elementType);
 
 			GS::ObjectState subelementModel;
 			subelementModel.Add (ElementBase::ApplicationId, guid);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
@@ -50,6 +50,7 @@ static const char* Beams = "beams";
 static const char* Columns = "columns";
 static const char* DirectShapes = "directShapes";
 static const char* Doors = "doors";
+static const char* GridElements = "gridElements";
 static const char* Objects = "objects";
 static const char* MeshModels = "meshModels";
 static const char* Roofs = "roofs";
@@ -450,6 +451,17 @@ static const char* pos = "pos";
 static const char* transform = "transform";
 }
 
+namespace GridElement
+{
+// Main
+static const char* begin = "begin";
+static const char* end = "end";
+static const char* angle = "angle";
+static const char* markerText = "markerText";
+static const char* isArc = "isArc";
+static const char* arcAngle = "arcAngle";
+}
+
 
 namespace Slab
 {
@@ -721,6 +733,14 @@ static const char* Vertices = "vertices";
 static const char* VertexX = "x";
 static const char* VertexY = "y";
 static const char* VertexZ = "z";
+static const char* PointId1 = "v1";
+static const char* PointId2 = "v2";
+static const char* PolygonId1 = "p1";
+static const char* PolygonId2 = "p2";
+static const char* EdgeStatus = "s";
+static const char* HiddenEdgeValueName = "HiddenEdge";
+static const char* SmoothEdgeValueName = "SmoothEdge";
+static const char* VisibleEdgeValueName = "VisibleEdge";
 static const char* Polygons = "polygons";
 static const char* Materials = "materials";
 static const char* PointIds = "pointIds";

--- a/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/LibpartImportManager.cpp
@@ -229,7 +229,7 @@ GSErrCode LibpartImportManager::CreateLibraryPart (const ModelInfo& modelInfo,
 		line = GS::String::SPrintf ("%s", GS::EOL);
 		ACAPI_LibPart_WriteSection (line.GetLength(), line.ToCStr());
 
-		GS::HashTable<GS::Pair<Int32, Int32>, GS::UShort> edges = modelInfo.GetEdges ();
+		const GS::HashTable<ModelInfo::EdgeId, ModelInfo::EdgeData>& edges = modelInfo.GetEdges ();
 
 		UInt32 edgeIndex = 1;
 		UInt32 polygonIndex = 1;
@@ -254,21 +254,22 @@ GSErrCode LibpartImportManager::CreateLibraryPart (const ModelInfo& modelInfo,
 				Int32 end = i == pointIds.GetSize () - 1 ? 0 : i + 1;
 
 				Int32 startPointId = pointIds[start], endPointId = pointIds[end];
-				GS::Pair<Int32, Int32> edge (startPointId, endPointId);
-				GS::Pair<Int32, Int32> inverseEdge (endPointId, startPointId);
+				ModelInfo::EdgeId edge (startPointId, endPointId);
 
 				bool smooth = false;
-				bool hidden = false;
-				GS::UShort edgeStatus;
-				if (edges.Get (edge, &edgeStatus) || edges.Get(inverseEdge, &edgeStatus)) {
-					switch (edgeStatus) {
+				bool hidden = true;
+				if (edges.ContainsKey(edge)) {
+					ModelInfo::EdgeData edgeData = edges.Get (edge);
+		
+					switch (edgeData.edgeStatus) {
 					case ModelInfo::HiddenEdge:
-						hidden = true;
 						break;
 					case ModelInfo::SmoothEdge:
+						hidden = false;
 						smooth = true;
 						break;
 					case ModelInfo::VisibleEdge:
+						hidden = false;
 						break;
 					default:
 						break;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Objects/ModelInfo.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Objects/ModelInfo.cpp
@@ -39,6 +39,7 @@ ModelInfo::Material::Material (const UMAT& aumat) :
 {
 }
 
+
 ModelInfo::Material::Material (GS::UniString& name, short transparency, GS_RGBColor& ambientColor, GS_RGBColor& emissionColor) :
 	name (name),
 	transparency (transparency),
@@ -67,6 +68,37 @@ GSErrCode ModelInfo::Material::Restore (const GS::ObjectState& os)
 	os.Get (Model::Transparency, transparency);
 
 	return NoError;
+}
+
+
+ModelInfo::EdgeId::EdgeId (Int32 vertexId1, Int32 vertexId2) :
+	vertexId1 (vertexId1), vertexId2 (vertexId2)
+{
+}
+
+
+bool ModelInfo::EdgeId::operator== (ModelInfo::EdgeId otherEdgeId) const
+{
+	return (vertexId1 == otherEdgeId.vertexId1 && vertexId2 == otherEdgeId.vertexId2) ||
+	(vertexId1 == otherEdgeId.vertexId2 && vertexId2 == otherEdgeId.vertexId1);
+}
+
+
+ULong ModelInfo::EdgeId::GenerateHashValue (void) const
+{
+	return GS::CalculateHashValue (GS::Max(vertexId1, vertexId2), GS::Min(vertexId1, vertexId2));
+}
+
+
+ModelInfo::EdgeData::EdgeData () :
+	edgeStatus (HiddenEdge), polygonId1 (InvalidPolygonId), polygonId2 (InvalidPolygonId)
+{
+}
+
+
+ModelInfo::EdgeData::EdgeData (EdgeStatus edgeStatus, Int32 polygonId1 /* = InvalidPolygonId */, Int32 polygonId2 /* = InvalidPolygonId */)
+	: edgeStatus (edgeStatus), polygonId1 (polygonId1), polygonId2 (polygonId2)
+{
 }
 
 
@@ -104,6 +136,24 @@ void ModelInfo::AddVertex (const Vertex& vertex)
 void ModelInfo::AddVertex (Vertex&& vertex)
 {
 	vertices.Push (std::move (vertex));
+}
+
+
+void ModelInfo::AddEdge (const EdgeId& edgeId, const EdgeData& edgeData)
+{
+	if (edges.ContainsKey (edgeId))
+		edges[edgeId] = edgeData;
+	else
+		edges.Add (edgeId, edgeData);
+}
+
+
+void ModelInfo::AddEdge (EdgeId&& edgeId, EdgeData&& edgeData)
+{
+	if (edges.ContainsKey (edgeId))
+		edges[edgeId] = edgeData;
+	else
+		edges.Add (edgeId, edgeData);
 }
 
 
@@ -156,6 +206,39 @@ GSErrCode ModelInfo::GetMaterial (const UInt32 materialIndex, ModelInfo::Materia
 GSErrCode ModelInfo::Store (GS::ObjectState& os) const
 {
 	os.Add (Model::Vertices, vertices);
+	
+	GS::Array<GS::ObjectState> edgeArray;
+
+	for (auto edge : edges)
+	{
+		// skip hidden edges
+		if (edge.value->edgeStatus == HiddenEdge)
+			continue;
+		
+		GS::ObjectState osEdge;
+		
+		osEdge.Add (Model::PointId1, edge.key->vertexId1);
+		osEdge.Add (Model::PointId2, edge.key->vertexId2);
+
+		if (edge.value->polygonId1 != EdgeData::InvalidPolygonId)
+			osEdge.Add (Model::PolygonId1, edge.value->polygonId1);
+
+		if (edge.value->polygonId2 != EdgeData::InvalidPolygonId)
+			osEdge.Add (Model::PolygonId2, edge.value->polygonId2);
+
+		GS::UniString edgeStatusName (Model::HiddenEdgeValueName);
+		if (edge.value->edgeStatus == SmoothEdge)
+			edgeStatusName = Model::SmoothEdgeValueName;
+		else if (edge.value->edgeStatus == VisibleEdge)
+			edgeStatusName = Model::VisibleEdgeValueName;
+	
+		osEdge.Add (Model::EdgeStatus, edgeStatusName);
+		
+		edgeArray.Push (osEdge);
+	}
+
+	os.Add (Model::Edges, edgeArray);
+
 	os.Add (Model::Polygons, polygons);
 	os.Add (Model::Materials, materials);
 
@@ -167,9 +250,36 @@ GSErrCode ModelInfo::Restore (const GS::ObjectState& os)
 {
 	os.Get (Model::Ids, ids);
 	os.Get (Model::Vertices, vertices);
+
+	GS::Array<GS::ObjectState> edgeArray;
+	os.Get (Model::Edges, edgeArray);
+	
+	for (GS::ObjectState osEdge : edgeArray)
+	{
+		if (!osEdge.Contains (Model::PointId1) || !osEdge.Contains (Model::PointId2) || !osEdge.Contains (Model::EdgeStatus))
+			continue;
+		
+		Int32 pointId1 (0), pointId2 (0);
+		osEdge.Get (Model::PointId1, pointId1);
+		osEdge.Get (Model::PointId2, pointId2);
+
+		EdgeId edgeId (pointId1, pointId2);
+		
+		EdgeStatus edgeStatus (HiddenEdge);
+		GS::UniString edgeStatusName;
+		osEdge.Get (Model::EdgeStatus, edgeStatusName);
+		if (edgeStatusName == Model::SmoothEdgeValueName)
+			edgeStatus = SmoothEdge;
+		else if (edgeStatusName == Model::VisibleEdgeValueName)
+			edgeStatus = VisibleEdge;
+	
+		EdgeData edgeData (edgeStatus);
+		
+		edges.Add(edgeId, edgeData);
+	}
+	
 	os.Get (Model::Polygons, polygons);
 	os.Get (Model::Materials, materials);
-	os.Get (Model::Edges, edges);
 
 	return NoError;
 }

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Objects/ModelInfo.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Objects/ModelInfo.hpp
@@ -33,6 +33,44 @@ public:
 		double z = {};
 	};
 
+	class EdgeId {
+	public:
+		Int32	vertexId1, vertexId2;
+
+		EdgeId (Int32 vertexId1, Int32 vertexId2);
+
+		bool operator== (EdgeId otherEdgeId) const;
+		
+		ULong GenerateHashValue (void) const;
+	};
+
+	class EdgeData {
+	public:
+		static const Int32 InvalidPolygonId = -1;
+
+		EdgeStatus	edgeStatus;
+		Int32		polygonId1, polygonId2;
+
+		EdgeData ();
+		EdgeData (EdgeStatus edgeStatus, Int32 polygonId1 = InvalidPolygonId, Int32 polygonId2 = InvalidPolygonId);
+	};
+
+	class Polygon {
+	public:
+		Polygon () = default;
+		Polygon (const GS::Array<Int32>& pointIds, UInt32 material);
+
+		inline const GS::Array<Int32>& GetPointIds () const { return pointIds; }
+		inline const Int32 GetMaterial () const { return material; }
+
+		GSErrCode Store (GS::ObjectState& os) const;
+		GSErrCode Restore (const GS::ObjectState& os);
+
+	private:
+		GS::Array<Int32> pointIds;
+		UInt32 material = {};
+	};
+	
 	class Material {
 	public:
 		Material () = default;
@@ -55,25 +93,12 @@ public:
 
 	};
 
-	class Polygon {
-	public:
-		Polygon () = default;
-		Polygon (const GS::Array<Int32>& pointIds, UInt32 material);
-
-		inline const GS::Array<Int32>& GetPointIds () const { return pointIds; }
-		inline const Int32 GetMaterial () const { return material; }
-
-		GSErrCode Store (GS::ObjectState& os) const;
-		GSErrCode Restore (const GS::ObjectState& os);
-
-	private:
-		GS::Array<Int32> pointIds;
-		UInt32 material = {};
-	};
-
 public:
 	void AddVertex (const Vertex& vertex);
 	void AddVertex (Vertex&& vertex);
+
+	void AddEdge (const EdgeId& edgeId, const EdgeData& edgeData);
+	void AddEdge (EdgeId&& edgeId, EdgeData&& edgeData);
 
 	void AddPolygon (const Polygon& polygon);
 	void AddPolygon (Polygon&& polygon);
@@ -85,9 +110,9 @@ public:
 	GSErrCode GetMaterial (const UInt32 materialIndex, ModelInfo::Material& material) const;
 
 	inline const GS::Array<Vertex>& GetVertices () const { return vertices; }
+	inline const GS::HashTable<EdgeId, EdgeData>& GetEdges () const { return edges; }
 	inline const GS::Array<Polygon>& GetPolygons () const { return polygons; }
 	inline const GS::Array<Material>& GetMaterials () const { return materials; }
-	inline const GS::HashTable<GS::Pair<GS::Int32, GS::Int32>, GS::UShort>& GetEdges () const { return edges; }
 	inline const GS::Array<GS::UniString>& GetIds () const { return ids; }
 
 	GSErrCode Store (GS::ObjectState& os) const;
@@ -96,9 +121,9 @@ public:
 private:
 	GS::Array<GS::UniString> ids;
 	GS::Array<Vertex> vertices;
+	GS::HashTable<EdgeId, EdgeData> edges;
 	GS::Array<Polygon> polygons;
 	GS::Array<Material> materials;
-	GS::HashTable<GS::Pair<GS::Int32, GS::Int32>, GS::UShort> edges;
 };
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
@@ -22,6 +22,7 @@
 #define GetBeamDataCommandName					"GetBeamData";
 #define GetColumnDataCommandName				"GetColumnData";
 #define GetElementBaseDataCommandName			"GetElementBaseData";
+#define GetGridElementCommandName				"GetGridElementData";
 #define GetObjectDataCommandName				"GetObjectData";
 #define GetSlabDataCommandName					"GetSlabData";
 #define GetRoomDataCommandName					"GetRoomData";
@@ -36,7 +37,8 @@
 #define CreateWindowCommandName					"CreateWindow";
 #define CreateBeamCommandName					"CreateBeam";
 #define CreateColumnCommandName					"CreateColumn";
-#define CreateObjectCommandName                 "CreateObject";
+#define CreateGridElementCommandName			"CreateGridElement";
+#define CreateObjectCommandName					"CreateObject";
 #define CreateSlabCommandName					"CreateSlab";
 #define CreateSkylightCommandName				"CreateSkylight";
 #define CreateRoofCommandName					"CreateRoof";

--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
@@ -1,27 +1,28 @@
 #include "TypeNameTables.hpp"
 
 
-const GS::HashTable<API_ElemTypeID, GS::UniString> elementNames
+const GS::HashTable<API_ElemType, GS::UniString> elementNames
 {
-	{ API_ZombieElemID,					"InvalidType"},
-	{ API_WallID,						"Wall"},
-	{ API_ColumnID,						"Column"},
-	{ API_BeamID,						"Beam"},
-	{ API_WindowID,						"Window"},
-	{ API_DoorID,						"Door"},
-	{ API_ObjectID,						"Object"},
-	{ API_LampID,						"Lamp"},
-	{ API_SlabID,						"Slab"},
-	{ API_RoofID,						"Roof"},
-	{ API_MeshID,						"Mesh"},
-	{ API_ZoneID,						"Zone"},
-	{ API_CurtainWallID,				"CurtainWall"},
-	{ API_ShellID,						"Shell"},
-	{ API_SkylightID,					"Skylight"},
-	{ API_MorphID,						"Morph"},
-	{ API_StairID,						"Stair"},
-	{ API_RailingID,					"Railing"},
-	{ API_OpeningID,					"Opening"}
+	{ { API_ZombieElemID, APIVarId_Generic},	"InvalidType"},
+	{ { API_WallID, APIVarId_Generic},			"Wall"},
+	{ { API_ColumnID, APIVarId_Generic},		"Column"},
+	{ { API_BeamID, APIVarId_Generic},			"Beam"},
+	{ { API_WindowID, APIVarId_Generic},		"Window"},
+	{ { API_DoorID, APIVarId_Generic},			"Door"},
+	{ { API_ObjectID, APIVarId_Generic},		"Object"},
+	{ { API_LampID, APIVarId_Generic},			"Lamp"},
+	{ { API_SlabID, APIVarId_Generic},			"Slab"},
+	{ { API_RoofID, APIVarId_Generic},			"Roof"},
+	{ { API_MeshID, APIVarId_Generic},			"Mesh"},
+	{ { API_ZoneID, APIVarId_Generic},			"Zone"},
+	{ { API_CurtainWallID, APIVarId_Generic},	"CurtainWall"},
+	{ { API_ShellID, APIVarId_Generic},			"Shell"},
+	{ { API_SkylightID, APIVarId_Generic},		"Skylight"},
+	{ { API_MorphID, APIVarId_Generic},			"Morph"},
+	{ { API_StairID, APIVarId_Generic},			"Stair"},
+	{ { API_RailingID, APIVarId_Generic},		"Railing"},
+	{ { API_OpeningID, APIVarId_Generic},		"Opening"},
+	{ { API_ObjectID, APIVarId_GridElement},	"GridElement"}
 };
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.hpp
@@ -4,7 +4,9 @@
 #include "APIEnvir.h"
 #include "ACAPinc.h"
 
-extern const GS::HashTable<API_ElemTypeID, GS::UniString> elementNames;
+#include "Utility.hpp"
+
+extern const GS::HashTable<API_ElemType, GS::UniString> elementNames;
 extern const GS::HashTable<API_ModelElemStructureType, GS::UniString> structureTypeNames;
 
 extern const GS::HashTable<API_WallTypeID, GS::UniString> wallTypeNames;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Utility.hpp
@@ -9,14 +9,67 @@
 #define UNUSED(x) (void)(x)
 
 
+#ifndef ServerMainVers_2600
+struct API_ElemType {
+	API_ElemTypeID			typeID;			// type of the element
+	API_ElemVariationID		variationID;	// type subcategory
+
+	API_ElemType () = default;
+
+	API_ElemType (API_ElemTypeID typeID)
+		: typeID (typeID), variationID (APIVarId_Generic)
+	{}
+
+	API_ElemType (API_ElemTypeID typeID, API_ElemVariationID variationID)
+		: typeID (typeID), variationID (variationID)
+	{}
+
+	API_ElemType&	operator= (const API_ElemType&) = default;
+
+	API_ElemType&	operator= (API_ElemTypeID newTypeID)
+	{
+		typeID = newTypeID;
+		variationID = APIVarId_Generic;
+		return *this;
+	}
+
+	bool	operator== (const API_ElemType& other) const
+	{
+		return typeID == other.typeID && variationID == other.variationID;
+	}
+
+	bool	operator!= (const API_ElemType& other) const
+	{
+		return !operator== (other);
+	}
+
+	bool	operator== (API_ElemTypeID otherTypeID) const
+	{
+		return typeID == otherTypeID;
+	}
+
+	bool	operator!= (API_ElemTypeID otherTypeID) const
+	{
+		return !operator== (otherTypeID);
+	}
+
+	ULong	GenerateHashValue (void) const
+	{
+		return GS::CalculateHashValue (typeID, variationID);
+	}
+};
+#endif
+
+
 namespace Utility {
 
 // Element Type
-API_ElemTypeID GetElementType (const API_Elem_Head& header);
-API_ElemTypeID GetElementType (const API_Guid& guid);
+API_ElemType GetElementType (const API_Elem_Head& header);
+API_ElemType GetElementType (const API_Guid& guid);
 GS::ErrCode GetNonLocalizedElementTypeName (const API_Elem_Head& header, GS::UniString& typeName);
 GS::ErrCode GetLocalizedElementTypeName (const API_Elem_Head& header, GS::UniString& typeName);
 void SetElementType (API_Elem_Head& header, const API_ElemTypeID& elementType);
+void SetElementType (API_Elem_Head& header, const API_ElemType& elementType);
 
 bool ElementExists (const API_Guid& guid);
 

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateGridElement.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateGridElement.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
+
+namespace Archicad.Communication.Commands
+{
+  sealed internal class CreateGridElement : ICommand<IEnumerable<ApplicationObject>>
+  {
+    [JsonObject(MemberSerialization.OptIn)]
+    public sealed class Parameters
+    {
+      [JsonProperty("gridElements")]
+      private IEnumerable<Archicad.GridElement> Datas { get; }
+
+      public Parameters(IEnumerable<Archicad.GridElement> datas)
+      {
+        Datas = datas;
+      }
+    }
+
+    [JsonObject(MemberSerialization.OptIn)]
+    private sealed class Result
+    {
+      [JsonProperty("applicationObjects")]
+      public IEnumerable<ApplicationObject> ApplicationObjects { get; private set; }
+    }
+
+    private IEnumerable<Archicad.GridElement> Datas { get; }
+
+    public CreateGridElement(IEnumerable<Archicad.GridElement> datas)
+    {
+      Datas = datas;
+    }
+
+    public async Task<IEnumerable<ApplicationObject>> Execute()
+    {
+      var result = await HttpCommandExecutor.Execute<Parameters, Result>("CreateGridElement", new Parameters(Datas));
+      return result == null ? null : result.ApplicationObjects;
+    }
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetGridElementData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetGridElementData.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Speckle.Core.Kits;
+using Speckle.Newtonsoft.Json;
+using Objects.BuiltElements;
+
+namespace Archicad.Communication.Commands
+{
+  sealed internal class GetGridElementData : ICommand<IEnumerable<Archicad.GridElement>>
+  {
+    [JsonObject(MemberSerialization.OptIn)]
+    public sealed class Parameters
+    {
+      [JsonProperty("applicationIds")]
+      private IEnumerable<string> ApplicationIds { get; }
+
+      public Parameters(IEnumerable<string> applicationIds)
+      {
+        ApplicationIds = applicationIds;
+      }
+    }
+
+    [JsonObject(MemberSerialization.OptIn)]
+    private sealed class Result
+    {
+      [JsonProperty("gridElements")]
+      public IEnumerable<Archicad.GridElement> Datas { get; private set; }
+    }
+
+    private IEnumerable<string> ApplicationIds { get; }
+
+    public GetGridElementData(IEnumerable<string> applicationIds)
+    {
+      ApplicationIds = applicationIds;
+    }
+
+    public async Task<IEnumerable<Archicad.GridElement>> Execute()
+    {
+      Result result = await HttpCommandExecutor.Execute<Parameters, Result>(
+        "GetGridElementData",
+        new Parameters(ApplicationIds)
+      );
+
+      return result.Datas;
+    }
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
@@ -45,7 +45,7 @@ namespace Archicad.Communication
         AddOnCommandRequest<TParameters> request = new AddOnCommandRequest<TParameters>(commandName, parameters);
 
         string requestMsg = SerializeRequest(request);
-        Console.WriteLine(requestMsg);
+        //Console.WriteLine(requestMsg);
         string responseMsg;
 
         using (
@@ -55,7 +55,7 @@ namespace Archicad.Communication
           )
         )
           responseMsg = await ConnectionManager.Instance.Send(requestMsg);
-        Console.WriteLine(responseMsg);
+        //Console.WriteLine(responseMsg);
         AddOnCommandResponse<TResult> response = DeserializeResponse<AddOnCommandResponse<TResult>>(responseMsg);
 
         // TODO

--- a/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
@@ -30,20 +30,32 @@ namespace Archicad.Communication
       return JsonConvert.DeserializeObject<TResponse>(obj, settings);
     }
 
-    public static async Task<TResult> Execute<TParameters, TResult>(string commandName, TParameters parameters) where TParameters : class where TResult : class
+    public static async Task<TResult> Execute<TParameters, TResult>(string commandName, TParameters parameters)
+      where TParameters : class
+      where TResult : class
     {
       var context = Archicad.Helpers.Timer.Context.Peek;
-      using (context?.cumulativeTimer?.Begin(ConnectorArchicad.Properties.OperationNameTemplates.HttpCommandExecute, commandName))
+      using (
+        context?.cumulativeTimer?.Begin(
+          ConnectorArchicad.Properties.OperationNameTemplates.HttpCommandExecute,
+          commandName
+        )
+      )
       {
         AddOnCommandRequest<TParameters> request = new AddOnCommandRequest<TParameters>(commandName, parameters);
 
         string requestMsg = SerializeRequest(request);
-        //Console.WriteLine(requestMsg);
+        Console.WriteLine(requestMsg);
         string responseMsg;
 
-        using (context?.cumulativeTimer?.Begin(ConnectorArchicad.Properties.OperationNameTemplates.HttpCommandAPI, commandName))
+        using (
+          context?.cumulativeTimer?.Begin(
+            ConnectorArchicad.Properties.OperationNameTemplates.HttpCommandAPI,
+            commandName
+          )
+        )
           responseMsg = await ConnectionManager.Instance.Send(requestMsg);
-        //Console.WriteLine(responseMsg);
+        Console.WriteLine(responseMsg);
         AddOnCommandResponse<TResult> response = DeserializeResponse<AddOnCommandResponse<TResult>>(responseMsg);
 
         // TODO

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ConverterArchicad.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ConverterArchicad.cs
@@ -66,6 +66,7 @@ namespace Objects.Converter.Archicad
         Objects.BuiltElements.Column _ => true,
         Objects.BuiltElements.Floor _ => true,
         Objects.BuiltElements.Ceiling _ => true,
+        Objects.BuiltElements.GridLine => true,
         Objects.BuiltElements.Roof _ => true,
         Objects.BuiltElements.Room _ => true,
         Objects.BuiltElements.Wall _ => true,

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/GridLineConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/GridLineConverter.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Archicad.Communication;
+using Archicad.Model;
+using Objects.Geometry;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using Speckle.Core.Models.GraphTraversal;
+
+namespace Archicad.Converters
+{
+  public sealed class GridLineConverter : IConverter
+  {
+    public Type Type => typeof(Archicad.GridElement);
+
+    public async Task<List<ApplicationObject>> ConvertToArchicad(
+      IEnumerable<TraversalContext> elements,
+      CancellationToken token
+    )
+    {
+      var archicadGridElements = new List<Archicad.GridElement>();
+
+      var context = Archicad.Helpers.Timer.Context.Peek;
+      using (
+        context?.cumulativeTimer?.Begin(ConnectorArchicad.Properties.OperationNameTemplates.ConvertToNative, Type.Name)
+      )
+      {
+        foreach (var tc in elements)
+        {
+          token.ThrowIfCancellationRequested();
+
+          switch (tc.current)
+          {
+            case Objects.BuiltElements.GridLine grid:
+
+              Archicad.GridElement archicadGridElement = new Archicad.GridElement
+              {
+                id = grid.id,
+                applicationId = grid.applicationId,
+                markerText = grid.label
+              };
+
+              if (grid.baseLine is Line)
+              {
+                var baseLine = (Line)grid.baseLine;
+                archicadGridElement.begin = Utils.ScaleToNative(baseLine.start);
+                archicadGridElement.end = Utils.ScaleToNative(baseLine.end);
+                archicadGridElement.isArc = false;
+              }
+              else if (grid.baseLine is Arc)
+              {
+                var baseLine = (Arc)grid.baseLine;
+                archicadGridElement.begin = Utils.ScaleToNative(baseLine.startPoint);
+                archicadGridElement.end = Utils.ScaleToNative(baseLine.endPoint);
+                archicadGridElement.arcAngle = baseLine.angleRadians;
+                archicadGridElement.isArc = true;
+              }
+
+              archicadGridElements.Add(archicadGridElement);
+              break;
+          }
+        }
+      }
+
+      var result = await AsyncCommandProcessor.Execute(
+        new Communication.Commands.CreateGridElement(archicadGridElements),
+        token
+      );
+
+      return result is null ? new List<ApplicationObject>() : result.ToList();
+    }
+
+    public async Task<List<Base>> ConvertToSpeckle(
+      IEnumerable<Model.ElementModelData> elements,
+      CancellationToken token
+    )
+    {
+      var elementModels = elements as ElementModelData[] ?? elements.ToArray();
+      IEnumerable<Archicad.GridElement> data = await AsyncCommandProcessor.Execute(
+        new Communication.Commands.GetGridElementData(elementModels.Select(e => e.applicationId)),
+        token
+      );
+
+      if (data is null)
+      {
+        return new List<Base>();
+      }
+
+      List<Base> gridlines = new List<Base>();
+      foreach (Archicad.GridElement archicadGridElement in data)
+      {
+        Objects.BuiltElements.GridLine speckleGridLine = new Objects.BuiltElements.GridLine();
+
+        // convert from Archicad to Speckle data structure
+        // Speckle base properties
+        speckleGridLine.id = archicadGridElement.id;
+        speckleGridLine.applicationId = archicadGridElement.applicationId;
+        speckleGridLine.label = archicadGridElement.markerText;
+        speckleGridLine.units = Units.Meters;
+
+        // Archicad properties
+        // elementType and classifications do not exist in Objects.BuiltElements.GridLine
+        //speckleGrid.elementType = archicadGridElement.elementType;
+        //speckleGrid.classifications = archicadGridElement.classifications;
+
+        if (!archicadGridElement.isArc)
+        {
+          speckleGridLine.baseLine = new Line(archicadGridElement.begin, archicadGridElement.end);
+        }
+        else
+        {
+          speckleGridLine.baseLine = new Arc(
+            archicadGridElement.begin,
+            archicadGridElement.end,
+            archicadGridElement.arcAngle
+          );
+        }
+
+        speckleGridLine.displayValue = Operations.ModelConverter
+          .MeshesAndLinesToSpeckle(elementModels.First(e => e.applicationId == archicadGridElement.applicationId).model)
+          .Cast<Base>()
+          .ToList();
+
+        gridlines.Add(speckleGridLine);
+      }
+
+      return gridlines;
+    }
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
@@ -20,6 +20,7 @@ using Room = Objects.BuiltElements.Archicad.ArchicadRoom;
 using Wall = Objects.BuiltElements.Wall;
 using Window = Objects.BuiltElements.Archicad.ArchicadWindow;
 using Skylight = Objects.BuiltElements.Archicad.ArchicadSkylight;
+using GridLine = Objects.BuiltElements.GridLine;
 
 namespace Archicad
 {
@@ -145,8 +146,15 @@ namespace Archicad
       bool forReceive
     )
     {
-      if (forReceive && conversionOptions != null && !conversionOptions.ReceiveParametric)
-        return DefaultConverterForReceive;
+      if (forReceive)
+      {
+        // always convert to Archicad GridElement
+        if (elementType.IsAssignableFrom(typeof(GridLine)))
+          return Converters[typeof(Archicad.GridElement)];
+
+        if (conversionOptions != null && !conversionOptions.ReceiveParametric)
+          return DefaultConverterForReceive;
+      }
 
       if (Converters.ContainsKey(elementType))
         return Converters[elementType];
@@ -168,6 +176,8 @@ namespace Archicad
         return Converters[typeof(Roof)];
       if (elementType.IsAssignableFrom(typeof(Objects.BuiltElements.Room)))
         return Converters[typeof(Archicad.Room)];
+      if (elementType.IsAssignableFrom(typeof(Archicad.GridElement)))
+        return Converters[typeof(Archicad.GridElement)];
 
       return forReceive ? DefaultConverterForReceive : DefaultConverterForSend;
     }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementTypeProvider.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementTypeProvider.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Beam = Objects.BuiltElements.Archicad.ArchicadBeam;
 using Column = Objects.BuiltElements.Archicad.ArchicadColumn;
 using DirectShape = Objects.BuiltElements.Archicad.DirectShape;
 using Door = Objects.BuiltElements.Archicad.ArchicadDoor;
 using Floor = Objects.BuiltElements.Archicad.ArchicadFloor;
+using GridElement = Archicad.GridElement;
 using Roof = Objects.BuiltElements.Archicad.ArchicadRoof;
 using Room = Archicad.Room;
 using Shell = Objects.BuiltElements.Archicad.ArchicadShell;
@@ -28,7 +29,8 @@ namespace Archicad
         { "Column", typeof(Column) },
         { "Door", typeof(Door) },
         { "Window", typeof(Window) },
-        { "Skylight", typeof(Skylight) }
+        { "Skylight", typeof(Skylight) },
+        { "GridElement", typeof(GridElement) }
       };
 
     public static Type GetTypeByName(string name)

--- a/ConnectorArchicad/ConnectorArchicad/Elements/GridElement.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Elements/GridElement.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Objects.Geometry;
+using Objects.BuiltElements.Archicad;
+
+namespace Archicad
+{
+  public class GridElement
+  {
+    // Speckle-specific properties
+    // Base
+    public string? id { get; set; }
+    public string? applicationId { get; set; }
+
+    // Archicad API properties
+    // Element base
+    public string? elementType { get; set; }
+    public List<Classification>? classifications { get; set; }
+
+    // Grid
+    public Point begin { get; set; }
+    public Point end { get; set; }
+    public string markerText { get; set; }
+    public bool isArc { get; set; }
+    public double arcAngle { get; set; }
+
+    public GridElement() { }
+
+    public GridElement(string id, string applicationId)
+    {
+      this.id = id;
+      this.applicationId = applicationId;
+    }
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Model/MeshModel.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Model/MeshModel.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.Extensions.Primitives;
-using Speckle.Newtonsoft.Json;
 using Objects.Geometry;
+using Speckle.Newtonsoft.Json;
+using Speckle.Newtonsoft.Json.Linq;
 
 namespace Archicad.Model
 {
   public sealed class MeshModel
   {
-    public enum EdgeStatus 
+    public enum EdgeStatus
     {
       HiddenEdge = 1, // invisible
       SmoothEdge = 2, // visible if countour bit
@@ -18,9 +18,9 @@ namespace Archicad.Model
 
     #region --- Classes ---
 
-    public class MeshModelEdgeConverter : JsonConverter<Dictionary<Tuple<int, int>, EdgeStatus>>
+    public class MeshModelEdgeConverter : JsonConverter<Dictionary<EdgeId, EdgeData>>
     {
-      public override void WriteJson(JsonWriter writer, Dictionary<Tuple<int, int>, EdgeStatus> value, JsonSerializer serializer)
+      public override void WriteJson(JsonWriter writer, Dictionary<EdgeId, EdgeData> value, JsonSerializer serializer)
       {
         StringBuilder jsonString = new StringBuilder();
         jsonString.Append("[");
@@ -28,30 +28,93 @@ namespace Archicad.Model
         bool first = true;
         foreach (var entry in value)
         {
+          // skip hidden edges
+          if (entry.Value.edgeStatus == EdgeStatus.HiddenEdge)
+            continue;
+
           if (!first)
             jsonString.Append(", ");
           else
             first = false;
 
-          jsonString.Append("{ \"first\": ");
+          jsonString.Append("{ \"v1\": ");
+          jsonString.Append(entry.Key.vertexId1.ToString());
 
-          jsonString.Append("{ \"first\": ");
-          jsonString.Append(entry.Key.Item1.ToString());
-          jsonString.Append(", \"second\": ");
-          jsonString.Append(entry.Key.Item2.ToString());
-          jsonString.Append(" }");
+          jsonString.Append(", \"v2\": ");
+          jsonString.Append(entry.Key.vertexId2.ToString());
 
-          jsonString.Append(", \"second\" :");
-          jsonString.Append(((byte)entry.Value).ToString());
-          jsonString.Append(" }");
+          if (entry.Value.polygonId1 != EdgeData.InvalidPolygonId)
+          {
+            jsonString.Append(", \"p1\": ");
+            jsonString.Append(entry.Value.polygonId1.ToString());
+          }
+
+          if (entry.Value.polygonId2 != EdgeData.InvalidPolygonId)
+          {
+            jsonString.Append(", \"p2\": ");
+            jsonString.Append(entry.Value.polygonId2.ToString());
+          }
+
+          jsonString.Append(", \"s\": \"");
+          jsonString.Append(entry.Value.edgeStatus.ToString());
+
+          jsonString.Append("\" }");
         }
-        jsonString.Append ("]");
+
+        jsonString.Append("]");
         writer.WriteRawValue(jsonString.ToString());
       }
 
-      public override Dictionary<Tuple<int, int>, EdgeStatus> ReadJson(JsonReader reader, Type objectType, Dictionary<Tuple<int, int>, EdgeStatus> existingValue, bool hasExistingValue, JsonSerializer serializer)
+      public override Dictionary<EdgeId, EdgeData> ReadJson(
+        JsonReader reader,
+        Type objectType,
+        Dictionary<EdgeId, EdgeData> existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer
+      )
       {
-        return new Dictionary<Tuple<int, int>, EdgeStatus>();
+        Dictionary<EdgeId, EdgeData> edges = new Dictionary<EdgeId, EdgeData>();
+
+        JArray ja = JArray.Load(reader);
+
+        foreach (JObject jo in ja)
+        {
+          JToken v1;
+          jo.TryGetValue("v1", out v1);
+
+          JToken v2;
+          jo.TryGetValue("v2", out v2);
+
+          JToken s;
+          jo.TryGetValue("s", out s);
+
+          JToken p1;
+          jo.TryGetValue("p1", out p1);
+
+          JToken p2;
+          jo.TryGetValue("p2", out p2);
+
+          if (v1 == null || v2 == null || s == null)
+            continue;
+
+          EdgeId edgeId = new EdgeId(((int)v1), ((int)v2));
+
+          MeshModel.EdgeStatus edgeStatus = MeshModel.EdgeStatus.HiddenEdge;
+          if (((string)s).Equals("SmoothEdge"))
+            edgeStatus = MeshModel.EdgeStatus.SmoothEdge;
+          else if (((string)s).Equals("VisibleEdge"))
+            edgeStatus = MeshModel.EdgeStatus.VisibleEdge;
+
+          EdgeData edgeData = new EdgeData(
+            edgeStatus,
+            p1 != null ? ((int)p1) : MeshModel.EdgeData.InvalidPolygonId,
+            p2 != null ? ((int)p2) : MeshModel.EdgeData.InvalidPolygonId
+          );
+
+          edges.Add(edgeId, edgeData);
+        }
+
+        return edges;
       }
     }
 
@@ -74,6 +137,59 @@ namespace Archicad.Model
       #endregion
     }
 
+    public sealed class EdgeId
+    {
+      #region --- Fields ---
+
+      public int vertexId1 { get; set; }
+
+      public int vertexId2 { get; set; }
+
+      #endregion
+
+      #region --- Methods ---
+
+      public EdgeId(int vertexId1, int vertexId2)
+      {
+        this.vertexId1 = vertexId1;
+        this.vertexId2 = vertexId2;
+      }
+
+      public bool Equals(EdgeId edge) => edge.vertexId1.Equals(vertexId1) && edge.vertexId2.Equals(vertexId2);
+
+      public override bool Equals(object o) => Equals(o as EdgeId);
+
+      public override int GetHashCode() => vertexId1.GetHashCode() ^ vertexId2.GetHashCode();
+
+      #endregion
+    }
+
+    public sealed class EdgeData
+    {
+      public const int InvalidPolygonId = -1;
+
+      #region --- Fields ---
+
+      public EdgeStatus edgeStatus { get; set; }
+
+      public int polygonId1 { get; set; }
+
+      public int polygonId2 { get; set; }
+
+      #endregion
+
+      #region --- Methods ---
+
+      public EdgeData(EdgeStatus edgeStatus, int polygonId1 = InvalidPolygonId, int polygonId2 = InvalidPolygonId)
+      {
+        this.edgeStatus = edgeStatus;
+        this.polygonId1 = polygonId1;
+        this.polygonId2 = polygonId2;
+      }
+
+      #endregion
+    }
+
     public sealed class Material
     {
       #region --- Classes ---
@@ -85,7 +201,6 @@ namespace Archicad.Model
         public int green { get; set; }
 
         public int blue { get; set; }
-
       }
 
       #endregion
@@ -116,16 +231,16 @@ namespace Archicad.Model
 
     public List<string> ids { get; set; } = new List<string>();
 
-    public List<Polygon> polygons { get; set; } = new List<Polygon>();
-
     public List<Vertex> vertices { get; set; } = new List<Vertex>();
+
+    [JsonConverter(typeof(MeshModelEdgeConverter))]
+    public Dictionary<EdgeId, EdgeData> edges { get; set; } = new Dictionary<EdgeId, EdgeData>();
+
+    public List<Polygon> polygons { get; set; } = new List<Polygon>();
 
     public List<Material> materials { get; set; } = new List<Material>();
 
-    [JsonConverter(typeof(MeshModelEdgeConverter))]
-    public Dictionary<Tuple<int, int>, EdgeStatus> edges { get; set; } = new Dictionary<Tuple<int, int>, EdgeStatus>();
-
-    public bool IsCoplanar (Polygon polygon)
+    public bool IsCoplanar(Polygon polygon)
     {
       Vector vector1 = Archicad.Converters.Utils.VertexToVector(vertices[polygon.pointIds[0]]);
       Vector vector2 = Archicad.Converters.Utils.VertexToVector(vertices[polygon.pointIds[1]]);
@@ -141,7 +256,7 @@ namespace Archicad.Model
 
     private bool IsCoplanar(Vector vector1, Vector vector2, Vector vector3, Vector vector4)
     {
-      var dotProduct = Vector.DotProduct(vector2 - vector1, Vector.CrossProduct(vector4 - vector1, vector3 - vector1)); 
+      var dotProduct = Vector.DotProduct(vector2 - vector1, Vector.CrossProduct(vector4 - vector1, vector3 - vector1));
       return Math.Abs(dotProduct) < Speckle.Core.Helpers.Constants.SmallEps;
     }
 

--- a/Objects/Objects/BuiltElements/GridLine.cs
+++ b/Objects/Objects/BuiltElements/GridLine.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
+using Objects.Geometry;
 
 namespace Objects.BuiltElements;
 
-public class GridLine : Base
+public class GridLine : Base, IDisplayValue<List<Base>>
 {
   public GridLine() { }
 
@@ -29,4 +31,7 @@ public class GridLine : Base
   public string label { get; set; }
 
   public string units { get; set; }
+
+  [DetachProperty]
+  public List<Base> displayValue { get; set; }
 }


### PR DESCRIPTION
## Description & motivation

https://github.com/specklesystems/speckle-sharp/issues/2930

## Changes:

Objects:
* `GridLine` implements `IDisplayValue<List<Base>>`
  * Geometry could be Meshes or Lines

C# Connector:
* `MeshModel` class
  * uses edge information for both directions
  * edge information is stored as dictionary (hash table in C++) in runtime with `EdgeID` as key and `EdgeData` as value, but serialized as arrays (with custom JSON serializer)
  * Hidden edges filtered from data transfer between the add-on and the connector for performance reasons
  * GridLine converter uses `MeshesAndLinesToSpeckle`, which handles 3D lines in Meshes

C++ Add-on:
* Element type identification changed, now `TypeID` and `VariationID` pair is used (because GridElement in Archicad is a subtpye of Object with variation id `APIVarId_GridElement`)
* GridElement converters introduced


## Screenshots:

<img width="1421" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/afff43af-4991-47e9-8c60-4205afde910a">

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

