### PR TITLE
fix(revit): extrusion roof and freeform elements conversion

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertFreeformElement.cs
@@ -52,6 +52,7 @@ namespace Objects.Converter.Revit
         appObj.Update(status: ApplicationObject.State.Failed);
         return appObj;
       }
+
       Doc.LoadFamily(tempPath, new FamilyLoadOption(), out var fam);
       var symbol = Doc.GetElement(fam.GetFamilySymbolIds().First()) as DB.FamilySymbol;
       symbol.Activate();
@@ -186,10 +187,12 @@ namespace Objects.Converter.Revit
         t.Start();
 
         //by default free form elements are always generic models
-        BuiltInCategory bic = BuiltInCategory.OST_GenericModel;
-        Category cat = famDoc.Settings.Categories.get_Item(bic);
+        Category cat = null;
         if (freeformElement is not null && !string.IsNullOrEmpty(freeformElement.subcategory))
         {
+          BuiltInCategory bic = BuiltInCategory.OST_GenericModel;
+          cat = famDoc.Settings.Categories.get_Item(bic);
+
           //subcategory
           if (cat.SubCategories.Contains(freeformElement.subcategory))
           {
@@ -204,7 +207,10 @@ namespace Objects.Converter.Revit
         foreach (var s in solids)
         {
           var f = DB.FreeFormElement.Create(famDoc, s);
-          f.Subcategory = cat;
+          if (cat is not null)
+          {
+            f.Subcategory = cat;
+          }
         }
 
         t.Commit();

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertGeometry.cs
@@ -743,9 +743,17 @@ namespace Objects.Converter.Revit
       var xn = new XYZ(1, 0, 0);
 
       if (ixn.IsAlmostEqualTo(xn))
+      {
         xn = new XYZ(0, 1, 0);
+      }
+      else if (ixn.Negate().IsAlmostEqualTo(xn))
+      {
+        xn = new XYZ(0, -1, 0);
+      }
 
-      return ixn.CrossProduct(xn).Normalize();
+      var cross = ixn.CrossProduct(xn);
+
+      return cross.Normalize();
     }
 
     public Geometry.Surface FaceToSpeckle(DB.Face face, DB.BoundingBoxUV uvBox, Document doc, string units = null)

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertRoof.cs
@@ -72,6 +72,7 @@ namespace Objects.Converter.Revit
       {
         case RevitExtrusionRoof speckleExtrusionRoof:
         {
+          // get the norm
           var referenceLine = LineToNative(speckleExtrusionRoof.referenceLine);
           var norm = GetPerpendicular(referenceLine.GetEndPoint(0) - referenceLine.GetEndPoint(1)).Negate();
           ReferencePlane plane = Doc.Create.NewReferencePlane(
@@ -87,10 +88,11 @@ namespace Objects.Converter.Revit
             level = ConvertLevelToRevit(referenceLine, out levelState, out baseOffset);
           }
 
-          //create floor without a type
+          //create floor without a type with the profile
+          var profile = CurveToNative(speckleExtrusionRoof.referenceLine);
           var start = ScaleToNative(speckleExtrusionRoof.start, speckleExtrusionRoof.units);
           var end = ScaleToNative(speckleExtrusionRoof.end, speckleExtrusionRoof.units);
-          revitRoof = Doc.Create.NewExtrusionRoof(outline, plane, level, roofType, start, end);
+          revitRoof = Doc.Create.NewExtrusionRoof(profile, plane, level, roofType, start, end);
 
           // sometimes Revit flips the roof so the start offset is the end and vice versa.
           // In that case, delete the created roof, flip the referencePlane and recreate it.
@@ -99,7 +101,7 @@ namespace Objects.Converter.Revit
           {
             Doc.Delete(revitRoof.Id);
             plane.Flip();
-            revitRoof = Doc.Create.NewExtrusionRoof(outline, plane, level, roofType, start, end);
+            revitRoof = Doc.Create.NewExtrusionRoof(profile, plane, level, roofType, start, end);
           }
           break;
         }


### PR DESCRIPTION
## Description & motivation
Extrusion roofs were not being properly converted to native due to incorrect use of `roof.outline` in place of `extrusionRoof.referenceLine`.

Freeform elements received in revit from GH with no subcategory assigned are now successfully created. Previously, setting null or generic model default subcategory was throwing errors on solid creation.

## Changes:
- Revit converter

