### PR TITLE
fix: Use context to extract units on vector converter.

### DIFF
--- a/DUI3-DX/Converters/Rhino/Speckle.Converters.Rhino7/Geometry/VectorToSpeckleConverter.cs
+++ b/DUI3-DX/Converters/Rhino/Speckle.Converters.Rhino7/Geometry/VectorToSpeckleConverter.cs
@@ -18,5 +18,6 @@ public class VectorToSpeckleConverter : IHostObjectToSpeckleConversion, IRawConv
 
   public Base Convert(object target) => RawConvert((RG.Vector3d)target);
 
-  public SOG.Vector RawConvert(RG.Vector3d target) => new(target.X, target.Y, target.Z, Units.Meters);
+  public SOG.Vector RawConvert(RG.Vector3d target) =>
+    new(target.X, target.Y, target.Z, _contextStack.Current.SpeckleUnits);
 }


### PR DESCRIPTION
Fixes bug found during today's standup demo! 🙌🏼