### PR TITLE
fix(autocadcivil): Cnx 9042 creating a new file doesnt update DUI saved streams

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Events.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Events.cs
@@ -68,8 +68,8 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
       if (streams.Count > 0)
       {
         SpeckleAutocadCommand.CreateOrFocusSpeckle();
-        UpdateSavedStreams?.Invoke(streams);
       }
+      UpdateSavedStreams?.Invoke(streams);
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Events.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Events.cs
@@ -70,6 +70,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
         SpeckleAutocadCommand.CreateOrFocusSpeckle();
       }
       UpdateSavedStreams?.Invoke(streams);
+      MainViewModel.GoHome();
     }
     catch (Exception ex) when (!ex.IsFatal())
     {


### PR DESCRIPTION
## Description & motivation

Fixes regression in DUI saved stream updating with document event handling, caused by [this pr](https://github.com/specklesystems/speckle-sharp/pull/3119/files#diff-b6cd7f4d722cb29e541152b4256cbc85d8dc354014ff06e85337f13b7e580124L69)

Regression: creating new files (with no saved streams) did not update DUI saved streams when switching from a file with saved streams.

## Changes:

- autocad connector event handling

