### PR TITLE
fix(ci): Pinned MinIO version in core docker compose

### DIFF
--- a/Core/docker-compose.yml
+++ b/Core/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       retries: 30
 
   minio:
-    image: "minio/minio"
+    image: "minio/minio:RELEASE.2023-10-25T06-33-25Z"
     command: server /data --console-address ":9001"
     restart: always
     volumes:


### PR DESCRIPTION
Core tests for #3016 were failing due to the `minio/minio` container failing health check.
The current compose file used for the core integration tests uses `minio/minio` latest which is currently an alias for `RELEASE.2023-11-01T01-57-10Z`

This PR pinns the version to the release before last `minio/minio:RELEASE.2023-10-25T06-33-25Z`

https://app.circleci.com/pipelines/github/specklesystems/speckle-sharp/12266/workflows/dc31cf3a-3dbc-40c1-953d-209c2ccadaf9/jobs/93448

We'll look into why the health check is failing on the newer version some other time.

