### PR TITLE
Clearer error message for failed spaces

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -29,7 +29,7 @@ namespace Objects.Converter.Revit
       // Determine Space Location
       if (speckleSpace.basePoint is null)
       {
-        appObj.Update(status: ApplicationObject.State.Failed, logItem: "Unplaced spaces are not supported");
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: "Space Base Point was null");
         return appObj;
       }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/Partial Classes/ConvertSpace.cs
@@ -27,6 +27,12 @@ namespace Objects.Converter.Revit
         return appObj;
 
       // Determine Space Location
+      if (speckleSpace.basePoint is null)
+      {
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: "Unplaced spaces are not supported");
+        return appObj;
+      }
+
       var level = ConvertLevelToRevit(speckleSpace.level, out _);
       var basePoint = PointToNative(speckleSpace.basePoint);
       var upperLimit = ConvertLevelToRevit(speckleSpace.topLevel, out _);


### PR DESCRIPTION
For Revit to native, we are still updating the app object directly.
Not nice, but safer imo than throwing right now until we properly refactor this aspect of the connector (like we've already done for ToSpeckle)