### PR TITLE
bug(rhino): fixes missing user strings on nested instances when receiving

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -642,21 +642,9 @@ public partial class ConverterRhinoGh
     // get the transform
     var transform = TransformToNative(instance.transform);
 
-    // get any parameters
-    var parameters = instance["parameters"] as Base;
+    // set attributes
     var attributes = new RH.ObjectAttributes();
-    if (parameters != null)
-    {
-      foreach (var member in parameters.GetMembers(DynamicBaseMemberType.Dynamic))
-      {
-        if (member.Value is Parameter parameter)
-        {
-          var convertedParameter = ParameterToNative(parameter);
-          var name = $"{convertedParameter.Item1}({member.Key})";
-          attributes.SetUserString(name, convertedParameter.Item2);
-        }
-      }
-    }
+    SetUserInfo(instance, attributes);
 
     // create the instance
     Guid instanceId = Doc.Objects.AddInstanceObject(instanceDef.Index, transform, attributes);

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -92,6 +92,39 @@ public partial class ConverterRhinoGh
   private static string UserStrings = "userStrings";
   private static string UserDictionary = "userDictionary";
 
+  private void SetUserInfo(Base obj, ObjectAttributes attributes)
+  {
+    // set user strings
+    if (obj[UserStrings] is Base userStrings)
+    {
+      foreach (var member in userStrings.GetMembers(DynamicBaseMemberType.Dynamic))
+      {
+        attributes.SetUserString(member.Key, member.Value as string);
+      }
+    }
+
+    // set name or label
+    var name = obj["name"] as string ?? obj["label"] as string; // gridlines have a "label" prop instead of name?
+    if (name != null)
+    {
+      attributes.Name = name;
+    }
+
+    // set revit parameters as user strings
+    if (obj["parameters"] is Base parameters)
+    {
+      foreach (var member in parameters.GetMembers(DynamicBaseMemberType.Dynamic))
+      {
+        if (member.Value is Objects.BuiltElements.Revit.Parameter parameter)
+        {
+          var convertedParameter = ParameterToNative(parameter);
+          var paramName = $"{convertedParameter.Item1}({member.Key})";
+          attributes.SetUserString(paramName, convertedParameter.Item2);
+        }
+      }
+    }
+  }
+
   /// <summary>
   /// Attaches the provided user strings, user dictionaries, and and name to Base
   /// </summary>


### PR DESCRIPTION
## Description & motivation

Adds missing user strings to nested blocks when converting to native.  Refer to this community post for more info: [https://speckle.community/t/questions-about-nested-blocks-from-rhino/8955/3](https://speckle.community/t/questions-about-nested-blocks-from-rhino/8955/3)


## Validation of changes:

Receive this commit: [https://latest.speckle.dev/streams/3f895e614f/commits/ff0ab3fe69](https://latest.speckle.dev/streams/3f895e614f/commits/ff0ab3fe69)
