### PR TITLE
fix(rhino8): adds runtime identifier to rhino 8 connector

### DIFF
--- a/ConnectorRhino/ConnectorRhino8/ConnectorRhino8.csproj
+++ b/ConnectorRhino/ConnectorRhino8/ConnectorRhino8.csproj
@@ -19,6 +19,8 @@
     They are loaded from the nuget mac folder
     REMEMBER to update its numbers if updating the nugets
     -->
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <DefineConstants>$(DefineConstants);RHINO8;RHINO6_OR_GREATER;RHINO7_OR_GREATER;RHINO8_OR_GREATER</DefineConstants>
     <OutputType>Library</OutputType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
Previously, the Rhino 8 connector was not building due to invalid paths for some dlls. This is fixed by targeting x64 on build.