### PR TITLE
fix(rhino): uses correct method for cleaning layer paths on receive

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Utils.cs
@@ -50,6 +50,28 @@ public static class Utils
   }
 
   /// <summary>
+  /// Creates a valid path for Rhino layers.
+  /// </summary>
+  /// <param name="str"></param>
+  /// <returns></returns>
+  public static string MakeValidPath(string str)
+  {
+    if (string.IsNullOrEmpty(str))
+    {
+      return str;
+    }
+
+    string validPath = "";
+    string[] layerNames = str.Split(new string[] { Layer.PathSeparator }, StringSplitOptions.None);
+    foreach (var item in layerNames)
+    {
+      validPath += string.IsNullOrEmpty(validPath) ? MakeValidName(item) : Layer.PathSeparator + MakeValidName(item);
+    }
+
+    return validPath;
+  }
+
+  /// <summary>
   /// Attemps to retrieve a Guid from a string
   /// </summary>
   /// <param name="s"></param>
@@ -174,7 +196,7 @@ public static class Utils
   public static Layer GetLayer(this RhinoDoc doc, string path, bool makeIfNull = false)
   {
     Layer layer;
-    var cleanPath = MakeValidName(path);
+    var cleanPath = MakeValidPath(path);
     int index = doc.Layers.FindByFullPath(cleanPath, RhinoMath.UnsetIntIndex);
     if (index is RhinoMath.UnsetIntIndex && makeIfNull)
     {

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Organization.cs
@@ -55,7 +55,7 @@ public partial class ConverterRhinoGh
     };
 
     // see if this layer already exists in the doc
-    var layerPath = MakeValidName(collection["path"] as string);
+    var layerPath = MakeValidPath(collection["path"] as string);
     Layer existingLayer = GetLayer(layerPath);
 
     // update this layer if it exists & receive mode is on update


### PR DESCRIPTION
## Description & motivation
Uses the `MakeValidPath` method to clean layer paths for layer creation, by adding an `@` char to the beginning of any layer name in the path that begins with invalid characters.

## Changes:

- rhino converter and connector 

## Screenshots:

Created grasshopper layers:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/aecc8445-0ee8-4918-a5d0-59313813d584)

