### PR TITLE
fix(Archicad): CNX-9031 CNX-9040 Missing elements in Archicad from revit/objects stream and between localized versions of Archicads

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateCommand.cpp
@@ -105,9 +105,8 @@ GSErrCode CreateCommand::GetElementBaseFromObjectState (const GS::ObjectState& o
 		BNZeroMemory (&attribute, sizeof (API_Attribute));
 		attribute.header.typeID = API_LayerID;
 		attribute.header.uniStringNamePtr = &layer;
-		err = ACAPI_Attribute_Get (&attribute);
 
-		if (err == NoError) {
+		if (NoError == ACAPI_Attribute_Get (&attribute)) {
 			element.header.layer = attribute.header.index;
 			ACAPI_ELEMENT_MASK_SET (elementMask, API_Elem_Head, layer);
 		}

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/BeamConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/BeamConverter.cs
@@ -42,17 +42,19 @@ public sealed class Beam : IConverter
 
             // upgrade (if not Archicad beam): Objects.BuiltElements.Beam --> Objects.BuiltElements.Archicad.ArchicadBeam
             {
-              var baseLine = (Line)beam.baseLine;
-              var newBeam = new Objects.BuiltElements.Archicad.ArchicadBeam
+              if (beam.baseLine is Line baseLine)
               {
-                id = beam.id,
-                applicationId = beam.applicationId,
-                archicadLevel = Archicad.Converters.Utils.ConvertLevel(beam.level),
-                begC = Utils.ScaleToNative(baseLine.start),
-                endC = Utils.ScaleToNative(baseLine.end)
-              };
-
-              beams.Add(newBeam);
+                beams.Add(
+                  new Objects.BuiltElements.Archicad.ArchicadBeam
+                  {
+                    id = beam.id,
+                    applicationId = beam.applicationId,
+                    archicadLevel = Archicad.Converters.Utils.ConvertLevel(beam.level),
+                    begC = Utils.ScaleToNative(baseLine.start),
+                    endC = Utils.ScaleToNative(baseLine.end)
+                  }
+                );
+              }
             }
 
             break;

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ColumnConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/ColumnConverter.cs
@@ -41,21 +41,25 @@ public sealed class Column : IConverter
             columns.Add(archicadColumn);
             break;
           case Objects.BuiltElements.Column column:
-            var baseLine = (Line)column.baseLine;
-            Objects.BuiltElements.Archicad.ArchicadColumn newColumn =
-              new()
-              {
-                id = column.id,
-                applicationId = column.applicationId,
-                archicadLevel = Archicad.Converters.Utils.ConvertLevel(column.level),
-                origoPos = Utils.ScaleToNative(baseLine.start),
-                height = Math.Abs(
-                  Utils.ScaleToNative(baseLine.end.z, baseLine.end.units)
-                    - Utils.ScaleToNative(baseLine.start.z, baseLine.start.units)
-                )
-              };
 
-            columns.Add(newColumn);
+            {
+              if (column.baseLine is Line baseLine)
+              {
+                columns.Add(
+                  new Objects.BuiltElements.Archicad.ArchicadColumn
+                  {
+                    id = column.id,
+                    applicationId = column.applicationId,
+                    archicadLevel = Archicad.Converters.Utils.ConvertLevel(column.level),
+                    origoPos = Utils.ScaleToNative(baseLine.start),
+                    height = Math.Abs(
+                      Utils.ScaleToNative(baseLine.end.z, baseLine.end.units)
+                        - Utils.ScaleToNative(baseLine.start.z, baseLine.start.units)
+                    )
+                  }
+                );
+              }
+            }
             break;
         }
       }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/FloorConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/FloorConverter.cs
@@ -5,8 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Archicad.Communication;
 using Objects;
-using Speckle.Core.Models;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
+using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
 
 namespace Archicad.Converters;
@@ -39,16 +40,24 @@ public sealed class Floor : IConverter
             break;
           case Objects.BuiltElements.Floor floor:
 
-            Objects.BuiltElements.Archicad.ArchicadFloor newFloor =
-              new()
+            {
+              try
               {
-                id = floor.id,
-                applicationId = floor.applicationId,
-                archicadLevel = Archicad.Converters.Utils.ConvertLevel(floor.level),
-                shape = Utils.PolycurvesToElementShape(floor.outline, floor.voids)
-              };
-
-            floors.Add(newFloor);
+                floors.Add(
+                  new Objects.BuiltElements.Archicad.ArchicadFloor
+                  {
+                    id = floor.id,
+                    applicationId = floor.applicationId,
+                    archicadLevel = Archicad.Converters.Utils.ConvertLevel(floor.level),
+                    shape = Utils.PolycurvesToElementShape(floor.outline, floor.voids)
+                  }
+                );
+              }
+              catch (SpeckleException ex)
+              {
+                SpeckleLog.Logger.Error(ex, "Polycurves conversion failed.");
+              }
+            }
             break;
         }
       }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoofConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoofConverter.cs
@@ -5,8 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Archicad.Communication;
 using Objects;
-using Speckle.Core.Models;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
+using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
 
 namespace Archicad.Converters;
@@ -43,15 +44,25 @@ public sealed class Roof : IConverter
             shells.Add(archiShell);
             break;
           case Objects.BuiltElements.Roof roof:
-            roofs.Add(
-              new Objects.BuiltElements.Archicad.ArchicadRoof
+
+            {
+              try
               {
-                id = roof.id,
-                applicationId = roof.applicationId,
-                archicadLevel = Archicad.Converters.Utils.ConvertLevel(roof.level),
-                shape = Utils.PolycurvesToElementShape(roof.outline, roof.voids)
+                roofs.Add(
+                  new Objects.BuiltElements.Archicad.ArchicadRoof
+                  {
+                    id = roof.id,
+                    applicationId = roof.applicationId,
+                    archicadLevel = Archicad.Converters.Utils.ConvertLevel(roof.level),
+                    shape = Utils.PolycurvesToElementShape(roof.outline, roof.voids)
+                  }
+                );
               }
-            );
+              catch (SpeckleException ex)
+              {
+                SpeckleLog.Logger.Error(ex, "Polycurves conversion failed.");
+              }
+            }
             break;
         }
       }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/RoomConverter.cs
@@ -9,6 +9,7 @@ using Objects;
 using Objects.BuiltElements.Archicad;
 using Objects.Geometry;
 using Speckle.Core.Kits;
+using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;
 
@@ -63,21 +64,27 @@ public sealed class Room : IConverter
           case Objects.BuiltElements.Room speckleRoom:
 
             {
-              Archicad.Room archicadRoom =
-                new()
-                {
-                  // Speckle base properties
-                  id = speckleRoom.id,
-                  applicationId = speckleRoom.applicationId,
-                  // Speckle general properties
-                  name = speckleRoom.name,
-                  number = speckleRoom.number,
-                  // Archicad properties
-                  level = Archicad.Converters.Utils.ConvertLevel(speckleRoom.level),
-                  shape = Utils.PolycurvesToElementShape(speckleRoom.outline, speckleRoom.voids)
-                };
-
-              rooms.Add(archicadRoom);
+              try
+              {
+                rooms.Add(
+                  new Archicad.Room
+                  {
+                    // Speckle base properties
+                    id = speckleRoom.id,
+                    applicationId = speckleRoom.applicationId,
+                    // Speckle general properties
+                    name = speckleRoom.name,
+                    number = speckleRoom.number,
+                    // Archicad properties
+                    level = Archicad.Converters.Utils.ConvertLevel(speckleRoom.level),
+                    shape = Utils.PolycurvesToElementShape(speckleRoom.outline, speckleRoom.voids)
+                  }
+                );
+              }
+              catch (SpeckleException ex)
+              {
+                SpeckleLog.Logger.Error(ex, "Polycurves conversion failed.");
+              }
             }
             break;
         }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
@@ -221,12 +221,14 @@ public static class Utils
 
   public static Objects.BuiltElements.Archicad.ArchicadLevel ConvertLevel(Objects.BuiltElements.Level level)
   {
-    return new Objects.BuiltElements.Archicad.ArchicadLevel
-    {
-      id = level.id,
-      applicationId = level.applicationId,
-      elevation = level.elevation * Units.GetConversionFactor(level.units, Units.Meters),
-      name = level.name
-    };
+    return (level == null)
+      ? null
+      : new Objects.BuiltElements.Archicad.ArchicadLevel
+      {
+        id = level.id,
+        applicationId = level.applicationId,
+        elevation = level.elevation * Units.GetConversionFactor(level.units, Units.Meters),
+        name = level.name
+      };
   }
 }

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/WallConverter.cs
@@ -41,21 +41,21 @@ public sealed class Wall : IConverter
             walls.Add(archiWall);
             break;
           case Objects.BuiltElements.Wall wall:
-            var baseLine = (Line)wall.baseLine;
-
-            ArchicadWall newWall =
-              new()
-              {
-                id = wall.id,
-                applicationId = wall.applicationId,
-                archicadLevel = Archicad.Converters.Utils.ConvertLevel(wall.level),
-                startPoint = Utils.ScaleToNative(baseLine.start),
-                endPoint = Utils.ScaleToNative(baseLine.end),
-                height = Utils.ScaleToNative(wall.height, wall.units),
-                flipped = (tc.current is RevitWall revitWall) ? revitWall.flipped : false
-              };
-
-            walls.Add(newWall);
+            if (wall.baseLine is Line baseLine)
+            {
+              walls.Add(
+                new ArchicadWall
+                {
+                  id = wall.id,
+                  applicationId = wall.applicationId,
+                  archicadLevel = Archicad.Converters.Utils.ConvertLevel(wall.level),
+                  startPoint = Utils.ScaleToNative(baseLine.start),
+                  endPoint = Utils.ScaleToNative(baseLine.end),
+                  height = Utils.ScaleToNative(wall.height, wall.units),
+                  flipped = (tc.current is RevitWall revitWall) ? revitWall.flipped : false
+                }
+              );
+            }
             break;
         }
       }


### PR DESCRIPTION
## Description & motivation

https://spockle.atlassian.net/browse/CNX-9031
https://spockle.atlassian.net/browse/CNX-9040

## Changes:

1. C# Connector: Improved exception handling around native-to-native conversion from Revit to Archicad.
2. C++ Add-on: Layer attribute search error ignored

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
