### PR TITLE
enhancement(Navisworks): Add global unhandled exception handler

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
@@ -79,6 +79,8 @@ internal sealed class SpeckleNavisworksCommandPlugin : DockPanePlugin
     {
       var ex = (Exception)e.ExceptionObject;
       SpeckleLog.Logger.Fatal(ex, "Unhandled Navisworks Error: {error}", ex.Message);
+
+      // rethrow to pass to application error handler, which it would have done anyway
       throw ex;
     }
   }

--- a/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
@@ -43,6 +43,8 @@ internal sealed class SpeckleNavisworksCommandPlugin : DockPanePlugin
   public override Control CreateControlPane()
   {
     AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+    AppDomain.CurrentDomain.UnhandledException += Current_Domain_UnhandledException;
+
     Setup.Init(ConnectorBindingsNavisworks.HostAppNameVersion, ConnectorBindingsNavisworks.HostAppName);
     try
     {
@@ -70,6 +72,21 @@ internal sealed class SpeckleNavisworksCommandPlugin : DockPanePlugin
     speckleHost.CreateControl();
 
     return speckleHost;
+  }
+
+  private static void Current_Domain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+  {
+    {
+      var ex = (Exception)e.ExceptionObject;
+      SpeckleLog.Logger.Fatal(ex, "Unhandled Navisworks Error: {error}", ex.Message);
+      throw ex;
+    }
+  }
+
+  protected override void OnUnloading()
+  {
+    AppDomain.CurrentDomain.UnhandledException -= Current_Domain_UnhandledException;
+    base.OnUnloading();
   }
 
   public override void DestroyControlPane(Control pane)

--- a/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Entry/SpeckleNavisworksCommand.cs
@@ -74,6 +74,18 @@ internal sealed class SpeckleNavisworksCommandPlugin : DockPanePlugin
     return speckleHost;
   }
 
+  /// <summary>
+  /// Handles unhandled exceptions within the application.
+  /// Specifically designed for use within the Speckle plugin for Navisworks,
+  /// this method logs the exception details before rethrowing the exception
+  /// to allow the application's default error handling to proceed.
+  /// </summary>
+  /// <param name="sender">The source of the unhandled exception event. This is typically
+  /// the object that raised the event.</param>
+  /// <param name="e">An UnhandledExceptionEventArgs object that contains the event data,
+  /// including the unhandled exception.</param>
+  /// <exception cref="Exception">The exception that was unhandled and led to the triggering
+  /// of this event handler.</exception>
   private static void Current_Domain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
   {
     {


### PR DESCRIPTION
Each plugin is in an isolated Worker Thread (until it isn't) but despite this, there are `currentdomain` errors that can trigger the Navisworks Application error handler kicking in, even in debug.

In this specific case, I'm looking to head off errors arising from the Main Thread invocation that can fail to capture with the InvokerHelper wrappers I have employed; these are almost exclusively Interop errors and get caught by the hostApp global error handler. As such, these errors are on the main thread.

I intend to see what this can learn. This logs the fatal error and then rethrows to ensure no change in operation and then learns from the logging, which should be more contextual than relying on crash dumps, which, more often than not, do not deserialise innerException stack traces.