### PR TITLE
fix(dui3): Make all basic binding commands available to sendbindings command type

### DIFF
--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/IBasicConnectorBinding.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/IBasicConnectorBinding.cs
@@ -37,7 +37,7 @@ public class BasicConnectorBindingCommands
   private const string SET_MODEL_PROGRESS_UI_COMMAND_NAME = "setModelProgress";
   private const string SET_MODEL_ERROR_UI_COMMAND_NAME = "setModelError";
 
-  private IBridge _bridge;
+  protected IBridge _bridge;
 
   public BasicConnectorBindingCommands(IBridge bridge)
   {

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/SendBindingUICommands.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/SendBindingUICommands.cs
@@ -3,21 +3,17 @@ using Speckle.Connectors.DUI.Bridge;
 
 namespace Speckle.Connectors.DUI.Bindings;
 
-// POC: have put this static back but unsure about it or the IBridge having this responsibility... and the static
-public class SendBindingUICommands
+// POC: Send Commands share all commands from BasicBindings + some, this pattern should be revised
+public class SendBindingUICommands : BasicConnectorBindingCommands
 {
   private string REFRESH_SEND_FILTERS_UI_COMMAND_NAME = "refreshSendFilters";
   private string SET_MODELS_EXPIRED_UI_COMMAND_NAME = "setModelsExpired";
   private string SET_MODEL_CREATED_VERSION_ID_UI_COMMAND_NAME = "setModelCreatedVersionId";
 
-  private IBridge _bridge;
-
   public delegate SendBindingUICommands Factory(IBridge bridge);
 
   public SendBindingUICommands(IBridge bridge)
-  {
-    _bridge = bridge;
-  }
+    : base(bridge) { }
 
   // POC.. the only reasons this needs the bridge is to send? realtionship to these messages and the bridge is unclear
   public void RefreshSendFilters() => _bridge.Send(REFRESH_SEND_FILTERS_UI_COMMAND_NAME);


### PR DESCRIPTION
Fixes progress reporting in Rhino DUI3 DI connector.

The assumption that we could inject BasicBindings into the SendBinding and use the BasicBinding commands is not correct, as they have different bridges and that seems to conflict and error out on the JS side.

Solution I found that was somewhat acceptable is to use inheritance so that `SendBindingCommands` is now also a `BasicBindingCommands` and inherits every available command from it too.

This seems to work as expected, progress is reported on the C# side and shown correctly on the JS side