### PR TITLE
Fix bug in setting space limits in ConvertSpace.cs

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertSpace.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Autodesk.Revit.DB;
 using Objects.BuiltElements;
@@ -48,7 +49,7 @@ public partial class ConverterRevit
     var activeViewPhaseName = activeViewPhase?.Name;
     var targetPhaseName = targetPhase?.Name;
 
-    if (activeViewPhase.Id != targetPhase.Id)
+    if (targetPhase != null && activeViewPhase.Id != targetPhase.Id)
     {
       appObj.Update(
         logItem: $"Space Phase {targetPhase.Name} not selected in the Active View.",
@@ -133,9 +134,8 @@ public partial class ConverterRevit
     }
 
     TrySetParam(revitSpace, BuiltInParameter.ROOM_UPPER_LEVEL, upperLimit);
-
-    revitSpace.LimitOffset = ScaleToNative(speckleSpace.topOffset, speckleSpace.units);
-    revitSpace.BaseOffset = ScaleToNative(speckleSpace.baseOffset, speckleSpace.units);
+    TrySetParam(revitSpace, BuiltInParameter.ROOM_UPPER_OFFSET, ScaleToNative(speckleSpace.topOffset, speckleSpace.units));
+    TrySetParam(revitSpace, BuiltInParameter.ROOM_LOWER_OFFSET, ScaleToNative(speckleSpace.baseOffset, speckleSpace.units));
   }
 
   /// <summary>


### PR DESCRIPTION
Now using BuiltInParameters ROOM_UPPER_OFFSET and ROOM_LOWER_OFFSET for setting LimitOffset and BaseOffset.

## Description & motivation

Stumbled upon this issue, not being able to update Spaces within Revit from version 2.16.0 onwards. Checked the code and noticed the problem occurred on the updated lines. `LimitOffset` and `BaseOffset` should not be set directly by assigning, but should be updated indirectly with the existing `TrySetParam()` functionality, targetting the `ROOM_UPPER_OFFSET` AND `ROOM_LOWER_OFFSET` parameters. I've checked with both Revit 21 and Revit 23 for which it fixes the issue and properly updates all Spaces within the model.

## Changes:

Just two lines updated to properly set LimitOffset and BaseOffset of Spaces during SpaceToNative.

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

Haven't added tests, but did verify the working in Revit 21 and 23.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
