### PR TITLE
fix(archicad): Archicad nullable levels fix

### DIFF
--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -141,10 +141,10 @@ namespace Objects.BuiltElements.Archicad
       get => archicadLevel;
       internal set
       {
-        if (value is not ArchicadLevel l)
+        if (value is ArchicadLevel or null)
+          archicadLevel = value as ArchicadLevel;
+        else
           throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
-
-        archicadLevel = l;
       }
     }
 

--- a/Objects/Objects/BuiltElements/Beam.cs
+++ b/Objects/Objects/BuiltElements/Beam.cs
@@ -142,9 +142,11 @@ namespace Objects.BuiltElements.Archicad
       internal set
       {
         if (value is ArchicadLevel or null)
+        {
           archicadLevel = value as ArchicadLevel;
-        else
-          throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
+        }
+
+        throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
       }
     }
 

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -167,10 +167,10 @@ namespace Objects.BuiltElements.Archicad
       get => archicadLevel;
       internal set
       {
-        if (value is not ArchicadLevel l)
+        if (value is ArchicadLevel or null)
+          archicadLevel = value as ArchicadLevel;
+        else
           throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
-
-        archicadLevel = l;
       }
     }
 

--- a/Objects/Objects/BuiltElements/Column.cs
+++ b/Objects/Objects/BuiltElements/Column.cs
@@ -168,9 +168,11 @@ namespace Objects.BuiltElements.Archicad
       internal set
       {
         if (value is ArchicadLevel or null)
+        {
           archicadLevel = value as ArchicadLevel;
-        else
-          throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
+        }
+
+        throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
       }
     }
 

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -103,10 +103,10 @@ namespace Objects.BuiltElements.Archicad
       get => archicadLevel;
       internal set
       {
-        if (value is not ArchicadLevel l)
+        if (value is ArchicadLevel or null)
+          archicadLevel = value as ArchicadLevel;
+        else
           throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
-
-        archicadLevel = l;
       }
     }
 

--- a/Objects/Objects/BuiltElements/Floor.cs
+++ b/Objects/Objects/BuiltElements/Floor.cs
@@ -104,9 +104,11 @@ namespace Objects.BuiltElements.Archicad
       internal set
       {
         if (value is ArchicadLevel or null)
+        {
           archicadLevel = value as ArchicadLevel;
-        else
-          throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
+        }
+
+        throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
       }
     }
 

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -153,10 +153,10 @@ namespace Objects.BuiltElements.Archicad
       get => archicadLevel;
       internal set
       {
-        if (value is not ArchicadLevel l)
+        if (value is ArchicadLevel or null)
+          archicadLevel = value as ArchicadLevel;
+        else
           throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
-
-        archicadLevel = l;
       }
     }
 

--- a/Objects/Objects/BuiltElements/Roof.cs
+++ b/Objects/Objects/BuiltElements/Roof.cs
@@ -154,9 +154,11 @@ namespace Objects.BuiltElements.Archicad
       internal set
       {
         if (value is ArchicadLevel or null)
+        {
           archicadLevel = value as ArchicadLevel;
-        else
-          throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
+        }
+
+        throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
       }
     }
 

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -309,9 +309,11 @@ namespace Objects.BuiltElements.Archicad
       internal set
       {
         if (value is ArchicadLevel or null)
+        {
           archicadLevel = value as ArchicadLevel;
-        else
-          throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
+        }
+
+        throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
       }
     }
 

--- a/Objects/Objects/BuiltElements/Wall.cs
+++ b/Objects/Objects/BuiltElements/Wall.cs
@@ -308,10 +308,10 @@ namespace Objects.BuiltElements.Archicad
       get => archicadLevel;
       internal set
       {
-        if (value is not ArchicadLevel l)
+        if (value is ArchicadLevel or null)
+          archicadLevel = value as ArchicadLevel;
+        else
           throw new ArgumentException($"Expected object of type {nameof(ArchicadLevel)}");
-
-        archicadLevel = l;
       }
     }
 


### PR DESCRIPTION
## Description & motivation

In case of null objects, `public override Level? level` can accept nulls, however an exception is thrown.

## Changes:

Enable nulls to be set as `level` properties.

## To-do before merge:

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
