### PR TITLE
chore(dev): Remove CRL check from proxy client

### DIFF
--- a/Core/Core/Helpers/Http.cs
+++ b/Core/Core/Helpers/Http.cs
@@ -177,7 +177,6 @@ public static class Http
     }
   }
 
-  [SuppressMessage("Security", "CA5399: Enable HttpClient certificate revocation list check")]
   public static HttpClient GetHttpProxyClient(SpeckleHttpClientHandler? handler = null, TimeSpan? timeout = null)
   {
     IWebProxy proxy = WebRequest.GetSystemWebProxy();

--- a/Core/Core/Helpers/Http.cs
+++ b/Core/Core/Helpers/Http.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Net.NetworkInformation;
@@ -176,13 +177,13 @@ public static class Http
     }
   }
 
+  [SuppressMessage("Security", "CA5399: Enable HttpClient certificate revocation list check")]
   public static HttpClient GetHttpProxyClient(SpeckleHttpClientHandler? handler = null, TimeSpan? timeout = null)
   {
     IWebProxy proxy = WebRequest.GetSystemWebProxy();
     proxy.Credentials = CredentialCache.DefaultCredentials;
 
     handler ??= new SpeckleHttpClientHandler();
-    handler.CheckCertificateRevocationList = true;
     var client = new HttpClient(handler);
     client.Timeout = timeout ?? TimeSpan.FromSeconds(100);
     return client;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,13 +57,14 @@
       CA5368; CA5370; CA5371; CA5372; CA5373; CA5374; CA5375;
       CA5376; CA5377; CA5378; CA5379; CA5380; CA5381; CA5382; CA5383;
       CA5384; CA5385; CA5386; CA5387; CA5388; CA5389; CA5390; CA5391;
-      CA5392; CA5393; CA5395; CA5396; CA5397; CA5398; CA5399;
+      CA5392; CA5393; CA5395; CA5396; CA5397; CA5398;
       CA5400; CA5401; CA5402; CA5403; CA5404; CA5405
       <!-- The following security anaysers are ommited for the listed reasons -->
       <!--"CA5394: Do not use insecure randomness" - random number generators used for non cryptographic usecases-->
       <!--"CA2109: Review visible event handlers" - threat has not existed since net4.5-->
       <!--"CA3075: Insecure DTD Processing" - we assume loaded XML is trusted-->
       <!--"CA5369: Use XmlReader for Deserialize" - we assume loaded XML is trusted-->
+      <!--"CA5399: Enable HttpClient certificate revocation list check" - causes issues with corporate networks that use SSL decryption. HTTPClientHandler does check for invalid SSL certs without this property set true-->
     </WarningsAsErrors>
 
     <!-- False if running on CI, will prevent copying of files to local folders -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
       CS1591;CS1573;CS1572;CS1570;CS1587;CS1574;
       CS1711;CS1734;
       <!--Others we don't want-->
-      CA1815;CA1054;
+      CA1815;CA1054;CA5399;
       <!--Nullability-->
       CS8618;CS8602;CS8600;
       CS1998; IDE0007; CS0618;
@@ -59,7 +59,7 @@
       CA5384; CA5385; CA5386; CA5387; CA5388; CA5389; CA5390; CA5391;
       CA5392; CA5393; CA5395; CA5396; CA5397; CA5398;
       CA5400; CA5401; CA5402; CA5403; CA5404; CA5405
-      <!-- The following security anaysers are ommited for the listed reasons -->
+      <!-- The following security analysers are ommited as errors for the listed reasons -->
       <!--"CA5394: Do not use insecure randomness" - random number generators used for non cryptographic usecases-->
       <!--"CA2109: Review visible event handlers" - threat has not existed since net4.5-->
       <!--"CA3075: Insecure DTD Processing" - we assume loaded XML is trusted-->


### PR DESCRIPTION
See #3018 

Removes the additional line to check certificate revocation list
Suppresses CA5399 violation on method
Makes CA5399 a nowarn 