### PR TITLE
feat(Archicad): Send and receive layer information

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateBeam.cpp
@@ -40,6 +40,10 @@ GSErrCode CreateBeam::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, beamMask);
+	if (err != NoError)
+		return err;
+
 	// Positioning
 	Objects::Point3D startPoint;
 	if (os.Contains (Beam::begC)) {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateColumn.cpp
@@ -43,6 +43,10 @@ GSErrCode CreateColumn::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	// Positioning - geometry
 	Objects::Point3D origoPos;
 	if (os.Contains (Column::origoPos)) {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
@@ -45,6 +45,30 @@ void CreateCommand::GetStoryFromObjectState (const GS::ObjectState& os, const do
 }
 
 
+GSErrCode CreateCommand::GetElementBaseFromObjectState (const GS::ObjectState& os, API_Element& element, API_Element& elementMask) const
+{
+	GSErrCode err = NoError;
+	// layer
+	GS::UniString layer;
+	if (os.Contains (ElementBase::Layer)) {
+		os.Get (ElementBase::Layer, layer);
+
+		API_Attribute attribute;
+		BNZeroMemory (&attribute, sizeof (API_Attribute));
+		attribute.header.typeID = API_LayerID;
+		attribute.header.uniStringNamePtr = &layer;
+		err = ACAPI_Attribute_Get (&attribute);
+
+		if (err == NoError) {
+			element.header.layer = attribute.header.index;
+			ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, layer);
+		}
+	}
+
+	return err;
+}
+
+
 GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
 	GS::ObjectState result;
@@ -155,7 +179,7 @@ GS::ObjectState CreateCommand::Execute (const GS::ObjectState& parameters, GS::P
 }
 
 
-GS::ErrCode CreateCommand::ImportClassificationsAndProperties (const GS::ObjectState& os, API_Guid& elemGuid) const
+GSErrCode CreateCommand::ImportClassificationsAndProperties (const GS::ObjectState& os, API_Guid& elemGuid) const
 {
 	GSErrCode err = NoError;
 	GS::Array<GS::ObjectState> classifications;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.hpp
@@ -39,10 +39,14 @@ protected:
 								short& floorIndex,
 								double& relativeLevel) const;
 
+	GSErrCode				GetElementBaseFromObjectState (const GS::ObjectState& os, 
+								API_Element& element,
+								API_Element& elementMask) const;
+
 public:
 	virtual GS::ObjectState	Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 
-	GS::ErrCode				ImportClassificationsAndProperties (const GS::ObjectState& os, API_Guid& elemGuid) const;
+	GSErrCode				ImportClassificationsAndProperties (const GS::ObjectState& os, API_Guid& elemGuid) const;
 };
 }
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDoor.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateDoor.cpp
@@ -42,6 +42,10 @@ GSErrCode CreateDoor::GetElementFromObjectState (const GS::ObjectState& os,
 
 	Utility::SetElementType (element.header, API_DoorID);
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	*marker = new API_SubElement ();
 	BNZeroMemory (*marker, sizeof (API_SubElement));
 	err = Utility::GetBaseElementData (element, &memo, marker, log);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateObject.cpp
@@ -44,6 +44,10 @@ GSErrCode CreateObject::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	// get the mesh
 	GS::Array<GS::UniString> modelIds;
 	os.Get (Model::ModelIds, modelIds);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateRoof.cpp
@@ -41,6 +41,10 @@ GSErrCode CreateRoof::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	// The structure of the roof
 	if (os.Contains (Roof::RoofClassName)) {
 		GS::UniString roofClassName;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateShell.cpp
@@ -42,6 +42,10 @@ GSErrCode CreateShell::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	// The structure of the shell
 	if (os.Contains (Shell::ShellClassName)) {
 		GS::UniString shellClassName;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSkylight.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSkylight.cpp
@@ -49,6 +49,10 @@ GSErrCode CreateSkylight::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	if (!CheckEnvironment (os, element))
 		return Error;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateSlab.cpp
@@ -43,6 +43,10 @@ GSErrCode CreateSlab::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, mask);
+	if (err != NoError)
+		return err;
+
 	// Geometry and positioning
 	memoMask = APIMemoMask_Polygon | APIMemoMask_SideMaterials | APIMemoMask_EdgeTrims;
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWall.cpp
@@ -45,6 +45,10 @@ GSErrCode CreateWall::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	memoMask = APIMemoMask_Polygon;
 
 	// Wall geometry

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWindow.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateWindow.cpp
@@ -43,6 +43,10 @@ GSErrCode CreateWindow::GetElementFromObjectState (const GS::ObjectState& os,
 
 	Utility::SetElementType (element.header, API_WindowID);
 
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
 	*marker = new API_SubElement ();
 	BNZeroMemory (*marker, sizeof (API_SubElement));
 	err = Utility::GetBaseElementData (element, &memo, marker, log);

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateZone.cpp
@@ -43,6 +43,10 @@ GSErrCode CreateZone::GetElementFromObjectState (const GS::ObjectState& os,
 	if (err != NoError)
 		return err;
 
+	err = GetElementBaseFromObjectState (os, element, mask);
+	if (err != NoError)
+		return err;
+
 	memoMask = APIMemoMask_Polygon;
 
 	// The shape of the zone

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDataCommand.cpp
@@ -68,6 +68,14 @@ GS::ErrCode GetDataCommand::SerializeElementType(const API_Element& elem, const 
 
 	os.Add(FieldNames::ElementBase::ApplicationId, APIGuidToString (elem.header.guid));
 
+	API_Attribute attribute;
+	BNZeroMemory (&attribute, sizeof (API_Attribute));
+	attribute.header.typeID = API_LayerID;
+	attribute.header.index = elem.header.layer;
+	if (NoError == ACAPI_Attribute_Get (&attribute)) {
+		os.Add(FieldNames::ElementBase::Layer, GS::UniString{attribute.header.name});
+	}
+
 	err = ExportClassificationsAndProperties (elem, os);
 
 	return err;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
@@ -32,6 +32,7 @@ static const char* ElementTypes = "elementTypes";
 static const char* Elements = "elements";
 static const char* SubElements = "subElements";
 static const char* Level = "level";
+static const char* Layer = "layer";
 static const char* Shape = "shape";
 static const char* Shape1 = "shape1";
 static const char* Shape2 = "shape2";

--- a/ConnectorArchicad/ConnectorArchicad/Elements/Object.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Elements/Object.cs
@@ -10,7 +10,6 @@ using System.Text;
 using Speckle.Newtonsoft.Json;
 using Archicad.Model;
 
-
 namespace Archicad
 {
   public class ArchicadObject
@@ -24,6 +23,8 @@ namespace Archicad
 
     public ArchicadLevel level { get; set; }
 
+    public string? layer { get; set; }
+
     public Point pos { get; set; }
     public Objects.Other.Transform transform { get; set; }
 
@@ -34,7 +35,6 @@ namespace Archicad
     public ArchicadObject() { }
 
     [SchemaInfo("ArchicadObject", "Creates an Archicad object.", "Archicad", "Structure")]
-
     public ArchicadObject(string id, string applicationId, Point basePoint, List<string> modelIds)
     {
       this.id = id;

--- a/ConnectorArchicad/ConnectorArchicad/Elements/Room.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Elements/Room.cs
@@ -26,6 +26,7 @@ namespace Archicad
     public string? elementType { get; set; }
     public List<Classification>? classifications { get; set; }
     public ArchicadLevel? level { get; set; }
+    public string? layer { get; set; }
 
     // Room
     public double? height { get; set; }

--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -124,35 +124,56 @@ namespace Objects.BuiltElements.Archicad
     public ArchicadBeam() { }
 
     // Element base
-    public string? /*APINullabe*/ elementType { get; set; }
-    public List<Classification>? /*APINullabe*/ classifications { get; set; }
+    public string? /*APINullabe*/
+    elementType { get; set; }
+    public List<Classification>? /*APINullabe*/
+    classifications { get; set; }
 
-    public ArchicadLevel? /*APINullabe*/ level { get; set; }
+    public ArchicadLevel? /*APINullabe*/
+    level { get; set; }
+
+    public string? /*APINullabe*/
+    layer { get; set; }
 
     // Positioning
     public Point begC { get; set; }
     public Point endC { get; set; }
-    public bool? /*APINullabe*/ isSlanted { get; set; }
-    public double? /*APINullabe*/ slantAngle { get; set; }
-    public string? /*APINullabe*/ beamShape { get; set; }
-    public int? /*APINullabe*/ sequence { get; set; }
-    public double? /*APINullabe*/ curveAngle { get; set; }
-    public double? /*APINullabe*/ verticalCurveHeight { get; set; }
-    public bool? /*APINullabe*/ isFlipped { get; set; }
+    public bool? /*APINullabe*/
+    isSlanted { get; set; }
+    public double? /*APINullabe*/
+    slantAngle { get; set; }
+    public string? /*APINullabe*/
+    beamShape { get; set; }
+    public int? /*APINullabe*/
+    sequence { get; set; }
+    public double? /*APINullabe*/
+    curveAngle { get; set; }
+    public double? /*APINullabe*/
+    verticalCurveHeight { get; set; }
+    public bool? /*APINullabe*/
+    isFlipped { get; set; }
 
     // End Cuts
-    public uint? /*APINullabe*/ nCuts { get; set; }
+    public uint? /*APINullabe*/
+    nCuts { get; set; }
     public Dictionary<string, AssemblySegmentCut>? Cuts { get; set; }
 
     // Reference Axis
-    public short? /*APINullabe*/ anchorPoint { get; set; }
+    public short? /*APINullabe*/
+    anchorPoint { get; set; }
     public double? offset { get; set; }
     public double? profileAngle { get; set; }
 
     // Segment
-    public uint? /*APINullabe*/ nSegments { get; set; }
-    public uint? /*APINullabe*/ nProfiles { get; set; }
-    public Dictionary<string, BeamSegment>? /*APINullabe*/ segments { get; set; }
+    public uint? /*APINullabe*/
+    nSegments { get; set; }
+    public uint? /*APINullabe*/
+    nProfiles { get; set; }
+    public Dictionary<
+      string,
+      BeamSegment
+    >? /*APINullabe*/
+    segments { get; set; }
 
     // Scheme
     public uint? nSchemes { get; set; }
@@ -162,11 +183,16 @@ namespace Objects.BuiltElements.Archicad
     public Dictionary<string, Hole>? Holes { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string? /*APINullabe*/ showOnStories { get; set; }
-    public string? /*APINullabe*/ displayOptionName { get; set; }
-    public string? /*APINullabe*/ uncutProjectionMode { get; set; }
-    public string? /*APINullabe*/ overheadProjectionMode { get; set; }
-    public string? /*APINullabe*/ showProjectionName { get; set; }
+    public string? /*APINullabe*/
+    showOnStories { get; set; }
+    public string? /*APINullabe*/
+    displayOptionName { get; set; }
+    public string? /*APINullabe*/
+    uncutProjectionMode { get; set; }
+    public string? /*APINullabe*/
+    overheadProjectionMode { get; set; }
+    public string? /*APINullabe*/
+    showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces
     public short? cutContourLinePen { get; set; }
@@ -175,21 +201,32 @@ namespace Objects.BuiltElements.Archicad
     public short? overrideCutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines
-    public string? /*APINullabe*/ showOutline { get; set; }
-    public short? /*APINullabe*/ uncutLinePen { get; set; }
-    public string? /*APINullabe*/ uncutLinetype { get; set; }
-    public short? /*APINullabe*/ overheadLinePen { get; set; }
-    public string? /*APINullabe*/ overheadLinetype { get; set; }
-    public short? /*APINullabe*/ hiddenLinePen { get; set; }
-    public string? /*APINullabe*/ hiddenLinetype { get; set; }
+    public string? /*APINullabe*/
+    showOutline { get; set; }
+    public short? /*APINullabe*/
+    uncutLinePen { get; set; }
+    public string? /*APINullabe*/
+    uncutLinetype { get; set; }
+    public short? /*APINullabe*/
+    overheadLinePen { get; set; }
+    public string? /*APINullabe*/
+    overheadLinetype { get; set; }
+    public short? /*APINullabe*/
+    hiddenLinePen { get; set; }
+    public string? /*APINullabe*/
+    hiddenLinetype { get; set; }
 
     // Floor Plan and Section - Symbol
-    public string? /*APINullabe*/ showReferenceAxis { get; set; }
-    public short? /*APINullabe*/ referencePen { get; set; }
-    public string? /*APINullabe*/ referenceLinetype { get; set; }
+    public string? /*APINullabe*/
+    showReferenceAxis { get; set; }
+    public short? /*APINullabe*/
+    referencePen { get; set; }
+    public string? /*APINullabe*/
+    referenceLinetype { get; set; }
 
     // Floor Plan and Section - Cover Fills
-    public bool? /*APINullabe*/ useCoverFill { get; set; }
+    public bool? /*APINullabe*/
+    useCoverFill { get; set; }
     public bool? useCoverFillFromSurface { get; set; }
     public short? coverFillForegroundPen { get; set; }
     public short? coverFillBackgroundPen { get; set; }

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -150,53 +150,82 @@ namespace Objects.BuiltElements.Archicad
     public ArchicadColumn() { }
 
     // Element base
-    public string? /*APINullabe*/ elementType { get; set; }
-    public List<Classification>? /*APINullabe*/ classifications { get; set; }
+    public string? /*APINullabe*/
+    elementType { get; set; }
+    public List<Classification>? /*APINullabe*/
+    classifications { get; set; }
 
-    public ArchicadLevel? /*APINullabe*/ level { get; set; }
+    public ArchicadLevel? /*APINullabe*/
+    level { get; set; }
+
+    public string? /*APINullabe*/
+    layer { get; set; }
 
     // Wall geometry
     public Point origoPos { get; set; }
     public double height { get; set; }
 
     // Positioning - story relation
-    public double? /*APINullabe*/ bottomOffset { get; set; }
-    public double? /*APINullabe*/ topOffset { get; set; }
-    public short? /*APINullabe*/ relativeTopStory { get; set; }
+    public double? /*APINullabe*/
+    bottomOffset { get; set; }
+    public double? /*APINullabe*/
+    topOffset { get; set; }
+    public short? /*APINullabe*/
+    relativeTopStory { get; set; }
 
     // Positioning - slanted column
-    public bool? /*APINullabe*/ isSlanted { get; set; }
-    public double? /*APINullabe*/ slantAngle { get; set; }
-    public double? /*APINullabe*/ slantDirectionAngle { get; set; }
-    public bool? /*APINullabe*/ isFlipped { get; set; }
+    public bool? /*APINullabe*/
+    isSlanted { get; set; }
+    public double? /*APINullabe*/
+    slantAngle { get; set; }
+    public double? /*APINullabe*/
+    slantDirectionAngle { get; set; }
+    public bool? /*APINullabe*/
+    isFlipped { get; set; }
 
     // Positioning - wrapping
-    public bool? /*APINullabe*/ wrapping { get; set; }
+    public bool? /*APINullabe*/
+    wrapping { get; set; }
 
     // Positioning - Defines the relation of column to zones (Zone Boundary, Reduce Zone Area Only, No Effect on Zones)
-    public string? /*APINullabe*/ columnRelationToZoneName { get; set; }
+    public string? /*APINullabe*/
+    columnRelationToZoneName { get; set; }
 
     // End Cuts
-    public uint? /*APINullabe*/ nCuts { get; set; }
-    public Dictionary<string, AssemblySegmentCut>? /*APINullabe*/ Cuts { get; set; }
+    public uint? /*APINullabe*/
+    nCuts { get; set; }
+    public Dictionary<
+      string,
+      AssemblySegmentCut
+    >? /*APINullabe*/
+    Cuts { get; set; }
 
     // Reference Axis
     public short? coreAnchor { get; set; }
     public double? axisRotationAngle { get; set; }
 
     // Segment
-    public uint? /*APINullabe*/ nSegments { get; set; }
-    public uint? /*APINullabe*/ nProfiles { get; set; }
-    public Dictionary<string, ColumnSegment>? /*APINullabe*/ segments { get; set; }
+    public uint? /*APINullabe*/
+    nSegments { get; set; }
+    public uint? /*APINullabe*/
+    nProfiles { get; set; }
+    public Dictionary<
+      string,
+      ColumnSegment
+    >? /*APINullabe*/
+    segments { get; set; }
 
     // Scheme
     public uint? nSchemes { get; set; }
     public Dictionary<string, AssemblySegmentScheme>? Schemes { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string? /*APINullabe*/ showOnStories { get; set; }
-    public string? /*APINullabe*/ displayOptionName { get; set; }
-    public string? /*APINullabe*/ showProjectionName { get; set; }
+    public string? /*APINullabe*/
+    showOnStories { get; set; }
+    public string? /*APINullabe*/
+    displayOptionName { get; set; }
+    public string? /*APINullabe*/
+    showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces
     public short? corePen { get; set; }
@@ -207,21 +236,32 @@ namespace Objects.BuiltElements.Archicad
     public short? overrideCutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines
-    public short? /*APINullabe*/ uncutLinePen { get; set; }
-    public string? /*APINullabe*/ uncutLinetype { get; set; }
-    public short? /*APINullabe*/ overheadLinePen { get; set; }
-    public string? /*APINullabe*/ overheadLinetype { get; set; }
-    public short? /*APINullabe*/ hiddenLinePen { get; set; }
-    public string? /*APINullabe*/ hiddenLinetype { get; set; }
+    public short? /*APINullabe*/
+    uncutLinePen { get; set; }
+    public string? /*APINullabe*/
+    uncutLinetype { get; set; }
+    public short? /*APINullabe*/
+    overheadLinePen { get; set; }
+    public string? /*APINullabe*/
+    overheadLinetype { get; set; }
+    public short? /*APINullabe*/
+    hiddenLinePen { get; set; }
+    public string? /*APINullabe*/
+    hiddenLinetype { get; set; }
 
     // Floor Plan and Section - Floor Plan Symbol
-    public string? /*APINullabe*/ coreSymbolTypeName { get; set; }
-    public double? /*APINullabe*/ coreSymbolPar1 { get; set; }
-    public double? /*APINullabe*/ coreSymbolPar2 { get; set; }
-    public short? /*APINullabe*/ coreSymbolPen { get; set; }
+    public string? /*APINullabe*/
+    coreSymbolTypeName { get; set; }
+    public double? /*APINullabe*/
+    coreSymbolPar1 { get; set; }
+    public double? /*APINullabe*/
+    coreSymbolPar2 { get; set; }
+    public short? /*APINullabe*/
+    coreSymbolPen { get; set; }
 
     // Floor Plan and Section - Cover Fills
-    public bool? /*APINullabe*/ useCoverFill { get; set; }
+    public bool? /*APINullabe*/
+    useCoverFill { get; set; }
     public bool? useCoverFillFromSurface { get; set; }
     public short? coverFillForegroundPen { get; set; }
     public short? coverFillBackgroundPen { get; set; }

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -88,25 +88,34 @@ namespace Objects.BuiltElements.Archicad
   public sealed class ArchicadFloor : Floor
   {
     // Element base
-    public string? /*APINullabe*/ elementType { get; set; }
-    public List<Classification>? /*APINullabe*/ classifications { get; set; }
+    public string? /*APINullabe*/
+    elementType { get; set; }
+    public List<Classification>? /*APINullabe*/
+    classifications { get; set; }
 
-    public ArchicadLevel? /*APINullabe*/ level { get; set; }
+    public ArchicadLevel? /*APINullabe*/
+    level { get; set; }
+
+    public string? /*APINullabe*/
+    layer { get; set; }
 
     // Geometry and positioning
     public double? thickness { get; set; }
     public ElementShape shape { get; set; }
-    public string? /*APINullabe*/ structure { get; set; }
+    public string? /*APINullabe*/
+    structure { get; set; }
     public string? compositeName { get; set; }
     public string? buildingMaterialName { get; set; }
-    public string? /*APINullabe*/ referencePlaneLocation { get; set; }
+    public string? /*APINullabe*/
+    referencePlaneLocation { get; set; }
 
     // EdgeTrims
     public string? edgeAngleType { get; set; }
     public double? edgeAngle { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string? /*APINullabe*/ showOnStories { get; set; }
+    public string? /*APINullabe*/
+    showOnStories { get; set; }
     public Visibility? visibilityCont { get; set; }
     public Visibility? visibilityFill { get; set; }
 

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -120,7 +120,6 @@ namespace Objects.BuiltElements.Revit.RevitRoof
   }
 }
 
-
 namespace Objects.BuiltElements.Archicad
 {
   /*
@@ -139,14 +138,21 @@ namespace Objects.BuiltElements.Archicad
     }
 
     // Element base
-    public string? /*APINullabe*/ elementType { get; set; }
-    public List<Classification>? /*APINullabe*/ classifications { get; set; }
+    public string? /*APINullabe*/
+    elementType { get; set; }
+    public List<Classification>? /*APINullabe*/
+    classifications { get; set; }
 
-    public ArchicadLevel? /*APINullabe*/ level { get; set; }
+    public ArchicadLevel? /*APINullabe*/
+    level { get; set; }
+
+    public string? /*APINullabe*/
+    layer { get; set; }
 
     // Geometry and positioning
     public double? thickness { get; set; }
-    public string? /*APINullabe*/ structure { get; set; }
+    public string? /*APINullabe*/
+    structure { get; set; }
     public string? compositeName { get; set; }
     public string? buildingMaterialName { get; set; }
 
@@ -155,26 +161,36 @@ namespace Objects.BuiltElements.Archicad
     public double? edgeAngle { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string? /*APINullabe*/ showOnStories { get; set; }
+    public string? /*APINullabe*/
+    showOnStories { get; set; }
     public Visibility? visibilityCont { get; set; }
     public Visibility? visibilityFill { get; set; }
-    public string? /*APINullabe*/ displayOptionName { get; set; }
-    public string? /*APINullabe*/ showProjectionName { get; set; }
+    public string? /*APINullabe*/
+    displayOptionName { get; set; }
+    public string? /*APINullabe*/
+    showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces
-    public short? /*APINullabe*/ sectContPen { get; set; }
-    public string? /*APINullabe*/ sectContLtype { get; set; }
+    public short? /*APINullabe*/
+    sectContPen { get; set; }
+    public string? /*APINullabe*/
+    sectContLtype { get; set; }
     public short? cutFillPen { get; set; }
     public short? cutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines
-    public short? /*APINullabe*/ contourPen { get; set; }
-    public string? /*APINullabe*/ contourLineType { get; set; }
-    public short? /*APINullabe*/ overheadLinePen { get; set; }
-    public string? /*APINullabe*/ overheadLinetype { get; set; }
+    public short? /*APINullabe*/
+    contourPen { get; set; }
+    public string? /*APINullabe*/
+    contourLineType { get; set; }
+    public short? /*APINullabe*/
+    overheadLinePen { get; set; }
+    public string? /*APINullabe*/
+    overheadLinetype { get; set; }
 
     // Floor Plan and Section - Cover Fills
-    public bool? /*APINullabe*/ useFloorFill { get; set; }
+    public bool? /*APINullabe*/
+    useFloorFill { get; set; }
     public short? floorFillPen { get; set; }
     public short? floorFillBGPen { get; set; }
     public string? floorFillName { get; set; }
@@ -194,7 +210,8 @@ namespace Objects.BuiltElements.Archicad
     public string? sideMat { get; set; }
     public string? botMat { get; set; }
     public bool? materialsChained { get; set; }
-    public string? /*APINullabe*/ trimmingBodyName { get; set; }
+    public string? /*APINullabe*/
+    trimmingBodyName { get; set; }
   }
 
   /*
@@ -237,9 +254,14 @@ namespace Objects.BuiltElements.Archicad
     public ElementShape shape { get; set; }
     public BaseLine? baseLine { get; set; }
     public bool? posSign { get; set; }
-    public ElementShape? /*APINullabe*/ pivotPolygon { get; set; }
+    public ElementShape? /*APINullabe*/
+    pivotPolygon { get; set; }
     public short? levelNum { get; set; }
-    public Dictionary<string, RoofLevel>? /*APINullabe*/ levels { get; set; }
+    public Dictionary<
+      string,
+      RoofLevel
+    >? /*APINullabe*/
+    levels { get; set; }
     public Dictionary<string, PivotPolyEdge>? roofPivotPolyEdges { get; set; }
   }
 
@@ -267,13 +289,19 @@ namespace Objects.BuiltElements.Archicad
     }
 
     // Geometry and positioning
-    public string? /*APINullabe*/ shellClassName { get; set; }
-    public Transform? /*APINullabe*/ basePlane { get; set; }
-    public bool? /*APINullabe*/ flipped { get; set; }
-    public bool? /*APINullabe*/ hasContour { get; set; }
-    public int? /*APINullabe*/ numHoles { get; set; }
+    public string? /*APINullabe*/
+    shellClassName { get; set; }
+    public Transform? /*APINullabe*/
+    basePlane { get; set; }
+    public bool? /*APINullabe*/
+    flipped { get; set; }
+    public bool? /*APINullabe*/
+    hasContour { get; set; }
+    public int? /*APINullabe*/
+    numHoles { get; set; }
     public Dictionary<string, ShellContourData>? shellContours { get; set; }
-    public string? /*APINullabe*/ defaultEdgeType { get; set; }
+    public string? /*APINullabe*/
+    defaultEdgeType { get; set; }
 
     public double? slantAngle { get; set; }
     public double? revolutionAngle { get; set; }
@@ -283,11 +311,16 @@ namespace Objects.BuiltElements.Archicad
     public double? begPlaneTilt { get; set; }
     public double? endPlaneTilt { get; set; }
     public ElementShape shape { get; set; }
-    public ElementShape? /*APINullabe*/ shape1 { get; set; }
-    public ElementShape? /*APINullabe*/ shape2 { get; set; }
-    public Transform? /*APINullabe*/ axisBase { get; set; }
-    public Transform? /*APINullabe*/ plane1 { get; set; }
-    public Transform? /*APINullabe*/ plane2 { get; set; }
+    public ElementShape? /*APINullabe*/
+    shape1 { get; set; }
+    public ElementShape? /*APINullabe*/
+    shape2 { get; set; }
+    public Transform? /*APINullabe*/
+    axisBase { get; set; }
+    public Transform? /*APINullabe*/
+    plane1 { get; set; }
+    public Transform? /*APINullabe*/
+    plane2 { get; set; }
     public Point? begC { get; set; }
     public double? begAngle { get; set; }
     public Vector? extrusionVector { get; set; }

--- a/Objects/Objects/BuiltElements/Room.cs
+++ b/Objects/Objects/BuiltElements/Room.cs
@@ -78,6 +78,9 @@ namespace Objects.BuiltElements.Archicad
     [JsonIgnore]
     public ArchicadLevel archicadLevel { get; set; }
 
+    public string? /*APINullabe*/
+    layer { get; set; }
+
     public override Level level
     {
       get => archicadLevel;

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -281,19 +281,29 @@ namespace Objects.BuiltElements.Archicad
     public ArchicadWall() { }
 
     // Element base
-    public string? /*APINullabe*/ elementType { get; set; }
-    public List<Classification>? /*APINullabe*/ classifications { get; set; }
+    public string? /*APINullabe*/
+    elementType { get; set; }
+    public List<Classification>? /*APINullabe*/
+    classifications { get; set; }
 
-    public ArchicadLevel? /*APINullabe*/ level { get; set; }
+    public ArchicadLevel? /*APINullabe*/
+    level { get; set; }
+
+    public string? /*APINullabe*/
+    layer { get; set; }
 
     // Wall geometry
-    public double? /*APINullabe*/ baseOffset { get; set; }
+    public double? /*APINullabe*/
+    baseOffset { get; set; }
     public Point startPoint { get; set; }
     public Point endPoint { get; set; }
 
-    public string? /*APINullabe*/ structure { get; set; }
-    public string? /*APINullabe*/ geometryMethod { get; set; }
-    public string? /*APINullabe*/ wallComplexity { get; set; }
+    public string? /*APINullabe*/
+    structure { get; set; }
+    public string? /*APINullabe*/
+    geometryMethod { get; set; }
+    public string? /*APINullabe*/
+    wallComplexity { get; set; }
 
     public string? buildingMaterialName { get; set; }
     public string? compositeName { get; set; }
@@ -302,7 +312,8 @@ namespace Objects.BuiltElements.Archicad
 
     public ElementShape? shape { get; set; }
 
-    public double? /*APINullabe*/ thickness { get; set; }
+    public double? /*APINullabe*/
+    thickness { get; set; }
 
     public double? outsideSlantAngle { get; set; }
     public double? insideSlantAngle { get; set; }
@@ -310,19 +321,28 @@ namespace Objects.BuiltElements.Archicad
     public bool? polyWalllCornersCanChange { get; set; }
 
     // Wall and stories relation
-    public double? /*APINullabe*/ topOffset { get; set; }
-    public short? /*APINullabe*/ relativeTopStory { get; set; }
-    public string? /*APINullabe*/ referenceLineLocation { get; set; }
+    public double? /*APINullabe*/
+    topOffset { get; set; }
+    public short? /*APINullabe*/
+    relativeTopStory { get; set; }
+    public string? /*APINullabe*/
+    referenceLineLocation { get; set; }
     public double? referenceLineOffset { get; set; }
-    public double? /*APINullabe*/ offsetFromOutside { get; set; }
-    public int? /*APINullabe*/ referenceLineStartIndex { get; set; }
-    public int? /*APINullabe*/ referenceLineEndIndex { get; set; }
+    public double? /*APINullabe*/
+    offsetFromOutside { get; set; }
+    public int? /*APINullabe*/
+    referenceLineStartIndex { get; set; }
+    public int? /*APINullabe*/
+    referenceLineEndIndex { get; set; }
     public bool flipped { get; set; }
 
     // Floor Plan and Section - Floor Plan Display
-    public string? /*APINullabe*/ showOnStories { get; set; }
-    public string? /*APINullabe*/ displayOptionName { get; set; }
-    public string? /*APINullabe*/ showProjectionName { get; set; }
+    public string? /*APINullabe*/
+    showOnStories { get; set; }
+    public string? /*APINullabe*/
+    displayOptionName { get; set; }
+    public string? /*APINullabe*/
+    showProjectionName { get; set; }
 
     // Floor Plan and Section - Cut Surfaces parameters
     public short? cutLinePen { get; set; }
@@ -331,10 +351,14 @@ namespace Objects.BuiltElements.Archicad
     public short? overrideCutFillBackgroundPen { get; set; }
 
     // Floor Plan and Section - Outlines parameters
-    public short? /*APINullabe*/ uncutLinePen { get; set; }
-    public string? /*APINullabe*/ uncutLinetype { get; set; }
-    public short? /*APINullabe*/ overheadLinePen { get; set; }
-    public string? /*APINullabe*/ overheadLinetype { get; set; }
+    public short? /*APINullabe*/
+    uncutLinePen { get; set; }
+    public string? /*APINullabe*/
+    uncutLinetype { get; set; }
+    public short? /*APINullabe*/
+    overheadLinePen { get; set; }
+    public string? /*APINullabe*/
+    overheadLinetype { get; set; }
 
     // Model - Override Surfaces
     public string? referenceMaterialName { get; set; }
@@ -344,10 +368,14 @@ namespace Objects.BuiltElements.Archicad
     public int? oppositeMaterialStartIndex { get; set; }
     public int? oppositeMaterialEndIndex { get; set; }
     public string? sideMaterialName { get; set; }
-    public bool? /*APINullabe*/ materialsChained { get; set; }
-    public bool? /*APINullabe*/ inheritEndSurface { get; set; }
-    public bool? /*APINullabe*/ alignTexture { get; set; }
-    public int? /*APINullabe*/ sequence { get; set; }
+    public bool? /*APINullabe*/
+    materialsChained { get; set; }
+    public bool? /*APINullabe*/
+    inheritEndSurface { get; set; }
+    public bool? /*APINullabe*/
+    alignTexture { get; set; }
+    public int? /*APINullabe*/
+    sequence { get; set; }
 
     // Model - Log Details (log height, start with half log, surface of horizontal edges, log shape)
     public double? logHeight { get; set; }
@@ -356,11 +384,14 @@ namespace Objects.BuiltElements.Archicad
     public string? logShape { get; set; }
 
     // Model - Defines the relation of wall to zones (Zone Boundary, Reduce Zone Area Only, No Effect on Zones)
-    public string? /*APINullabe*/ wallRelationToZoneName { get; set; }
+    public string? /*APINullabe*/
+    wallRelationToZoneName { get; set; }
 
     // Does it have any embedded object?
-    public bool? /*APINullabe*/ hasDoor { get; set; }
+    public bool? /*APINullabe*/
+    hasDoor { get; set; }
 
-    public bool? /*APINullabe*/ hasWindow { get; set; }
+    public bool? /*APINullabe*/
+    hasWindow { get; set; }
   }
 }


### PR DESCRIPTION
## Description & motivation

To send and receive `layer` information from Archicad.

## Changes:

Objects:
* new `Layer` string type property is introduced

Archicad Connector:
* send and receive codes changed accordingly 
* when receiving, an Archicad layer with that specific name should be present (like other Archicad attributes, no attributes are created)

## Screenshots:


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
