### PR TITLE
fix(Archicad): Timeout after 100s when sending large models #2

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Communication/ConnectionManager.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/ConnectionManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Archicad.Communication
@@ -17,7 +18,7 @@ namespace Archicad.Communication
 
     public void Start(uint portNumber)
     {
-      HttpClient = new HttpClient { BaseAddress = new System.Uri("http://127.0.0.1:" + portNumber) };
+      HttpClient = new HttpClient { BaseAddress = new System.Uri("http://127.0.0.1:" + portNumber), Timeout = TimeSpan.FromSeconds(300) };
     }
 
     public void Stop()


### PR DESCRIPTION
## Description & motivation

Additional timeout increase for https://github.com/specklesystems/speckle-sharp/pull/3038.

## Changes:

Timeout of HTTP request calls to Archicad API has been increased to 300s.
(Investigation of possible performance slow down is to come later.)

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
