### PR TITLE
Fixing account equality

### DIFF
--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -256,7 +256,10 @@ public static class AccountManager
     account.serverInfo.url = upgradeUri.ToString().TrimEnd('/');
     account.serverInfo.frontend2 = true;
 
-    s_accountStorage.UpdateObject(account.id, JsonConvert.SerializeObject(account));
+    // setting the id to null will force it to be recreated
+    account.id = null;
+
+    s_accountStorage.UpdateObject(account.id!, JsonConvert.SerializeObject(account));
   }
 
   /// <summary>
@@ -281,7 +284,9 @@ public static class AccountManager
 
     foreach (var acc in accounts)
     {
-      if (acc.serverInfo.url == serverUrl && !filtered.Any(x => x.id != acc.id))
+      // we use the userInfo to detect the same account rather than the account.id
+      // which should NOT match for essentially the same accounts but on different servers - i.e. FE1 & FE2
+      if (acc.serverInfo.url == serverUrl && !filtered.Any(x => x.userInfo.id == acc.userInfo.id))
       {
         filtered.Add(acc);
       }

--- a/Core/Tests/Speckle.Core.Tests.Unit/Credentials/AccountServerMigrationTests.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Credentials/AccountServerMigrationTests.cs
@@ -17,6 +17,9 @@ public class AccountServerMigrationTests
     Account newAccount = CreateTestAccount(NEW_URL, new(OLD_URL), null);
     Account otherAccount = CreateTestAccount(OTHER_URL, null, null);
 
+    // new account user must match old account user id
+    newAccount.userInfo.id = oldAccount.userInfo.id;
+
     List<Account> givenAccounts = new() { oldAccount, newAccount, otherAccount };
 
     yield return new TestCaseData(givenAccounts, NEW_URL, new[] { newAccount })
@@ -69,7 +72,7 @@ public class AccountServerMigrationTests
       },
       userInfo = new UserInfo
       {
-        id = new Guid().ToString(),
+        id = Guid.NewGuid().ToString(),
         email = "user@example.com",
         name = "user"
       }


### PR DESCRIPTION
We're now:
- Comparing same accounts using the user's ID
- Ensuring that when an account is upgraded it will get a new ID
- Fixed unit tests accordingly 