### PR TITLE
CNX-8753-Downgrade-Text.Json

### DIFF
--- a/ConnectorCore/BatchUploader.Sdk/BatchUploader.Sdk.csproj
+++ b/ConnectorCore/BatchUploader.Sdk/BatchUploader.Sdk.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Using the 7.0.3 version of System.Text.Json in Batchuploader SDK is causing conflicts with core/revit


