### PR TITLE
exporting group parameters from Revit

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -343,8 +343,10 @@ public partial class ConverterRevit
     List<string> exclusions = null
   )
   {
-    
-    if (group == null) { return; }
+    if (group == null)
+    {
+      return;
+    }
 
     exclusions ??= new();
     using var parameters = group.Parameters;
@@ -359,9 +361,7 @@ public partial class ConverterRevit
       var speckleParam = ParameterToSpeckle(param, internalName);
       paramDict[internalName] = speckleParam;
     }
-    
     // no need for checking for type parameters
-    
   }
 
   /// <summary>

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -256,7 +256,6 @@ public partial class ConverterRevit
     {
       speckleElement["parameters"] = paramBase;
     }
-
     speckleElement["elementId"] = revitElement.Id.ToString();
     speckleElement.applicationId = revitElement.UniqueId;
     speckleElement["units"] = ModelUnits;
@@ -336,6 +335,33 @@ public partial class ConverterRevit
       var speckleParam = ParameterToSpeckle(param, internalName, isTypeParameter);
       paramDict[internalName] = speckleParam;
     }
+  }
+
+  private void AddGroupParamsToDict(
+    DB.Group group,
+    Dictionary<string, Parameter> paramDict,
+    List<string> exclusions = null
+  )
+  {
+    
+    if (group == null) { return; }
+
+    exclusions ??= new();
+    using var parameters = group.Parameters;
+    foreach (DB.Parameter param in parameters)
+    {
+      var internalName = GetParamInternalName(param);
+      if (paramDict.ContainsKey(internalName) || exclusions.Contains(internalName))
+      {
+        continue;
+      }
+
+      var speckleParam = ParameterToSpeckle(param, internalName);
+      paramDict[internalName] = speckleParam;
+    }
+    
+    // no need for checking for type parameters
+    
   }
 
   /// <summary>

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertGroup.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertGroup.cs
@@ -22,11 +22,11 @@ public partial class ConverterRevit
     @base["level"] = ConvertAndCacheLevel(revitGroup, BuiltInParameter.GROUP_LEVEL);
 
     AddHostedDependentElements(revitGroup, @base, elIdsToConvert.ToList());
-    
+
     //adding parameters
     var allParams = new Dictionary<string, Objects.BuiltElements.Revit.Parameter>();
     AddGroupParamsToDict(revitGroup, allParams);
-    
+
     Base paramBase = new();
     //sort by key
     foreach (var kv in allParams.OrderBy(x => x.Key))
@@ -49,7 +49,7 @@ public partial class ConverterRevit
     {
       @base["parameters"] = paramBase;
     }
-    
+
     return @base;
   }
 

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertGroup.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertGroup.cs
@@ -23,9 +23,7 @@ public partial class ConverterRevit
 
     AddHostedDependentElements(revitGroup, @base, elIdsToConvert.ToList());
     
-    
-    // adding parameters:
-    
+    //adding parameters
     var allParams = new Dictionary<string, Objects.BuiltElements.Revit.Parameter>();
     AddGroupParamsToDict(revitGroup, allParams);
     
@@ -51,7 +49,6 @@ public partial class ConverterRevit
     {
       @base["parameters"] = paramBase;
     }
-    
     
     return @base;
   }


### PR DESCRIPTION
## Description & motivation

Currently the parameters of Revit's model groups aren't exported to Speckle at all. Similar to other built elements, the added code aims to add the parameters property object to the exported speckle element.

[as dicussed in the Speckle Community Forum](https://speckle.community/t/revits-built-in-parameter-all-model-type-name-saves-null/8256/12?u=samberger)



## Changes:

- added function `AddGroupParamsToDict()` to `ConversionUtils.cs`
- added parameters export to `GroupToSpeckle()` in `ConvertGroup.cs`

## To-do before merge:

- Unfortunately, I wasn't able to test the code myself, but most of it was copied from other converters and adapted accordingly for groups. So maybe do an extra double check. Sorry.


## Screenshots:

The exported data for `groups` before:

![grafik](https://github.com/specklesystems/speckle-sharp/assets/9541240/81f45b73-ba5a-4bcd-9e23-8af94bb706d2)

There should be an additional `parameters{}` property after.


## Checklist:


- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
