### PR TITLE
fix(Archicad): Crash when sending columns with "subtract from zone" relation

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
@@ -114,8 +114,11 @@ const GS::HashTable<API_ZoneRelID, GS::UniString> relationToZoneNames
 {
 	{ APIZRel_Boundary,			"Zone Boundary"},
 	{ APIZRel_ReduceArea,		"Reduce Zone Area Only"},
-	{ APIZRel_None,				"No Effect on Zones"},
+	{ APIZRel_None,				"No Effect on Zones"}
+#ifdef ServerMainVers_2700
+	,
 	{ APIZRel_SubtractFromZone,	"Subtract from Zones"}
+#endif
 };
 
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
@@ -114,7 +114,8 @@ const GS::HashTable<API_ZoneRelID, GS::UniString> relationToZoneNames
 {
 	{ APIZRel_Boundary,			"Zone Boundary"},
 	{ APIZRel_ReduceArea,		"Reduce Zone Area Only"},
-	{ APIZRel_None,				"No Effect on Zones"}
+	{ APIZRel_None,				"No Effect on Zones"},
+	{ APIZRel_SubtractFromZone,	"Subtract from Zones"}
 };
 
 


### PR DESCRIPTION
## Description & motivation

https://spockle.atlassian.net/browse/CNX-8849


## Changes:

There is new zone relation type (APIZRel_SubtractFromZone) introduced in AC27 which was not handled in a hashset.

Crashed here:
`	os.Add (Column::ColumnRelationToZoneName, relationToZoneNames.Get (elem.column.zoneRel));`

Hashset entry added to `relationToZoneNames` according to the AC27 API.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.