### PR TITLE
fix(Archicad): Timeout after 100s when sending large models

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/HttpCommandExecutor.cs
@@ -42,10 +42,17 @@ namespace Archicad.Communication
         )
       )
       {
+        bool log = false;
+
         AddOnCommandRequest<TParameters> request = new AddOnCommandRequest<TParameters>(commandName, parameters);
 
         string requestMsg = SerializeRequest(request);
-        Console.WriteLine(requestMsg);
+
+        if (log)
+        {
+          Console.WriteLine(requestMsg);
+        }
+
         string responseMsg;
 
         using (
@@ -54,8 +61,15 @@ namespace Archicad.Communication
             commandName
           )
         )
+        {
           responseMsg = await ConnectionManager.Instance.Send(requestMsg);
-        Console.WriteLine(responseMsg);
+        }
+
+        if (log)
+        {
+          Console.WriteLine(responseMsg);
+        }
+
         AddOnCommandResponse<TResult> response = DeserializeResponse<AddOnCommandResponse<TResult>>(responseMsg);
 
         // TODO


### PR DESCRIPTION
## Changes:

Dump of HTTP request and response messages between Archicad add-on and the Connector has been removed.
It is a debug code should not be there in production.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
