### PR TITLE
Hotfix(metrics): CNX-9196 add object type event tracking for mixpanel in autocad, rhino, and revit

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
@@ -285,7 +285,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
           .Select(o => new { TypeName = o.Key, Count = o.Value })
           .OrderBy(pair => pair.Count)
           .Reverse()
-          .Take(250);
+          .Take(200);
 
         Analytics.TrackEvent(
           Analytics.Events.ConvertToNative,

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
@@ -292,7 +292,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
           .Select(o => new { TypeName = o.Key, Count = o.Value })
           .OrderBy(pair => pair.Count)
           .Reverse()
-          .Take(25);
+          .Take(250);
 
         Analytics.TrackEvent(
           Analytics.Events.ConvertToNative,

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
@@ -11,7 +11,6 @@ using DesktopUI2;
 using DesktopUI2.Models;
 using DesktopUI2.ViewModels;
 using Speckle.Core.Api;
-using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
@@ -288,8 +288,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
         // track the object type counts as an event before we try to send
         // this will tell us the composition of a commit the user is trying to send, even if it's not successfully sent
         Analytics.TrackEvent(
-          AccountManager.GetDefaultAccount(),
-          Analytics.Events.ReceiveObjectReport,
+          Analytics.Events.ConvertToNative,
           loggingTypeCountDict.ToDictionary(o => o.Key, o => o.Value as object)
         );
 

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
@@ -223,14 +223,8 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
           if (StoredObjects.TryGetValue(commitObj.OriginalId, out Base commitBaseObj))
           {
             // log received object type
-            if (typeCountDict.TryGetValue(commitBaseObj.speckle_type, out int value))
-            {
-              typeCountDict[commitBaseObj.speckle_type] = ++value;
-            }
-            else
-            {
-              typeCountDict.Add(commitBaseObj.speckle_type, 1);
-            }
+            typeCountDict.TryGetValue(commitBaseObj.speckle_type, out var currentCount);
+            typeCountDict[commitBaseObj.speckle_type] = ++currentCount;
           }
           else
           {
@@ -287,8 +281,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
         // track the object type counts as an event before we try to receive
         // this will tell us the composition of a commit the user is trying to receive, even if it's not successfully received
         // we are capped at 255 properties for mixpanel events, so we need to check dict entries
-        var typeCountArray = typeCountDict
-          .ToArray()
+        var typeCountList = typeCountDict
           .Select(o => new { TypeName = o.Key, Count = o.Value })
           .OrderBy(pair => pair.Count)
           .Reverse()
@@ -296,7 +289,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
         Analytics.TrackEvent(
           Analytics.Events.ConvertToNative,
-          new Dictionary<string, object>() { { "typeCount", typeCountArray } }
+          new Dictionary<string, object>() { { "typeCount", typeCountList } }
         );
 
         // add applicationID xdata before bake

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -180,7 +180,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
         var commitCollections = new Dictionary<string, Collection>();
 
         // track object types for mixpanel logging
-        Dictionary<string, int> loggingTypeCountDict = new();
+        Dictionary<string, int> typeCountDict = new();
 
         foreach (var autocadObjectHandle in state.SelectedObjectIds)
         {
@@ -206,13 +206,13 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
           // log selection object type
           var objectType = obj.GetType().ToString();
-          if (loggingTypeCountDict.TryGetValue(objectType, out int value))
+          if (typeCountDict.TryGetValue(objectType, out int value))
           {
-            loggingTypeCountDict[objectType] = ++value;
+            typeCountDict[objectType] = ++value;
           }
           else
           {
-            loggingTypeCountDict.Add(objectType, 1);
+            typeCountDict.Add(objectType, 1);
           }
 
           // create applicationobject for reporting
@@ -358,9 +358,17 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
         // track the object type counts as an event before we try to send
         // this will tell us the composition of a commit the user is trying to convert and send, even if it's not successfully converted or sent
+        // we are capped at 255 properties for mixpanel events, so we need to check dict entries
+        var typeCountArray = typeCountDict
+          .ToArray()
+          .Select(o => new { TypeName = o.Key, Count = o.Value })
+          .OrderBy(pair => pair.Count)
+          .Reverse()
+          .Take(25);
+
         Analytics.TrackEvent(
           Analytics.Events.ConvertToSpeckle,
-          loggingTypeCountDict.ToDictionary(o => o.Key, o => o.Value as object)
+          new Dictionary<string, object>() { { "typeCount", typeCountArray } }
         );
 
         tr.Commit();

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -205,6 +205,17 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
             continue;
           }
 
+          // log selection object type
+          var objectType = obj.GetType().ToString();
+          if (loggingTypeCountDict.TryGetValue(objectType, out int value))
+          {
+            loggingTypeCountDict[objectType] = ++value;
+          }
+          else
+          {
+            loggingTypeCountDict.Add(objectType, 1);
+          }
+
           // create applicationobject for reporting
           Base converted = null;
           var descriptor = ObjectDescriptor(obj);
@@ -304,14 +315,6 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
             // log report object
             reportObj.Update(status: ApplicationObject.State.Created, logItem: $"Sent as {converted.GetType().Name}");
             progress.Report.Log(reportObj);
-            if (loggingTypeCountDict.TryGetValue(converted.speckle_type, out int value))
-            {
-              loggingTypeCountDict[converted.speckle_type] = ++value;
-            }
-            else
-            {
-              loggingTypeCountDict.Add(converted.speckle_type, 1);
-            }
 
             convertedCount++;
           }
@@ -355,10 +358,9 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
         #endregion
 
         // track the object type counts as an event before we try to send
-        // this will tell us the composition of a commit the user is trying to send, even if it's not successfully sent
+        // this will tell us the composition of a commit the user is trying to convert and send, even if it's not successfully converted or sent
         Analytics.TrackEvent(
-          AccountManager.GetDefaultAccount(),
-          Analytics.Events.SendObjectReport,
+          Analytics.Events.ConvertToSpeckle,
           loggingTypeCountDict.ToDictionary(o => o.Key, o => o.Value as object)
         );
 

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -206,14 +206,8 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
           // log selection object type
           var objectType = obj.GetType().ToString();
-          if (typeCountDict.TryGetValue(objectType, out int value))
-          {
-            typeCountDict[objectType] = ++value;
-          }
-          else
-          {
-            typeCountDict.Add(objectType, 1);
-          }
+          typeCountDict.TryGetValue(objectType, out var currentCount);
+          typeCountDict[objectType] = ++currentCount;
 
           // create applicationobject for reporting
           Base converted = null;
@@ -359,8 +353,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
         // track the object type counts as an event before we try to send
         // this will tell us the composition of a commit the user is trying to convert and send, even if it's not successfully converted or sent
         // we are capped at 255 properties for mixpanel events, so we need to check dict entries
-        var typeCountArray = typeCountDict
-          .ToArray()
+        var typeCountList = typeCountDict
           .Select(o => new { TypeName = o.Key, Count = o.Value })
           .OrderBy(pair => pair.Count)
           .Reverse()
@@ -368,7 +361,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
         Analytics.TrackEvent(
           Analytics.Events.ConvertToSpeckle,
-          new Dictionary<string, object>() { { "typeCount", typeCountArray } }
+          new Dictionary<string, object>() { { "typeCount", typeCountList } }
         );
 
         tr.Commit();

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -364,7 +364,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
           .Select(o => new { TypeName = o.Key, Count = o.Value })
           .OrderBy(pair => pair.Count)
           .Reverse()
-          .Take(25);
+          .Take(250);
 
         Analytics.TrackEvent(
           Analytics.Events.ConvertToSpeckle,

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -9,7 +9,6 @@ using DesktopUI2;
 using DesktopUI2.Models;
 using DesktopUI2.ViewModels;
 using Speckle.Core.Api;
-using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -357,7 +357,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
           .Select(o => new { TypeName = o.Key, Count = o.Value })
           .OrderBy(pair => pair.Count)
           .Reverse()
-          .Take(250);
+          .Take(200);
 
         Analytics.TrackEvent(
           Analytics.Events.ConvertToSpeckle,

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -90,8 +90,7 @@ public partial class ConnectorBindingsRevit
     // track the object type counts as an event before we try to send
     // this will tell us the composition of a commit the user is trying to send, even if it's not successfully sent
     Speckle.Core.Logging.Analytics.TrackEvent(
-      AccountManager.GetDefaultAccount(),
-      Speckle.Core.Logging.Analytics.Events.ReceiveObjectReport,
+      Speckle.Core.Logging.Analytics.Events.ConvertToNative,
       loggingTypeCountDict.ToDictionary(o => o.Key, o => o.Value as object)
     );
 

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -94,7 +94,7 @@ public partial class ConnectorBindingsRevit
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
-      .Take(25);
+      .Take(250);
 
     Analytics.TrackEvent(
       Analytics.Events.ConvertToNative,

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -87,7 +87,7 @@ public partial class ConnectorBindingsRevit
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
-      .Take(250);
+      .Take(200);
 
     Analytics.TrackEvent(
       Analytics.Events.ConvertToNative,

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -16,7 +16,6 @@ using RevitSharedResources.Interfaces;
 using RevitSharedResources.Models;
 using Serilog.Context;
 using Speckle.Core.Api;
-using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Receive.cs
@@ -75,22 +75,15 @@ public partial class ConnectorBindingsRevit
       progress.Report.Log(previewObj);
       if (StoredObjects.TryGetValue(previewObj.OriginalId, out Base previewBaseObj))
       {
-        if (typeCountDict.TryGetValue(previewBaseObj.speckle_type, out int value))
-        {
-          typeCountDict[previewBaseObj.speckle_type] = ++value;
-        }
-        else
-        {
-          typeCountDict.Add(previewBaseObj.speckle_type, 1);
-        }
+        typeCountDict.TryGetValue(previewBaseObj.speckle_type, out var currentCount);
+        typeCountDict[previewBaseObj.speckle_type] = ++currentCount;
       }
     }
 
     // track the object type counts as an event before we try to receive
     // this will tell us the composition of a commit the user is trying to convert and receive, even if it's not successfully converted or received
     // we are capped at 255 properties for mixpanel events, so we need to check dict entries
-    var typeCountArray = typeCountDict
-      .ToArray()
+    var typeCountList = typeCountDict
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
@@ -98,7 +91,7 @@ public partial class ConnectorBindingsRevit
 
     Analytics.TrackEvent(
       Analytics.Events.ConvertToNative,
-      new Dictionary<string, object>() { { "typeCount", typeCountArray } }
+      new Dictionary<string, object>() { { "typeCount", typeCountList } }
     );
 
     converter.ReceiveMode = state.ReceiveMode;

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -117,16 +117,10 @@ public partial class ConnectorBindingsRevit
             break;
           }
 
-          // log selected object type
-          string revitObjectType = revitElement.GetType().ToString();
-          if (typeCountDict.TryGetValue(revitObjectType, out int value))
-          {
-            typeCountDict[revitObjectType] = ++value;
-          }
-          else
-          {
-            typeCountDict.Add(revitObjectType, 1);
-          }
+          // log selection object type
+          var revitObjectType = revitElement.GetType().ToString();
+          typeCountDict.TryGetValue(revitObjectType, out var currentCount);
+          typeCountDict[revitObjectType] = ++currentCount;
 
           bool isAlreadyConverted = GetOrCreateApplicationObject(
             revitElement,
@@ -199,8 +193,7 @@ public partial class ConnectorBindingsRevit
     // track the object type counts as an event before we try to send
     // this will tell us the composition of a commit the user is trying to convert and send, even if it's not successfully converted or sent
     // we are capped at 255 properties for mixpanel events, so we need to check dict entries
-    var typeCountArray = typeCountDict
-      .ToArray()
+    var typeCountList = typeCountDict
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
@@ -208,7 +201,7 @@ public partial class ConnectorBindingsRevit
 
     Analytics.TrackEvent(
       Analytics.Events.ConvertToSpeckle,
-      new Dictionary<string, object>() { { "typeCount", typeCountArray } }
+      new Dictionary<string, object>() { { "typeCount", typeCountList } }
     );
 
     commitObjectBuilder.BuildCommitObject(commitObject);

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -118,6 +118,17 @@ public partial class ConnectorBindingsRevit
             break;
           }
 
+          // log selected object type
+          string revitObjectType = revitElement.GetType().ToString();
+          if (loggingTypeCountDict.TryGetValue(revitObjectType, out int value))
+          {
+            loggingTypeCountDict[revitObjectType] = ++value;
+          }
+          else
+          {
+            loggingTypeCountDict.Add(revitObjectType, 1);
+          }
+
           bool isAlreadyConverted = GetOrCreateApplicationObject(
             revitElement,
             converter.Report,
@@ -145,14 +156,6 @@ public partial class ConnectorBindingsRevit
               status: ApplicationObject.State.Created,
               logItem: $"Sent as {ConnectorRevitUtils.SimplifySpeckleType(result.speckle_type)}"
             );
-            if (loggingTypeCountDict.TryGetValue(result.speckle_type, out int value))
-            {
-              loggingTypeCountDict[result.speckle_type] = ++value;
-            }
-            else
-            {
-              loggingTypeCountDict.Add(result.speckle_type, 1);
-            }
 
             if (result.applicationId != reportObj.applicationId)
             {
@@ -195,10 +198,9 @@ public partial class ConnectorBindingsRevit
     }
 
     // track the object type counts as an event before we try to send
-    // this will tell us the composition of a commit the user is trying to send, even if it's not successfully sent
+    // this will tell us the composition of a commit the user is trying to convert and send, even if it's not successfully converted or sent
     Analytics.TrackEvent(
-      AccountManager.GetDefaultAccount(),
-      Analytics.Events.SendObjectReport,
+      Analytics.Events.ConvertToSpeckle,
       loggingTypeCountDict.ToDictionary(o => o.Key, o => o.Value as object)
     );
 

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -204,7 +204,7 @@ public partial class ConnectorBindingsRevit
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
-      .Take(25);
+      .Take(250);
 
     Analytics.TrackEvent(
       Analytics.Events.ConvertToSpeckle,

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -16,7 +16,6 @@ using RevitSharedResources.Interfaces;
 using RevitSharedResources.Models;
 using Serilog.Context;
 using Speckle.Core.Api;
-using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;

--- a/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
+++ b/ConnectorRevit/ConnectorRevit/UI/ConnectorBindingsRevit.Send.cs
@@ -197,7 +197,7 @@ public partial class ConnectorBindingsRevit
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
-      .Take(250);
+      .Take(200);
 
     Analytics.TrackEvent(
       Analytics.Events.ConvertToSpeckle,

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -322,7 +322,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
             .Select(o => new { TypeName = o.Key, Count = o.Value })
             .OrderBy(pair => pair.Count)
             .Reverse()
-            .Take(250);
+            .Take(200);
 
           Speckle.Core.Logging.Analytics.TrackEvent(
             Speckle.Core.Logging.Analytics.Events.ConvertToNative,

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -225,14 +225,8 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
             // log received object type
             if (StoredObjects.TryGetValue(previewObj.OriginalId, out Base previewBaseObj))
             {
-              if (typeCountDict.TryGetValue(previewBaseObj.speckle_type, out int value))
-              {
-                typeCountDict[previewBaseObj.speckle_type] = ++value;
-              }
-              else
-              {
-                typeCountDict.Add(previewBaseObj.speckle_type, 1);
-              }
+              typeCountDict.TryGetValue(previewBaseObj.speckle_type, out var currentCount);
+              typeCountDict[previewBaseObj.speckle_type] = ++currentCount;
             }
 
             if (previewObj.Status != ApplicationObject.State.Unknown)
@@ -324,8 +318,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
           // track the object type counts as an event before we try to receive
           // this will tell us the composition of a commit the user is trying to convert and receive, even if it's not successfully converted or received
           // we are capped at 255 properties for mixpanel events, so we need to check dict entries
-          var typeCountArray = typeCountDict
-            .ToArray()
+          var typeCountList = typeCountDict
             .Select(o => new { TypeName = o.Key, Count = o.Value })
             .OrderBy(pair => pair.Count)
             .Reverse()
@@ -333,7 +326,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
 
           Speckle.Core.Logging.Analytics.TrackEvent(
             Speckle.Core.Logging.Analytics.Events.ConvertToNative,
-            new Dictionary<string, object>() { { "typeCount", typeCountArray } }
+            new Dictionary<string, object>() { { "typeCount", typeCountList } }
           );
 
           // undo notes edit

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -329,7 +329,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
             .Select(o => new { TypeName = o.Key, Count = o.Value })
             .OrderBy(pair => pair.Count)
             .Reverse()
-            .Take(25);
+            .Take(250);
 
           Speckle.Core.Logging.Analytics.TrackEvent(
             Speckle.Core.Logging.Analytics.Events.ConvertToNative,

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -14,7 +14,6 @@ using Rhino.DocObjects;
 using Rhino.Geometry;
 using Rhino.Render;
 using Speckle.Core.Api;
-using Speckle.Core.Credentials;
 using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using Speckle.Core.Models.GraphTraversal;

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Receive.cs
@@ -322,11 +322,10 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
 
           RhinoDoc.LayerTableEvent += RhinoDoc_LayerChange; // reactivate the layer handler
 
-          // track the object type counts as an event before we try to send
-          // this will tell us the composition of a commit the user is trying to send, even if it's not successfully sent
+          // track the object type counts as an event before we try to receive
+          // this will tell us the composition of a commit the user is trying to convert and receive, even if it's not successfully converted or received.
           Speckle.Core.Logging.Analytics.TrackEvent(
-            AccountManager.GetDefaultAccount(),
-            Speckle.Core.Logging.Analytics.Events.ReceiveObjectReport,
+            Speckle.Core.Logging.Analytics.Events.ConvertToNative,
             loggingTypeCountDict.ToDictionary(o => o.Key, o => o.Value as object)
           );
 

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Send.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Send.cs
@@ -243,7 +243,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
-      .Take(250);
+      .Take(200);
 
     Speckle.Core.Logging.Analytics.TrackEvent(
       Speckle.Core.Logging.Analytics.Events.ConvertToSpeckle,

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Send.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Send.cs
@@ -250,7 +250,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
-      .Take(25);
+      .Take(250);
 
     Speckle.Core.Logging.Analytics.TrackEvent(
       Speckle.Core.Logging.Analytics.Events.ConvertToSpeckle,

--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Send.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/UI/ConnectorBindingsRhino.Send.cs
@@ -68,14 +68,8 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
       {
         // log selection object type
         var objectType = obj.GetType().ToString();
-        if (typeCountDict.TryGetValue(objectType, out int value))
-        {
-          typeCountDict[objectType] = ++value;
-        }
-        else
-        {
-          typeCountDict.Add(objectType, 1);
-        }
+        typeCountDict.TryGetValue(objectType, out var currentCount);
+        typeCountDict[objectType] = ++currentCount;
 
         // create applicationObject
         reportObj = new ApplicationObject(selectedId, descriptor);
@@ -245,8 +239,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
     // track the object type counts as an event before we try to send
     // this will tell us the composition of a commit the user is trying to convert and send, even if it's not successfully converted or sent
     // we are capped at 255 properties for mixpanel events, so we need to check dict entries
-    var typeCountArray = typeCountDict
-      .ToArray()
+    var typeCountList = typeCountDict
       .Select(o => new { TypeName = o.Key, Count = o.Value })
       .OrderBy(pair => pair.Count)
       .Reverse()
@@ -254,7 +247,7 @@ public partial class ConnectorBindingsRhino : ConnectorBindings
 
     Speckle.Core.Logging.Analytics.TrackEvent(
       Speckle.Core.Logging.Analytics.Events.ConvertToSpeckle,
-      new Dictionary<string, object>() { { "typeCount", typeCountArray } }
+      new Dictionary<string, object>() { { "typeCount", typeCountList } }
     );
 
     progress.CancellationToken.ThrowIfCancellationRequested();

--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -67,7 +67,17 @@ public static class Analytics
     /// <summary>
     /// Event triggered by the Mapping Tool
     /// </summary>
-    MappingsAction
+    MappingsAction,
+
+    /// <summary>
+    /// Event triggered on send, capturing the object type counts of the sent commit
+    /// </summary>
+    SendObjectReport,
+
+    /// <summary>
+    /// Event triggered on receive, capturing the object type counts of the received commit
+    /// </summary>
+    ReceiveObjectReport
   }
 
   private const string MIXPANEL_TOKEN = "acd87c5a50b56df91a795e999812a3a4";

--- a/Core/Core/Logging/Analytics.cs
+++ b/Core/Core/Logging/Analytics.cs
@@ -70,14 +70,14 @@ public static class Analytics
     MappingsAction,
 
     /// <summary>
-    /// Event triggered on send, capturing the object type counts of the sent commit
+    /// Event triggered when user selects object to convert to Speckle on Send
     /// </summary>
-    SendObjectReport,
+    ConvertToSpeckle,
 
     /// <summary>
-    /// Event triggered on receive, capturing the object type counts of the received commit
+    /// Event triggered when user selects object to convert to Native on Receive
     /// </summary>
-    ReceiveObjectReport
+    ConvertToNative
   }
 
   private const string MIXPANEL_TOKEN = "acd87c5a50b56df91a795e999812a3a4";

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -143,7 +143,6 @@ public partial class ConverterAutocadCivil : ISpeckleConverter
               break;
             case AcadDB.Polyline o:
               @base = o.IsOnlyLines ? PolylineToSpeckle(o) : (Base)PolycurveToSpeckle(o);
-
               break;
             case AcadDB.Polyline3d o:
               @base = PolylineToSpeckle(o);


### PR DESCRIPTION
## Description & motivation

Adds two new events for mixpanel tracking: `SendObjectReport` and `ReceiveObjectReport`.
Attaches a dictionary containing each Speckle type found in the sent/received commit and their count, and tracks this event separately from send and receive events.

Added for AutoCAD, Rhino, and Revit.
