### PR TITLE
CI: Use Keylocker to sign releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,20 +30,20 @@ jobs:
                     value: << pipeline.git.tag >>
           steps:
             - run: git branch internal_circleci
-            - path-filtering/set-parameters:
-                mapping: |
-                  Core/.* core true
-                  (Core|Objects|ConnectorRhino|ConnectorGrasshopper|.*/ConverterRhinoGh)/.* rhino true
-                  (Core|Objects|ConnectorRevit|.*/ConverterRevit)/.* revit true
-                  (Core|Objects|ConnectorDynamo|.*/ConverterDynamo)/.* dynamo true
-                  (Core|Objects|ConnectorAutocadCivil|.*/ConverterAutocadCivil)/.* autocadcivil true
-                  (Core|Objects|ConnectorCSI|.*/ConverterCSI)/.* csi true
-                  (Core|Objects|ConnectorBentley|.*/ConverterBentley)/.* bentley true
-                  (Core|Objects|ConnectorTeklaStructures|.*/ConverterTeklaStructures)/.* teklastructures true
-                  (Core|Objects|ConnectorArchicad)/.* archicad true
-                  (Core|Objects|ConnectorNavisworks|.*/ConverterNavisworks)/.* navisworks true
-                base-revision: main
-                output-path: .circleci/scripts/parameters.json
+            # - path-filtering/set-parameters:
+            #     mapping: |
+            #       Core/.* core true
+            #       (Core|Objects|ConnectorRhino|ConnectorGrasshopper|.*/ConverterRhinoGh)/.* rhino true
+            #       (Core|Objects|ConnectorRevit|.*/ConverterRevit)/.* revit true
+            #       (Core|Objects|ConnectorDynamo|.*/ConverterDynamo)/.* dynamo true
+            #       (Core|Objects|ConnectorAutocadCivil|.*/ConverterAutocadCivil)/.* autocadcivil true
+            #       (Core|Objects|ConnectorCSI|.*/ConverterCSI)/.* csi true
+            #       (Core|Objects|ConnectorBentley|.*/ConverterBentley)/.* bentley true
+            #       (Core|Objects|ConnectorTeklaStructures|.*/ConverterTeklaStructures)/.* teklastructures true
+            #       (Core|Objects|ConnectorArchicad)/.* archicad true
+            #       (Core|Objects|ConnectorNavisworks|.*/ConverterNavisworks)/.* navisworks true
+            #     base-revision: main
+            #     output-path: .circleci/scripts/parameters.json
       - run: cat .circleci/scripts/parameters.json
       - run: pip install pyyaml
       - run: # run a command

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -221,19 +221,18 @@ jobs: # Each project will have individual jobs for each specific task it has to 
                   curl.exe -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:$env:SM_API_KEY" -o smtools-windows-x64.msi
                   msiexec.exe /i smtools-windows-x64.msi /quiet /qn | Wait-Process
             - run:
-                name: Create Auth & OV Signing Cert
+                name: Setup Digicert ONE Client Cert
                 command: |
                   cd C:\
                   echo $env:SM_CLIENT_CERT_FILE_B64 > certificate.txt
                   certutil -decode certificate.txt certificate.p12
-                  echo $env:SM_OV_PEM_CERT > SpeckleOVCertificate-2024.pem
             - run:
                 name: Sync Certs
                 command: |
                   & $env:SSM\smksp_cert_sync.exe
             - run:
                 name: Build Installer
-                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\%SLUG%.iss /Sbyparam=$p /DSIGN_INSTALLER
+                command: speckle-sharp-ci-tools\InnoSetup\ISCC.exe speckle-sharp-ci-tools\%SLUG%.iss /Sbyparam=$p /DSIGN_INSTALLER /DCODE_SIGNING_CERT_FINGERPRINT=%SM_CODE_SIGNING_CERT_SHA1_HASH%
                 shell: cmd.exe #does not work in powershell
                 environment:
                   SLUG: << parameters.slug >>

--- a/.circleci/scripts/connector-jobs.yml
+++ b/.circleci/scripts/connector-jobs.yml
@@ -9,13 +9,13 @@ rhino:
       dllname: SpeckleConnectorRhino.rhp
       slug: rhino
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorRhino
       dllname: SpeckleConnectorRhino.rhp
       slug: grasshopper
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector-dotnet-mac:
       name: rhino-build-mac
       slnname: ConnectorRhino
@@ -50,7 +50,7 @@ dynamo:
       dllname: SpeckleConnectorDynamo.dll
       slug: dynamo
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
 
 revit:
   - build-connector:
@@ -58,7 +58,7 @@ revit:
       dllname: SpeckleConnectorRevit.dll
       slug: revit
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
 
 autocadcivil:
   - build-connector:
@@ -66,44 +66,44 @@ autocadcivil:
       dllname: SpeckleConnectorAutocad.dll
       slug: autocad
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorAutocadCivil
       dllname: SpeckleConnectorAutocad.dll
       slug: civil3d
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorAutocadCivil
       dllname: SpeckleConnectorAutocad.dll
       slug: advancesteel
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
 bentley:
   - build-connector:
       slnname: ConnectorBentley
       dllname: SpeckleConnectorMicroStation.dll
       slug: microstation
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorBentley
       dllname: SpeckleConnectorOpenBuildings.dll
       slug: openbuildings
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorBentley
       dllname: SpeckleConnectorOpenRail.dll
       slug: openrail
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorBentley
       dllname: SpeckleConnectorOpenRoads.dll
       slug: openroads
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
 
 teklastructures:
   - build-connector:
@@ -111,32 +111,32 @@ teklastructures:
       dllname: SpeckleConnectorTeklaStructures.dll
       slug: teklastructures
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
 csi:
   - build-connector:
       slnname: ConnectorCSI
       dllname: SpeckleConnectorCSI.dll
       slug: etabs
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorCSI
       dllname: SpeckleConnectorCSI.dll
       slug: sap2000
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorCSI
       dllname: SpeckleConnectorCSI.dll
       slug: safe
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-connector:
       slnname: ConnectorCSI
       dllname: SpeckleConnectorCSI.dll
       slug: csibridge
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
 
 archicad:
   - build-archicad-add-on:
@@ -165,7 +165,7 @@ archicad:
       slug: archicad
       build-with-msbuild: false
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker
   - build-archicad-add-on-mac:
       archicadversion: "25"
       requires:
@@ -205,4 +205,4 @@ navisworks:
       dllname: SpeckleConnectorNavisworks.dll
       slug: navisworks
       context:
-        - digicert-signing-connectors-test
+        - digicert-keylocker

--- a/.circleci/scripts/parameters.json
+++ b/.circleci/scripts/parameters.json
@@ -1,12 +1,12 @@
 {
   "core": true,
   "rhino": true,
-  "revit": true,
-  "dynamo": true,
-  "csi": true,
-  "autocadcivil": true,
-  "bentley": true,
-  "archicad": true,
-  "teklastructures": true,
-  "navisworks": true
+  "revit": false,
+  "dynamo": false,
+  "csi": false,
+  "autocadcivil": false,
+  "bentley": false,
+  "archicad": false,
+  "teklastructures": false,
+  "navisworks": false
 }

--- a/.circleci/scripts/parameters.json
+++ b/.circleci/scripts/parameters.json
@@ -1,12 +1,12 @@
 {
   "core": true,
   "rhino": true,
-  "revit": false,
-  "dynamo": false,
-  "csi": false,
-  "autocadcivil": false,
-  "bentley": false,
-  "archicad": false,
-  "teklastructures": false,
-  "navisworks": false
+  "revit": true,
+  "dynamo": true,
+  "csi": true,
+  "autocadcivil": true,
+  "bentley": true,
+  "archicad": true,
+  "teklastructures": true,
+  "navisworks": true
 }


### PR DESCRIPTION
Update ci script to use `digicert-keylocker` context.

Additionally disabled diffing for now