### PR TITLE
feat(dui): better fe2 compatibility

### DIFF
--- a/Core/Core/Api/GraphQL/Models.cs
+++ b/Core/Core/Api/GraphQL/Models.cs
@@ -383,6 +383,10 @@ public class ServerInfo
   public string version { get; set; }
   public string adminContact { get; set; }
   public string description { get; set; }
+  //NOTE: this field is not returned from the GQL API
+  //it is manually populated by checking against the response headers
+  //TODO: deprecate after the transition from fe1 to fe2
+  public bool frontend2 { get; set; }
 }
 
 public class StreamData

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -275,6 +276,7 @@ public static class AccountManager
         account.userInfo = userServerInfo.activeUser;
         account.serverInfo = userServerInfo.serverInfo;
         account.serverInfo.url = url;
+        account.serverInfo.frontend2 = await IsFrontend2Server(url).ConfigureAwait(false);
       }
       catch (Exception)
       {
@@ -584,6 +586,29 @@ public static class AccountManager
     catch (Exception e)
     {
       throw new SpeckleException(e.Message, e);
+    }
+  }
+
+  private static async Task<bool> IsFrontend2Server(string server)
+  {
+    try
+    {
+      using var client = Http.GetHttpProxyClient();
+      var response = await client.GetAsync(server).ConfigureAwait(false);
+
+      if (response.Headers.TryGetValues("x-speckle-frontend-2", out IEnumerable<string> values))
+      {
+        if (values.Any() && bool.Parse(values.FirstOrDefault()))
+        {
+          return true;
+        }
+      }
+
+      return false;
+    }
+    catch (Exception e)
+    {
+      return false;
     }
   }
 

--- a/DesktopUI2/DesktopUI2/ViewModels/CommentViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/CommentViewModel.cs
@@ -122,8 +122,7 @@ public class CommentViewModel : ReactiveObject
 
     var url =
       $"{_client.Account.serverInfo.url}/streams/{StreamId}/{r0.resourceType}s/{r0.resourceId}?cId={Comment.id}{overlay}";
-    var config = ConfigManager.Load();
-    if (config.UseFe2)
+    if (_client.Account.serverInfo.frontend2)
       url = $"{_client.Account.serverInfo.url}/projects/{StreamId}/";
 
     Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });

--- a/DesktopUI2/DesktopUI2/ViewModels/DialogViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/DialogViewModel.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using DesktopUI2.Models;
+using ReactiveUI;
+
+namespace DesktopUI2.ViewModels
+{
+  public class DialogViewModel : ReactiveObject
+  {
+    //UI Binding
+    public bool UseFe2
+    {
+      get
+      {
+        var config = ConfigManager.Load();
+        return config.UseFe2;
+      }
+    }
+  }
+}

--- a/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
@@ -492,8 +492,6 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
         new MenuItemViewModel(ToggleDarkThemeCommand, "Toggle dark/light theme", MaterialIconKind.SunMoonStars)
       );
 
-      menu.Items.Add(new MenuItemViewModel(ToggleFe2Command, "Toggle NEW Frontend support", MaterialIconKind.NewBox));
-
 #if DEBUG
       menu.Items.Add(new MenuItemViewModel(TestCommand, "Test stuff", MaterialIconKind.Bomb));
 #endif
@@ -579,7 +577,7 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
     var streamAcc = parameter as StreamAccountWrapper;
     var url = $"{streamAcc.Account.serverInfo.url.TrimEnd('/')}/streams/{streamAcc.Stream.id}";
 
-    if (UseFe2)
+    if (streamAcc.Account.serverInfo.frontend2)
       url = $"{streamAcc.Account.serverInfo.url.TrimEnd('/')}/projects/{streamAcc.Stream.id}";
 
     Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
@@ -940,6 +938,7 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
   public bool HasSavedStreams => SavedStreams != null && SavedStreams.Any();
   public bool HasStreams => FilteredStreams != null && FilteredStreams.Any();
 
+  //UI Binding
   public bool UseFe2
   {
     get

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -94,8 +94,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
   {
     get
     {
-      var config = ConfigManager.Load();
-      if (config.UseFe2)
+      if (Client.Account.serverInfo.frontend2)
       {
         //sender
         if (!IsReceiver)
@@ -592,6 +591,15 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
   }
 
+  //UI Binding
+  public bool UseFe2
+  {
+    get
+    {
+      return Client.Account.serverInfo.frontend2;
+    }
+  }
+
   public DateTime? LastUsedTime
   {
     get => StreamState.LastUsed;
@@ -602,14 +610,6 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
   }
 
-  public bool IsFe2Server(string url)
-  {
-    if (url.Contains("latest.speckle.systems") || url.Contains("app.speckle.systems"))
-      return true;
-    var config = ConfigManager.Load();
-    return config.UseFe2;
-
-  }
 
   private bool _isRemovingStream;
 
@@ -1305,8 +1305,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
           OnClick = () =>
           {
             var url = $"{StreamState.ServerUrl}/streams/{StreamState.StreamId}/commits/{commitId}";
-            var config = ConfigManager.Load();
-            if (config.UseFe2)
+            if (Client.Account.serverInfo.frontend2)
               url = $"{StreamState.ServerUrl}/projects/{StreamState.StreamId}/models/{SelectedBranch.Branch.id}";
             OpenUrl(url);
           },

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -250,11 +250,25 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
 
       Branches = await Client.StreamGetBranches(Stream.id, 100, 0).ConfigureAwait(true);
 
-      var index = Branches.FindIndex(x => x.name == StreamState.BranchName);
-      if (index != -1)
-        SelectedBranch = BranchesViewModel[index];
+      //TODO: Core's API calls and the StreamWrapper class need to be updated to properly support FE2 links
+      //this is a temporary workaround
+      var index = -1;
+      if (UseFe2)
+      {
+        index = Branches.FindIndex(x => x.id == StreamState.BranchName);
+      }
       else
+      {
+        index = Branches.FindIndex(x => x.name == StreamState.BranchName);
+      }
+      if (index != -1)
+      {
+        SelectedBranch = BranchesViewModel[index];
+      }
+      else
+      {
         SelectedBranch = BranchesViewModel[0];
+      }
 
       //restore selected filter
       if (StreamState.Filter != null)

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -602,13 +602,13 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
   }
 
-  public bool UseFe2
+  public bool IsFe2Server(string url)
   {
-    get
-    {
-      var config = ConfigManager.Load();
-      return config.UseFe2;
-    }
+    if (url.Contains("latest.speckle.systems") || url.Contains("app.speckle.systems"))
+      return true;
+    var config = ConfigManager.Load();
+    return config.UseFe2;
+
   }
 
   private bool _isRemovingStream;

--- a/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Comments.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Comments.xaml
@@ -18,6 +18,7 @@
     <conv:RoleCanSendValueConverter x:Key="RoleCanSendValueConverter" />
     <conv:RoleValueConverter x:Key="RoleValueConverter" />
     <conv:StringOpacityValueConverter x:Key="StringOpacityValueConverter" />
+    <conv:Fe2TextValueConverter x:Key="Fe2TextValueConverter" />
   </UserControl.Resources>
   <ScrollViewer Name="activityScroller">
     <Grid RowDefinitions="*,auto">
@@ -26,7 +27,7 @@
         IsVisible="{Binding !Comments.Count}"
         Orientation="Vertical"
         Spacing="20">
-        <TextBlock Text="💬 There are no comments yet on this Stream!" TextWrapping="Wrap" />
+        <TextBlock Text="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='💬 There are no comments yet on this Stream!'}" TextWrapping="Wrap" />
         <Button
           Classes="Flat"
           Command="{Binding ViewOnlineSavedStreamCommand}"

--- a/DesktopUI2/DesktopUI2/Views/Pages/HomeView.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/HomeView.xaml
@@ -89,7 +89,7 @@
           Background="Transparent"
           Classes="Mini"
           Command="{Binding ToggleFe2Command}"
-          ToolTip.Tip="Toggle NEW Frontend support">
+          ToolTip.Tip="Toggle NEW Frontend terminology">
           <Button.Content>
             <Grid>
               <icons:MaterialIcon
@@ -220,7 +220,7 @@
                   Grid.Column="1"
                   Margin="2,0,0,0"
                   VerticalAlignment="Center"
-                  ToolTip.Tip="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='Filter streams by ownership of favorite'}">
+                  ToolTip.Tip="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='Filter streams by ownership or favorite'}">
 
                   <MenuItem
                     Width="30"

--- a/DesktopUI2/DesktopUI2/Views/Pages/HomeView.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/HomeView.xaml
@@ -27,7 +27,7 @@
       Padding="10"
       Background="{DynamicResource PrimaryHueMidBrush}"
       CornerRadius="0">
-      <Grid ColumnDefinitions="auto,auto,*,auto,auto,auto,auto">
+      <Grid ColumnDefinitions="auto,auto,*,auto,auto,auto,auto,auto">
 
         <Canvas
           Grid.Column="0"
@@ -70,7 +70,7 @@
           TextTrimming="CharacterEllipsis" />
 
 
-        <icons:MaterialIcon
+        <!--<icons:MaterialIcon
           Grid.Column="4"
           Width="18"
           Height="18"
@@ -79,12 +79,43 @@
           Foreground="White"
           IsVisible="{Binding UseFe2}"
           Kind="NewBox"
-          ToolTip.Tip="Links are pointing to the NEW frontend" />
+          ToolTip.Tip="Links are pointing to the NEW frontend" />-->
+
+        <!--  FE2  -->
+        <m:FloatingButton
+          Grid.Column="5"
+          VerticalAlignment="Center"
+          assists:ShadowAssist.ShadowDepth="Depth0"
+          Background="Transparent"
+          Classes="Mini"
+          Command="{Binding ToggleFe2Command}"
+          ToolTip.Tip="Toggle NEW Frontend support">
+          <Button.Content>
+            <Grid>
+              <icons:MaterialIcon
+                Width="18"
+                Height="18"
+                assists:ShadowAssist.ShadowDepth="0"
+                Foreground="White"
+                IsVisible="{Binding UseFe2}"
+                Kind="NewBox" />
+              <icons:MaterialIcon
+                Width="18"
+                Height="18"
+                assists:ShadowAssist.ShadowDepth="0"
+                Foreground="White"
+                IsVisible="{Binding !UseFe2}"
+                Kind="NewBox"
+                Opacity="0.5" />
+            </Grid>
+          </Button.Content>
+        </m:FloatingButton>
+
 
         <!--  ACCOUNT MENU  -->
 
         <Menu
-          Grid.Column="5"
+          Grid.Column="6"
           VerticalAlignment="Center"
           IsEnabled="{Binding !InProgress}"
           Items="{Binding MenuItems}">
@@ -103,7 +134,7 @@
 
 
         <!--  NOTIFICATIONS  -->
-        <Grid Grid.Column="6" IsVisible="{Binding Notifications.Count}">
+        <Grid Grid.Column="7" IsVisible="{Binding Notifications.Count}">
           <m:FloatingButton
             VerticalAlignment="Center"
             assists:ShadowAssist.ShadowDepth="Depth0"

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/AddAccountDialog.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/AddAccountDialog.xaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using DesktopUI2.ViewModels;
 
 namespace DesktopUI2.Views.Windows.Dialogs;
 
@@ -24,6 +25,7 @@ public class AddAccountDialog : DialogUserControl
   private void InitializeComponent()
   {
     AvaloniaXamlLoader.Load(this);
+
     UrlField = this.FindControl<TextBox>("url");
 
     UrlField.Text = Url;

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/AddFromUrlDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/AddFromUrlDialog.xaml
@@ -2,28 +2,32 @@
   x:Class="DesktopUI2.Views.Windows.Dialogs.AddFromUrlDialog"
   xmlns="https://github.com/avaloniaui"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:conv="clr-namespace:DesktopUI2.Views.Converters"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   mc:Ignorable="d">
+  <UserControl.Resources>
+    <conv:Fe2TextValueConverter x:Key="Fe2TextValueConverter" />
+  </UserControl.Resources>
   <Grid RowDefinitions="auto, auto, auto, auto, auto, auto">
     <TextBlock
       Margin="15,15,15,0"
       Classes="Subtitle1"
-      Text="Add a Stream by ID or URL"
+      Text="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='Add a Stream by ID or URL'}"
       TextTrimming="CharacterEllipsis" />
 
     <TextBlock
       Grid.Row="1"
       Margin="15"
       Foreground="Gray"
-      Text="Stream IDs and Stream/Branch/Commit URLs are supported."
+      Text="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='Stream IDs and Stream/Branch/Commit URLs are supported.'}"
       TextWrapping="Wrap" />
 
     <TextBox
       Name="url"
       Grid.Row="2"
       Margin="15,0"
-      Watermark="Stream URL" />
+      Watermark="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='Stream URL'}" />
 
     <StackPanel
       Grid.Row="5"

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/AddFromUrlDialog.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/AddFromUrlDialog.xaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using DesktopUI2.ViewModels;
 
 namespace DesktopUI2.Views.Windows.Dialogs;
 
@@ -24,6 +25,7 @@ public class AddFromUrlDialog : DialogUserControl
   private void InitializeComponent()
   {
     AvaloniaXamlLoader.Load(this);
+    this.DataContext = new DialogViewModel();
     UrlField = this.FindControl<TextBox>("url");
 
     UrlField.Text = Url;

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
@@ -66,7 +66,7 @@
       Name="name"
       Grid.Row="2"
       Margin="15,5"
-      Watermark="Stream Name (optional)" />
+      Watermark="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='Stream Name (optional)'}" />
 
     <TextBox
       Name="description"

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
@@ -2,6 +2,7 @@
   x:Class="DesktopUI2.Views.Windows.Dialogs.NewStreamDialog"
   xmlns="https://github.com/avaloniaui"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:conv="clr-namespace:DesktopUI2.Views.Converters"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -18,11 +19,14 @@
 
 
   </UserControl.Styles>
+  <UserControl.Resources>
+    <conv:Fe2TextValueConverter x:Key="Fe2TextValueConverter" />
+  </UserControl.Resources>
   <Grid RowDefinitions="auto, auto, auto, auto, auto, auto">
     <TextBlock
       Margin="15,15,15,0"
       Classes="Subtitle1"
-      Text="Create a new Stream"
+      Text="{Binding UseFe2, Converter={StaticResource Fe2TextValueConverter}, ConverterParameter='Create a new Stream'}"
       TextTrimming="CharacterEllipsis" />
     <ComboBox
       Name="accounts"
@@ -73,8 +77,8 @@
     <ToggleSwitch
       Name="isPublic"
       Grid.Row="4"
-      Margin="15"/>
-    
+      Margin="15" />
+
     <StackPanel
       Grid.Row="5"
       Margin="15"

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml.cs
@@ -14,6 +14,7 @@ public class NewStreamDialog : DialogUserControl
   public NewStreamDialog(List<AccountViewModel> accounts)
   {
     InitializeComponent();
+    this.DataContext = new DialogViewModel();
     var combo = this.FindControl<ComboBox>("accounts");
     combo.Items = accounts;
     try


### PR DESCRIPTION
Depends on: #2989 

This PR improves how DUI2 integrates with FE2:

- moves the FE2 toggle to the main toolbar
- any stream related action (eg view online) now automatically detects if a stream is on fe2 and uses the new routes
- added more string replacements here and there

NOTE: this PR depends on some changes to Manager which are already being rolled out (current beta)

![fe2-toggle](https://github.com/specklesystems/speckle-sharp/assets/2679513/07674cbd-2596-4e36-a30c-e8a315d012a8)
