### PR TITLE
fix(Archicad): Sending "Skylights" element type throws null reference

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
@@ -97,25 +97,42 @@ public sealed partial class ElementConverterManager
       // subelements translated into "elements" property of the parent
       if (typeof(Fenestration).IsAssignableFrom(elemenType))
       {
+        Collection elementCollection = null;
+
         foreach (Base item in objects)
         {
           Base parent = allObjects.Find(x => x.applicationId == ((Fenestration)item).parentApplicationId);
 
-          if (parent["elements"] == null)
+          if (parent == null)
           {
-            parent["elements"] = new List<Base>() { item };
+            // parent skipped, so add to collection
+            if (elementCollection == null)
+            {
+              elementCollection = new Collection(element, "Element Type");
+              elementCollection.applicationId = element;
+              objectToCommit.elements.Add(elementCollection);
+            }
+
+            elementCollection.elements.Add(item);
           }
           else
           {
-            var elements = parent["elements"] as List<Base>;
-            elements.Add(item);
+            if (parent["elements"] == null)
+            {
+              parent["elements"] = new List<Base>() { item };
+            }
+            else
+            {
+              var elements = parent["elements"] as List<Base>;
+              elements.Add(item);
+            }
           }
         }
       }
       // parents translated as new collections
       else
       {
-        var elementCollection = new Collection(element, "Element Type");
+        Collection elementCollection = new(element, "Element Type");
         elementCollection.applicationId = element;
         elementCollection.elements = objects;
         objectToCommit.elements.Add(elementCollection);


### PR DESCRIPTION
## Description & motivation

Fix of https://spockle.atlassian.net/browse/CNX-8984

## Changes:

In case of opening elements' parents (roofs/shells of skylights or walls/slabs of doors/windows) are filtered out from send operation, a separate collection is created for the openings.


## Screenshots:

<img width="1008" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/4728b4b2-9542-49ba-9d06-9cec38598a92">

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
