### PR TITLE
fix(dui): broken fe2 url when in oneclick mode

### DIFF
--- a/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
@@ -314,7 +313,6 @@ public class OneClickViewModel : ReactiveObject, IRoutableViewModel
 
         return $"{_fileStream.ServerUrl.TrimEnd('/')}/streams/{_fileStream.StreamId}/{commit}";
       }
-
     }
   }
 

--- a/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
@@ -299,13 +299,22 @@ public class OneClickViewModel : ReactiveObject, IRoutableViewModel
   {
     get
     {
-      var commit = "";
-      if (!string.IsNullOrEmpty(Id))
+      var account = AccountManager.GetDefaultAccount();
+      if (account.serverInfo.frontend2)
       {
-        commit = "commits/" + Id;
+        return $"{_fileStream.ServerUrl.TrimEnd('/')}/projects/{_fileStream.StreamId}";
+      }
+      else
+      {
+        var commit = "";
+        if (!string.IsNullOrEmpty(Id))
+        {
+          commit = "commits/" + Id;
+        }
+
+        return $"{_fileStream.ServerUrl.TrimEnd('/')}/streams/{_fileStream.StreamId}/{commit}";
       }
 
-      return $"{_fileStream.ServerUrl.TrimEnd('/')}/streams/{_fileStream.StreamId}/{commit}";
     }
   }
 


### PR DESCRIPTION
We forgot to add the switch in the One Click Mode.
Here's a quick fix for it that should be probably released as hotfix sometime soon.
Community report: https://speckle.community/t/rhino-speckle-connector-server-link-issue/8170/2