### PR TITLE
bug(rhino): missing application ids when converting instances to native

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Utils.cs
@@ -103,6 +103,12 @@ public partial class ConverterRhinoGh
       }
     }
 
+    // set application id
+    if (!string.IsNullOrWhiteSpace(obj.applicationId))
+    {
+      attributes.SetUserString(ApplicationIdKey, obj.applicationId);
+    }
+
     // set name or label
     var name = obj["name"] as string ?? obj["label"] as string; // gridlines have a "label" prop instead of name?
     if (name != null)


### PR DESCRIPTION
## Description & motivation

Missing application ids on nested instances are now set in the InstanceToNative method. This was resulting in some instances not correctly updating, leading to duplicate instances on update receive mode.

