### PR TITLE
CNX-8866 Grasshopper nodes format result URL in Stream/Branch format regardless of the input format

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
@@ -695,7 +695,7 @@ public class NewVariableInputSendComponentWorker : WorkerInstance
               );
               wrapper.CommitId = commitId;
               wrapper.SetAccount(client.Account);
-              
+
               OutputWrappers.Add(wrapper);
             }
             catch (Exception e) when (!e.IsFatal())

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputSendComponent.cs
@@ -689,8 +689,13 @@ public class NewVariableInputSendComponentWorker : WorkerInstance
               var commitId = await client.CommitCreate(commitCreateInput, CancellationToken);
 
               var wrapper = new StreamWrapper(
-                $"{client.Account.serverInfo.url}/streams/{((ServerTransport)transport).StreamId}/commits/{commitId}?u={client.Account.userInfo.id}"
+                ((ServerTransport)transport).StreamId,
+                client.Account.userInfo.id,
+                client.Account.serverInfo.url
               );
+              wrapper.CommitId = commitId;
+              wrapper.SetAccount(client.Account);
+              
               OutputWrappers.Add(wrapper);
             }
             catch (Exception e) when (!e.IsFatal())

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Streams/StreamListComponentV2.cs
@@ -92,10 +92,15 @@ public class StreamListComponentV2 : GH_SpeckleTaskCapableComponent<List<StreamW
 
   private Task<List<StreamWrapper>> ListStreams(Account account, int limit)
   {
-    var client = new Client(account);
+    using var client = new Client(account);
     var res = client
       .StreamsGet(limit, CancelToken)
-      .Result.Select(stream => new StreamWrapper(stream.id, account.userInfo.id, account.serverInfo.url))
+      .Result.Select(stream =>
+      {
+        var s = new StreamWrapper(stream.id, account.userInfo.id, account.serverInfo.url);
+        s.SetAccount(account);
+        return s;
+      })
       .ToList();
     return Task.FromResult(res);
   }


### PR DESCRIPTION
https://spockle.atlassian.net/browse/CNX-8866

Fixes how Grasshopper duplicates StreamWrapper's by also propagating the original account.
This ensures that the logic to expose FE2 or FE1 logic gets also preserved after the streamwrapper was validated.