### PR TITLE
fix(grasshopper): CNX-8642 resolving account by id from the accounts list will return the first account found in a server running fe1 fe2

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
@@ -77,7 +77,7 @@ public class AccountListComponent : GH_ValueList, ISpeckleTrackingDocumentObject
         defaultAccountIndex = index + 1;
       }
 
-      ListItems.Add(new GH_ValueListItem(account.ToString(), $"\"{account.userInfo.id}\""));
+      ListItems.Add(new GH_ValueListItem(account.ToString(), $"\"{account.serverInfo.url}?u={account.userInfo.id}\""));
       index++;
     }
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Accounts/Accounts.ListAccounts.cs
@@ -1,29 +1,31 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using ConnectorGrasshopper.Extras;
 using ConnectorGrasshopper.Properties;
 using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Special;
+using Grasshopper.Kernel.Types;
 using Speckle.Core.Credentials;
 
 namespace ConnectorGrasshopper.Accounts;
 
 public class AccountListComponent : GH_ValueList, ISpeckleTrackingDocumentObject
 {
-  private string selectedServerUrl;
-
-  private string selectedUserId;
+  private Uri? _selectedAccountUrl;
 
   public AccountListComponent()
   {
     MutableNickName = false;
     //SetAccountList();
     Tracker = new ComponentTracker(null);
+    _selectedAccountUrl = null;
   }
 
   protected override Bitmap Icon => Resources.Accounts;
@@ -56,9 +58,6 @@ public class AccountListComponent : GH_ValueList, ISpeckleTrackingDocumentObject
     ListItems.Clear();
     ListItems.Add(new GH_ValueListItem("No account selected", ""));
     var accounts = AccountManager.GetAccounts().ToList();
-    var defaultAccount = AccountManager.GetDefaultAccount();
-    int index = 0,
-      defaultAccountIndex = 0;
 
     if (accounts.Count == 0)
     {
@@ -70,24 +69,18 @@ public class AccountListComponent : GH_ValueList, ISpeckleTrackingDocumentObject
       return;
     }
 
-    foreach (var account in accounts)
-    {
-      if (defaultAccount != null && account.userInfo.id == defaultAccount.userInfo.id)
-      {
-        defaultAccountIndex = index + 1;
-      }
-
-      ListItems.Add(new GH_ValueListItem(account.ToString(), $"\"{account.serverInfo.url}?u={account.userInfo.id}\""));
-      index++;
-    }
-
     Tracker.TrackNodeRun("Accounts list");
 
-    if (string.IsNullOrEmpty(selectedServerUrl) && string.IsNullOrEmpty(selectedUserId))
-    {
-      // This is a new component, use default account
-      SelectItem(defaultAccountIndex);
+    var valueItems = accounts.Select(
+      account => new GH_ValueListItem(account.ToString(), $"\"{AccountManager.GetLocalIdentifierForAccount(account)}\"")
+    );
+    ListItems.AddRange(valueItems);
 
+    if (_selectedAccountUrl == null)
+    {
+      // This is a new component, use default account + 1 (first item is "No account selected")
+      var defaultAccountIndex = accounts.FindIndex(acc => acc.isDefault);
+      SelectItem(defaultAccountIndex + 1);
       return;
     }
 
@@ -98,27 +91,33 @@ public class AccountListComponent : GH_ValueList, ISpeckleTrackingDocumentObject
 
   private int GetSelectedAccountIndex(List<Account> accounts)
   {
-    //TODO: Refactor this into a method
-    // Check for the specific user ID that was selected before.
-    var acc = accounts.Find(a => a.userInfo.id == selectedUserId);
+    if (_selectedAccountUrl == null)
+    {
+      return -1;
+    }
+
+    var acc = AccountManager.GetAccountForLocalIdentifier(_selectedAccountUrl);
     if (acc != null)
     {
       var accIndex = accounts.IndexOf(acc);
       return accIndex + 1;
     }
-
-    // If the selected account doesn't work, try with another account in the same server
-    acc = accounts.FirstOrDefault(a => a.serverInfo.url == selectedServerUrl);
-    if (acc != null)
+    else
     {
-      var accIndex = accounts.IndexOf(acc);
-      AddRuntimeMessage(
-        GH_RuntimeMessageLevel.Remark,
-        "Account mismatch. Using a different account for the same server."
-      );
+      // If the selected account doesn't work, try with another account in the same server
+      acc = accounts.FirstOrDefault(a => a.serverInfo.url == _selectedAccountUrl.GetLeftPart(UriPartial.Authority));
+      if (acc != null)
+      {
+        var accIndex = accounts.IndexOf(acc);
+        AddRuntimeMessage(
+          GH_RuntimeMessageLevel.Remark,
+          "Account mismatch. Using a different account for the same server."
+        );
 
-      return accIndex + 1;
+        return accIndex + 1;
+      }
     }
+
     // If no accounts exist on the selected server, throw error in node.
     return -1;
   }
@@ -128,37 +127,48 @@ public class AccountListComponent : GH_ValueList, ISpeckleTrackingDocumentObject
     // Set isNew to false, indicating this node already existed in some way. This prevents the `NodeCreate` event from being raised.
     IsNew = false;
 
-    reader.TryGetString("selectedId", ref selectedUserId);
-    reader.TryGetString("selectedServer", ref selectedServerUrl);
+    string? userId = null;
+    string? serverUrl = null;
+    var idSuccess = reader.TryGetString("selectedId", ref userId);
+    var serverSuccess = reader.TryGetString("selectedServer", ref serverUrl);
+
+    var isIdValid = idSuccess && userId != "-";
+    var isServerValid = serverSuccess && serverUrl != "-";
+
+    string? accountUrl = null;
+    var accountUrlSuccess = reader.TryGetString(nameof(FirstSelectedItem), ref accountUrl);
+    var isAccountUrlValid = accountUrlSuccess && !string.IsNullOrEmpty(accountUrl);
+
+    if (isAccountUrlValid)
+    {
+      _selectedAccountUrl = new(accountUrl);
+    }
+    else if (isIdValid && isServerValid)
+    {
+      _selectedAccountUrl = new(serverUrl + "?id=" + userId);
+    }
 
     return base.Read(reader);
   }
 
   public override bool Write(GH_IWriter writer)
   {
-    var selectedUserId = FirstSelectedItem.Expression?.Trim('"');
-    var selectedAccount = AccountManager.GetAccounts().FirstOrDefault(a => a.userInfo.id == selectedUserId);
-    if (selectedAccount != null)
-    {
-      writer.SetString("selectedId", selectedUserId);
-      writer.SetString("selectedServer", selectedAccount.serverInfo.url);
-    }
-    else
-    {
-      writer.SetString("selectedId", "-");
-      writer.SetString("selectedServer", "-");
-    }
+    writer.SetString(nameof(FirstSelectedItem), FirstSelectedItem.Expression.Trim('"'));
     return base.Write(writer);
   }
 
+  /// <summary>
+  /// Custom method for collecting volatile data.
+  /// </summary>
   protected override void CollectVolatileData_Custom()
   {
     m_data.ClearData();
-
-    if (FirstSelectedItem.Value != null)
+    if (FirstSelectedItem.Value is GH_String strGoo)
     {
-      m_data.Append(FirstSelectedItem.Value, new GH_Path(0));
+      var x = AccountManager.GetAccountForLocalIdentifier(new Uri(strGoo.Value));
+      m_data.Append(new GH_SpeckleAccountGoo { Value = x }, new GH_Path(0));
     }
+    AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "hello");
   }
 
   public override void AddedToDocument(GH_Document document)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/GH_SpeckleAccount.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/GH_SpeckleAccount.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Drawing;
-using System.Linq;
 using ConnectorGrasshopper.Properties;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using Speckle.Core.Credentials;
-using Speckle.Core.Logging;
 
 namespace ConnectorGrasshopper.Extras;
 
@@ -16,12 +14,6 @@ public class GH_SpeckleAccountGoo : GH_Goo<Account>
   public GH_SpeckleAccountGoo(Account account)
   {
     m_value = account;
-  }
-
-  [Obsolete("Implementation is faulty", true)]
-  public GH_SpeckleAccountGoo(string userId)
-  {
-    m_value = AccountManager.GetAccounts().First(acc => acc.id == userId);
   }
 
   public override bool IsValid => m_value != null;
@@ -40,46 +32,12 @@ public class GH_SpeckleAccountGoo : GH_Goo<Account>
 
   public override bool CastFrom(object source)
   {
-    var temp = string.Empty;
-    if (source is GH_String ghString)
-    {
-      temp = ghString.Value;
-    }
-    else if (source is string text)
-    {
-      temp = text;
-    }
-
-    if (!string.IsNullOrEmpty(temp))
-    {
-      var searchResult = AccountManager
-        .GetAccounts()
-        .FirstOrDefault(acc => $"{acc.serverInfo.url}?u={acc.userInfo.id}" == temp);
-
-      if (searchResult == null)
-      {
-        SpeckleLog.Logger.Warning("Failed to get local account with same server+id combination as the provided string");
-        SpeckleLog.Logger.Information("Attempting match by ID only for backwards compatibility.");
-
-        searchResult = AccountManager.GetAccounts().FirstOrDefault(acc => acc.userInfo.id == temp);
-      }
-
-      if (searchResult != null)
-      {
-        Value = searchResult;
-        return true;
-      }
-
-      return false;
-    }
-
     if (source is Account account)
     {
       Value = account;
       return true;
     }
 
-    // Last ditch attempt, tries to use the casting logic of the parent.
     return base.CastFrom(source);
   }
 

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -1,6 +1,9 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+
 using Speckle.Core.Api;
 using Speckle.Core.Helpers;
 using Speckle.Core.Logging;
@@ -89,4 +92,30 @@ public class Account : IEquatable<Account>
   }
 
   #endregion
+
+  /// <summary>
+  /// Retrieves the local identifier for the current user.
+  /// </summary>
+  /// <returns>
+  /// Returns a <see cref="Uri"/> object representing the local identifier for the current user.
+  /// The local identifier is created by appending the user ID as a query parameter to the server URL.
+  /// </returns>
+  /// <remarks>
+  /// Notice that the generated Uri is not intended to be used as a functioning Uri, but rather as a
+  /// unique identifier for a specific account in a local environment. The format of the Uri, containing a query parameter with the user ID,
+  /// serves this specific purpose. Therefore, it should not be used for forming network requests or
+  /// expecting it to lead to an actual webpage. The primary intent of this Uri is for unique identification in a Uri format.
+  /// </remarks>
+  /// <example>
+  ///   This sample shows how to call the GetLocalIdentifier method.
+  ///   <code>
+  ///     Uri localIdentifier = GetLocalIdentifier();
+  ///     Console.WriteLine(localIdentifier);
+  ///   </code>
+  ///   For a fictional `User ID: 123` and `Server: https://speckle.xyz`, the output might look like this:
+  ///   <code>
+  ///     https://speckle.xyz?id=123
+  ///   </code>
+  /// </example>
+  internal Uri GetLocalIdentifier() => new($"{serverInfo.url}?id={userInfo.id}");
 }

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -1,9 +1,6 @@
 #nullable disable
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-
 using Speckle.Core.Api;
 using Speckle.Core.Helpers;
 using Speckle.Core.Logging;

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -359,10 +359,7 @@ public static class AccountManager
   /// <param name="account">The account for which to retrieve the local identifier.</param>
   /// <returns>The local identifier for the specified account in the form of "SERVER_URL?u=USER_ID".</returns>
   /// <remarks>
-  /// Notice that the generated Uri is not intended to be used as a functioning Uri, but rather as a
-  /// unique identifier for a specific account in a local environment. The format of the Uri, containing a query parameter with the user ID,
-  /// serves this specific purpose. Therefore, it should not be used for forming network requests or
-  /// expecting it to lead to an actual webpage. The primary intent of this Uri is for unique identification in a Uri format.
+  /// <inheritdoc cref="Account.GetLocalIdentifier"/>
   /// </remarks>
   public static Uri? GetLocalIdentifierForAccount(Account account)
   {

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -12,8 +12,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Client.Http;
-using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Primitives;
 using Speckle.Core.Api;
 using Speckle.Core.Api.GraphQL.Serializer;
 using Speckle.Core.Helpers;

--- a/Core/Tests/Speckle.Core.Tests.Unit/Credentials/Accounts.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Credentials/Accounts.cs
@@ -81,4 +81,24 @@ public class CredentialInfrastructure
     Assert.That(acc.serverInfo.url, Is.EqualTo("https://sample.com"));
     Assert.That(acc.token, Is.EqualTo("secret"));
   }
+
+  [Test]
+  public void EnsureLocalIdentifiers_AreUniqueAcrossServers()
+  {
+    // Accounts with the same user ID in different servers should always result in different local identifiers.
+    string id = "12345";
+    var acc1 = new Account
+    {
+      serverInfo = new ServerInfo { url = "https://speckle.xyz" },
+      userInfo = new UserInfo { id = id }
+    }.GetLocalIdentifier();
+
+    var acc2 = new Account
+    {
+      serverInfo = new ServerInfo { url = "https://app.speckle.systems" },
+      userInfo = new UserInfo { id = id }
+    }.GetLocalIdentifier();
+
+    Assert.That(acc1, Is.Not.EqualTo(acc2));
+  }
 }


### PR DESCRIPTION
Fixes ambiguity between accounts by no longer trying to find an account exclusively by it's user ID.

The accounts are now distinguished by their "Local Identifier", which is basically just the server URL with an `id` query parameter holding the user ID.

`https://speckle.xyz/?id=USER_ID`

This guarantees uniqueness of each user+server pair.

Changes in this PR include:
- `Account` class: Addition of internal `GetLocalIdentifier`
- `AccountManager` class:Addition of `GetLocalIdentifierForAccount` and `GetAccountForLocalIdentifier`
- `Accounts.ListAccounts` GH component: Now uses the above AccountManager methods everywhere it's needed. It also now outputs actual `Account` instances instead of the previous user ID, so the solution is now more robust.
- `GH_SpeckleAccount` class: No longer requires casting from strings, as the only place this was used was in the AccountList component, and this no longer outputs strings.