### PR TITLE
Suppress CRL checking

### DIFF
--- a/Core/Core/Helpers/Http.cs
+++ b/Core/Core/Helpers/Http.cs
@@ -214,7 +214,7 @@ public class SpeckleHttpClientHandler : HttpClientHandler
   public SpeckleHttpClientHandler(IEnumerable<TimeSpan>? delay = null)
   {
     _delay = delay ?? Http.DefaultDelay();
-    CheckCertificateRevocationList = true;
+    CheckCertificateRevocationList = false;
   }
 
   protected override async Task<HttpResponseMessage> SendAsync(


### PR DESCRIPTION
We have a reported issue of crashing in Revit 2024 which appears to relate to cert validation.

As a test we setting this to false to not check for valid certification...

https://speckle.community/t/revit-2024-1-1-speckle-not-functional/7598

This involved explicitly setting the property on the handler.