### PR TITLE
feat(dui): adds support for updating stream cards to FE2

### DIFF
--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -333,6 +333,23 @@ public static class AccountManager
   }
 
   /// <summary>
+  /// Upgrades an account from https://speckle.xyz to https://app.speckle.systems
+  /// </summary>
+  /// <param name="id"></param>
+  public static void UpgradeAccount(string id)
+  {
+    var account = GetAccounts().FirstOrDefault(acc => acc.id == id);
+    if (account == null)
+      throw new SpeckleAccountManagerException($"Account {id} not found");
+
+    if (!account.serverInfo.url.Contains("https://speckle.xyz"))
+      throw new SpeckleAccountManagerException($"Can only upgrade accounts on speckle.xyz");
+
+    account.serverInfo.url = DEFAULT_SERVER_URL;
+    AccountStorage.UpdateObject(account.id, JsonConvert.SerializeObject(account));
+  }
+
+  /// <summary>
   /// Changes the default account
   /// </summary>
   /// <param name="id"></param>

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -346,7 +346,7 @@ public static class AccountManager
       throw new SpeckleAccountManagerException($"Can only upgrade accounts on speckle.xyz");
 
     account.serverInfo.url = DEFAULT_SERVER_URL;
-    AccountStorage.UpdateObject(account.id, JsonConvert.SerializeObject(account));
+    s_accountStorage.UpdateObject(account.id, JsonConvert.SerializeObject(account));
   }
 
   /// <summary>

--- a/DesktopUI2/DesktopUI2/Models/StreamState.cs
+++ b/DesktopUI2/DesktopUI2/Models/StreamState.cs
@@ -42,6 +42,18 @@ public class StreamState
       if (_client == null)
       {
         var account = AccountManager.GetAccounts(ServerUrl).FirstOrDefault(x => x.userInfo.id == UserId);
+        if (account == null)
+        {
+          //try fetching the account without specifying the Sevrer URL
+          //if the user has upgraded from FE1 to FE2 this would be the case
+          account = AccountManager.GetAccounts().FirstOrDefault(x => x.userInfo.id == UserId);
+          //replace old URL with the new one
+          if (account != null)
+          {
+            ServerUrl = account.serverInfo.url;
+          }
+        }
+
         if (account != null)
         {
           _client = new Client(account);


### PR DESCRIPTION
When loading stream cards into DUI:

- first tries matching them by user ID and Stream URL
- then by just user ID

This will allow upgrading (and eventually downgrading too) stream cards from FE1 to FE2 on any server.
This is guaranteed by the fact that the User ID is consistent across frontends.