### PR TITLE
Chore(build): CNX-8713 CNX-8572 CNX-8389: Enforce no more warning  (Unique Analyser codes) for SDK projects

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
@@ -29,7 +29,7 @@ public class App : IExtensionApplication
   public RibbonControl ribbon;
 
   #region Initializing and termination
-  
+
   [SuppressMessage(
     "Design",
     "CA1031:Do not catch general exception types",

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
@@ -2,6 +2,7 @@ using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.Windows;
 using Speckle.ConnectorAutocadCivil.UI;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -28,6 +29,12 @@ public class App : IExtensionApplication
   public RibbonControl ribbon;
 
   #region Initializing and termination
+  
+  [SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Justification = "Is top level plugin catch"
+  )]
   public void Initialize()
   {
     //Advance Steel addon is initialized after ribbon creation
@@ -62,10 +69,15 @@ public class App : IExtensionApplication
       bindings.RegisterAppEvents();
       SpeckleAutocadCommand.Bindings = bindings;
     }
-    catch (System.Exception e)
+    catch (System.Exception ex)
     {
+      SpeckleLog.Logger.Fatal(
+        ex,
+        "Add-in initialize context (true = application, false = doc): {isApplicationContext}",
+        Application.DocumentManager.IsApplicationContext
+      );
       Forms.MessageBox.Show(
-        $"Add-in initialize context (true = application, false = doc): {Application.DocumentManager.IsApplicationContext.ToString()}. Error encountered: {e.ToString()}"
+        $"Add-in initialize context (true = application, false = doc): {Application.DocumentManager.IsApplicationContext.ToString()}. Error encountered: {ex}"
       );
     }
   }

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/SpeckleAutocadCommand.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/SpeckleAutocadCommand.cs
@@ -20,6 +20,7 @@ using DesktopUI2.ViewModels;
 using DesktopUI2.Views;
 using Speckle.ConnectorAutocadCivil.UI;
 using Speckle.Core.Logging;
+using Exception = System.Exception;
 
 #if ADVANCESTEEL
 [assembly: CommandClass(typeof(Speckle.ConnectorAutocadCivil.Entry.SpeckleAutocadCommand))]
@@ -64,6 +65,11 @@ public class SpeckleAutocadCommand
     BuildAvaloniaApp().Start(AppMain, null);
   }
 
+  [SuppressMessage(
+    "Design",
+    "CA1031:Do not catch general exception types",
+    Justification = "Is top level plugin catch"
+  )]
   public static void CreateOrFocusSpeckle(bool showWindow = true)
   {
     if (MainWindow == null)
@@ -95,7 +101,10 @@ public class SpeckleAutocadCommand
         }
       }
     }
-    catch { }
+    catch (Exception ex)
+    {
+      SpeckleLog.Logger.Fatal(ex, "Failed to create or focus Speckle window");
+    }
   }
 
   private static void AppMain(Avalonia.Application app, string[] args)

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -84,9 +84,9 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
       progress.Report.Merge(converter.Report);
     }
-    catch (Exception e)
+    catch (Exception ex) when (!ex.IsFatal())
     {
-      progress.Report.LogOperationError(e);
+      progress.Report.LogOperationError(ex);
     }
 
     if (convertedCount == 0)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -745,7 +745,7 @@ public class VariableInputReceiveComponentWorker : WorkerInstance
             }
           );
         }
-        catch
+        catch (Exception ex) when (!ex.IsFatal())
         {
           // Do nothing!
         }

--- a/Core/Core/Api/GraphQL/Serializer/MapConverter.cs
+++ b/Core/Core/Api/GraphQL/Serializer/MapConverter.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using GraphQL;
 using Speckle.Newtonsoft.Json;
@@ -34,6 +35,11 @@ internal sealed class MapConverter : JsonConverter<Map>
     throw new ArgumentException("This converter can only parse when the root element is a JSON Object.");
   }
 
+  [SuppressMessage(
+    "Maintainability",
+    "CA1508:Avoid dead conditional code",
+    Justification = "False positive, see https://github.com/dotnet/roslyn-analyzers/issues/6893"
+  )]
   private object ReadToken(JToken token)
   {
     return token switch

--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -15,6 +15,21 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IsDesktopBuild)' == false">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>
+      $(WarningsNotAsErrors);
+      CA1000; CA1001; CA1003; CA1024; CA1033; CA1034; CA1051; CA1055; CA1063; CA1065;
+      CA1502; CA1506;
+      CA1708; CA1710; CA1711; CA1716; CA1720; CA1721; CA1724;
+      CA1816; CA1851; CA1861;
+      CA2201;
+      CS0419; CS0618; CS0659; CS0809;
+      CS8600; CS8602; CS8603; CS8604;
+      IDE0032; IDE0059; IDE0130; IDE1006;
+    </WarningsNotAsErrors>
+  </PropertyGroup>
+  
   <ItemGroup>
     <InternalsVisibleTo Include="Speckle.Core.Tests.Unit" />
     <InternalsVisibleTo Include="Speckle.Core.Tests.Integration" />

--- a/Core/Core/Credentials/Account.cs
+++ b/Core/Core/Credentials/Account.cs
@@ -33,7 +33,7 @@ public class Account : IEquatable<Account>
 
   public string refreshToken { get; set; }
 
-  public bool isDefault { get; set; } = false;
+  public bool isDefault { get; set; }
   public bool isOnline { get; set; } = true;
 
   public ServerInfo serverInfo { get; set; }

--- a/Core/Core/Helpers/Path.cs
+++ b/Core/Core/Helpers/Path.cs
@@ -20,7 +20,7 @@ public static class SpecklePathProvider
 
   private static string s_objectsFolderName = "Objects";
 
-  private static string s_logFolderName = "Logs";
+  private const string LOG_FOLDER_NAME = "Logs";
 
   private static string UserDataPathEnvVar => "SPECKLE_USERDATA_PATH";
   private static string? Path => Environment.GetEnvironmentVariable(UserDataPathEnvVar);
@@ -168,7 +168,7 @@ public static class SpecklePathProvider
   public static string LogFolderPath(string hostApplicationName, string? hostApplicationVersion)
   {
     return EnsureFolderExists(
-      EnsureFolderExists(UserSpeckleFolderPath, s_logFolderName),
+      EnsureFolderExists(UserSpeckleFolderPath, LOG_FOLDER_NAME),
       $"{hostApplicationName}{hostApplicationVersion ?? ""}"
     );
   }

--- a/Core/Transports/MongoDBTransport/MongoDBTransport.csproj
+++ b/Core/Transports/MongoDBTransport/MongoDBTransport.csproj
@@ -10,6 +10,12 @@
     <RootNamespace>Speckle.Core.Transports</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Label="Legacy Code Exceptions" Condition="$(IsDesktopBuild) == 'false'">
+    <WarningLevel>0</WarningLevel>
+    <EnableNetAnalyzers>false</EnableNetAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.19.2" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,7 +79,7 @@
     <WarningsAsErrors>
       $(WarningsAsErrors);
       IDE0011;IDE0090;IDE0161;IDE0005;
-      CA1806;
+      CA1806;CA1806;CA1806;CA1031;
     </WarningsAsErrors>
   </PropertyGroup>
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -1064,20 +1064,21 @@ public partial class ConverterAutocadCivil
     // assign additional pipe props
     AddNameAndDescriptionProperty(pipe.Name, pipe.Description, specklePipe);
 
-    try { specklePipe["shape"] = pipe.CrossSectionalShape.ToString(); } catch { }
-    try { specklePipe["slope"] = pipe.Slope; } catch { }
-    try { specklePipe["flowDirection"] = pipe.FlowDirection.ToString(); } catch { }
-    try { specklePipe["flowRate"] = pipe.FlowRate; } catch { }
-    try { specklePipe["network"] = pipe.NetworkName; } catch { }
-    try { specklePipe["startOffset"] = pipe.StartOffset; } catch { }
-    try { specklePipe["endOffset"] = pipe.EndOffset; } catch { }
-    try { specklePipe["startStation"] = pipe.StartStation; } catch { }
-    try { specklePipe["endStation"] = pipe.EndStation; } catch { }
-    try { specklePipe["startStructure"] = pipe.StartStructureId.ToString(); } catch { }
-    try { specklePipe["endStructure"] = pipe.EndStructureId.ToString(); } catch { }
+    try { specklePipe["shape"] = pipe.CrossSectionalShape.ToString(); } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["slope"] = pipe.Slope; } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["flowDirection"] = pipe.FlowDirection.ToString(); } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["flowRate"] = pipe.FlowRate; } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["network"] = pipe.NetworkName; } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["startOffset"] = pipe.StartOffset; } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["endOffset"] = pipe.EndOffset; } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["startStation"] = pipe.StartStation; } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["endStation"] = pipe.EndStation; } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["startStructure"] = pipe.StartStructureId.ToString(); } catch(Exception ex) when(!ex.IsFatal()) { }
+    try { specklePipe["endStructure"] = pipe.EndStructureId.ToString(); } catch(Exception ex) when(!ex.IsFatal()) { }
 
     return specklePipe;
   }
+  
   public Pipe PipeToSpeckle(PressurePipe pipe)
   {
     // get the pipe curve

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Geometry.cs
@@ -3,6 +3,7 @@ using Grasshopper.Kernel.Types;
 #endif
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Linq;
 using Objects.Geometry;
@@ -437,7 +438,7 @@ public partial class ConverterRhinoGh
         //let the converter pick the best type of curve
         myPolyc.Append((RH.Curve)ConvertToNative((Base)segment));
       }
-      catch
+      catch (Exception ex) when (!ex.IsFatal())
       {
         notes.Add($"Could not append curve {segment.GetType()} to PolyCurve");
       }
@@ -986,7 +987,7 @@ public partial class ConverterRhinoGh
       joinedMesh.Append(RH.Mesh.CreateFromBrep(brep, mySettings));
       return joinedMesh;
     }
-    catch (Exception e)
+    catch (Exception ex) when (!ex.IsFatal())
     {
       return null;
     }
@@ -1076,14 +1077,16 @@ public partial class ConverterRhinoGh
 
       return newBrep;
     }
-    catch (Exception e)
+    catch (Exception ex) when (!ex.IsFatal())
     {
-      notes.Add(e.ToFormattedString());
+      notes.Add(ex.ToFormattedString());
       return null;
     }
   }
 
   // TODO: We're no longer creating new extrusions - they are converted as brep. This is here just for backwards compatibility.
+  [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Obsolete")]
+  [Obsolete("Unused")]
   public RH.Extrusion ExtrusionToNative(Extrusion extrusion)
   {
     RH.Curve outerProfile = CurveToNative((Curve)extrusion.profile);

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Mappings.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Mappings.cs
@@ -11,6 +11,7 @@ using Objects.BuiltElements;
 using Objects.BuiltElements.Revit;
 using Objects.Geometry;
 using Objects.Other;
+using Speckle.Core.Logging;
 
 namespace Objects.Converter.RhinoGh;
 
@@ -187,7 +188,7 @@ public partial class ConverterRhinoGh
 
       notes.Add($"Attached {schemaObject.speckle_type} schema");
     }
-    catch (Exception ex)
+    catch (Exception ex) when (!ex.IsFatal())
     {
       notes.Add($"Could not attach {schemaObject.speckle_type} schema: {ex.Message}");
     }

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -117,9 +117,9 @@ public partial class ConverterRhinoGh
         {
           userStringsBase[key] = userStrings[key];
         }
-        catch (Exception e)
+        catch (Exception ex) when (!ex.IsFatal())
         {
-          notes.Add($"Could not attach user string: {e.Message}");
+          notes.Add($"Could not attach user string: {ex.Message}");
         }
       }
 

--- a/Objects/Objects/BuiltElements/AdvanceSteel/AsteelBolt.cs
+++ b/Objects/Objects/BuiltElements/AdvanceSteel/AsteelBolt.cs
@@ -12,8 +12,6 @@ public abstract class AsteelBolt : Base, IAsteelObject
   public Base userAttributes { get; set; }
 
   public Base asteelProperties { get; set; }
-
-  public AsteelBolt() { }
 }
 
 public class AsteelCircularBolt : AsteelBolt

--- a/Objects/Objects/BuiltElements/Revit/Parameter.cs
+++ b/Objects/Objects/BuiltElements/Revit/Parameter.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 

--- a/Objects/Objects/Geometry/Extrusion.cs
+++ b/Objects/Objects/Geometry/Extrusion.cs
@@ -1,11 +1,16 @@
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 
 namespace Objects.Geometry;
 
+[Obsolete("Unused")]
+[SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Obsolete")]
 public class Extrusion : Base, IHasVolume, IHasArea, IHasBoundingBox
 {
+  [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Obsolete")]
   public double? length;
 
   public Extrusion() { }

--- a/Objects/Objects/Objects.csproj
+++ b/Objects/Objects/Objects.csproj
@@ -13,6 +13,19 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IsDesktopBuild)' == false">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>
+      $(WarningsNotAsErrors);
+      CA1008; CA1024; CA1034; CA1051; CA1065;
+      CA1708; CA1711; CA1716; CA1724; CA1725;
+      CA1819;
+      CA2201; CA2225;
+      CS0659; CS0661; CS0728;
+      IDE0041; IDE0060; IDE1006;
+    </WarningsNotAsErrors>
+  </PropertyGroup>
+  
   <ItemGroup>
     <InternalsVisibleTo Include="Objects.Tests.Unit" />
   </ItemGroup>

--- a/Objects/Objects/Objects.csproj
+++ b/Objects/Objects/Objects.csproj
@@ -17,7 +17,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>
       $(WarningsNotAsErrors);
-      CA1008; CA1024; CA1034; CA1051; CA1065;
+      CA1008; CA1024; CA1034; CA1065;
       CA1708; CA1711; CA1716; CA1724; CA1725;
       CA1819;
       CA2201; CA2225;

--- a/Objects/Objects/Utils/MeshTriangulationHelper.cs
+++ b/Objects/Objects/Utils/MeshTriangulationHelper.cs
@@ -197,10 +197,10 @@ public static class MeshTriangulationHelper
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
   private static bool TestPointTriangle(Vector3 v, Vector3 a, Vector3 b, Vector3 c)
   {
-    bool Test(Vector3 _v, Vector3 _a, Vector3 _b)
+    static bool Test(Vector3 v, Vector3 a, Vector3 b)
     {
-      Vector3 crossA = _v.Cross(_a);
-      Vector3 crossB = _v.Cross(_b);
+      Vector3 crossA = v.Cross(a);
+      Vector3 crossB = a.Cross(b);
       double dotWithEpsilon = double.Epsilon + crossA.Dot(crossB);
       return Math.Sign(dotWithEpsilon) != -1;
     }


### PR DESCRIPTION
- For CI builds only:
    - Added `TreatWarningsAsErrors` on all SDK projects
    - Added existing warning codes as `WarningsNotAsErrors`

This means that no new types of warnings can be introduced without CI erroring.
It won't stop new violations of any of the existing types.

Remaining Warnings in Objects

```
      69 | IDE1006 
      33 | CA1819 
      26 | CA1034 
      11 | IDE0060 
       9 | CA1708 
       7 | CA2225 
       6 | CA2201 
       5 | CA1711 
       4 | CA1008 
       4 | CA1724 
       4 | CS0728 
       3 | CA1716 
       2 | CA1024 
       1 | CA1051 
       1 | CA1065 
       1 | CA1725 
       1 | CS0659 
       1 | CS0661 
       1 | IDE0041 
```


Remaining Warnings in Core
```
      59 | IDE1006 
      10 | CA1003 
       8 | CA1051 
       8 | CA1724 
       7 | CA1710 
       5 | CS8600 
       5 | CS8602 
       4 | CA1000 
       3 | CA1063 
       3 | CA1502 
       3 | CA1720 
       3 | CA1851 
       3 | CS0618 
       3 | CS8604 
       2 | CA1708 
       2 | CA1711 
       2 | CA2201 
       2 | CS8603 
       2 | IDE0032 
       2 | IDE0059 
       2 | IDE0130 
       1 | CA1001 
       1 | CA1024 
       1 | CA1033 
       1 | CA1034 
       1 | CA1055 
       1 | CA1065 
       1 | CA1506 
       1 | CA1716 
       1 | CA1721 
       1 | CA1816 
       1 | CA1861 
       1 | CS0659 
       1 | CS0809 
```