### PR TITLE
fix(gh): Fixes sorting on dropdown for input enum values

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
@@ -25,7 +25,6 @@ namespace ConnectorGrasshopper;
 
 public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterComponent
 {
-  private GH_Document _document;
   private DebounceDispatcher nicknameChangeDebounce = new();
   private bool readFailed;
 
@@ -179,8 +178,6 @@ public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterC
       return;
     }
 
-    _document = document;
-
     var dialog = new CreateSchemaObjectDialog();
     dialog.Owner = Instances.EtoDocumentEditor;
     var mouse = Control.MousePosition;
@@ -299,7 +296,7 @@ public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterC
 
       var vals = Enum.GetValues(propType).Cast<Enum>().Select(x => x.ToString()).ToList();
       var options = CreateDropDown(propName, vals, Attributes.Bounds.X, Params.Input[index].Attributes.Bounds.Y);
-      _document.AddObject(options, false);
+      OnPingDocument().AddObject(options, false);
       Params.Input[index].AddSource(options);
     }
   }
@@ -314,13 +311,12 @@ public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterC
     valueList.ListMode = GH_ValueListMode.DropDown;
     valueList.ListItems.Clear();
 
-    values = values.OrderBy(x=>x).ToList();
-
     for (int i = 0; i < values.Count; i++)
       valueList.ListItems.Add(new GH_ValueListItem(values[i], i.ToString()));
-    
+
     valueList.Attributes.Pivot = new PointF(x - 200, y - 10);
 
+    valueList.ListItems.Sort((item, listItem) => string.Compare(item.Name, listItem.Name));
     return valueList;
   }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
@@ -228,6 +228,8 @@ public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterC
     foreach (var p in props)
       RegisterPropertyAsInputParameter(p, k++);
 
+    UserInterfaceUtils.CreateCanvasDropdownForAllEnumInputs(this, props);
+
     Name = constructor.GetCustomAttribute<SchemaInfo>().Name;
     Description = constructor.GetCustomAttribute<SchemaInfo>().Description;
 
@@ -285,23 +287,9 @@ public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterC
       newInputParam.Access = GH_ParamAccess.item;
 
     Params.RegisterInputParam(newInputParam, index);
-
-    //add dropdown
-    if (propType.IsEnum)
-    {
-      //expire solution so that node gets proper size
-      ExpireSolution(true);
-
-      var instance = Activator.CreateInstance(propType);
-
-      var vals = Enum.GetValues(propType).Cast<Enum>().Select(x => x.ToString()).ToList();
-      var options = CreateDropDown(propName, vals, Attributes.Bounds.X, Params.Input[index].Attributes.Bounds.Y);
-      OnPingDocument().AddObject(options, false);
-      Params.Input[index].AddSource(options);
-    }
   }
 
-  public static GH_ValueList CreateDropDown(string name, List<string> values, float x, float y)
+  public static GH_ValueList CreateDropDown(string name, List<(string name, int value)> values, float x, float y)
   {
     var valueList = new GH_ValueList();
     valueList.CreateAttributes();
@@ -312,7 +300,7 @@ public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterC
     valueList.ListItems.Clear();
 
     for (int i = 0; i < values.Count; i++)
-      valueList.ListItems.Add(new GH_ValueListItem(values[i], i.ToString()));
+      valueList.ListItems.Add(new GH_ValueListItem(values[i].name, values[i].value.ToString()));
 
     valueList.Attributes.Pivot = new PointF(x - 200, y - 10);
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -361,6 +361,8 @@ public abstract class CreateSchemaObjectBase : SelectKitComponentBase, IGH_Varia
 
     valueList.Attributes.Pivot = new PointF(x - 200, y - 10);
 
+    valueList.ListItems.Sort((item, listItem) => string.Compare(item.Name, listItem.Name));
+
     return valueList;
   }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -275,6 +275,8 @@ public abstract class CreateSchemaObjectBase : SelectKitComponentBase, IGH_Varia
     foreach (var p in props)
       RegisterPropertyAsInputParameter(p, k++);
 
+    UserInterfaceUtils.CreateCanvasDropdownForAllEnumInputs(this, props);
+
     Name = constructor.GetCustomAttribute<SchemaInfo>().Name;
     Description = constructor.GetCustomAttribute<SchemaInfo>().Description;
 
@@ -330,40 +332,6 @@ public abstract class CreateSchemaObjectBase : SelectKitComponentBase, IGH_Varia
       newInputParam.Access = GH_ParamAccess.item;
 
     Params.RegisterInputParam(newInputParam, index);
-
-    //add dropdown
-    if (propType.IsEnum)
-    {
-      //expire solution so that node gets proper size
-      ExpireSolution(true);
-
-      var instance = Activator.CreateInstance(propType);
-
-      var vals = Enum.GetValues(propType).Cast<Enum>().Select(x => x.ToString()).ToList();
-      var options = CreateDropDown(propName, vals, Attributes.Bounds.X, Params.Input[index].Attributes.Bounds.Y);
-      OnPingDocument().AddObject(options, false);
-      Params.Input[index].AddSource(options);
-    }
-  }
-
-  public static GH_ValueList CreateDropDown(string name, List<string> values, float x, float y)
-  {
-    var valueList = new GH_ValueList();
-    valueList.CreateAttributes();
-    valueList.Name = name;
-    valueList.NickName = name + ":";
-    valueList.Description = "Select an option...";
-    valueList.ListMode = GH_ValueListMode.DropDown;
-    valueList.ListItems.Clear();
-
-    for (int i = 0; i < values.Count; i++)
-      valueList.ListItems.Add(new GH_ValueListItem(values[i], i.ToString()));
-
-    valueList.Attributes.Pivot = new PointF(x - 200, y - 10);
-
-    valueList.ListItems.Sort((item, listItem) => string.Compare(item.Name, listItem.Name));
-
-    return valueList;
   }
 
   public override void SolveInstanceWithLogContext(IGH_DataAccess DA)

--- a/ConnectorGrasshopper/ConnectorGrasshopperUtils/UserInterfaceUtils.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperUtils/UserInterfaceUtils.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Reflection;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Special;
+
+namespace ConnectorGrasshopperUtils;
+
+public static class UserInterfaceUtils
+{
+  /// <summary>
+  /// Used to Create
+  /// </summary>
+  /// <param name="name"></param>
+  /// <param name="x"></param>
+  /// <param name="y"></param>
+  /// <typeparam name="T"></typeparam>
+  /// <returns></returns>
+  public static GH_ValueList CreateEnumDropDown(Type enumType, string name, float xPos, float yPos, bool sorted = true)
+  {
+    if (!enumType.IsEnum)
+    {
+      throw new ArgumentException($"Input type must be {typeof(Enum)} but got {enumType.Name} ", nameof(enumType));
+    }
+
+    // Convert all values of an enum into a GH_ValueListItem and add them to the value list.
+    // This preserves both the name of the Enum value, as well as it's declared integer value (saved as a string).
+    var items = Enum.GetValues(enumType)
+      .Cast<Enum>()
+      .Select(x => new GH_ValueListItem(name: x.ToString(), expression: Convert.ToInt32(x).ToString()))
+      .ToList();
+
+    var valueList = new GH_ValueList();
+    valueList.CreateAttributes();
+    valueList.Name = name;
+    valueList.NickName = name + ":";
+    valueList.Description = "Select an option...";
+    valueList.ListMode = GH_ValueListMode.DropDown;
+    valueList.Attributes.Pivot = new PointF(xPos, yPos);
+
+    valueList.ListItems.Clear();
+    valueList.ListItems.AddRange(items);
+
+    if (sorted)
+    {
+      valueList.ListItems.Sort((itemA, itemB) => string.Compare(itemA.Name, itemB.Name));
+    }
+
+    return valueList;
+  }
+
+  /// <summary>
+  /// Creates a dropdown component on the canvas for every <see cref="Enum"/> type input of the component.
+  /// This assumes the inputs have already been created, and that there is a 1 to 1 relationship between
+  /// the number of inputs of the component and the number of properties.
+  /// </summary>
+  /// <param name="component">The component to connect the dropdowns to</param>
+  /// <param name="props">The <see cref="PropertyInfo"/> list of the class being created as a component.</param>
+  public static void CreateCanvasDropdownForAllEnumInputs(IGH_Component component, ParameterInfo[] props)
+  {
+    //Expiring solution ensures the size and position of the parent are  updated before placing any input connections
+    component.ExpireSolution(true);
+
+    for (int index = 0; index < props.Length; index++)
+    {
+      ParameterInfo p = props[index];
+      if (!p.ParameterType.IsEnum)
+      {
+        continue;
+      }
+
+      var options = CreateEnumDropDown(
+        p.ParameterType,
+        p.Name,
+        component.Attributes.Bounds.X - 200,
+        component.Params.Input[index].Attributes.Bounds.Y - 1
+      );
+      component.OnPingDocument().AddObject(options, false);
+      component.Params.Input[index].AddSource(options);
+    }
+  }
+}


### PR DESCRIPTION
Fixes issue originally introduced in https://github.com/specklesystems/speckle-sharp/pull/2694: Sorting was performed on the original values, which changed the indexes of the enum, hence modifying it's return value to an unrelated one.

### Solution

Unifies the implementation of the dropdown enum creation into the GrasshopperUtils project (already existing), so that miss-alignment around this cannot occur anymore.
Introduces new `UserInterfaceUtils` class to hold this logic (and any other in the future related to Grasshopper UI things)
- `CreateEnumDropdown` -> Is the replacement of the original `CreateDropdown`, but now works more robustly and should preserve all integer values of an enum regardless of sorting.
- `CreateCanvasDropdownForAllEnumInputs` (name pending revision 😅): Will create all the necessary dropdowns in the canvas for a given component, and relies on `CreateEnumDropdown`

This changes have been propagated to both `CreateSchemaObject` and `CreateSchemaObjectBase`. I'm not going to open a ticket to align these further in the future, but I'll have it in mind once we get to cleaning up Grasshopper connector.

Tested on my machine and verified that:
- [x] Enum values are returned as expected, without relying upon order.
- [x] Dropdown is sorted alphabetically

> BONUS
> Additionally, I moved the Enum dropdown creation logic to **after** all the inputs have been created. This fixes an issue reported by SOM a while ago that I couldn't make sense of at the time. 
> ![Screenshot 2023-11-02 at 17 22 27](https://github.com/specklesystems/speckle-sharp/assets/2316535/049e4921-d365-489b-a795-b8dad2a02dba)
