### PR TITLE
Hotfix to tolerate server branch limits of 100 and 500

### DIFF
--- a/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.BranchOperations.cs
+++ b/Core/Core/Api/GraphQL/Client.GraphqlCleintOperations/Client.BranchOperations.cs
@@ -11,6 +11,28 @@ namespace Speckle.Core.Api;
 public partial class Client
 {
   /// <summary>
+  /// Get branches from a given stream, first with a max of 500 and then with a max of 100.
+  /// This ensures that if the server API is limiting to 100 branches, that any failure will try again at the lower value.
+  /// </summary>
+  /// <param name="streamId">Id of the stream to get the branches from</param>
+  /// <param name="commitsLimit">Max number of commits to retrieve</param>
+  /// <returns></returns>
+  public async Task<List<Branch>> StreamGetBranchesWithLimitRetry(string streamId, int commitsLimit = 10)
+  {
+    List<Branch>? branches = null;
+    try
+    {
+      branches = await StreamGetBranches(streamId, 500, commitsLimit).ConfigureAwait(true);
+    }
+    catch (SpeckleGraphQLException<StreamData>)
+    {
+      branches = await StreamGetBranches(streamId, 100, commitsLimit).ConfigureAwait(true);
+    }
+
+    return branches;
+  }
+
+  /// <summary>
   /// Get branches from a given stream
   /// </summary>
   /// <param name="streamId">Id of the stream to get the branches from</param>

--- a/Core/Core/Api/GraphQL/Client.cs
+++ b/Core/Core/Api/GraphQL/Client.cs
@@ -155,7 +155,7 @@ public partial class Client : IDisposable
     {
       var result = await ExecuteWithResiliencePolicies(async () =>
         {
-          var result = await GQLClient.SendMutationAsync<T>(request, cancellationToken).ConfigureAwait(false);
+          GraphQLResponse<T> result = await GQLClient.SendMutationAsync<T>(request, cancellationToken).ConfigureAwait(false);
           MaybeThrowFromGraphQLErrors(request, result);
           return result.Data;
         })

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamSelectorViewModel.cs
@@ -98,7 +98,7 @@ public class StreamSelectorViewModel : ReactiveObject
   {
     using var client = new Client(SelectedStream.Account);
 
-    Branches = (await client.StreamGetBranches(SelectedStream.Stream.id, 100, 1).ConfigureAwait(true))
+    Branches = (await client.StreamGetBranchesWithLimitRetry(SelectedStream.Stream.id, 1).ConfigureAwait(true))
       .Where(x => x.commits.totalCount > 0)
       .ToList();
 

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -23,6 +23,7 @@ using DesktopUI2.Views;
 using DesktopUI2.Views.Pages;
 using DesktopUI2.Views.Windows.Dialogs;
 using DynamicData;
+using GraphQL;
 using Material.Dialog.Icons;
 using Material.Icons;
 using Material.Icons.Avalonia;
@@ -249,7 +250,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       AvailableFilters = new List<FilterViewModel>(Bindings.GetSelectionFilters().Select(x => new FilterViewModel(x)));
       SelectedFilter = AvailableFilters[0];
 
-      Branches = await Client.StreamGetBranches(Stream.id, 100, 0).ConfigureAwait(true);
+      Branches = await Client.StreamGetBranchesWithLimitRetry(Stream.id, 0).ConfigureAwait(true);
 
       var index = Branches.FindIndex(x => x.name == StreamState.BranchName);
       if (index != -1)
@@ -417,7 +418,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     try
     {
       var prevBranchName = SelectedBranch != null ? SelectedBranch.Branch.name : StreamState.BranchName;
-      Branches = await Client.StreamGetBranches(Stream.id, 500, 0).ConfigureAwait(true);
+      Branches = await Client.StreamGetBranchesWithLimitRetry(Stream.id, 0).ConfigureAwait(true);
 
       var index = Branches.FindIndex(x => x.name == prevBranchName);
       if (index != -1)


### PR DESCRIPTION
## Summary
Currently if the server's GQL backend supports only 100 elements and we request 500, then the call to get the branches fails a bit opaquely. With this change, if the call fails asking for 500, we drop to asking for 100.

## Changes:
Just a DUI change to proxy the call through another method and retry on failed 500 request with 100 limt.

## Validation of changes:
Validation would need performing on a speckle.xyz exhibting the problem.

## Checklist:

- [X] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [X] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [X] My commits are related to the pull request and do not amend unrelated code or documentation.
- [X] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
