### PR TITLE
log(structral): Unified logging between structural connectors

### DIFF
--- a/ConnectorCSI/ConnectorCSIShared/Util/ConnectorCSIUtils.cs
+++ b/ConnectorCSI/ConnectorCSIShared/Util/ConnectorCSIUtils.cs
@@ -25,7 +25,7 @@ namespace Speckle.ConnectorCSI.Util
     //    public static string CSISlug = HostApplications.CSI.Slug;
     //#endif
 
-    public static Dictionary<string, (string, string)> ObjectIDsTypesAndNames { get; set; }
+    public static Dictionary<string, (string typeName, string name)> ObjectIDsTypesAndNames { get; set; }
 
     public static List<SpeckleException> ConversionErrors { get; set; }
 

--- a/ConnectorCSI/ConnectorCSIShared/cPlugin.cs
+++ b/ConnectorCSI/ConnectorCSIShared/cPlugin.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DesktopUI2;
 using DesktopUI2.ViewModels;
 using DesktopUI2.Views;
 using System.Timers;
@@ -13,9 +9,9 @@ using Avalonia.Controls;
 using Avalonia.ReactiveUI;
 using CSiAPIv1;
 using Speckle.ConnectorCSI.UI;
-
 using System.Reflection;
 using System.IO;
+using Speckle.Core.Logging;
 
 namespace SpeckleConnectorCSI
 {
@@ -68,6 +64,7 @@ namespace SpeckleConnectorCSI
     public static void OpenOrFocusSpeckle(cSapModel model)
     {
       Bindings = new ConnectorBindingsCSI(model);
+      Setup.Init(Bindings.GetHostAppNameVersion(), Bindings.GetHostAppName());
       CreateOrFocusSpeckle();
     }
 

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -91,7 +91,10 @@ namespace Speckle.ConnectorRevit.UI
           CurrentDoc.Document
         );
         await elementTypeMapper
-          .Map(state.Settings.FirstOrDefault(x => x.Slug == "receive-mappings"), state.Settings.FirstOrDefault(x => x.Slug == DsFallbackSlug))
+          .Map(
+            state.Settings.FirstOrDefault(x => x.Slug == "receive-mappings"),
+            state.Settings.FirstOrDefault(x => x.Slug == DsFallbackSlug)
+          )
           .ConfigureAwait(false);
       }
       catch (Exception ex)
@@ -247,10 +250,6 @@ namespace Speckle.ConnectorRevit.UI
         }
       }
 
-      using var _d0 = LogContext.PushProperty("converterName", converter.Name);
-      using var _d1 = LogContext.PushProperty("converterAuthor", converter.Author);
-      using var _d2 = LogContext.PushProperty("conversionDirection", nameof(ISpeckleConverter.ConvertToNative));
-
       var convertedObjectsCache = new ConvertedObjectsCache();
       converter.SetContextDocument(convertedObjectsCache);
 
@@ -279,6 +278,11 @@ namespace Speckle.ConnectorRevit.UI
           // Do nothing, default values will do.
           break;
       }
+
+      using var d0 = LogContext.PushProperty("converterName", converter.Name);
+      using var d1 = LogContext.PushProperty("converterAuthor", converter.Author);
+      using var d2 = LogContext.PushProperty("conversionDirection", nameof(ISpeckleConverter.ConvertToNative));
+      using var d4 = LogContext.PushProperty("converterReceiveMode", converter.ReceiveMode);
 
       // convert
       var index = -1;


### PR DESCRIPTION
Unified connector logging between CSI, Tekla, and Revit

- Fixed issue with CSI connectors reporting as CoreUnknown
    - Added `Setup.Init` call just after we create bindings (same way Revit & Autocad)

- Added new connector helper functions for logging converter errors
   - I was finding that I was duplicating the big catch cases between connectors. So I extracted them out to two functions. One for logging to seq, the other for grabbing the correct AppObject status to report.
   
- Added converter settings to logging
   - Previously, we were just reporting the converter name + author + direction. I added the converter settings dictionary to the mix so we can create some dashboards on which settings users are using. This might help us inform defaults + where to focus our effort in future.