### PR TITLE
Dim/dui3/send change detection poc

### DIFF
--- a/ConnectorAutocadCivil/AutocadCivilDUI3/AutocadCivilDUI3Shared/Bindings/SendBinding.cs
+++ b/ConnectorAutocadCivil/AutocadCivilDUI3/AutocadCivilDUI3Shared/Bindings/SendBinding.cs
@@ -108,8 +108,8 @@ public class SendBinding : ISendBinding, ICancelable
       // 7 - Serialize and Send objects
       var transport = new ServerTransport(account, modelCard.ProjectId);
       BasicConnectorBindingCommands.SetModelProgress(Parent, modelCardId, new ModelCardProgress { Status = "Uploading..." });
-      var sendResult = await Speckle.Core.Api.Operations
-        .Send(commitObject, transport, true, null, true, cts.Token)
+      var sendResult = await SendHelper
+        .Send(commitObject, transport, true, null, cts.Token)
         .ConfigureAwait(true);
       
       // Store the converted references in memory for future send operations, overwriting the existing values for the given application id.

--- a/ConnectorRevit/RevitDUI3/RevitDUI3Shared/Bindings/SendBinding.cs
+++ b/ConnectorRevit/RevitDUI3/RevitDUI3Shared/Bindings/SendBinding.cs
@@ -107,8 +107,8 @@ public class SendBinding : ISendBinding, ICancelable
       // 7 - Serialize and Send objects
       var transport = new ServerTransport(account, modelCard.ProjectId);
       BasicConnectorBindingCommands.SetModelProgress(Parent, modelCardId, new ModelCardProgress { Status = "Uploading..." });
-      var sendResult = await Speckle.Core.Api.Operations
-        .Send(commitObject, transport, true, null, true, cts.Token)
+      var sendResult = await SendHelper
+        .Send(commitObject, transport, true, null, cts.Token)
         .ConfigureAwait(true);
       
       // Update cache of previously converted elements

--- a/ConnectorRevit/RevitDUI3/RevitDUI3Shared/Bindings/SendBinding.cs
+++ b/ConnectorRevit/RevitDUI3/RevitDUI3Shared/Bindings/SendBinding.cs
@@ -129,7 +129,9 @@ public class SendBinding : ISendBinding, ICancelable
       SendBindingUiCommands.SetModelCreatedVersionId(Parent, modelCardId, versionId);
       apiClient.Dispose();
     }
-    catch (Exception e)
+#pragma warning disable CA1031
+    catch (Exception e) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
+#pragma warning restore CA1031
     {
       if (e is OperationCanceledException)
       {

--- a/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
+++ b/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
@@ -147,8 +147,8 @@ public class SendBinding : ISendBinding, ICancelable
       // 7 - Serialize and Send objects
       BasicConnectorBindingCommands.SetModelProgress(Parent, modelCardId, new ModelCardProgress { Status = "Uploading..." });
       var transport = new ServerTransport(account, modelCard.ProjectId);
-      var sendResult = await Speckle.Core.Api.Operations
-        .Send(commitObject, transport, true, null, true, cts.Token)
+      var sendResult = await SendHelper
+        .Send(commitObject, transport, true, null, cts.Token)
         .ConfigureAwait(true);
 
       // Store the converted references in memory for future send operations, overwriting the existing values for the given application id.

--- a/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
+++ b/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
@@ -151,6 +151,7 @@ public class SendBinding : ISendBinding, ICancelable
         .Send(commitObject, transport, true, null, true, cts.Token)
         .ConfigureAwait(true);
 
+      // Store the converted references in memory for future send operations, overwriting the existing values for the given application id.
       foreach (var kvp in sendResult.convertedReferences)
       {
         _convertedObjectReferences[kvp.Key] = kvp.Value;
@@ -171,7 +172,7 @@ public class SendBinding : ISendBinding, ICancelable
       apiClient.Dispose();
     }
 #pragma warning disable CA1031
-    catch (Exception e)
+    catch (Exception e) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
 #pragma warning restore CA1031
     {
       if (e is OperationCanceledException) // We do not want to display an error, we just stop sending.

--- a/Core/Core/Api/Helpers.cs
+++ b/Core/Core/Api/Helpers.cs
@@ -160,7 +160,7 @@ public static class Helpers
     using ServerTransport transport = new(client.Account, sw.StreamId);
     var branchName = string.IsNullOrEmpty(sw.BranchName) ? "main" : sw.BranchName;
 
-    var objectId = await Operations.Send(data, transport, useDefaultCache, onProgressAction).ConfigureAwait(false);
+    var objectReference = await Operations.Send(data, transport, useDefaultCache, onProgressAction).ConfigureAwait(false);
 
     Analytics.TrackEvent(client.Account, Analytics.Events.Send);
 
@@ -170,7 +170,7 @@ public static class Helpers
         {
           streamId = sw.StreamId,
           branchName = branchName,
-          objectId = objectId,
+          objectId = objectReference.rootObjId,
           message = message,
           sourceApplication = sourceApplication,
           totalChildrenCount = totalChildrenCount

--- a/Core/Core/Api/Helpers.cs
+++ b/Core/Core/Api/Helpers.cs
@@ -160,7 +160,7 @@ public static class Helpers
     using ServerTransport transport = new(client.Account, sw.StreamId);
     var branchName = string.IsNullOrEmpty(sw.BranchName) ? "main" : sw.BranchName;
 
-    var objectReference = await Operations.Send(data, transport, useDefaultCache, onProgressAction).ConfigureAwait(false);
+    var objectId = await Operations.Send(data, transport, useDefaultCache, onProgressAction).ConfigureAwait(false);
 
     Analytics.TrackEvent(client.Account, Analytics.Events.Send);
 
@@ -170,7 +170,7 @@ public static class Helpers
         {
           streamId = sw.StreamId,
           branchName = branchName,
-          objectId = objectReference.rootObjId,
+          objectId = objectId,
           message = message,
           sourceApplication = sourceApplication,
           totalChildrenCount = totalChildrenCount

--- a/Core/Core/Api/Operations/Operations.Send.Obsolete.cs
+++ b/Core/Core/Api/Operations/Operations.Send.Obsolete.cs
@@ -162,7 +162,7 @@ public static partial class Operations
       }
       else
       {
-        serializerV2 = new BaseObjectSerializerV2(transports, internalProgressAction, default, cancellationToken);
+        serializerV2 = new BaseObjectSerializerV2(transports, internalProgressAction, false, cancellationToken);
       }
 
       foreach (var t in transports)

--- a/Core/Core/Api/Operations/Operations.Send.Obsolete.cs
+++ b/Core/Core/Api/Operations/Operations.Send.Obsolete.cs
@@ -162,7 +162,7 @@ public static partial class Operations
       }
       else
       {
-        serializerV2 = new BaseObjectSerializerV2(transports, internalProgressAction, cancellationToken);
+        serializerV2 = new BaseObjectSerializerV2(transports, internalProgressAction, default, cancellationToken);
       }
 
       foreach (var t in transports)

--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -59,11 +59,18 @@ public class DataChunk : Base
   public List<object> data { get; set; } = new();
 }
 
-public class ObjectReference
+public class ObjectReference : Base
 {
-  public string speckle_type = "reference";
+  public new string speckle_type = "reference";
 
   public string referencedId { get; set; }
+  
+  public Dictionary<string,int> closure { get; set; }
+}
+
+public class ObjectReferenceWithClosure
+{
+  // TODO
 }
 
 public class ProgressEventArgs : EventArgs

--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -68,11 +68,6 @@ public class ObjectReference : Base
   public Dictionary<string,int> closure { get; set; }
 }
 
-public class ObjectReferenceWithClosure
-{
-  // TODO
-}
-
 public class ProgressEventArgs : EventArgs
 {
   public ProgressEventArgs(int current, int total, string scope)

--- a/DesktopUI3/DUI3/Bindings/ISendBinding.cs
+++ b/DesktopUI3/DUI3/Bindings/ISendBinding.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using DUI3.Models;
 using DUI3.Models.Card;
 using DUI3.Utils;
+using Speckle.Newtonsoft.Json;
 
 namespace DUI3.Bindings;
 
@@ -42,6 +43,9 @@ public static class SendBindingUiCommands
 public class SenderModelCard : ModelCard
 {
   public ISendFilter SendFilter { get; set; }
+
+  [JsonIgnore]
+  public List<string> ChangedObjectIds { get; set; } = new();
 }
 
 public interface ISendFilter
@@ -80,10 +84,4 @@ public abstract class DirectSelectionSendFilter : DiscriminatedObject, ISendFilt
   public List<string> SelectedObjectIds { get; set; } = new List<string>();
   public abstract List<string> GetObjectIds();
   public abstract bool CheckExpiry(string[] changedObjectIds);
-}
-
-public class CreateVersionArgs
-{
-  public string ModelCardId { get; set; }
-  public string ObjectId { get; set; }
 }

--- a/DesktopUI3/DUI3/Bindings/ISendBinding.cs
+++ b/DesktopUI3/DUI3/Bindings/ISendBinding.cs
@@ -45,7 +45,7 @@ public class SenderModelCard : ModelCard
   public ISendFilter SendFilter { get; set; }
 
   [JsonIgnore]
-  public List<string> ChangedObjectIds { get; set; } = new();
+  public HashSet<string> ChangedObjectIds { get; set; } = new();
 }
 
 public interface ISendFilter


### PR DESCRIPTION
MVP showing how we can avoid re-converting previously converted objects that have not changed. This PR: 
- introduces backwards compatible changes to `Core` and, specifically, `BaseObjectSerializerV2`:
  - BaseObjectSerializerV2 now optionally tracks all detachable base objs that have an `applicationId` during the serialization process
  - ObjectReference now inherits from Base and has a closure property (to be able to insert it in place of real objects)
  - BaseObjectSerializerV2 now treats ObjectReferences before Bases, and ensures that if they participate in the closure generation
- introduces a monkey copy-pasted version of the Core `Send` operation in `DUI3` that returns the `rootObjectId` as well as the SerializerV2's ObjectReference cache (see first bullet point) 
- modifies the SendBinding of Rhino, Revit and AutoCAD to leverage the above, specifically:
  - if a corresponding ObjectReference is not found in the cache, we actually convert the object
  - if a corresponding ObjectReference is found in the cache and the object has not changed, we insert it in the tree and skip conversion
  - `ExpiryChecks` functions now make sure each sender model card now keeps track of its relevant changed object ids (encapsulating cache invalidation for the above operations)