### PR TITLE
Cnx 8920 use account migration when selecting accounts in sdk

### DIFF
--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -266,7 +266,22 @@ public static class AccountManager
   /// <returns></returns>
   public static IEnumerable<Account> GetAccounts(string serverUrl)
   {
-    return GetAccounts().Where(acc => acc.serverInfo.url == serverUrl);
+    var accounts = GetAccounts().ToList();
+    foreach (var acc in accounts)
+    {
+      if (acc.serverInfo?.migration?.movedFrom == new Uri(serverUrl))
+      {
+        yield return acc;
+      }
+    }
+
+    foreach (var acc in accounts)
+    {
+      if (acc.serverInfo.url == serverUrl)
+      {
+        yield return acc;
+      }
+    }
   }
 
   /// <summary>

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -375,11 +375,6 @@ public class StreamWrapper
   /// <exception cref="SpeckleException">Verification of the current state of the stream wrapper with provided <paramref name="acc"/> was unsuccessful. The <paramref name="acc"/> could be invalid, or lack permissions for the <see cref="StreamId"/>, or the <see cref="StreamId"/> or <see cref="BranchName"/> are invalid</exception>
   public async Task ValidateWithAccount(Account acc)
   {
-    if (ServerUrl != acc.serverInfo.url)
-    {
-      throw new ArgumentException($"Account is not from server {ServerUrl}", nameof(acc));
-    }
-
     Uri url;
     try
     {
@@ -388,6 +383,11 @@ public class StreamWrapper
     catch (UriFormatException ex)
     {
       throw new ArgumentException("Server Url is improperly formatted", nameof(acc), ex);
+    }
+
+    if (ServerUrl != acc.serverInfo.url && url != acc.serverInfo.migration?.movedFrom)
+    {
+      throw new ArgumentException($"Account is not from server {ServerUrl}", nameof(acc));
     }
 
     try

--- a/Core/Tests/Speckle.Core.Tests.Unit/Credentials/AccountServerMigrationTests.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Credentials/AccountServerMigrationTests.cs
@@ -1,0 +1,87 @@
+﻿using NUnit.Framework;
+using Speckle.Core.Api;
+using Speckle.Core.Credentials;
+
+namespace Speckle.Core.Tests.Unit.Credentials;
+
+public class AccountServerMigrationTests
+{
+  private readonly List<Account> _accountsToCleanUp = new();
+
+  public static IEnumerable<TestCaseData> MigrationTestCase()
+  {
+    const string OLD_URL = "https://old.example.com";
+    const string NEW_URL = "https://new.example.com";
+    const string OTHER_URL = "https://other.example.com";
+    Account oldAccount = CreateTestAccount(OLD_URL, null, new(NEW_URL));
+    Account newAccount = CreateTestAccount(NEW_URL, new(OLD_URL), null);
+    Account otherAccount = CreateTestAccount(OTHER_URL, null, null);
+
+    List<Account> givenAccounts = new() { oldAccount, newAccount, otherAccount };
+
+    yield return new TestCaseData(givenAccounts, NEW_URL, new[] { newAccount })
+      .SetName("Get New")
+      .SetDescription("When requesting for new account, ensure only this account is returned");
+
+    yield return new TestCaseData(givenAccounts, OLD_URL, new[] { newAccount, oldAccount }) //TODO: Maybe we want this without duplicates
+      .SetName("Get New via Old")
+      .SetDescription("When requesting for old account, ensure migrated account is returned first");
+
+    var reversed = Enumerable.Reverse(givenAccounts).ToList();
+
+    yield return new TestCaseData(reversed, OLD_URL, new[] { newAccount, oldAccount })
+      .SetName("Get New via Old (Reversed order)")
+      .SetDescription("Account order shouldn't matter");
+  }
+
+  [Test]
+  [TestCaseSource(nameof(MigrationTestCase))]
+  public void TestServerMigration(IList<Account> accounts, string requestedUrl, IList<Account> expectedSequence)
+  {
+    AddAccounts(accounts);
+
+    var result = AccountManager.GetAccounts(requestedUrl).ToList();
+
+    Assert.That(result, Is.EquivalentTo(expectedSequence));
+  }
+
+  [TearDown]
+  public void TearDown()
+  {
+    //Clean up any of the test accounts we made
+    foreach (var acc in _accountsToCleanUp)
+    {
+      Fixtures.DeleteAccount(acc);
+    }
+    _accountsToCleanUp.Clear();
+  }
+
+  private static Account CreateTestAccount(string url, Uri movedFrom, Uri movedTo)
+  {
+    return new Account
+    {
+      token = "myToken",
+      serverInfo = new ServerInfo
+      {
+        url = url,
+        name = "myServer",
+        migration = new ServerMigration { movedTo = movedTo, movedFrom = movedFrom }
+      },
+      userInfo = new UserInfo
+      {
+        id = new Guid().ToString(),
+        email = "user@example.com",
+        name = "user"
+      }
+    };
+  }
+
+  private void AddAccounts(IEnumerable<Account> accounts)
+  {
+    foreach (Account account in accounts)
+    {
+      _accountsToCleanUp.Add(account);
+      Fixtures.UpdateOrSaveAccount(account);
+    }
+  }
+}

--- a/Core/Tests/Speckle.Core.Tests.Unit/Credentials/Accounts.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Credentials/Accounts.cs
@@ -7,14 +7,14 @@ namespace Speckle.Core.Tests.Unit.Credentials;
 [TestFixture]
 public class CredentialInfrastructure
 {
-  [SetUp]
+  [OneTimeSetUp]
   public void SetUp()
   {
     _testAccount1 = new Account
     {
       refreshToken = "bla",
       token = "bla",
-      serverInfo = new ServerInfo { url = "bla", company = "bla" },
+      serverInfo = new ServerInfo { url = "https://bla.example.com", company = "bla" },
       userInfo = new UserInfo { email = "one@two.com" }
     };
 
@@ -22,14 +22,14 @@ public class CredentialInfrastructure
     {
       refreshToken = "foo",
       token = "bar",
-      serverInfo = new ServerInfo { url = "baz", company = "qux" },
+      serverInfo = new ServerInfo { url = "https://baz.example.com", company = "qux" },
       userInfo = new UserInfo { email = "three@four.com" }
     };
 
     _testAccount3 = new Account
     {
       token = "secret",
-      serverInfo = new ServerInfo { url = "https://sample.com", name = "qux" },
+      serverInfo = new ServerInfo { url = "https://example.com", name = "qux" },
       userInfo = new UserInfo
       {
         email = "six@five.com",
@@ -43,7 +43,7 @@ public class CredentialInfrastructure
     Fixtures.SaveLocalAccount(_testAccount3);
   }
 
-  [TearDown]
+  [OneTimeTearDown]
   public void TearDown()
   {
     Fixtures.DeleteLocalAccount(_testAccount1.id);
@@ -62,24 +62,23 @@ public class CredentialInfrastructure
     Assert.That(accs, Has.Count.GreaterThanOrEqualTo(3)); // Tests are adding three accounts, you might have extra accounts on your machine when testing :D
   }
 
+  public static IEnumerable<Account> TestCases => AccountManager.GetAccounts();
+
   [Test]
-  public void GetAccountsForServer()
+  [TestCaseSource(nameof(TestCases))]
+  public void GetAccountsForServer(Account target)
   {
-    var accs = AccountManager.GetAccounts("baz").ToList();
+    var accs = AccountManager.GetAccounts(target.serverInfo.url).ToList();
 
     Assert.That(accs, Has.Count.EqualTo(1));
-    Assert.That(accs[0].serverInfo.company, Is.EqualTo("qux"));
-    Assert.That(accs[0].serverInfo.url, Is.EqualTo("baz"));
-    Assert.That(accs[0].refreshToken, Is.EqualTo("foo"));
-  }
 
-  [Test]
-  public void GetLocalAccount()
-  {
-    var acc = AccountManager.GetAccounts().FirstOrDefault(x => x.userInfo.id == "123345");
+    var acc = accs[0];
 
-    Assert.That(acc.serverInfo.url, Is.EqualTo("https://sample.com"));
-    Assert.That(acc.token, Is.EqualTo("secret"));
+    Assert.That(acc, Is.Not.SameAs(target), "We expect new objects (no reference equality)");
+    Assert.That(acc.serverInfo.company, Is.EqualTo(target.serverInfo.company));
+    Assert.That(acc.serverInfo.url, Is.EqualTo(target.serverInfo.url));
+    Assert.That(acc.refreshToken, Is.EqualTo(target.refreshToken));
+    Assert.That(acc.token, Is.EqualTo(target.token));
   }
 
   [Test]

--- a/Core/Tests/Speckle.Core.Tests.Unit/Fixtures.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Fixtures.cs
@@ -30,9 +30,14 @@ public abstract class Fixtures
     "TestAccount.json"
   );
 
-  public static void UpdateOrSaveAccount(Account account)
+  public static void DeleteAccount(Account account)
   {
     s_accountStorage.DeleteObject(account.id);
+  }
+
+  public static void UpdateOrSaveAccount(Account account)
+  {
+    DeleteAccount(account);
     string serializedObject = JsonConvert.SerializeObject(account);
     s_accountStorage.SaveObjectSync(account.id, serializedObject);
   }


### PR DESCRIPTION
- Ensuring accounts migrated to a new server are returned first
- Ensuring we have no duplicate accounts (by ID)
- Unit test added from Jedd's branch (and reviewed)