### PR TITLE
feat(gh): Add support for TextEntity conversion both ways.

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.cs
@@ -610,6 +610,7 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       case RH.Extrusion _:
       case RH.Brep _:
       case RH.NurbsSurface _:
+      case RH.TextEntity _:
         return true;
 
 #if GRASSHOPPER
@@ -623,7 +624,6 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       case ViewInfo _:
       case InstanceDefinition _:
       case InstanceObject _:
-      case RH.TextEntity _:
       case RH.Dimension _:
       case Layer _:
         return true;
@@ -657,6 +657,7 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       case Brep _:
       case Surface _:
       case Element1D _:
+      case Text _:
         return true;
 #if GRASSHOPPER
       case Interval _:
@@ -676,7 +677,6 @@ public partial class ConverterRhinoGh : ISpeckleConverter
       case GridLine _:
       case Alignment _:
       case Level _:
-      case Text _:
       case Dimension _:
       case Collection c when !c.collectionType.ToLower().Contains("model"):
         return true;


### PR DESCRIPTION
TextEntity cannot be fetched from Rhino, but can be created through a Python/C# script, and obviously received through Speckle.

![Screenshot 2023-11-22 at 11 33 04](https://github.com/specklesystems/speckle-sharp/assets/2316535/6858070f-db8e-41c3-bf0a-0c4654964253)


It also cannot be baked from Grasshopper, so users are left the responsibility of knowing what to do with these.

Since they're convertible, you can always plug them into a "Deconstruct Speckle Object" to get their inner info.
