### PR TITLE
fix(dui): bump branch limit to 500

### DIFF
--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -417,7 +417,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     try
     {
       var prevBranchName = SelectedBranch != null ? SelectedBranch.Branch.name : StreamState.BranchName;
-      Branches = await Client.StreamGetBranches(Stream.id, 100, 0).ConfigureAwait(true);
+      Branches = await Client.StreamGetBranches(Stream.id, 500, 0).ConfigureAwait(true);
 
       var index = Branches.FindIndex(x => x.name == prevBranchName);
       if (index != -1)


### PR DESCRIPTION
Increases the limit of branches pulled from DUI from 100 to 500.
https://speckle.community/t/is-there-a-limit-in-the-number-of-branches-you-can-have-in-a-stream/7692/5?u=teocomi