### PR TITLE
feat(Core): CNX-8352 operations.send

### DIFF
--- a/Automate/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/Automate/Speckle.Automate.Sdk/AutomationContext.cs
@@ -97,7 +97,7 @@ public class AutomationContext
     }
 
     var rootObjectId = await Operations
-      .Send(rootObject, new List<ITransport> { serverTransport, memoryTransport }, useDefaultCache: false)
+      .Send(rootObject, new List<ITransport> { serverTransport, memoryTransport })
       .ConfigureAwait(false);
 
     var branch = await SpeckleClient.BranchGet(AutomationRunData.ProjectId, branchName).ConfigureAwait(false);

--- a/Automate/Tests/Speckle.Automate.Sdk.Tests.Integration/SpeckleAutomate.cs
+++ b/Automate/Tests/Speckle.Automate.Sdk.Tests.Integration/SpeckleAutomate.cs
@@ -19,10 +19,8 @@ public sealed class AutomationContextTest : IDisposable
     Branch model = await client.BranchGet(projectId, branchName, 1);
     string modelId = model.id;
 
-    string rootObjId = await Operations.Send(
-      testObject,
-      new List<ITransport> { new ServerTransport(client.Account, projectId) }
-    );
+    using ServerTransport remoteTransport = new(client.Account, projectId);
+    string rootObjId = await Operations.Send(testObject, remoteTransport, false);
 
     string versionId = await client.CommitCreate(
       new()

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Developer/Local.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Developer/Local.cs
@@ -21,7 +21,7 @@ public static class Local
     converter.OnError += (sender, args) => throw args.Error;
 
     var @base = converter.ConvertRecursivelyToSpeckle(data);
-    var objectId = Task.Run(async () => await Operations.Send(@base, disposeTransports: true)).Result;
+    var objectId = Task.Run(() => Operations.Send(@base)).Result;
 
     return objectId;
   }

--- a/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
+++ b/ConnectorDynamo/ConnectorDynamoFunctions/Functions.cs
@@ -243,7 +243,7 @@ public static class Functions
       Analytics.Events.Receive,
       new Dictionary<string, object>()
       {
-        { "sourceHostApp", HostApplications.GetHostAppFromString(commit.sourceApplication)?.Slug },
+        { "sourceHostApp", HostApplications.GetHostAppFromString(commit.sourceApplication).Slug },
         { "sourceHostAppVersion", commit.sourceApplication },
         { "isMultiplayer", commit.authorId != client.Account.userInfo.id }
       }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SendLocalComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SendLocalComponent.cs
@@ -85,7 +85,7 @@ public class SendLocalWorker : WorkerInstance
       var converted = Utilities.DataTreeToNestedLists(data, converter);
       var ObjectToSend = new Base();
       ObjectToSend["@data"] = converted;
-      sentObjectId = Operations.Send(ObjectToSend, disposeTransports: true).Result;
+      sentObjectId = Operations.Send(ObjectToSend).Result;
     }
     catch (Exception e)
     {

--- a/Core/Core/Api/Helpers.cs
+++ b/Core/Core/Api/Helpers.cs
@@ -143,7 +143,6 @@ public static class Helpers
   /// <param name="account">Account to use. If not provided the default account will be used.</param>
   /// <param name="useDefaultCache">Toggle for the default cache. If set to false, it will only send to the provided transports.</param>
   /// <param name="onProgressAction">Action invoked on progress iterations.</param>
-  /// <param name="onErrorAction">Action invoked on internal errors.</param>
   /// <returns></returns>
   public static async Task<string> Send(
     string stream,
@@ -153,20 +152,17 @@ public static class Helpers
     int totalChildrenCount = 0,
     Account account = null,
     bool useDefaultCache = true,
-    Action<ConcurrentDictionary<string, int>> onProgressAction = null,
-    Action<string, Exception> onErrorAction = null
+    Action<ConcurrentDictionary<string, int>> onProgressAction = null
   )
   {
     var sw = new StreamWrapper(stream);
 
     using var client = new Client(account ?? await sw.GetAccount().ConfigureAwait(false));
 
-    var transport = new ServerTransport(client.Account, sw.StreamId);
+    using ServerTransport transport = new(client.Account, sw.StreamId);
     var branchName = string.IsNullOrEmpty(sw.BranchName) ? "main" : sw.BranchName;
 
-    var objectId = await Operations
-      .Send(data, new List<ITransport> { transport }, useDefaultCache, onProgressAction, onErrorAction, true)
-      .ConfigureAwait(false);
+    var objectId = await Operations.Send(data, transport, useDefaultCache, onProgressAction).ConfigureAwait(false);
 
     Analytics.TrackEvent(client.Account, Analytics.Events.Send);
 

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -228,6 +228,15 @@ public static partial class Operations
       serializerVersion
     );
 
+  ///<inheritdoc cref="Send(Speckle.Core.Models.Base,System.Threading.CancellationToken,System.Collections.Generic.List{Speckle.Core.Transports.ITransport}?,bool,System.Action{System.Collections.Concurrent.ConcurrentDictionary{string,int}}?,System.Action{string,System.Exception}?,bool,Speckle.Core.Api.SerializerVersion)"/>
+  [Obsolete("This overload has been deprecated along with serializer v1. Use other Send overloads instead.")]
+  [SuppressMessage("Naming", "CA1720:Identifier contains type name")]
+  public static Task<string> Send(
+    Base @object,
+    bool disposeTransports,
+    SerializerVersion serializerVersion = SerializerVersion.V2
+  ) => Send(@object, CancellationToken.None, null, true, null, null, disposeTransports, serializerVersion);
+
   /// <summary>
   /// Sends an object via the provided transports. Defaults to the local cache.
   /// </summary>

--- a/Core/Core/Api/Operations/Operations.Send.cs
+++ b/Core/Core/Api/Operations/Operations.Send.cs
@@ -25,26 +25,27 @@ public static partial class Operations
   /// <remarks/>
   /// <inheritdoc cref="Send(Base, IReadOnlyCollection{ITransport}, Action{ConcurrentDictionary{string, int}}?, CancellationToken)"/>
   /// <param name="useDefaultCache">When <see langword="true"/>, an additional <see cref="SQLiteTransport"/> will be included</param>
+  /// <exception cref="ArgumentNullException">The <paramref name="transport"/> or <paramref name="value"/> was <see langword="null"/></exception>
   /// <example><code>
   /// using ServerTransport destination = new(account, streamId);
   /// string objectId = await Send(mySpeckleObject, destination, true);
   /// </code></example>
   public static async Task<string> Send(
     Base value,
-    ITransport? transport,
+    ITransport transport,
     bool useDefaultCache,
     Action<ConcurrentDictionary<string, int>>? onProgressAction = null,
     CancellationToken cancellationToken = default
   )
   {
-    List<ITransport> transports = new();
-    if (transport != null)
+    if (transport is null)
     {
-      transports.Add(transport);
+      throw new ArgumentNullException(nameof(transport), "Expected a transport to be explicitly specified");
     }
 
+    List<ITransport> transports = new() { transport };
     using SQLiteTransport? localCache = useDefaultCache ? new SQLiteTransport { TransportName = "LC" } : null;
-    if (localCache != null)
+    if (localCache is not null)
     {
       transports.Add(localCache);
     }

--- a/Core/Core/Api/Operations/Operations.Serialize.cs
+++ b/Core/Core/Api/Operations/Operations.Serialize.cs
@@ -18,11 +18,11 @@ public static partial class Operations
   /// please use any of the "Send" methods.
   /// <see cref="Send(Speckle.Core.Models.Base,System.Collections.Generic.List{Speckle.Core.Transports.ITransport}?,bool,System.Action{System.Collections.Concurrent.ConcurrentDictionary{string,int}}?,System.Action{string,System.Exception}?,bool,Speckle.Core.Api.SerializerVersion)"/>
   /// </remarks>
-  /// <param name="object"></param>
-  /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+  /// <param name="value">The object to serialise</param>
+  /// <param name="cancellationToken"></param>
   /// <returns>A json string representation of the object.</returns>
   public static string Serialize(
-    Base @object,
+    Base value,
     CancellationToken cancellationToken = default,
     SerializerVersion serializerVersion = SerializerVersion.V2
   )
@@ -32,13 +32,12 @@ public static partial class Operations
       var (serializer, settings) = GetSerializerInstance();
       serializer.CancellationToken = cancellationToken;
 
-      return JsonConvert.SerializeObject(@object, settings);
+      return JsonConvert.SerializeObject(value, settings);
     }
     else
     {
-      var serializer = new BaseObjectSerializerV2();
-      serializer.CancellationToken = cancellationToken;
-      return serializer.Serialize(@object);
+      var serializer = new BaseObjectSerializerV2 { CancellationToken = cancellationToken };
+      return serializer.Serialize(value);
     }
   }
 
@@ -47,7 +46,7 @@ public static partial class Operations
   /// </summary>
   /// <param name="objects"></param>
   /// <returns></returns>
-  [Obsolete("Please use the Serialize(Base @object) function. This function will be removed in later versions.")]
+  [Obsolete("Please use the Serialize(Base @object) function. This function will be removed in later versions.", true)]
   public static string Serialize(List<Base> objects)
   {
     var (_, settings) = GetSerializerInstance();

--- a/Core/Core/Api/Operations/Operations.cs
+++ b/Core/Core/Api/Operations/Operations.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -40,18 +41,14 @@ public static partial class Operations
   /// <returns></returns>
   private static Action<string, int> GetInternalProgressAction(
     ConcurrentDictionary<string, int> localProgressDict,
-    Action<ConcurrentDictionary<string, int>> onProgressAction = null
+    Action<ConcurrentDictionary<string, int>>? onProgressAction = null
   )
   {
     return (name, processed) =>
     {
-      if (localProgressDict.ContainsKey(name))
+      if (!localProgressDict.TryAdd(name, processed))
       {
         localProgressDict[name] += processed;
-      }
-      else
-      {
-        localProgressDict[name] = processed;
       }
 
       onProgressAction?.Invoke(localProgressDict);

--- a/Core/Core/Kits/Applications.cs
+++ b/Core/Core/Kits/Applications.cs
@@ -1,3 +1,6 @@
+#nullable enable
+using System.Diagnostics.Contracts;
+
 namespace Speckle.Core.Kits;
 
 public enum HostAppVersion
@@ -26,16 +29,16 @@ public enum HostAppVersion
   v717
 }
 
-public class HostApplication
+public readonly struct HostApplication
 {
+  public string Name { get; }
+  public string Slug { get; }
+
   public HostApplication(string name, string slug)
   {
     Name = name;
     Slug = slug;
   }
-
-  public string Name { get; private set; }
-  public string Slug { get; private set; }
 
   /// <summary>
   /// Returns the versioned app name given a specific version
@@ -53,45 +56,46 @@ public class HostApplication
 /// </summary>
 public static class HostApplications
 {
-  public static HostApplication Rhino = new("Rhino", "rhino");
-  public static HostApplication Grasshopper = new("Grasshopper", "grasshopper");
-  public static HostApplication Revit = new("Revit", "revit");
-  public static HostApplication Dynamo = new("Dynamo", "dynamo");
-  public static HostApplication Unity = new("Unity", "unity");
-  public static HostApplication GSA = new("GSA", "gsa");
-  public static HostApplication Civil = new("Civil 3D", "civil3d");
-  public static HostApplication AutoCAD = new("AutoCAD", "autocad");
-  public static HostApplication MicroStation = new("MicroStation", "microstation");
-  public static HostApplication OpenRoads = new("OpenRoads", "openroads");
-  public static HostApplication OpenRail = new("OpenRail", "openrail");
-  public static HostApplication OpenBuildings = new("OpenBuildings", "openbuildings");
-  public static HostApplication ETABS = new("ETABS", "etabs");
-  public static HostApplication SAP2000 = new("SAP2000", "sap2000");
-  public static HostApplication CSiBridge = new("CSiBridge", "csibridge");
-  public static HostApplication SAFE = new("SAFE", "safe");
-  public static HostApplication TeklaStructures = new("Tekla Structures", "teklastructures");
-  public static HostApplication Dxf = new("DXF Converter", "dxf");
-  public static HostApplication Excel = new("Excel", "excel");
-  public static HostApplication Unreal = new("Unreal", "unreal");
-  public static HostApplication PowerBI = new("Power BI", "powerbi");
-  public static HostApplication Blender = new("Blender", "blender");
-  public static HostApplication QGIS = new("QGIS", "qgis");
-  public static HostApplication ArcGIS = new("ArcGIS", "arcgis");
-  public static HostApplication SketchUp = new("SketchUp", "sketchup");
-  public static HostApplication Archicad = new("Archicad", "archicad");
-  public static HostApplication TopSolid = new("TopSolid", "topsolid");
-  public static HostApplication Python = new("Python", "python");
-  public static HostApplication NET = new(".NET", "net");
-  public static HostApplication Navisworks = new("Navisworks", "navisworks");
-  public static HostApplication AdvanceSteel = new("Advance Steel", "advancesteel");
-  public static HostApplication Other = new("Other", "other");
+  public static readonly HostApplication Rhino = new("Rhino", "rhino"),
+    Grasshopper = new("Grasshopper", "grasshopper"),
+    Revit = new("Revit", "revit"),
+    Dynamo = new("Dynamo", "dynamo"),
+    Unity = new("Unity", "unity"),
+    GSA = new("GSA", "gsa"),
+    Civil = new("Civil 3D", "civil3d"),
+    AutoCAD = new("AutoCAD", "autocad"),
+    MicroStation = new("MicroStation", "microstation"),
+    OpenRoads = new("OpenRoads", "openroads"),
+    OpenRail = new("OpenRail", "openrail"),
+    OpenBuildings = new("OpenBuildings", "openbuildings"),
+    ETABS = new("ETABS", "etabs"),
+    SAP2000 = new("SAP2000", "sap2000"),
+    CSiBridge = new("CSiBridge", "csibridge"),
+    SAFE = new("SAFE", "safe"),
+    TeklaStructures = new("Tekla Structures", "teklastructures"),
+    Dxf = new("DXF Converter", "dxf"),
+    Excel = new("Excel", "excel"),
+    Unreal = new("Unreal", "unreal"),
+    PowerBI = new("Power BI", "powerbi"),
+    Blender = new("Blender", "blender"),
+    QGIS = new("QGIS", "qgis"),
+    ArcGIS = new("ArcGIS", "arcgis"),
+    SketchUp = new("SketchUp", "sketchup"),
+    Archicad = new("Archicad", "archicad"),
+    TopSolid = new("TopSolid", "topsolid"),
+    Python = new("Python", "python"),
+    NET = new(".NET", "net"),
+    Navisworks = new("Navisworks", "navisworks"),
+    AdvanceSteel = new("Advance Steel", "advancesteel"),
+    Other = new("Other", "other");
 
   /// <summary>
   /// Gets a HostApplication form a string. It could be the versioned name or a string coming from a process running.
   /// </summary>
   /// <param name="appname">String with the name of the app</param>
   /// <returns></returns>
-  public static HostApplication GetHostAppFromString(string appname)
+  [Pure]
+  public static HostApplication GetHostAppFromString(string? appname)
   {
     if (appname == null)
     {

--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -32,7 +32,7 @@ public class Base : DynamicBase
   private string _type;
 
   /// <summary>
-  /// A speckle object's id is an unique hash based on its properties. <b>NOTE: this field will be null unless the object was deserialised from a source. Use the <see cref="GetId(bool)"/> function to get it.</b>
+  /// A speckle object's id is an uniq`ue hash based on its properties. <b>NOTE: this field will be null unless the object was deserialised from a source. Use the <see cref="GetId(bool)"/> function to get it.</b>
   /// </summary>
   [SchemaIgnore]
   public virtual string id { get; set; }

--- a/Core/Core/Models/Base.cs
+++ b/Core/Core/Models/Base.cs
@@ -32,7 +32,7 @@ public class Base : DynamicBase
   private string _type;
 
   /// <summary>
-  /// A speckle object's id is an uniq`ue hash based on its properties. <b>NOTE: this field will be null unless the object was deserialised from a source. Use the <see cref="GetId(bool)"/> function to get it.</b>
+  /// A speckle object's id is an unique hash based on its properties. <b>NOTE: this field will be null unless the object was deserialised from a source. Use the <see cref="GetId(bool)"/> function to get it.</b>
   /// </summary>
   [SchemaIgnore]
   public virtual string id { get; set; }

--- a/Core/Core/Transports/Exceptions.cs
+++ b/Core/Core/Transports/Exceptions.cs
@@ -1,9 +1,10 @@
 #nullable enable
 using System;
+using Speckle.Core.Logging;
 
 namespace Speckle.Core.Transports;
 
-public class TransportException : Exception
+public class TransportException : SpeckleException
 {
   public ITransport? Transport { get; }
 

--- a/Core/Core/Transports/ITransport.cs
+++ b/Core/Core/Transports/ITransport.cs
@@ -49,12 +49,12 @@ public interface ITransport
   public Action<string, Exception>? OnErrorAction { get; set; }
 
   /// <summary>
-  /// Optional: signals to the transport that writes are about to begin.
+  /// Signals to the transport that writes are about to begin.
   /// </summary>
   public void BeginWrite();
 
   /// <summary>
-  /// Optional: signals to the transport that no more items will need to be written.
+  /// Signals to the transport that no more items will need to be written.
   /// </summary>
   public void EndWrite();
 
@@ -62,14 +62,20 @@ public interface ITransport
   /// Saves an object.
   /// </summary>
   /// <param name="id">The hash of the object.</param>
-  /// <param name="serializedObject">The full string representation of the object.</param>
+  /// <param name="serializedObject">The full string representation of the object</param>
+  /// <exception cref="TransportException">Failed to save object</exception>
+  /// <exception cref="OperationCanceledException"><see cref="CancellationToken"/> requested cancel</exception>
   public void SaveObject(string id, string serializedObject);
 
   /// <summary>
-  /// Saves an object, retrieving its serialised version from the provided transport.
+  /// <inheritdoc cref="SaveObject(string, string)"/>
+  /// Retrieving its serialised version from the provided transport.
   /// </summary>
-  /// <param name="id">The hash of the object.</param>
+  /// <param name="id"><inheritdoc cref="SaveObject(string, string)"/></param>
   /// <param name="sourceTransport">The transport from where to retrieve it.</param>
+  /// <exception cref="TransportException"><inheritdoc cref="SaveObject(string, string)"/></exception>
+  /// <exception cref="InvalidOperationException"><inheritdoc cref="SaveObject(string, string)"/></exception>
+  /// <exception cref="OperationCanceledException"><inheritdoc cref="SaveObject(string, string)"/</exception>
   public void SaveObject(string id, ITransport sourceTransport);
 
   /// <summary>
@@ -80,7 +86,7 @@ public interface ITransport
 
   /// <param name="id">The object's hash.</param>
   /// <returns>The serialized object data, or <see langword="null"/> if the transport cannot find the object</returns>
-  /// <exception cref="OperationCanceledException"></exception>
+  /// <exception cref="OperationCanceledException"><see cref="CancellationToken"/> requested cancel</exception>
   public string? GetObject(string id);
 
   /// <summary>
@@ -90,9 +96,9 @@ public interface ITransport
   /// <param name="targetTransport">The transport you want to copy the object to.</param>
   /// <param name="onTotalChildrenCountKnown">(Optional) an <see cref="Action{T}"/> that will be invoked once, when the number of object children to be copied over is known.</param>
   /// <returns>The string representation of the root object.</returns>
-  /// <exception cref="InvalidOperationException">The transport was in an invalid state</exception>
   /// <exception cref="ArgumentException">The provided arguments are not valid</exception>
-  /// <exception cref="OperationCanceledException"></exception>
+  /// <exception cref="InvalidOperationException">The transport was in an invalid state</exception>
+  /// <exception cref="OperationCanceledException"><see cref="CancellationToken"/> requested cancel</exception>
   public Task<string> CopyObjectAndChildren(
     string id,
     ITransport targetTransport,

--- a/Core/Core/Transports/Memory.cs
+++ b/Core/Core/Transports/Memory.cs
@@ -57,10 +57,7 @@ public sealed class MemoryTransport : ITransport, ICloneable
   public void SaveObject(string id, string serializedObject)
   {
     var stopwatch = Stopwatch.StartNew();
-    if (CancellationToken.IsCancellationRequested)
-    {
-      return; // Check for cancellation
-    }
+    CancellationToken.ThrowIfCancellationRequested();
 
     Objects[id] = serializedObject;
 
@@ -107,18 +104,18 @@ public sealed class MemoryTransport : ITransport, ICloneable
 
   public Task WriteComplete()
   {
-    return Utilities.WaitUntil(() => true);
+    return Task.CompletedTask;
   }
 
-  public async Task<Dictionary<string, bool>> HasObjects(IReadOnlyList<string> objectIds)
+  public Task<Dictionary<string, bool>> HasObjects(IReadOnlyList<string> objectIds)
   {
-    Dictionary<string, bool> ret = new();
+    Dictionary<string, bool> ret = new(objectIds.Count);
     foreach (string objectId in objectIds)
     {
       ret[objectId] = Objects.ContainsKey(objectId);
     }
 
-    return ret;
+    return Task.FromResult(ret);
   }
 
   public bool GetWriteCompletionStatus()

--- a/Core/Core/Transports/SQLite.cs
+++ b/Core/Core/Transports/SQLite.cs
@@ -29,6 +29,14 @@ public sealed class SQLiteTransport : IDisposable, ICloneable, ITransport, IBlob
   /// </summary>
   private readonly Timer _writeTimer;
 
+  /// <summary>
+  /// Connects to an SQLite DB at {<paramref name="basePath"/>}/{<paramref name="applicationName"/>}/{<paramref name="scope"/>}.db
+  /// Will attempt to create db + directory structure as needed
+  /// </summary>
+  /// <param name="basePath">defaults to <see cref="SpecklePathProvider.UserApplicationDataPath"/> if <see langword="null"/></param>
+  /// <param name="applicationName">defaults to <c>"Speckle"</c> if <see langword="null"/></param>
+  /// <param name="scope">defaults to <c>"Data"</c> if <see langword="null"/></param>
+  /// <exception cref="TransportException">could not create directory, db, or failed to initialize a connection to the db</exception>
   public SQLiteTransport(string? basePath = null, string? applicationName = null, string? scope = null)
   {
     _basePath = basePath ?? SpecklePathProvider.UserApplicationDataPath();

--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -336,20 +336,11 @@ public class Api
 
     myObject["@Points"] = ptsList;
 
-    bool sendError = false;
     objectId = await Operations
-      .Send(
-        myObject,
-        new List<ITransport> { myServerTransport },
-        false,
-        disposeTransports: true,
-        onErrorAction: (s, e) =>
-        {
-          sendError = true;
-        }
-      )
+      .SendToTransports(myObject, new List<ITransport> { myServerTransport })
       .ConfigureAwait(false);
-    Assert.IsFalse(sendError);
+
+    Assert.That(objectId, Is.Not.Null);
 
     var res = await myClient
       .CommitCreate(

--- a/Core/IntegrationTests/Api.cs
+++ b/Core/IntegrationTests/Api.cs
@@ -336,9 +336,7 @@ public class Api
 
     myObject["@Points"] = ptsList;
 
-    objectId = await Operations
-      .SendToTransports(myObject, new List<ITransport> { myServerTransport })
-      .ConfigureAwait(false);
+    objectId = await Operations.Send(myObject, new List<ITransport> { myServerTransport }).ConfigureAwait(false);
 
     Assert.That(objectId, Is.Not.Null);
 

--- a/Core/IntegrationTests/ServerTransportTests.cs
+++ b/Core/IntegrationTests/ServerTransportTests.cs
@@ -57,7 +57,7 @@ public class ServerTransportTests
   {
     var myObject = Fixtures.GenerateNestedObject();
 
-    var objectId = await Operations.Send(myObject, new List<ITransport> { transport }).ConfigureAwait(false);
+    var objectId = await Operations.Send(myObject, transport).ConfigureAwait(false);
 
     var test = objectId;
     Assert.IsNotNull(test);
@@ -69,7 +69,7 @@ public class ServerTransportTests
     var myObject = Fixtures.GenerateSimpleObject();
     myObject["blobs"] = Fixtures.GenerateThreeBlobs();
 
-    var sentObjectId = await Operations.Send(myObject, new List<ITransport> { transport }).ConfigureAwait(false);
+    var sentObjectId = await Operations.Send(myObject, transport).ConfigureAwait(false);
 
     // NOTE: used to debug diffing
     // await Operations.Send(myObject, new List<ITransport> { transport });
@@ -104,7 +104,7 @@ public class ServerTransportTests
 
     var memTransport = new MemoryTransport();
     var sentObjectId = await Operations
-      .Send(myObject, new List<ITransport> { transport, memTransport }, false)
+      .SendToTransports(myObject, new List<ITransport> { transport, memTransport })
       .ConfigureAwait(false);
 
     var receivedObject = await Operations.Receive(sentObjectId, transport).ConfigureAwait(false);
@@ -137,7 +137,7 @@ public class ServerTransportTests
 
     var memTransport = new MemoryTransport();
     var sentObjectId = await Operations
-      .Send(myObject, new List<ITransport> { transport, memTransport }, false)
+      .SendToTransports(myObject, new List<ITransport> { transport, memTransport })
       .ConfigureAwait(false);
 
     memTransport = new MemoryTransport();

--- a/Core/IntegrationTests/ServerTransportTests.cs
+++ b/Core/IntegrationTests/ServerTransportTests.cs
@@ -57,7 +57,7 @@ public class ServerTransportTests
   {
     var myObject = Fixtures.GenerateNestedObject();
 
-    var objectId = await Operations.Send(myObject, transport).ConfigureAwait(false);
+    var objectId = await Operations.Send(myObject, transport, false).ConfigureAwait(false);
 
     var test = objectId;
     Assert.IsNotNull(test);
@@ -69,7 +69,7 @@ public class ServerTransportTests
     var myObject = Fixtures.GenerateSimpleObject();
     myObject["blobs"] = Fixtures.GenerateThreeBlobs();
 
-    var sentObjectId = await Operations.Send(myObject, transport).ConfigureAwait(false);
+    var sentObjectId = await Operations.Send(myObject, transport, false).ConfigureAwait(false);
 
     // NOTE: used to debug diffing
     // await Operations.Send(myObject, new List<ITransport> { transport });
@@ -104,7 +104,7 @@ public class ServerTransportTests
 
     var memTransport = new MemoryTransport();
     var sentObjectId = await Operations
-      .SendToTransports(myObject, new List<ITransport> { transport, memTransport })
+      .Send(myObject, new List<ITransport> { transport, memTransport })
       .ConfigureAwait(false);
 
     var receivedObject = await Operations.Receive(sentObjectId, transport).ConfigureAwait(false);
@@ -137,7 +137,7 @@ public class ServerTransportTests
 
     var memTransport = new MemoryTransport();
     var sentObjectId = await Operations
-      .SendToTransports(myObject, new List<ITransport> { transport, memTransport })
+      .Send(myObject, new List<ITransport> { transport, memTransport })
       .ConfigureAwait(false);
 
     memTransport = new MemoryTransport();

--- a/Core/IntegrationTests/Subscriptions/Commits.cs
+++ b/Core/IntegrationTests/Subscriptions/Commits.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Speckle.Core.Api;
 using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
@@ -65,16 +64,7 @@ public class Commits
     myObject["Points"] = ptsList;
 
     var objectId = await Operations
-      .Send(
-        myObject,
-        new List<ITransport> { myServerTransport },
-        false,
-        onErrorAction: (name, err) =>
-        {
-          Debug.WriteLine("Err in transport");
-          Debug.WriteLine(err.Message);
-        }
-      )
+      .SendToTransports(myObject, new List<ITransport> { myServerTransport })
       .ConfigureAwait(false);
 
     var commitInput = new CommitCreateInput

--- a/Core/IntegrationTests/Subscriptions/Commits.cs
+++ b/Core/IntegrationTests/Subscriptions/Commits.cs
@@ -63,9 +63,7 @@ public class Commits
 
     myObject["Points"] = ptsList;
 
-    var objectId = await Operations
-      .SendToTransports(myObject, new List<ITransport> { myServerTransport })
-      .ConfigureAwait(false);
+    var objectId = await Operations.Send(myObject, myServerTransport, false).ConfigureAwait(false);
 
     var commitInput = new CommitCreateInput
     {

--- a/Core/Tests/ClosureTests.cs
+++ b/Core/Tests/ClosureTests.cs
@@ -35,7 +35,7 @@ public class Closures
 
     var transport = new MemoryTransport();
 
-    var result = Operations.Send(d1, new List<ITransport> { transport }, false).Result;
+    var result = Operations.Send(d1, transport, false).Result;
 
     var test = Operations.Receive(result, localTransport: transport).Result;
 

--- a/Core/Tests/SendReceiveLocal.cs
+++ b/Core/Tests/SendReceiveLocal.cs
@@ -27,7 +27,7 @@ public class SendReceiveLocal
       ((List<Base>)myObject["@items"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "-___/---" });
     }
 
-    objId_01 = Operations.Send(myObject).Result;
+    objId_01 = Operations.Send(myObject, null, true).Result;
 
     Assert.NotNull(objId_01);
     TestContext.Out.WriteLine($"Written {numObjects + 1} objects. Commit id is {objId_01}");
@@ -55,7 +55,7 @@ public class SendReceiveLocal
       ((List<Base>)myObject["@items"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "-___/---" });
     }
 
-    objId_01 = Operations.Send(myObject).Result;
+    objId_01 = Operations.Send(myObject, null, true).Result;
 
     var commitPulled = Operations.Receive(objId_01).Result;
 
@@ -76,7 +76,7 @@ public class SendReceiveLocal
       ((List<Base>)myObject["@items"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "-ugh/---" });
     }
 
-    objId_01 = await Operations.Send(myObject).ConfigureAwait(false);
+    objId_01 = await Operations.Send(myObject, null, true).ConfigureAwait(false);
 
     Assert.NotNull(objId_01);
     TestContext.Out.WriteLine($"Written {numObjects + 1} objects. Commit id is {objId_01}");
@@ -100,7 +100,7 @@ public class SendReceiveLocal
     myObject["@dictionary"] = myDic;
     myObject["@list"] = myList;
 
-    objId_01 = await Operations.Send(myObject).ConfigureAwait(false);
+    objId_01 = await Operations.Send(myObject, null, true).ConfigureAwait(false);
 
     Assert.NotNull(objId_01);
 
@@ -135,7 +135,7 @@ public class SendReceiveLocal
       ((List<Base>)((dynamic)obj)["@LayerC"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "baz" });
     }
 
-    objId_01 = await Operations.Send(obj).ConfigureAwait(false);
+    objId_01 = await Operations.Send(obj, null, true).ConfigureAwait(false);
 
     Assert.NotNull(objId_01);
     TestContext.Out.WriteLine($"Written {numObjects + 1} objects. Commit id is {objId_01}");
@@ -171,10 +171,12 @@ public class SendReceiveLocal
       ((List<Base>)myObject["items"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "-fab/---" });
     }
 
-    ConcurrentDictionary<string, int> progress = null;
+    ConcurrentDictionary<string, int>? progress = null;
     commitId_02 = await Operations
       .Send(
         myObject,
+        null,
+        true,
         onProgressAction: dict =>
         {
           progress = dict;
@@ -183,7 +185,7 @@ public class SendReceiveLocal
       .ConfigureAwait(false);
 
     Assert.NotNull(progress);
-    Assert.GreaterOrEqual(progress.Keys.Count, 1);
+    Assert.GreaterOrEqual(progress!.Keys.Count, 1);
   }
 
   [Test(Description = "Should show progress!"), Order(5)]
@@ -204,6 +206,7 @@ public class SendReceiveLocal
   }
 
   [Test(Description = "Should dispose of transports after a send or receive operation if so specified.")]
+  [Obsolete("Send overloads that perform disposal are deprecated")]
   public async Task ShouldDisposeTransports()
   {
     var @base = new Base();
@@ -248,8 +251,8 @@ public class SendReceiveLocal
     @base["test"] = "the best";
 
     var myLocalTransport = new SQLiteTransport();
-    var id = await Operations.Send(@base, new List<ITransport> { myLocalTransport }, false).ConfigureAwait(false);
-    await Operations.Send(@base, new List<ITransport> { myLocalTransport }, false).ConfigureAwait(false);
+    var id = await Operations.Send(@base, myLocalTransport, false).ConfigureAwait(false);
+    await Operations.Send(@base, myLocalTransport, false).ConfigureAwait(false);
 
     var obj = await Operations.Receive(id, null, myLocalTransport).ConfigureAwait(false);
     await Operations.Receive(id, null, myLocalTransport).ConfigureAwait(false);

--- a/Core/Tests/SendReceiveLocal.cs
+++ b/Core/Tests/SendReceiveLocal.cs
@@ -7,12 +7,14 @@ using Speckle.Core.Transports;
 namespace TestsUnit;
 
 [TestFixture]
-public class SendReceiveLocal
+public class SendReceiveLocal : IDisposable
 {
   private string objId_01,
     commitId_02;
 
   private int numObjects = 3001;
+
+  private readonly SQLiteTransport _sut = new();
 
   [Test(Description = "Pushing a commit locally"), Order(1)]
   public void LocalUpload()
@@ -27,7 +29,8 @@ public class SendReceiveLocal
       ((List<Base>)myObject["@items"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "-___/---" });
     }
 
-    objId_01 = Operations.Send(myObject, null, true).Result;
+    using SQLiteTransport localTransport = new();
+    objId_01 = Operations.Send(myObject, localTransport, false).Result;
 
     Assert.NotNull(objId_01);
     TestContext.Out.WriteLine($"Written {numObjects + 1} objects. Commit id is {objId_01}");
@@ -55,7 +58,7 @@ public class SendReceiveLocal
       ((List<Base>)myObject["@items"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "-___/---" });
     }
 
-    objId_01 = Operations.Send(myObject, null, true).Result;
+    objId_01 = Operations.Send(myObject, _sut, false).Result;
 
     var commitPulled = Operations.Receive(objId_01).Result;
 
@@ -76,7 +79,7 @@ public class SendReceiveLocal
       ((List<Base>)myObject["@items"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "-ugh/---" });
     }
 
-    objId_01 = await Operations.Send(myObject, null, true).ConfigureAwait(false);
+    objId_01 = await Operations.Send(myObject, _sut, false).ConfigureAwait(false);
 
     Assert.NotNull(objId_01);
     TestContext.Out.WriteLine($"Written {numObjects + 1} objects. Commit id is {objId_01}");
@@ -100,7 +103,7 @@ public class SendReceiveLocal
     myObject["@dictionary"] = myDic;
     myObject["@list"] = myList;
 
-    objId_01 = await Operations.Send(myObject, null, true).ConfigureAwait(false);
+    objId_01 = await Operations.Send(myObject, _sut, false).ConfigureAwait(false);
 
     Assert.NotNull(objId_01);
 
@@ -135,7 +138,7 @@ public class SendReceiveLocal
       ((List<Base>)((dynamic)obj)["@LayerC"]).Add(new Point(i, i, i + rand.NextDouble()) { applicationId = i + "baz" });
     }
 
-    objId_01 = await Operations.Send(obj, null, true).ConfigureAwait(false);
+    objId_01 = await Operations.Send(obj, _sut, false).ConfigureAwait(false);
 
     Assert.NotNull(objId_01);
     TestContext.Out.WriteLine($"Written {numObjects + 1} objects. Commit id is {objId_01}");
@@ -175,8 +178,8 @@ public class SendReceiveLocal
     commitId_02 = await Operations
       .Send(
         myObject,
-        null,
-        true,
+        _sut,
+        false,
         onProgressAction: dict =>
         {
           progress = dict;
@@ -281,4 +284,9 @@ public class SendReceiveLocal
 
   //  Assert.AreEqual(rebase.GetId(true), id);
   //}
+
+  public void Dispose()
+  {
+    _sut.Dispose();
+  }
 }

--- a/Core/Transports/DiskTransport/DiskTransport.cs
+++ b/Core/Transports/DiskTransport/DiskTransport.cs
@@ -93,7 +93,15 @@ public class DiskTransport : ICloneable, ITransport
       return;
     }
 
-    File.WriteAllText(filePath, serializedObject, Encoding.UTF8);
+    try
+    {
+      File.WriteAllText(filePath, serializedObject, Encoding.UTF8);
+    }
+    catch (Exception ex)
+    {
+      throw new TransportException(this, $"Failed to write object {id} to disk", ex);
+    }
+
     SavedObjectCount++;
     OnProgressAction?.Invoke(TransportName, SavedObjectCount);
     stopwatch.Stop();

--- a/DesktopUI2/DesktopUI2/ConnectorHelpers.cs
+++ b/DesktopUI2/DesktopUI2/ConnectorHelpers.cs
@@ -193,6 +193,7 @@ public static class ConnectorHelpers
 
   /// <exception cref="OperationCanceledException"></exception>
   /// <exception cref="SpeckleException"></exception>
+  [Obsolete(nameof(Operations.Send) + "No longer accepts OnErrorHandler")]
   public static void DefaultSendErrorHandler(string error, Exception ex)
   {
     //Don't wrap cancellation exceptions!

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
       <!--Dissabled by design-->
       CA5399;CA1862;
       <!--XML comment-->
-      CS1591;
+      CS1591;CS1573;
       <!--Nullability-->
       CS8618;
       <!-- Globalization rules -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,8 +32,7 @@
       <!--Dissabled by design-->
       CA5399;CA1862;
       <!--XML comment-->
-      CS1591;CS1573;CS1572;CS1570;CS1587;CS1574;
-      CS1711;CS1734;
+      CS1591;
       <!--Nullability-->
       CS8618;
       <!-- Globalization rules -->


### PR DESCRIPTION
As part of our effort to reduce analyser warnings across our code base. It's important that our Core functions are clear about what exceptions types they throw.

This motivation for this PR was to focus on `Operations.Send` and attempt to enforce and provide clear guidance on the exception types that can be thrown.

Our original `Operations.Send` overloads were doing some smelly things:

In the signature of the function alone:
1. We were allowing users to pass in a `SerializerVerion` enum to switch to using the old v1 serializer. This serializer hasn't been used (or tested) in almost two years, its past time we drop exposing it as an option for `Operations.Send`
2. A long time ago, we were using `OnErrorAction` to signal errors in transports and sending. We have since deprecated this in favour of throwing proper Exceptions instead. This property is effectively unused with our current `Operations.Send`
3. We were exposing a `disposeTransports` boolean (defaulting to false) that, when true, we would loop through and dispose any `IDisposable` transports that the user passes through. This doesn't follow any normal C# guidance on how `IDisposables` should be handled, and on top of that, we weren't disposing inside a finally block, so if an exception did occur, we weren't disposing the transports anyway. Thus this "feature" was not really usable, and much cleaner solved by expecting caller to handle the disposal using e.g. using a `using` keyword.

And in the implementation:
1. We were performing input validation, logging, timers, error handling, SQLite setup, transport manipulation + extra nonsense for serailizer v1, as well as performing the actual send!

In my new implementation, we have far fewer parameters, removing the obsolete and questionable designed ones.
We have also separated logging and error handing into one function `SendToTransports` and the actual send logic in an internal `SendInternal` function. 