### PR TITLE
chore: Silence Bentley and AdvanceSteel warnings on CI

### DIFF
--- a/ConnectorAutocadCivil/AdvanceSteelAddinRegistrator/AdvanceSteelAddinRegistrator.csproj
+++ b/ConnectorAutocadCivil/AdvanceSteelAddinRegistrator/AdvanceSteelAddinRegistrator.csproj
@@ -8,6 +8,13 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Authors>Pedro Henrique Liberato</Authors>
   </PropertyGroup>
+
+  <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+    <WarningLevel>0</WarningLevel>
+    <EnableNetAnalyzers>false</EnableNetAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/ConnectorAutocadCivil/ConnectorAdvanceSteel2023/ConnectorAdvanceSteel2023.csproj
+++ b/ConnectorAutocadCivil/ConnectorAdvanceSteel2023/ConnectorAdvanceSteel2023.csproj
@@ -10,6 +10,13 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Authors>Pedro Henrique Liberato</Authors>
   </PropertyGroup>
+
+  <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+    <WarningLevel>0</WarningLevel>
+    <EnableNetAnalyzers>false</EnableNetAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  
   <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />
   <Target Name="AfterBuildMigrated" AfterTargets="Build" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <GenerateManifest InputFilename="$(ProjectDir)\MyAddons.xml" OutputFilename="C:\Program Files\Autodesk\AutoCAD 2023\ADVS\Addons\MyAddons.xml" MatchExpression="\$PATH\$" ReplacementText="$(TargetPath)" />

--- a/ConnectorAutocadCivil/ConnectorAdvanceSteel2024/ConnectorAdvanceSteel2024.csproj
+++ b/ConnectorAutocadCivil/ConnectorAdvanceSteel2024/ConnectorAdvanceSteel2024.csproj
@@ -10,6 +10,13 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Authors>Pedro Henrique Liberato</Authors>
   </PropertyGroup>
+
+  <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+    <WarningLevel>0</WarningLevel>
+    <EnableNetAnalyzers>false</EnableNetAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  
   <Import Project="..\ConnectorAutocadCivil\ConnectorAutocadCivilShared.projitems" Label="Shared" />
   <Target Name="AfterBuildMigrated" AfterTargets="Build" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <GenerateManifest InputFilename="$(ProjectDir)\MyAddons.xml" OutputFilename="C:\Program Files\Autodesk\AutoCAD 2024\ADVS\Addons\MyAddons.xml" MatchExpression="\$PATH\$" ReplacementText="$(TargetPath)" />

--- a/ConnectorBentley/ConnectorMicroStation/ConnectorMicroStation.csproj
+++ b/ConnectorBentley/ConnectorMicroStation/ConnectorMicroStation.csproj
@@ -13,6 +13,12 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <Import Project="..\ConnectorBentleyShared\ConnectorBentleyShared.projitems" Label="Shared" />
 
     <Target Name="Clean">

--- a/ConnectorBentley/ConnectorOpenBuildings/ConnectorOpenBuildings.csproj
+++ b/ConnectorBentley/ConnectorOpenBuildings/ConnectorOpenBuildings.csproj
@@ -12,6 +12,13 @@
         <DefineConstants>$(DefineConstants);OPENBUILDINGS</DefineConstants>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
+
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <Import Project="..\ConnectorBentleyShared\ConnectorBentleyShared.projitems" Label="Shared" />
 
     <Target Name="Clean">

--- a/ConnectorBentley/ConnectorOpenRail/ConnectorOpenRail.csproj
+++ b/ConnectorBentley/ConnectorOpenRail/ConnectorOpenRail.csproj
@@ -13,6 +13,12 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <Import Project="..\ConnectorBentleyShared\ConnectorBentleyShared.projitems" Label="Shared" />
 
     <ItemGroup Condition="'$(IsDesktopBuild)' == true">

--- a/ConnectorBentley/ConnectorOpenRoads/ConnectorOpenRoads.csproj
+++ b/ConnectorBentley/ConnectorOpenRoads/ConnectorOpenRoads.csproj
@@ -12,7 +12,13 @@
         <DefineConstants>$(DefineConstants);OPENROADS</DefineConstants>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
-
+  
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <Import Project="..\ConnectorBentleyShared\ConnectorBentleyShared.projitems" Label="Shared" />
 
     <Target Name="Clean">

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAdvanceSteel2023/ConverterAdvanceSteel2023.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAdvanceSteel2023/ConverterAdvanceSteel2023.csproj
@@ -15,6 +15,12 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+    <WarningLevel>0</WarningLevel>
+    <EnableNetAnalyzers>false</EnableNetAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" IncludeAssets="compile;build"/>
     <PackageReference Include="MathNet.Spatial" Version="0.6.0" IncludeAssets="compile;build"/>

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAdvanceSteel2024/ConverterAdvanceSteel2024.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAdvanceSteel2024/ConverterAdvanceSteel2024.csproj
@@ -15,6 +15,12 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+    <WarningLevel>0</WarningLevel>
+    <EnableNetAnalyzers>false</EnableNetAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" IncludeAssets="compile;build"/>
     <PackageReference Include="MathNet.Spatial" Version="0.6.0" IncludeAssets="compile;build"/>

--- a/Objects/Converters/ConverterBentley/ConverterMicroStation/ConverterMicroStation.csproj
+++ b/Objects/Converters/ConverterBentley/ConverterMicroStation/ConverterMicroStation.csproj
@@ -13,6 +13,12 @@
         <CopyToKitFolder>true</CopyToKitFolder>
     </PropertyGroup>
 
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <DefineConstants>TRACE;MICROSTATION</DefineConstants>
     </PropertyGroup>

--- a/Objects/Converters/ConverterBentley/ConverterOpenBuildings/ConverterOpenBuildings.csproj
+++ b/Objects/Converters/ConverterBentley/ConverterOpenBuildings/ConverterOpenBuildings.csproj
@@ -11,6 +11,12 @@
         <CopyToKitFolder>true</CopyToKitFolder>
     </PropertyGroup>
 
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <DefineConstants>TRACE;OPENBUILDINGS</DefineConstants>
     </PropertyGroup>

--- a/Objects/Converters/ConverterBentley/ConverterOpenRail/ConverterOpenRail.csproj
+++ b/Objects/Converters/ConverterBentley/ConverterOpenRail/ConverterOpenRail.csproj
@@ -11,6 +11,12 @@
         <CopyToKitFolder>true</CopyToKitFolder>
     </PropertyGroup>
 
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <DefineConstants>TRACE;OPENRAIL</DefineConstants>
     </PropertyGroup>

--- a/Objects/Converters/ConverterBentley/ConverterOpenRoads/ConverterOpenRoads.csproj
+++ b/Objects/Converters/ConverterBentley/ConverterOpenRoads/ConverterOpenRoads.csproj
@@ -9,9 +9,14 @@
         <Company>Arup</Company>
         <Description>Converter for OpenRoads Designer Connect</Description>
         <CopyToKitFolder>true</CopyToKitFolder>
-
     </PropertyGroup>
 
+    <PropertyGroup Label="Community Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+      <WarningLevel>0</WarningLevel>
+      <EnableNetAnalyzers>false</EnableNetAnalyzers>
+      <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+  
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
         <DefineConstants>TRACE;OPENROADS</DefineConstants>
     </PropertyGroup>


### PR DESCRIPTION
In order to move forward with our 0 Warnings epic, we need to reduce the noise coming from our community contributed projects, as we're not going to be changing anything on them.

This PR reduces the warning level to 0 for all community contributed projects, as well as disabling code analysis and code style enforcement on build.