### PR TITLE
feat(core): Adds SpeckleLogConfig input to Setup.Initialize

### DIFF
--- a/Core/Core/Logging/Setup.cs
+++ b/Core/Core/Logging/Setup.cs
@@ -40,7 +40,11 @@ public static class Setup
   /// </summary>
   internal static string VersionedHostApplication { get; private set; } = HostApplications.Other.Slug;
 
-  public static void Init(string versionedHostApplication, string hostApplication)
+  public static void Init(
+    string versionedHostApplication,
+    string hostApplication,
+    SpeckleLogConfiguration logConfiguration = null
+  )
   {
     if (_initialized)
     {
@@ -63,7 +67,7 @@ public static class Setup
     //start mutex so that Manager can detect if this process is running
     mutex = new Mutex(false, "SpeckleConnector-" + hostApplication);
 
-    SpeckleLog.Initialize(hostApplication, versionedHostApplication);
+    SpeckleLog.Initialize(hostApplication, versionedHostApplication, logConfiguration);
 
     foreach (var account in AccountManager.GetAccounts())
       Analytics.AddConnectorToProfile(account.GetHashedEmail(), hostApplication);


### PR DESCRIPTION
Opening this PR as a followup to my discord message about this.

This change allows devs to pass in the SpeckleLogConfig of choice when calling `Setup.Initialize` to allow for granular control over what gets logged.