### PR TITLE
fix(Archicad): Crash when sending a Corner Window

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementTypes.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetElementTypes.cpp
@@ -27,8 +27,12 @@ GS::ObjectState GetElementTypes::Execute (const GS::ObjectState& parameters, GS:
 	for (const GS::UniString& id : ids) {
 		API_Guid guid = APIGuidFromString (id.ToCStr ());
 		API_ElemType elementType = Utility::GetElementType (guid);
-		GS::UniString elemType = elementNames.Get (elementType);
-		GS::ObjectState listElem{ElementBase::ApplicationId, id, ElementBase::ElementType, elemType};
+
+		GS::UniString elementTypeName;
+		if (NoError != GetElementTypeName (elementType, elementTypeName))
+			continue;
+
+		GS::ObjectState listElem{ElementBase::ApplicationId, id, ElementBase::ElementType, elementTypeName};
 		listAdder (listElem);
 	}
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSubElementInfo.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetSubElementInfo.cpp
@@ -39,11 +39,14 @@ GS::ObjectState GetSubElementInfo::Execute (const GS::ObjectState& parameters, G
 
 			GS::UniString guid = APIGuidToString (currentGuid);
 			API_ElemType elementType = Utility::GetElementType (currentGuid);
-			GS::UniString elemType = elementNames.Get (elementType);
+
+			GS::UniString elementTypeName;
+			if (NoError != GetElementTypeName (elementType, elementTypeName))
+				continue;
 
 			GS::ObjectState subelementModel;
 			subelementModel.Add (ElementBase::ApplicationId, guid);
-			subelementModel.Add (ElementBase::ElementType, elemType);
+			subelementModel.Add (ElementBase::ElementType, elementTypeName);
 			listAdder (subelementModel);
 		}
 	}

--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
@@ -26,6 +26,27 @@ const GS::HashTable<API_ElemType, GS::UniString> elementNames
 };
 
 
+GSErrCode GetElementTypeName (const API_ElemType& elementType, GS::UniString& elementTypeName)
+{
+	// check typeID and variationID first
+	if (elementNames.ContainsKey(elementType)) {
+		elementTypeName = elementNames.Get (elementType);
+		return NoError;
+	}
+	
+	// check only typeID
+	for (auto elementNameIt : elementNames)
+	{
+		if (elementNameIt.key->typeID == elementType.typeID) {
+			elementTypeName = *(elementNameIt.value);
+			return NoError;
+		}
+	}
+	
+	return Error;
+}
+
+
 const GS::HashTable<API_ModelElemStructureType, GS::UniString> structureTypeNames
 {
 	{ API_BasicStructure,			"Basic"},

--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.hpp
@@ -7,6 +7,8 @@
 #include "Utility.hpp"
 
 extern const GS::HashTable<API_ElemType, GS::UniString> elementNames;
+GSErrCode GetElementTypeName (const API_ElemType& elementType, GS::UniString& elementTypeName);
+
 extern const GS::HashTable<API_ModelElemStructureType, GS::UniString> structureTypeNames;
 
 extern const GS::HashTable<API_WallTypeID, GS::UniString> wallTypeNames;


### PR DESCRIPTION
## Description & motivation

According to the introduction of Grid send and receive, Archicad element types are identified by `typeId` and `variationId` pairs (earlier only by `typeId`), because the GridElement in Archicad is an Object with subtype `APIVarId_GridElement`.
There could be other element types with `variationId` (e.g. corner window) in the model, which were not handled in a hashtable.

## Changes:

Checking the hash table before referencing an element in it.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

