### PR TITLE
CNX-8978: Civil3d missing elements due to unhandled exception

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -585,7 +585,7 @@ public partial class ConverterAutocadCivil
 
     // if offset profile, get offset distance and parent
     speckleProfile.offset = profile.Offset;
-    if (profile.OffsetParameters.ParentProfileId != ObjectId.Null)
+    if (profile.ProfileType is ProfileType.OffsetProfile && profile.OffsetParameters.ParentProfileId != ObjectId.Null)
     {
       if (Trans.GetObject(profile.OffsetParameters.ParentProfileId, OpenMode.ForRead) is CivilDB.Profile parent && parent.Name != null)
       {


### PR DESCRIPTION
## Description & motivation

Fixes an unhandled exception in the ProfileToSpeckle conversion which was missed during exception handling cleanup.

## Changes:

- civil3d converter

