### PR TITLE
fix(core): Fixed regression with stream collaborators query parameters

### DIFF
--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.StreamOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.StreamOperations.cs
@@ -380,7 +380,7 @@ public partial class Client
                         }
                       }
                     }",
-      Variables = new { streamId }
+      Variables = new { id = streamId }
     };
     var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false); //WARN: Why do we do this?
     return (await ExecuteGraphQLRequest<StreamData>(request, cancellationToken).ConfigureAwait(false)).stream;


### PR DESCRIPTION
In https://github.com/specklesystems/speckle-sharp/pull/2925, I accidently introduced a regression by renaming  `id` -> `streamId` in StreamGetPendingCollaborators

(side note, this demonstrates we are missing an integration test for this query)