### PR TITLE
fix(rvt): Modify signature of `RevitConverter.UpdateParameter` to return AppObj

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -1330,5 +1330,21 @@ namespace Objects.Converter.Revit
 
       return headOffset;
     }
+    
+  }
+  
+  public class ElementNotFoundException : Exception
+  {
+    public ElementNotFoundException(string message) : base(message)
+    {
+    }
+      
+    public ElementNotFoundException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public ElementNotFoundException()
+    {
+    }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -256,7 +256,6 @@ namespace Objects.Converter.Revit
 
       speckleElement["worksetId"] = revitElement.WorksetId.ToString();
 
-
       // assign the category if it is null
       // WARN: DirectShapes have a `category` prop of type `RevitCategory` (enum), NOT `string`. This is the only exception as of 2.16.
       // In all other cases this should be the display value string (localized name) of the catogory
@@ -270,8 +269,6 @@ namespace Objects.Converter.Revit
       //TODO: move this to a typed property, define full list of categories in Objects
       BuiltInCategory builtInCategory = Categories.GetBuiltInCategory(category);
       speckleElement["builtInCategory"] = builtInCategory.ToString();
-
-
 
       //NOTE: adds the quantities of all materials to an element
       var qs = MaterialQuantitiesToSpeckle(revitElement, speckleElement["units"] as string);
@@ -1329,22 +1326,6 @@ namespace Objects.Converter.Revit
       }
 
       return headOffset;
-    }
-    
-  }
-  
-  public class ElementNotFoundException : Exception
-  {
-    public ElementNotFoundException(string message) : base(message)
-    {
-    }
-      
-    public ElementNotFoundException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-
-    public ElementNotFoundException()
-    {
     }
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -157,6 +157,7 @@ namespace Objects.Converter.Revit
     const string DetailLevelMedium = "Medium";
     const string DetailLevelFine = "Fine";
     public ViewDetailLevel DetailLevelSetting => GetDetailLevelSetting() ?? ViewDetailLevel.Fine;
+
     private ViewDetailLevel? GetDetailLevelSetting()
     {
       if (!Settings.TryGetValue("detail-level", out string detailLevel))

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConverterRevit.cs
@@ -648,8 +648,7 @@ namespace Objects.Converter.Revit
           return RailingToNative(o);
 
         case BER.ParameterUpdater o:
-          UpdateParameter(o);
-          return null;
+          return UpdateParameter(o);
 
         case BE.View3D o:
           return ViewToNative(o);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/UpdateParameter.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/UpdateParameter.cs
@@ -43,9 +43,6 @@ namespace Objects.Converter.Revit
       }
       else
       {
-        Report.LogConversionError(
-          new System.Exception($"Could not find element to update: Element Id = {paramUpdater.elementId}")
-        );
         appObj.Update(
           status: ApplicationObject.State.Failed,
           logItem: $"Could not find element to update: Element Id = {paramUpdater.elementId}"

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/UpdateParameter.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/UpdateParameter.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Speckle.Core.Helpers;
 using Speckle.Core.Models;
 
-
 namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
@@ -17,8 +16,11 @@ namespace Objects.Converter.Revit
       //try to get element using ApplicationId
       //this will only work if the element has been successfully been received in Revit before
       //var element = GetExistingElementByApplicationId(paramUpdater.revitId);
-      
-      var appObj = new ApplicationObject(paramUpdater.id, paramUpdater.speckle_type) { applicationId = paramUpdater.applicationId };
+
+      var appObj = new ApplicationObject(paramUpdater.id, paramUpdater.speckle_type)
+      {
+        applicationId = paramUpdater.applicationId
+      };
       Element element = null;
 
       //try to get element using ElementId
@@ -34,19 +36,23 @@ namespace Objects.Converter.Revit
       if (element != null)
       {
         SetInstanceParameters(element, paramUpdater);
-        appObj.Update(status: ApplicationObject.State.Updated, logItem: $"Successfully updated instance parameters for element {paramUpdater.elementId}");
+        appObj.Update(
+          status: ApplicationObject.State.Updated,
+          logItem: $"Successfully updated instance parameters for element {paramUpdater.elementId}"
+        );
       }
       else
       {
         Report.LogConversionError(
-          new System.Exception($"Could not find element to update: Element Id = {paramUpdater.elementId}"));
+          new System.Exception($"Could not find element to update: Element Id = {paramUpdater.elementId}")
+        );
         appObj.Update(
           status: ApplicationObject.State.Failed,
-          logItem: $"Could not find element to update: Element Id = {paramUpdater.elementId}");
+          logItem: $"Could not find element to update: Element Id = {paramUpdater.elementId}"
+        );
       }
-      
+
       return appObj;
     }
-
   }
 }

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/UpdateParameter.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/UpdateParameter.cs
@@ -3,43 +3,49 @@ using Objects.BuiltElements.Revit;
 using Objects.Geometry;
 using System.Collections.Generic;
 using System.Linq;
+using Speckle.Core.Helpers;
+using Speckle.Core.Models;
 
 
 namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
-    public void UpdateParameter(ParameterUpdater paramUpdater)
+    public ApplicationObject UpdateParameter(ParameterUpdater paramUpdater)
     {
       //the below does not work because ApplicationIds are stored within a stream
       //try to get element using ApplicationId
       //this will only work if the element has been successfully been received in Revit before
       //var element = GetExistingElementByApplicationId(paramUpdater.revitId);
-
+      
+      var appObj = new ApplicationObject(paramUpdater.id, paramUpdater.speckle_type) { applicationId = paramUpdater.applicationId };
       Element element = null;
 
       //try to get element using ElementId
-      int intId;
-
-      if (int.TryParse(paramUpdater.elementId, out intId))
+      if (int.TryParse(paramUpdater.elementId, out int intId))
       {
         var elemId = new ElementId(intId);
         element = Doc.GetElement(elemId);
       }
 
       //try to get element using UniqueId
-      if (element == null)
-      {
-        element = Doc.GetElement(paramUpdater.elementId);
-      }
+      element ??= Doc.GetElement(paramUpdater.elementId);
 
-      if (element == null)
+      if (element != null)
       {
-        Report.LogConversionError(new System.Exception($"Could not find element to update: Element Id = {paramUpdater.elementId}"));
-        return;
+        SetInstanceParameters(element, paramUpdater);
+        appObj.Update(status: ApplicationObject.State.Updated, logItem: $"Successfully updated instance parameters for element {paramUpdater.elementId}");
       }
-
-      SetInstanceParameters(element, paramUpdater);
+      else
+      {
+        Report.LogConversionError(
+          new System.Exception($"Could not find element to update: Element Id = {paramUpdater.elementId}"));
+        appObj.Update(
+          status: ApplicationObject.State.Failed,
+          logItem: $"Could not find element to update: Element Id = {paramUpdater.elementId}");
+      }
+      
+      return appObj;
     }
 
   }


### PR DESCRIPTION
> ⚠️ Reported by Pavol, pending linking with Notion backlog issue

> ❗️Targeting `main` as I'm assuming we'd want this as a hotfix, but we can target `dev` if this is not the case.

Fixes issue with ParameterUpdater objects from Grasshopper not succeeding conversion when received in Revit.

Nothing was wrong with the conversion itself, but the addition of `DisplayableObject` conversions introduced the assumption that if the conversion returned `null` it had failed.

This assumption did not hold for `ParameterUpdater` conversions, where **it was always returning null** as the function had a `void` return.

### Solution

This PR changes the signature of the UpdateParameter method so that it returns an app object, in line with every other conversion. This results in the connector assuming conversion has succeeded (and correctly reporting it to the user as such)

![Screenshot 2023-11-02 at 11 34 50](https://github.com/specklesystems/speckle-sharp/assets/2316535/8b2abfb6-f175-470f-824b-ee6113cdc1ee)


### EDGE CASE NOT HANDLED

If a user were to set the `receive as display mesh` option, the parameter updater conversion **will fail** as this object is not displayable. I consider this the correct behaviour, but I wanted to leave it here to verify.