### PR TITLE
fix(rhino): CNX-8572 Handles ca1031 in Rhino converter files

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Drawing;
 using Objects.Other;
 using Rhino;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
@@ -33,7 +33,7 @@ public partial class ConverterRhinoGh
       string layerPath = MakeValidPath(path);
 
       // see if this layer already exists in the doc
-      Layer existingLayer = GetLayer(Doc, layerPath);
+      Layer existingLayer = GetLayer(Doc, layerPath, out int _);
 
       // update this layer if it exists & receive mode is on update
       if (existingLayer != null && ReceiveMode == ReceiveMode.Update)
@@ -43,7 +43,7 @@ public partial class ConverterRhinoGh
       }
       else // create this layer
       {
-        if (GetLayer(Doc, layerPath, true) is Layer newLayer)
+        if (GetLayer(Doc, layerPath, out _, true) is Layer newLayer)
         {
           layer = newLayer;
           status = ApplicationObject.State.Created;

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
@@ -21,42 +21,6 @@ public partial class ConverterRhinoGh
   // layers
   public ApplicationObject CollectionToNative(Collection collection)
   {
-    #region local functions
-    Layer GetLayer(string path)
-    {
-      var index = Doc.Layers.FindByFullPath(path, RhinoMath.UnsetIntIndex);
-      if (index != RhinoMath.UnsetIntIndex)
-      {
-        return Doc.Layers[index];
-      }
-
-      return null;
-    }
-    Layer MakeLayer(string name, Layer parentLayer = null)
-    {
-      try
-      {
-        Layer newLayer = new() { Name = name };
-        if (parentLayer != null)
-        {
-          newLayer.ParentLayerId = parentLayer.Id;
-        }
-
-        int newIndex = Doc.Layers.Add(newLayer);
-        if (newIndex < 0)
-        {
-          return null;
-        }
-
-        return Doc.Layers.FindIndex(newIndex);
-      }
-      catch (Exception e)
-      {
-        return null;
-      }
-    }
-    #endregion
-
     var appObj = new ApplicationObject(collection.id, collection.speckle_type)
     {
       applicationId = collection.applicationId
@@ -64,60 +28,60 @@ public partial class ConverterRhinoGh
     Layer layer = null;
     var status = ApplicationObject.State.Unknown;
 
-    // see if this layer already exists in the doc
-    var layerPath = RemoveInvalidRhinoChars(collection["path"] as string);
-    Layer existingLayer = GetLayer(layerPath);
+    if (collection["path"] is string path)
+    {
+      string layerPath = MakeValidPath(path);
 
-    // update this layer if it exists & receive mode is on update
-    if (existingLayer != null && ReceiveMode == ReceiveMode.Update)
-    {
-      layer = existingLayer;
-      status = ApplicationObject.State.Updated;
-    }
-    else // create this layer
-    {
-      Layer parent = null;
-      var parentIndex = layerPath.LastIndexOf(Layer.PathSeparator);
-      if (parentIndex != -1)
+      // see if this layer already exists in the doc
+      Layer existingLayer = GetLayer(Doc, layerPath);
+
+      // update this layer if it exists & receive mode is on update
+      if (existingLayer != null && ReceiveMode == ReceiveMode.Update)
       {
-        var parentPath = layerPath.Substring(0, parentIndex);
-        parent = GetLayer(parentPath);
-        if (parent == null)
+        layer = existingLayer;
+        status = ApplicationObject.State.Updated;
+      }
+      else // create this layer
+      {
+        if (GetLayer(Doc, layerPath, true) is Layer newLayer)
         {
-          appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not find layer parent: {parentPath}");
-          return appObj;
+          layer = newLayer;
+          status = ApplicationObject.State.Created;
         }
       }
-      layer = MakeLayer(collection.name, parent);
-      status = ApplicationObject.State.Created;
-    }
 
-    if (layer == null)
-    {
-      appObj.Update(status: ApplicationObject.State.Failed, logItem: "Could not create layer");
+      if (layer == null)
+      {
+        appObj.Update(status: ApplicationObject.State.Failed, logItem: $"Could not create layer with path {layerPath}");
+        return appObj;
+      }
+
+      // get attributes and rendermaterial
+      var displayStyle =
+        collection["displayStyle"] as DisplayStyle != null
+          ? DisplayStyleToNative(collection["displayStyle"] as DisplayStyle)
+          : new ObjectAttributes { ObjectColor = Color.AliceBlue };
+      var renderMaterial =
+        collection["renderMaterial"] as RenderMaterial != null
+          ? RenderMaterialToNative(collection["renderMaterial"] as RenderMaterial)
+          : null;
+      layer.Color = displayStyle.ObjectColor;
+      if (renderMaterial != null)
+      {
+        layer.RenderMaterial = renderMaterial;
+      }
+
+      layer.PlotWeight = displayStyle.PlotWeight;
+      layer.LinetypeIndex = displayStyle.LinetypeIndex;
+
+      appObj.Update(status: status, convertedItem: layer, createdId: layer.Id.ToString());
       return appObj;
     }
-
-    // get attributes and rendermaterial
-    var displayStyle =
-      collection["displayStyle"] as DisplayStyle != null
-        ? DisplayStyleToNative(collection["displayStyle"] as DisplayStyle)
-        : new ObjectAttributes { ObjectColor = Color.AliceBlue };
-    var renderMaterial =
-      collection["renderMaterial"] as RenderMaterial != null
-        ? RenderMaterialToNative(collection["renderMaterial"] as RenderMaterial)
-        : null;
-    layer.Color = displayStyle.ObjectColor;
-    if (renderMaterial != null)
+    else
     {
-      layer.RenderMaterial = renderMaterial;
+      appObj.Update(status: ApplicationObject.State.Failed, logItem: "Collection didn't have a layer path");
+      return appObj;
     }
-
-    layer.PlotWeight = displayStyle.PlotWeight;
-    layer.LinetypeIndex = displayStyle.LinetypeIndex;
-
-    appObj.Update(status: status, convertedItem: layer, createdId: layer.Id.ToString());
-    return appObj;
   }
 
   public Collection LayerToSpeckle(Layer layer)

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -16,18 +16,43 @@ namespace Objects.Converter.RhinoGh;
 
 public partial class ConverterRhinoGh
 {
-  public static string invalidRhinoChars = @"{}()";
+  public static string invalidRhinoChars = @"{}()[]";
 
   /// <summary>
-  /// Removes invalid characters for Rhino layer and block names
+  /// Creates a valid name for Rhino layers, blocks, and named views.
+  /// </summary>
+  /// <param name="str">Layer, block, or named view name</param>
+  /// <returns>The original name if valid, or "@name" if not.</returns>
+  /// <remarks>From trial and error, names cannot begin with invalidRhinoChars. This has been encountered in grasshopper branch syntax.</remarks>
+  public static string MakeValidName(string str)
+  {
+    return string.IsNullOrEmpty(str)
+      ? str
+      : invalidRhinoChars.Contains(str[0])
+        ? $"@{str}"
+        : str;
+  }
+
+  /// <summary>
+  /// Creates a valid path for Rhino layers.
   /// </summary>
   /// <param name="str"></param>
   /// <returns></returns>
-  public static string RemoveInvalidRhinoChars(string str)
+  public static string MakeValidPath(string str)
   {
-    // using this to handle grasshopper branch syntax
-    string cleanStr = str.Replace("{", "").Replace("}", "");
-    return cleanStr;
+    if (string.IsNullOrEmpty(str))
+    {
+      return str;
+    }
+
+    string validPath = "";
+    string[] layerNames = str.Split(new string[] { Layer.PathSeparator }, StringSplitOptions.None);
+    foreach (var item in layerNames)
+    {
+      validPath += string.IsNullOrEmpty(validPath) ? MakeValidName(item) : Layer.PathSeparator + MakeValidName(item);
+    }
+
+    return validPath;
   }
 
   /// <summary>
@@ -237,7 +262,6 @@ public partial class ConverterRhinoGh
   #endregion
 
   #region Layers
-
   public static Layer GetLayer(RhinoDoc doc, string path, out int index, bool MakeIfNull = false)
   {
     index = doc.Layers.FindByFullPath(path, RhinoMath.UnsetIntIndex);
@@ -255,7 +279,7 @@ public partial class ConverterRhinoGh
         currentLayer = GetLayer(doc, currentLayerPath, out index);
         if (currentLayer == null)
         {
-          currentLayer = MakeLayer(doc, layerNames[i], out index, parent);
+          currentLayer = MakeLayer(doc, layerNames[i], parent);
         }
 
         if (currentLayer == null)
@@ -270,23 +294,42 @@ public partial class ConverterRhinoGh
     return layer;
   }
 
-  private static Layer MakeLayer(RhinoDoc doc, string name, out int index, Layer parentLayer = null)
+  /// <summary>
+  /// Creates a layer from its name and parent
+  /// </summary>
+  /// <param name="doc"></param>
+  /// <param name="name"></param>
+  /// <param name="parentLayer"></param>
+  /// <returns>The new layer</returns>
+  /// <exception cref="ArgumentException">Layer name is invalid.</exception>
+  /// <exception cref="InvalidOperationException">Layer parent could not be set, or a layer with the same name already exists.</exception>
+  public static Layer MakeLayer(RhinoDoc doc, string name, Layer parentLayer = null)
   {
-    index = -1;
-    Layer newLayer = new() { Color = Color.White, Name = name };
+    if (!Layer.IsValidName(name))
+    {
+      throw new ArgumentException("Layer name is invalid.");
+    }
+
+    using Layer newLayer = new() { Color = Color.AliceBlue, Name = name };
     if (parentLayer != null)
     {
-      newLayer.ParentLayerId = parentLayer.Id;
+      try
+      {
+        newLayer.ParentLayerId = parentLayer.Id;
+      }
+      catch (Exception e)
+      {
+        throw new InvalidOperationException("Could not set layer parent id.", e);
+      }
     }
 
     int newIndex = doc.Layers.Add(newLayer);
-    if (newIndex < 0)
+    if (newIndex is -1)
     {
-      return null;
+      throw new InvalidOperationException("A layer with the same name already exists.");
     }
 
-    index = newIndex;
-    return doc.Layers.FindIndex(newIndex);
+    return newLayer;
   }
 
   #endregion


### PR DESCRIPTION
## Description & motivation

Handles ca1031 warnings in the rhino converter. Mostly concerns layer handling, and `CollectionToNative` conversions, including a minor fix for missing invalid chars and minor refactoring to remove duplicated local methods.

## Changes:

- Rhino converter
