### PR TITLE
fix(Revit): CNX-8655 - handle FabricationPart host retrieval

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitCommitObjectBuilder.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/RevitCommitObjectBuilder.cs
@@ -206,7 +206,7 @@ public sealed class RevitCommitObjectBuilder : CommitObjectBuilder<Element>, IRe
       Autodesk.Revit.DB.FamilyInstance i => i.Host,
       Autodesk.Revit.DB.Opening i => i.Host,
       Autodesk.Revit.DB.DividedSurface i => i.Host,
-      Autodesk.Revit.DB.FabricationPart i => i.Document.GetElement(i.GetHostedInfo()?.HostId),
+      Autodesk.Revit.DB.FabricationPart i => HandleFabricationPart(i),
       Autodesk.Revit.DB.DisplacementElement i => i.Document.GetElement(i.ParentId),
       Autodesk.Revit.DB.Architecture.ContinuousRail i => i.Document.GetElement(i.HostRailingId),
       Autodesk.Revit.DB.Architecture.BuildingPad i => i.Document.GetElement(i.HostId),
@@ -221,6 +221,19 @@ public sealed class RevitCommitObjectBuilder : CommitObjectBuilder<Element>, IRe
       Autodesk.Revit.DB.Structure.Rebar i => i.Document.GetElement(i.GetHostId()),
       _ => null
     };
+  }
+
+  /// <summary>
+  /// Processes a FabricationPart to retrieve its associated host element. FabricationPart class has no HasHost method.
+  /// </summary>
+  /// <param name="fabricationPart">The FabricationPart to process.</param>
+  /// <returns>
+  /// The host element of the given FabricationPart, or null if no host is associated.
+  /// </returns>
+  private static Element? HandleFabricationPart(FabricationPart fabricationPart)
+  {
+    var hostedInfo = fabricationPart.GetHostedInfo();
+    return hostedInfo == null ? null : fabricationPart.Document.GetElement(hostedInfo.HostId);
   }
 
   /// <summary>


### PR DESCRIPTION
## Description & motivation

This commit refactors the `RevitCommitObjectBuilder` class to handle the retrieval of a FabricationPart's associated host element. It introduces a new private method, `HandleFabricationPart`, which processes a `FabricationPart` and returns its host element. The method checks if the `FabricationPart` has a host and retrieves it using the `GetHostedInfo()` method.

The prior code would pass `null` from `GetHostedInfo()` into `GetElement()` which threw from deep withing the Revit API

## Screenshots:
Before: 
<img width="462" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/760691/3c965584-5595-4209-beef-3453a8030144">

After:
<img width="458" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/760691/4263e4b8-416d-4478-b0da-85804e35d858">


## Validation of changes:

Manual testing with provided test file.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

