### PR TITLE
Fix(logging): profile union and set calls to analytics

### DIFF
--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -266,10 +266,6 @@ public static class Analytics
                 new List<string> { connector }
               }
             }
-          },
-          {
-            "set",
-            new Dictionary<string, object> { { "Identified", true } }
           }
         };
         string json = JsonConvert.SerializeObject(data);

--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -283,7 +283,7 @@ public static class Analytics
       }
     });
   }
-  
+
   internal static void IdentifyProfile(string hashedEmail, string connector)
   {
     Task.Run(async () =>

--- a/Core/Core/Logging/Setup.cs
+++ b/Core/Core/Logging/Setup.cs
@@ -78,6 +78,7 @@ public static class Setup
     foreach (var account in AccountManager.GetAccounts())
     {
       Analytics.AddConnectorToProfile(account.GetHashedEmail(), hostApplication);
+      Analytics.IdentifyProfile(account.GetHashedEmail(), hostApplication);
     }
   }
 


### PR DESCRIPTION
The `profile-union` and `profile-set` calls cannot be combined and were failing silently; this fixes that.
I'm pointing to `main` but this can go in any time, also in the next release.