### PR TITLE
fix(rvt): Revit's UnitToNative did not ensure units were parsed

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/Units.cs
@@ -6,7 +6,6 @@ namespace Objects.Converter.Revit
 {
   public partial class ConverterRevit
   {
-
     private string _modelUnits;
 
 #if REVIT2020
@@ -173,17 +172,18 @@ namespace Objects.Converter.Revit
     }
 
     private double? defaultConversionFactor;
+
     public double ScaleToSpeckle(double value)
     {
       defaultConversionFactor ??= ScaleToSpeckle(1, RevitLengthTypeId);
       return value * defaultConversionFactor.Value;
     }
-    
+
     public static double ScaleToSpeckle(double value, string units)
     {
       return ScaleToSpeckle(value, UnitsToNative(units));
     }
-    
+
     public static double ScaleToSpeckle(double value, ForgeTypeId forgeTypeId)
     {
       // our current profiling shows that the method "ConvertFromInternalUnits" is a huge bottleneck
@@ -213,13 +213,16 @@ namespace Objects.Converter.Revit
     {
       return UnitsToNativeString(UnitsToNative(units));
     }
+
     public static string UnitsToNativeString(ForgeTypeId forgeTypeId)
     {
       return forgeTypeId.TypeId;
     }
+
     public static ForgeTypeId UnitsToNative(string units)
     {
-      switch (units)
+      var u = Speckle.Core.Kits.Units.GetUnitsFromString(units);
+      switch (u)
       {
         case Speckle.Core.Kits.Units.Millimeters:
           return UnitTypeId.Millimeters;


### PR DESCRIPTION
Fixes issue encountered when testing QGIS->Revit

Units from qgis were on a valid value but not on the standard format.

Revit's UnitToNative implementation differed from others in that it was not ensuring the units string that was passed had the correct value (i.e. "m" instead of "meters").

![Screenshot 2023-11-13 at 18 06 20](https://github.com/specklesystems/speckle-sharp/assets/2316535/46ce4ef4-bde6-4fcd-a4d2-050637d2fbd5)


This is achieved by calling `Units.GetUnitsFromString`, which parses the string value into the standard unit string.