### PR TITLE
fix(core): Fixes Branch get Limit up to 500

### DIFF
--- a/Core/Core/Api/ServerLimits.cs
+++ b/Core/Core/Api/ServerLimits.cs
@@ -1,0 +1,13 @@
+namespace Speckle.Core.Api;
+
+/// <summary>
+/// Defines the limits for specific API calls on the Speckle Server.
+/// These are magic numbers! Should be aligned with server always.
+/// </summary>
+/// <remarks>
+/// ⚠️ Not all limits are reflected here!
+/// </remarks>
+public static class ServerLimits
+{
+  public const int BRANCH_GET_LIMIT = 500;
+}

--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -108,7 +108,6 @@ public class Api
     Assert.True(res);
   }
 
-
   [Test, Order(13)]
   public async Task StreamSearch()
   {
@@ -273,6 +272,59 @@ public class Api
     Assert.NotNull(res);
     // Branches are now returned in order of creation so 'main' should always go first.
     Assert.That(res[0].name, Is.EqualTo("main"));
+  }
+
+  [Test]
+  public async Task StreamGetBranches_Throws_WhenRequestingOverLimit()
+  {
+    Assert.ThrowsAsync<Exception>(
+      async () => await myClient.StreamGetBranches(streamId, ServerLimits.BRANCH_GET_LIMIT + 1).ConfigureAwait(false)
+    );
+    var res = await myClient.StreamGetBranches(streamId, ServerLimits.BRANCH_GET_LIMIT).ConfigureAwait(false);
+
+    Assert.That(res, Is.Not.Null);
+    Assert.That(res, Has.Count.EqualTo(ServerLimits.BRANCH_GET_LIMIT));
+  }
+
+  [Test]
+  public async Task StreamGetBranches_WithManyBranches()
+  {
+    var streamId = await myClient.StreamCreate(new StreamCreateInput { name = "Many branches stream" });
+
+    await CreateEmptyBranches(myClient, streamId, ServerLimits.BRANCH_GET_LIMIT);
+
+    var res = await myClient.StreamGetBranches(streamId, ServerLimits.BRANCH_GET_LIMIT);
+
+    Assert.That(res, Is.Not.Null);
+    Assert.That(res, Has.Count.EqualTo(ServerLimits.BRANCH_GET_LIMIT));
+  }
+
+  public async Task CreateEmptyBranches(
+    Client client,
+    string streamId,
+    int branchCount,
+    string branchPrefix = "Test branch"
+  )
+  {
+    // now let's send HTTP requests to each of these URLs in parallel
+    var options = new ParallelOptions { MaxDegreeOfParallelism = 20 };
+
+    // now let's send HTTP requests to each of these URLs in parallel
+    await Parallel.ForEachAsync(
+      Enumerable.Range(0, branchCount),
+      options,
+      async (i, cancellationToken) =>
+      {
+        await client.BranchCreate(
+          new BranchCreateInput { name = $"{branchPrefix} {i}", streamId = streamId },
+          cancellationToken
+        );
+      }
+    );
+
+    var branches = await client.StreamGetBranches(streamId);
+
+    Assert.That(branches, Has.Count.EqualTo(500));
   }
 
   #region commit

--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -274,26 +274,25 @@ public class Api
     Assert.That(res[0].name, Is.EqualTo("main"));
   }
 
-  [Test]
+  [Test, Order(51)]
   public async Task StreamGetBranches_Throws_WhenRequestingOverLimit()
   {
-    Assert.ThrowsAsync<Exception>(
+    Assert.ThrowsAsync<SpeckleGraphQLException<StreamData>>(
       async () => await myClient.StreamGetBranches(streamId, ServerLimits.BRANCH_GET_LIMIT + 1).ConfigureAwait(false)
     );
     var res = await myClient.StreamGetBranches(streamId, ServerLimits.BRANCH_GET_LIMIT).ConfigureAwait(false);
 
     Assert.That(res, Is.Not.Null);
-    Assert.That(res, Has.Count.EqualTo(ServerLimits.BRANCH_GET_LIMIT));
   }
 
-  [Test]
+  [Test, Order(52)]
   public async Task StreamGetBranches_WithManyBranches()
   {
-    var streamId = await myClient.StreamCreate(new StreamCreateInput { name = "Many branches stream" });
+    var newStreamId = await myClient.StreamCreate(new StreamCreateInput { name = "Many branches stream" });
 
-    await CreateEmptyBranches(myClient, streamId, ServerLimits.BRANCH_GET_LIMIT);
+    await CreateEmptyBranches(myClient, newStreamId, ServerLimits.BRANCH_GET_LIMIT);
 
-    var res = await myClient.StreamGetBranches(streamId, ServerLimits.BRANCH_GET_LIMIT);
+    var res = await myClient.StreamGetBranches(newStreamId, ServerLimits.BRANCH_GET_LIMIT);
 
     Assert.That(res, Is.Not.Null);
     Assert.That(res, Has.Count.EqualTo(ServerLimits.BRANCH_GET_LIMIT));
@@ -307,7 +306,7 @@ public class Api
   )
   {
     // now let's send HTTP requests to each of these URLs in parallel
-    var options = new ParallelOptions { MaxDegreeOfParallelism = 20 };
+    var options = new ParallelOptions { MaxDegreeOfParallelism = 5 };
 
     // now let's send HTTP requests to each of these URLs in parallel
     await Parallel.ForEachAsync(
@@ -321,10 +320,6 @@ public class Api
         );
       }
     );
-
-    var branches = await client.StreamGetBranches(streamId);
-
-    Assert.That(branches, Has.Count.EqualTo(500));
   }
 
   #region commit

--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -306,7 +306,7 @@ public class Api
   )
   {
     // now let's send HTTP requests to each of these URLs in parallel
-    var options = new ParallelOptions { MaxDegreeOfParallelism = 5 };
+    var options = new ParallelOptions { MaxDegreeOfParallelism = 2 };
 
     // now let's send HTTP requests to each of these URLs in parallel
     await Parallel.ForEachAsync(

--- a/Core/IntegrationTests/TestsIntegration.csproj
+++ b/Core/IntegrationTests/TestsIntegration.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />

--- a/Core/docker-compose.yml
+++ b/Core/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       S3_CREATE_BUCKET: "true"
 
       FILE_SIZE_LIMIT_MB: 100
+      MAX_PROJECT_MODELS_PER_PAGE: 500
 
       # TODO: Change this to a unique secret for this server
       SESSION_SECRET: "TODO:ReplaceWithLongString"

--- a/Core/docker-compose.yml
+++ b/Core/docker-compose.yml
@@ -98,7 +98,6 @@ services:
       S3_CREATE_BUCKET: "true"
 
       FILE_SIZE_LIMIT_MB: 100
-      MAX_PROJECT_MODELS_PER_PAGE: 500
 
       # TODO: Change this to a unique secret for this server
       SESSION_SECRET: "TODO:ReplaceWithLongString"

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
@@ -98,7 +98,9 @@ public class StreamSelectorViewModel : ReactiveObject
   {
     using var client = new Client(SelectedStream.Account);
 
-    Branches = (await client.StreamGetBranches(SelectedStream.Stream.id, 500, 1).ConfigureAwait(true))
+    Branches = (
+      await client.StreamGetBranches(SelectedStream.Stream.id, ServerLimits.BRANCH_GET_LIMIT, 1).ConfigureAwait(true)
+    )
       .Where(x => x.commits.totalCount > 0)
       .ToList();
 

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
@@ -98,7 +98,7 @@ public class StreamSelectorViewModel : ReactiveObject
   {
     using var client = new Client(SelectedStream.Account);
 
-    Branches = (await client.StreamGetBranches(SelectedStream.Stream.id, 100, 1).ConfigureAwait(true))
+    Branches = (await client.StreamGetBranches(SelectedStream.Stream.id, 500, 1).ConfigureAwait(true))
       .Where(x => x.commits.totalCount > 0)
       .ToList();
 

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -248,7 +248,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       AvailableFilters = new List<FilterViewModel>(Bindings.GetSelectionFilters().Select(x => new FilterViewModel(x)));
       SelectedFilter = AvailableFilters[0];
 
-      Branches = await Client.StreamGetBranches(Stream.id, 100, 0).ConfigureAwait(true);
+      Branches = await Client.StreamGetBranches(Stream.id, 500, 0).ConfigureAwait(true);
 
       //TODO: Core's API calls and the StreamWrapper class need to be updated to properly support FE2 links
       //this is a temporary workaround

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -248,7 +248,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       AvailableFilters = new List<FilterViewModel>(Bindings.GetSelectionFilters().Select(x => new FilterViewModel(x)));
       SelectedFilter = AvailableFilters[0];
 
-      Branches = await Client.StreamGetBranches(Stream.id, 500, 0).ConfigureAwait(true);
+      Branches = await Client.StreamGetBranches(Stream.id, ServerLimits.BRANCH_GET_LIMIT, 0).ConfigureAwait(true);
 
       //TODO: Core's API calls and the StreamWrapper class need to be updated to properly support FE2 links
       //this is a temporary workaround
@@ -430,7 +430,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     try
     {
       var prevBranchName = SelectedBranch != null ? SelectedBranch.Branch.name : StreamState.BranchName;
-      Branches = await Client.StreamGetBranches(Stream.id, 500, 0).ConfigureAwait(true);
+      Branches = await Client.StreamGetBranches(Stream.id, ServerLimits.BRANCH_GET_LIMIT, 0).ConfigureAwait(true);
 
       var index = Branches.FindIndex(x => x.name == prevBranchName);
       if (index != -1)


### PR DESCRIPTION
Fully aligns codebase with changes from #3021.

- Created a new `ServerLimits` static class to hold this magic number (and others that will come)
- Applied the change to all calls of `StreamGetBranches`
- Added tests to verify branch limits are respected in SDK and resulting data aligns with expectations.
- Added ENV var in docker-compose.yml to upgrade test server limit to 500.

Tests are quite simple, but I didn't want to start re-engineering our integration test logic to fit this particular edge-case (tests depend on each other, can get messy). Ideally, API.cs in the integration tests should be split into pieces.