### PR TITLE
fix(Archicad): Could not receive parametric elements with localized version of Archicad

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/BeamConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/BeamConverter.cs
@@ -35,6 +35,7 @@ public sealed class Beam : IConverter
         switch (tc.current)
         {
           case Objects.BuiltElements.Archicad.ArchicadBeam archiBeam:
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadBeam>(archiBeam);
             beams.Add(archiBeam);
             break;
           case Objects.BuiltElements.Beam beam:
@@ -97,7 +98,7 @@ public sealed class Beam : IConverter
       {
         // convert between DTOs
         Objects.BuiltElements.Archicad.ArchicadBeam beam =
-          Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadBeam>(jToken);
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadBeam>(jToken);
 
         // downgrade (always): Objects.BuiltElements.Archicad.ArchicadBeam --> Objects.BuiltElements.Beam
         {

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ColumnConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ColumnConverter.cs
@@ -35,6 +35,9 @@ public sealed class Column : IConverter
         switch (tc.current)
         {
           case Objects.BuiltElements.Archicad.ArchicadColumn archicadColumn:
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadColumn>(
+              archicadColumn
+            );
             columns.Add(archicadColumn);
             break;
           case Objects.BuiltElements.Column column:
@@ -94,7 +97,7 @@ public sealed class Column : IConverter
       {
         // convert between DTOs
         Objects.BuiltElements.Archicad.ArchicadColumn column =
-          Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadColumn>(jToken);
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadColumn>(jToken);
 
         column.units = Units.Meters;
         column.displayValue = Operations.ModelConverter.MeshesToSpeckle(

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/DoorConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/DoorConverter.cs
@@ -34,6 +34,7 @@ public sealed class Door : IConverter
         {
           case Objects.BuiltElements.Archicad.ArchicadDoor archicadDoor:
             archicadDoor.parentApplicationId = tc.parent.current.id;
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadDoor>(archicadDoor);
             doors.Add(archicadDoor);
             break;
           //case Objects.BuiltElements.Opening window:
@@ -85,7 +86,7 @@ public sealed class Door : IConverter
       foreach (Speckle.Newtonsoft.Json.Linq.JToken jToken in jArray)
       {
         Objects.BuiltElements.Archicad.ArchicadDoor door =
-          Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadDoor>(jToken);
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadDoor>(jToken);
         door.displayValue = Operations.ModelConverter.MeshesToSpeckle(
           elementModels.First(e => e.applicationId == door.applicationId).model
         );

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/FloorConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/FloorConverter.cs
@@ -34,6 +34,7 @@ public sealed class Floor : IConverter
         switch (tc.current)
         {
           case Objects.BuiltElements.Archicad.ArchicadFloor archiFloor:
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadFloor>(archiFloor);
             floors.Add(archiFloor);
             break;
           case Objects.BuiltElements.Floor floor:
@@ -90,7 +91,7 @@ public sealed class Floor : IConverter
       {
         // convert between DTOs
         Objects.BuiltElements.Archicad.ArchicadFloor slab =
-          Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadFloor>(jToken);
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadFloor>(jToken);
 
         slab.units = Units.Meters;
         slab.displayValue = Operations.ModelConverter.MeshesToSpeckle(

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoofConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoofConverter.cs
@@ -35,9 +35,11 @@ public sealed class Roof : IConverter
         switch (tc.current)
         {
           case Objects.BuiltElements.Archicad.ArchicadRoof archiRoof:
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadRoof>(archiRoof);
             roofs.Add(archiRoof);
             break;
           case Objects.BuiltElements.Archicad.ArchicadShell archiShell:
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadShell>(archiShell);
             shells.Add(archiShell);
             break;
           case Objects.BuiltElements.Roof roof:
@@ -103,7 +105,7 @@ public sealed class Roof : IConverter
         {
           // convert between DTOs
           Objects.BuiltElements.Archicad.ArchicadRoof roof =
-            Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadRoof>(jToken);
+            Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadRoof>(jToken);
 
           roof.units = Units.Meters;
           roof.displayValue = Operations.ModelConverter.MeshesToSpeckle(
@@ -145,7 +147,7 @@ public sealed class Roof : IConverter
         {
           // convert between DTOs
           Objects.BuiltElements.Archicad.ArchicadShell shell =
-            Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadShell>(jToken);
+            Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadShell>(jToken);
 
           shell.units = Units.Meters;
           shell.displayValue = Operations.ModelConverter.MeshesToSpeckle(

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/SkylightConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/SkylightConverter.cs
@@ -34,6 +34,9 @@ public sealed class Skylight : IConverter
         {
           case Objects.BuiltElements.Archicad.ArchicadSkylight archicadSkylight:
             archicadSkylight.parentApplicationId = tc.parent.current.id;
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadSkylight>(
+              archicadSkylight
+            );
             skylights.Add(archicadSkylight);
             break;
           //case Objects.BuiltElements.Opening skylight:
@@ -84,7 +87,7 @@ public sealed class Skylight : IConverter
       foreach (Speckle.Newtonsoft.Json.Linq.JToken jToken in jArray)
       {
         Objects.BuiltElements.Archicad.ArchicadSkylight skylight =
-          Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadSkylight>(jToken);
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadSkylight>(jToken);
 
         skylight.displayValue = Operations.ModelConverter.MeshesToSpeckle(
           elementModels.First(e => e.applicationId == skylight.applicationId).model

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using Archicad.Model;
-using Avalonia.Controls.Primitives;
 using Objects;
 using Objects.BuiltElements.Archicad;
 using Objects.Geometry;

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using Archicad.Model;
+using Avalonia.Controls.Primitives;
 using Objects;
 using Objects.BuiltElements.Archicad;
 using Objects.Geometry;
@@ -151,7 +153,7 @@ public static class Utils
     return shape;
   }
 
-  public static T ConvertDTOs<T>(dynamic jObject)
+  public static T ConvertToSpeckleDTOs<T>(dynamic jObject)
   {
     Objects.BuiltElements.Archicad.ArchicadLevel level = null;
     if (jObject.level != null)
@@ -197,6 +199,26 @@ public static class Utils
     }
 
     return speckleObject;
+  }
+
+  public static T ConvertToArchicadDTOs<T>(dynamic @object)
+  {
+    if (@object.elementProperties != null)
+    {
+      @object.elementProperties = null;
+    }
+
+    if (@object.componentProperties != null)
+    {
+      @object.componentProperties = null;
+    }
+
+    if (@object.GetType().GetProperty("elements") != null)
+    {
+      @object.elements = null;
+    }
+
+    return @object;
   }
 
   public static Objects.BuiltElements.Archicad.ArchicadLevel ConvertLevel(Objects.BuiltElements.Level level)

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
@@ -11,7 +11,6 @@ using Objects.Geometry;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
-using Speckle.Newtonsoft.Json.Linq;
 
 namespace Archicad.Converters;
 

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
@@ -11,6 +11,7 @@ using Objects.Geometry;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
+using Speckle.Newtonsoft.Json.Linq;
 
 namespace Archicad.Converters;
 
@@ -37,6 +38,7 @@ public sealed class Wall : IConverter
         switch (tc.current)
         {
           case Objects.BuiltElements.Archicad.ArchicadWall archiWall:
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadWall>(archiWall);
             walls.Add(archiWall);
             break;
           case Objects.BuiltElements.Wall wall:
@@ -97,7 +99,7 @@ public sealed class Wall : IConverter
       {
         // convert between DTOs
         Objects.BuiltElements.Archicad.ArchicadWall wall =
-          Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadWall>(jToken);
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadWall>(jToken);
 
         wall.units = Units.Meters;
         wall.displayValue = Operations.ModelConverter.MeshesToSpeckle(

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WindowConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WindowConverter.cs
@@ -7,7 +7,6 @@ using Archicad.Communication;
 using Archicad.Model;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
-using Speckle.Newtonsoft.Json.Linq;
 
 namespace Archicad.Converters;
 

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WindowConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WindowConverter.cs
@@ -7,6 +7,7 @@ using Archicad.Communication;
 using Archicad.Model;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
+using Speckle.Newtonsoft.Json.Linq;
 
 namespace Archicad.Converters;
 
@@ -34,6 +35,9 @@ public sealed class Window : IConverter
         {
           case Objects.BuiltElements.Archicad.ArchicadWindow archicadWindow:
             archicadWindow.parentApplicationId = tc.parent.current.id;
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadWindow>(
+              archicadWindow
+            );
             windows.Add(archicadWindow);
             break;
           //case Objects.BuiltElements.Opening window:
@@ -84,7 +88,7 @@ public sealed class Window : IConverter
       foreach (Speckle.Newtonsoft.Json.Linq.JToken jToken in jArray)
       {
         Objects.BuiltElements.Archicad.ArchicadWindow window =
-          Archicad.Converters.Utils.ConvertDTOs<Objects.BuiltElements.Archicad.ArchicadWindow>(jToken);
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadWindow>(jToken);
 
         window.displayValue = Operations.ModelConverter.MeshesToSpeckle(
           elementModels.First(e => e.applicationId == window.applicationId).model


### PR DESCRIPTION
## Description & motivation

Fixes: https://spockle.atlassian.net/browse/CNX-8875


## Changes:

Cause of the problem: during sending Archicad properties, for better readability on the server, property names and property values are exported as JSON key-value paris (see `PropertyGroup.ToBase` and other `.ToBase` functions). In case of localized version of Archicad these JSON keys can contain special characters. From the JSON standard point of view it is a valid format, however Archicad's JSON interpretation drops this data.
Since currently properties are not imported back to Archicad, we clear the `elementProperties` and `componentProperties` during receive process. (`elements` property can contain door/window subelements in the same JSON format, however since they are converted in a separate step, `elements` property also cleared.) 


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
