### PR TITLE
bug(revit): CNX-8730 deletes existing objects in a subtransaction during receive

### DIFF
--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -337,6 +337,7 @@ public partial class ConnectorBindingsRevit
       if (index % 50 == 0)
       {
         transactionManager.Commit();
+        transactionManager.Start();
       }
 
       // Check if parent conversion succeeded or fallback is enabled before attempting the children

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -122,7 +122,7 @@ public partial class ConnectorBindingsRevit
 
           if (state.ReceiveMode == ReceiveMode.Update)
           {
-            DeleteObjects(previousObjects, convertedObjects);
+            DeleteObjects(previousObjects, convertedObjects, transactionManager);
           }
 
           previousObjects.AddConvertedElements(convertedObjects);
@@ -159,10 +159,12 @@ public partial class ConnectorBindingsRevit
   //delete previously sent object that are no more in this stream
   private void DeleteObjects(
     IReceivedObjectIdMap<Base, Element> previousObjects,
-    IConvertedObjectsCache<Base, Element> convertedObjects
+    IConvertedObjectsCache<Base, Element> convertedObjects,
+    TransactionManager transactionManager
   )
   {
     var previousAppIds = previousObjects.GetAllConvertedIds().ToList();
+    transactionManager.StartSubtransaction();
     for (var i = previousAppIds.Count - 1; i >= 0; i--)
     {
       var appId = previousAppIds[i];
@@ -193,6 +195,8 @@ public partial class ConnectorBindingsRevit
         previousObjects.RemoveConvertedId(appId);
       }
     }
+
+    transactionManager.CommitSubtransaction();
   }
 
   private IConvertedObjectsCache<Base, Element> ConvertReceivedObjects(


### PR DESCRIPTION
## Description & motivation

When receiving in Revit in update mode, always deletes existing objects in a subtransaction. This fixes a bug where in certain conditions, attempts to delete existing objects are made without any active transaction.

This bug turned out to be completely unrelated to Sketchup direct shape mappings, but direct shapes are one of few objects that are properly "updated" (an existing direct shape object's shape is modified in update mode, vs the existing object being deleted and a new ds being created).

The following reproduction steps create the "failed update" behavior:
1. receive a direct shape
2. receive a new version of the same direct shape (same app id) on update mode -> success
3. receive a new version of a different direct shape (different app id) on update mode -> failure, existing directshape isn't deleted.

While my changes appear to fix the failed updating behavior described above, I'd like @connorivy to take a look at the proposed changes because it's still unclear to me why no active transaction existed (my guess is that passing the transaction manager to the converter, editing the direct shape in the converter closed the transaction, and therefore no open transaction was available when the connector attempts to delete the existing object ). There may be a more robust way to handle transactions due to the differences in direct shape editing in the converter compared to most other conversion routines.


## To-do before merge:

- [ ] Transaction manager review by @connorivy 

