### PR TITLE
fix(CSI): wrong case in shared CSI file path

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIShared.projitems
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIShared.projitems
@@ -46,7 +46,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PartialClasses\Geometry\ConvertStories.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PartialClasses\Geometry\ConvertTendon.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PartialClasses\Geometry\ConvertWall.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)partialclasses\loading\ConvertLoadCombination.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PartialClasses\Loading\ConvertLoadCombination.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PartialClasses\Loading\ConvertLoadPattern.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PartialClasses\Loading\Loading1DElements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PartialClasses\Loading\Loading2DElements.cs" />


### PR DESCRIPTION
Fixes incorrect casing on one of the paths for the ConverterCSIShared project.

This was breaking Nuget builds, which are done in Linux and have a stricter case-sensitivity than Windows (where our connectors and installers are built)