### PR TITLE
fix(revit): receiving generic mep elements

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertDuct.cs
@@ -16,14 +16,16 @@ namespace Objects.Converter.Revit
     public ApplicationObject DuctToNative(BuiltElements.Duct speckleDuct)
     {
       var speckleRevitDuct = speckleDuct as RevitDuct;
-      var docObj = GetExistingElementByApplicationId(speckleDuct.applicationId);
+      Element docObj = GetExistingElementByApplicationId(speckleDuct.applicationId);
       var appObj = new ApplicationObject(speckleDuct.id, speckleDuct.speckle_type) { applicationId = speckleDuct.applicationId };
 
       // skip if element already exists in doc & receive mode is set to ignore
       if (IsIgnore(docObj, appObj))
+      {
         return appObj;
+      }
 
-      var systemFamily = (speckleRevitDuct != null) ? speckleRevitDuct.systemName : "";
+      string systemFamily = (speckleRevitDuct != null) ? speckleRevitDuct.systemName : "";
       List<ElementType> types = new FilteredElementCollector(Doc).WhereElementIsElementType()
           .OfClass(typeof(MechanicalSystemType)).ToElements().Cast<ElementType>().ToList();
       var system = types.FirstOrDefault(x => x.Name == systemFamily);
@@ -36,7 +38,7 @@ namespace Objects.Converter.Revit
       Element duct = null;
       if (speckleDuct.baseCurve == null || speckleDuct.baseCurve is Line)
       {
-        var ductType = GetElementType<DuctType>(speckleDuct, appObj, out bool _);
+        DuctType ductType = GetElementType<DuctType>(speckleDuct, appObj, out bool _);
         if (ductType == null)
         {
           appObj.Update(status: ApplicationObject.State.Failed);
@@ -52,7 +54,7 @@ namespace Objects.Converter.Revit
       }
       else if (speckleDuct.baseCurve is Polyline polyline)
       {
-        var ductType = GetElementType<FlexDuctType>(speckleDuct, appObj, out bool _);
+        FlexDuctType ductType = GetElementType<FlexDuctType>(speckleDuct, appObj, out bool _);
         if (ductType == null)
         {
           appObj.Update(status: ApplicationObject.State.Failed);
@@ -60,10 +62,10 @@ namespace Objects.Converter.Revit
         }
 
         var speckleRevitFlexDuct = speckleDuct as RevitFlexDuct;
-        var points = polyline.GetPoints().Select(o => PointToNative(o)).ToList();
+        List<XYZ> points = polyline.GetPoints().Select(o => PointToNative(o)).ToList();
         DB.Level flexLevel = ConvertLevelToRevit(speckleRevitDuct != null ? speckleRevitDuct.level : LevelFromPoint(points.First()), out ApplicationObject.State flexState);
-        var startTangent = VectorToNative(speckleRevitFlexDuct.startTangent);
-        var endTangent = VectorToNative(speckleRevitFlexDuct.endTangent);
+        XYZ startTangent = VectorToNative(speckleRevitFlexDuct.startTangent);
+        XYZ endTangent = VectorToNative(speckleRevitFlexDuct.endTangent);
 
         DB.Mechanical.FlexDuct flexDuct = DB.Mechanical.FlexDuct.Create(Doc, system.Id, ductType.Id, flexLevel.Id, startTangent, endTangent, points);
         duct = flexDuct;
@@ -76,7 +78,9 @@ namespace Objects.Converter.Revit
 
       // deleting instead of updating for now!
       if (docObj != null)
+      {
         Doc.Delete(docObj.Id);
+      }
 
       if (speckleRevitDuct != null)
       {
@@ -87,9 +91,9 @@ namespace Objects.Converter.Revit
         TrySetParam(duct, BuiltInParameter.RBS_VELOCITY, speckleRevitDuct.velocity, speckleRevitDuct.units);
 
         SetInstanceParameters(duct, speckleRevitDuct);
-      }
 
-      CreateSystemConnections(speckleRevitDuct.Connectors, duct, receivedObjectsCache);
+        CreateSystemConnections(speckleRevitDuct.Connectors, duct, receivedObjectsCache);
+      }
 
       appObj.Update(status: ApplicationObject.State.Created, createdId: duct.UniqueId, convertedItem: duct);
       return appObj;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
@@ -185,25 +185,19 @@ namespace Objects.Converter.Revit
       {
         t.Start();
 
-        Category cat = null;
-        if (freeformElement != null)
+        //by default free form elements are always generic models
+        BuiltInCategory bic = BuiltInCategory.OST_GenericModel;
+        Category cat = famDoc.Settings.Categories.get_Item(bic);
+        if (freeformElement is not null && !string.IsNullOrEmpty(freeformElement.subcategory))
         {
           //subcategory
-
-          if (!string.IsNullOrEmpty(freeformElement.subcategory))
+          if (cat.SubCategories.Contains(freeformElement.subcategory))
           {
-            //by default free form elements are always generic models
-            //otherwise we'd need to supply base files for each category..?
-            BuiltInCategory bic = BuiltInCategory.OST_GenericModel;
-            cat = famDoc.Settings.Categories.get_Item(bic);
-            if (cat.SubCategories.Contains(freeformElement.subcategory))
-            {
-              cat = cat.SubCategories.get_Item(freeformElement.subcategory);
-            }
-            else
-            {
-              cat = famDoc.Settings.Categories.NewSubcategory(cat, freeformElement.subcategory);
-            }
+            cat = cat.SubCategories.get_Item(freeformElement.subcategory);
+          }
+          else
+          {
+            cat = famDoc.Settings.Categories.NewSubcategory(cat, freeformElement.subcategory);
           }
         }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertPipe.cs
@@ -20,24 +20,27 @@ namespace Objects.Converter.Revit
       var speckleRevitPipe = specklePipe as RevitPipe;
 
       // check to see if pipe already exists in the doc
-      var docObj = GetExistingElementByApplicationId(specklePipe.applicationId);
+      Element docObj = GetExistingElementByApplicationId(specklePipe.applicationId);
       var appObj = new ApplicationObject(specklePipe.id, specklePipe.speckle_type) { applicationId = specklePipe.applicationId };
 
       // skip if element already exists in doc & receive mode is set to ignore
       if (IsIgnore(docObj, appObj))
+      {
         return appObj;
+      }
 
       // get system info
-      var pipeType = GetElementType<DB.MEPCurveType>(specklePipe, appObj, out bool _);
+      MEPCurveType pipeType = GetElementType<DB.MEPCurveType>(specklePipe, appObj, out bool _);
       if (pipeType == null)
       {
         appObj.Update(status: ApplicationObject.State.Failed);
         return appObj;
       }
-      var systemTypes = new FilteredElementCollector(Doc).WhereElementIsElementType()
+
+      List<ElementType> systemTypes = new FilteredElementCollector(Doc).WhereElementIsElementType()
        .OfClass(typeof(DB.Plumbing.PipingSystemType)).ToElements().Cast<ElementType>().ToList();
       var systemFamily = speckleRevitPipe?.systemType ?? "";
-      var system = systemTypes.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
+      ElementType system = systemTypes.FirstOrDefault(x => x.Name == speckleRevitPipe?.systemName) ??
                    systemTypes.FirstOrDefault(x => x.Name == systemFamily);
       if (system == null)
       {
@@ -60,6 +63,7 @@ namespace Objects.Converter.Revit
             linePipe.SetSystemType(lineSystem);
             ((LocationCurve)linePipe.Location).Curve = baseLine;
           }
+
           pipe = linePipe;
           break;
         case Polyline _:
@@ -74,6 +78,7 @@ namespace Objects.Converter.Revit
           {
             flexPipeType = GetElementType<FlexPipeType>(specklePipe, appObj, out bool _);
           }
+
           if (flexPipeType == null)
           {
             appObj.Update(status: ApplicationObject.State.Failed);
@@ -85,11 +90,16 @@ namespace Objects.Converter.Revit
           if (specklePipe.baseCurve is Curve curve)
           {
             basePoly = curve.displayValue;
-            var baseCurve = CurveToNative(curve);
-            var start = baseCurve.GetEndPoint(0);
-            var end = baseCurve.GetEndPoint(1);
+            DB.Curve baseCurve = CurveToNative(curve);
+            XYZ start = baseCurve.GetEndPoint(0);
+            XYZ end = baseCurve.GetEndPoint(1);
           }
-          if (basePoly == null) break;
+
+          if (basePoly == null)
+          {
+            break;
+          }
+
           var polyPoints = basePoly.GetPoints().Select(o => PointToNative(o)).ToList();
 
           // get tangents if they exist
@@ -99,12 +109,15 @@ namespace Objects.Converter.Revit
           // get level
           DB.Level flexPolyLevel = ConvertLevelToRevit(speckleRevitFlexPipe != null ? speckleRevitFlexPipe.level : LevelFromPoint(polyPoints.First()), out levelState);
 
-          var flexPolyPipe = (startTangent != null && endTangent != null) ?
+          FlexPipe flexPolyPipe = (startTangent != null && endTangent != null) ?
             DB.Plumbing.FlexPipe.Create(Doc, system.Id, flexPipeType.Id, flexPolyLevel.Id, startTangent, endTangent, polyPoints) :
             DB.Plumbing.FlexPipe.Create(Doc, system.Id, flexPipeType.Id, flexPolyLevel.Id, polyPoints);
 
+          // deleting instead of updating for now!
           if (docObj != null)
-            Doc.Delete(docObj.Id); // deleting instead of updating for now!
+          {
+            Doc.Delete(docObj.Id); 
+          }
 
           pipe = flexPolyPipe;
           break;
@@ -114,11 +127,12 @@ namespace Objects.Converter.Revit
       }
 
       if (speckleRevitPipe != null)
+      {
         SetInstanceParameters(pipe, speckleRevitPipe);
+        CreateSystemConnections(speckleRevitPipe.Connectors, pipe, receivedObjectsCache);
+      }
 
       TrySetParam(pipe, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM, specklePipe.diameter, specklePipe.units);
-
-      CreateSystemConnections(speckleRevitPipe.Connectors, pipe, receivedObjectsCache);
 
       appObj.Update(status: ApplicationObject.State.Created, createdId: pipe.UniqueId, convertedItem: pipe);
       return appObj;

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -47,11 +47,11 @@ namespace Objects.Converter.Revit
       // retrieve the level
       var levelState = ApplicationObject.State.Unknown;
       double baseOffset = 0.0;
-      DB.Level level = speckleRoof.level is not null ? 
-        ConvertLevelToRevit(speckleRoof.level, out levelState) : 
-        outline is not null ? 
-        ConvertLevelToRevit(outline.get_Item(0), out levelState, out baseOffset) : 
-        null;
+      DB.Level level = speckleRoof.level is not null
+        ? ConvertLevelToRevit(speckleRoof.level, out levelState)
+        : outline is not null
+          ? ConvertLevelToRevit(outline.get_Item(0), out levelState, out baseOffset)
+          : null;
 
       var speckleRevitRoof = speckleRoof as RevitRoof;
 


### PR DESCRIPTION
## Description & motivation

Fixes bugs when receiving generic mep elements, which was a regression due to the recent revit `Network` refactor. This was causing failed conversions when receiving built elements from Grasshopper.

Includes some minor changes to `RoofToNative` and `FreeformElementToNative` conversions, but does not successfully fix receiving for those elements sent from Grasshopper BuiltElements test file.

## Changes:

- Revit converter

## Screenshots:

Before:
![Untitled](https://github.com/specklesystems/speckle-sharp/assets/16748799/7bd9b069-7139-4dd6-bf1b-43070ffe1191)

After:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/2ad67b5b-647a-43df-9ea5-cca7fb38bc60)

