### PR TITLE
POC/WIP Implementation of Blocks (instances) for Rhino

### DIFF
--- a/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
+++ b/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
@@ -15,6 +15,7 @@ using Speckle.Core.Credentials;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
 using DUI3.Utils;
+using Rhino.Commands;
 using Speckle.Core.Api;
 using Speckle.Core.Kits;
 using Speckle.Core.Logging;
@@ -45,6 +46,15 @@ public class SendBinding : ISendBinding, ICancelable
     RhinoDoc.LayerTableEvent += (_, _) =>
     {
       SendBindingUiCommands.RefreshSendFilters(Parent);
+    };
+
+    Command.BeginCommand += (_, e) =>
+    {
+      if (e.CommandEnglishName == "BlockEdit")
+      {
+        var selectedObject = RhinoDoc.ActiveDoc.Objects.GetSelectedObjects(false, false).First();
+        ChangedObjectIds.Add(selectedObject.Id.ToString());
+      }
     };
 
     RhinoDoc.AddRhinoObject += (_, e) =>
@@ -218,15 +228,19 @@ public class SendBinding : ISendBinding, ICancelable
 
     Dictionary<int, Collection> layerCollectionCache = new();
 
-    var unpacker = new RhinoInstanceUnpacker();
+    var selectionUnpacker = new RawSelectionUnpackerAkaBlockManager();
+    (
+      List<RhinoObject> atomicObjects,
+      Dictionary<string, InstanceProxy> instanceProxies,
+      List<InstanceDefinitionProxy> instanceDefinitionProxies
+    ) = selectionUnpacker.Unpack(rhinoObjects);
 
-    unpacker.Unpack(rhinoObjects);
+    rootObjectCollection["instanceDefs"] = instanceDefinitionProxies;
+    // POC: keeping here for inspiration for later
+    // rootObjectCollection["groups"] = "something";
+    // rootObjectCollection["hostingDefs"] = "somethingelse";
 
-    rootObjectCollection["instanceDefs"] = unpacker.DefinitionProxies.Select(kvp => kvp.Value);
-    rootObjectCollection["groups"] = "something";
-    rootObjectCollection["hostingDefs"] = "somethingelse";
-
-    foreach (RhinoObject rhinoObject in unpacker.FlatAtomicObjects.Values)
+    foreach (RhinoObject rhinoObject in atomicObjects)
     {
       if (cts.IsCancellationRequested)
       {
@@ -245,9 +259,12 @@ public class SendBinding : ISendBinding, ICancelable
       // If that's the case, we insert in the host collection just its object reference which has been saved from the prior conversion.
       Base converted;
 
-      if (rhinoObject is InstanceObject) // Special case for blocks, bypass cache; TODO: we need to think about cache invalidation of sub objects (are the proxy types enough?)
+      // Note for future readers: on instance definition elements and the cache
+      // The short of it is that when editing objects inside a block (=instance) the edited objects get new ids. While this could look like a purely simple Rhino api weirdness,
+      // it helps us out as those objects are automatically bypassing the cache based on this. This saves us from more complicated object tracking and we don't need to do... anything.
+      if (rhinoObject is InstanceObject) // Special case for blocks, bypass cache: the reason being that they're not really converted, they're just "mapped" to proxies in the block manager class.
       {
-        converted = unpacker.InstanceProxies[applicationId];
+        converted = instanceProxies[applicationId];
       }
       else if (
         !modelCard.ChangedObjectIds.Contains(applicationId)
@@ -349,7 +366,8 @@ public class SendBinding : ISendBinding, ICancelable
     foreach (SenderModelCard modelCard in senders)
     {
       var intersection = modelCard.SendFilter.GetObjectIds().Intersect(objectIdsList).ToList();
-      bool isExpired = intersection.Any();
+      bool isExpired = intersection.Count != 0;
+
       if (isExpired)
       {
         expiredSenderIds.Add(modelCard.ModelCardId);

--- a/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
+++ b/ConnectorRhino/ConnectorRhinoWebUI/Bindings/SendBinding.cs
@@ -222,7 +222,9 @@ public class SendBinding : ISendBinding, ICancelable
 
     unpacker.Unpack(rhinoObjects);
 
-    rootObjectCollection["instanceDefs"] = unpacker.FlatDefinitions.Select(kvp => kvp.Value);
+    rootObjectCollection["instanceDefs"] = unpacker.DefinitionProxies.Select(kvp => kvp.Value);
+    rootObjectCollection["groups"] = "something";
+    rootObjectCollection["hostingDefs"] = "somethingelse";
 
     foreach (RhinoObject rhinoObject in unpacker.FlatAtomicObjects.Values)
     {
@@ -243,9 +245,9 @@ public class SendBinding : ISendBinding, ICancelable
       // If that's the case, we insert in the host collection just its object reference which has been saved from the prior conversion.
       Base converted;
 
-      if (rhinoObject is InstanceObject) // Special case for blocks, bypass cache
+      if (rhinoObject is InstanceObject) // Special case for blocks, bypass cache; TODO: we need to think about cache invalidation of sub objects (are the proxy types enough?)
       {
-        converted = unpacker.FlatBlocks[applicationId];
+        converted = unpacker.InstanceProxies[applicationId];
       }
       else if (
         !modelCard.ChangedObjectIds.Contains(applicationId)

--- a/ConnectorRhino/ConnectorRhinoWebUI/Utils/RawSelectionUnpackerAkaBlockManager.cs
+++ b/ConnectorRhino/ConnectorRhinoWebUI/Utils/RawSelectionUnpackerAkaBlockManager.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.DoubleNumerics;
+using System.Linq;
+using Rhino.DocObjects;
+using Rhino.Geometry;
+using Speckle.Core.Models;
+
+namespace ConnectorRhinoWebUI.Utils;
+
+/// <summary>
+/// Unpacks a given list of rhino objects into their sub-constituent parts.
+/// This mofo is ~ready to be interfaced out, pending the test of the acad implementation. Note that it's a POC class, and we're doing the following nasty things in here:
+/// - transforms are converted ad hoc, can be fixed in the DX branch where there's proper DI and we can get in here a conversion routine for xform to other.transform
+/// - InstanceProxy and InstanceDefinitionProxy types are really raw, and specified in probably the wrong place (Core, and should be in Objects)
+/// </summary>
+public class RawSelectionUnpackerAkaBlockManager // naming is hard
+{
+  private Dictionary<string, InstanceProxy> InstanceProxies { get; set; } = new();
+  private Dictionary<string, List<InstanceProxy>> InstanceProxiesByDefinitionId { get; set; } = new();
+  private Dictionary<string, InstanceDefinitionProxy> DefinitionProxies { get; set; } = new();
+  private Dictionary<string, RhinoObject> FlatAtomicObjects { get; set; } = new();
+
+  /// <summary>
+  /// Unpacks a given list of objects into their atomic objects (raw geometry and instances) and any instance definitions.
+  /// </summary>
+  /// <param name="objects">Objects to unpack</param>
+  /// <returns>A tuple (because we're lazy), consisting of atomic objects (raw geometry), a list of instance proxies (to enable swapping the actual instance to an instance proxy during the conversion loop), and a list of instance definition proxies (to attach separately to the root commit object).</returns>
+  public (
+    List<RhinoObject> atomicObjects,
+    Dictionary<string, InstanceProxy> instanceProxies,
+    List<InstanceDefinitionProxy> instanceDefinitionProxies
+  ) Unpack(List<RhinoObject> objects)
+  {
+    InstanceProxies = new();
+    DefinitionProxies = new();
+    FlatAtomicObjects = new();
+    InstanceProxiesByDefinitionId = new();
+
+    foreach (var obj in objects)
+    {
+      if (obj is InstanceObject instanceObject)
+      {
+        UnpackInstance(instanceObject);
+      }
+      FlatAtomicObjects[obj.Id.ToString()] = obj;
+    }
+
+    return (FlatAtomicObjects.Values.ToList(), InstanceProxies, DefinitionProxies.Values.ToList());
+  }
+
+  private void UnpackInstance(InstanceObject instance, int depth = 0)
+  {
+    var instanceId = instance.Id.ToString();
+    var instanceDefinitionId = instance.InstanceDefinition.Id.ToString();
+    InstanceProxies[instanceId] = new InstanceProxy()
+    {
+      applicationId = instanceId,
+      DefinitionId = instance.InstanceDefinition.Id.ToString(),
+      Transform = XFormToMatrix(instance.InstanceXform),
+      MaxDepth = depth
+    };
+
+    // For each block instance that has the same definition, we need to keep track of the "maximum depth" at which is found.
+    // This will enable on receive to create them in the correct order (descending by max depth, interleaved definitions and instances).
+    // We need to interleave the creation of definitions and instances, as some definitions may depend on instances.
+    if (
+      !InstanceProxiesByDefinitionId.TryGetValue(
+        instanceDefinitionId,
+        out List<InstanceProxy> instanceProxiesWithSameDefinition
+      )
+    )
+    {
+      instanceProxiesWithSameDefinition = new List<InstanceProxy>();
+      InstanceProxiesByDefinitionId[instanceDefinitionId] = instanceProxiesWithSameDefinition;
+    }
+
+    // We ensure that all previous instance proxies that have the same definition are at this max depth. I kind of have a feeling this can be done more elegantly, but YOLO
+    foreach (var instanceProxy in instanceProxiesWithSameDefinition)
+    {
+      instanceProxy.MaxDepth = depth;
+    }
+
+    instanceProxiesWithSameDefinition.Add(InstanceProxies[instanceId]);
+
+    if (DefinitionProxies.TryGetValue(instanceDefinitionId, out InstanceDefinitionProxy value))
+    {
+      value.MaxDepth = depth;
+      return;
+    }
+
+    var definition = new InstanceDefinitionProxy
+    {
+      applicationId = instanceDefinitionId,
+      Objects = new List<string>(),
+      MaxDepth = depth,
+      ["name"] = instance.InstanceDefinition.Name,
+      ["description"] = instance.InstanceDefinition.Description
+    };
+
+    DefinitionProxies[instance.InstanceDefinition.Id.ToString()] = definition;
+
+    foreach (var obj in instance.InstanceDefinition.GetObjects())
+    {
+      definition.Objects.Add(obj.Id.ToString());
+      if (obj is InstanceObject localInstance)
+      {
+        UnpackInstance(localInstance, depth + 1);
+      }
+      FlatAtomicObjects[obj.Id.ToString()] = obj;
+    }
+  }
+
+  /// <summary>
+  /// POC: For change detection "inside" instances
+  /// TODO: Test & implement in the change detection part of the send binding
+  /// </summary>
+  /// <param name="obj"></param>
+  /// <returns></returns>
+  public static List<string> UnpackObjectToRawIds(RhinoObject obj)
+  {
+    var list = new List<string>();
+    void UnpackInstance(InstanceObject instance)
+    {
+      list.Add(instance.Id.ToString());
+      foreach (var obj in instance.InstanceDefinition.GetObjects())
+      {
+        list.Add(obj.Id.ToString());
+        if (obj is InstanceObject i)
+        {
+          UnpackInstance(i);
+        }
+      }
+    }
+
+    if (obj is InstanceObject instanceObject)
+    {
+      UnpackInstance(instanceObject);
+    }
+    else if (obj is not null)
+    {
+      list.Add(obj.Id.ToString());
+    }
+    return list;
+  }
+
+  public static List<string> UnpackObjectListToRawIds(IEnumerable<RhinoObject> objects)
+  {
+    var set = new HashSet<string>();
+    foreach (var obj in objects)
+    {
+      set.UnionWith(UnpackObjectToRawIds(obj));
+    }
+
+    return set.ToList();
+  }
+
+  // POC: Shouldn't be here, should be in converters? Esp. re unit conversion/scaling factors?
+  public static Matrix4x4 XFormToMatrix(Transform t) =>
+    new(t.M00, t.M01, t.M02, t.M03, t.M10, t.M11, t.M12, t.M13, t.M20, t.M21, t.M22, t.M23, t.M30, t.M31, t.M32, t.M33);
+
+  // POC: Ditto above comment
+  public static Transform MatrixToTransform(Matrix4x4 matrix)
+  {
+    Transform t = Transform.Identity;
+    t.M00 = matrix.M11;
+    t.M01 = matrix.M12;
+    t.M02 = matrix.M13;
+    t.M03 = matrix.M14;
+
+    t.M10 = matrix.M21;
+    t.M11 = matrix.M22;
+    t.M12 = matrix.M23;
+    t.M13 = matrix.M24;
+
+    t.M20 = matrix.M31;
+    t.M21 = matrix.M32;
+    t.M22 = matrix.M33;
+    t.M23 = matrix.M34;
+
+    t.M30 = matrix.M41;
+    t.M31 = matrix.M42;
+    t.M32 = matrix.M43;
+    t.M33 = matrix.M44;
+    return t;
+  }
+}

--- a/ConnectorRhino/ConnectorRhinoWebUI/Utils/Utils.cs
+++ b/ConnectorRhino/ConnectorRhinoWebUI/Utils/Utils.cs
@@ -1,4 +1,10 @@
+using System.Collections.Generic;
+using System.DoubleNumerics;
+using System.Linq;
+using Rhino.DocObjects;
+using Rhino.Geometry;
 using Speckle.Core.Kits;
+using Speckle.Core.Models;
 
 namespace ConnectorRhinoWebUI.Utils;
 
@@ -14,4 +20,111 @@ public static class Utils
   public static readonly string RhinoAppName = HostApplications.Rhino.GetVersion(HostAppVersion.v7);
   public static readonly string AppName = "Rhino";
 #endif
+
+  // POC
+  public static IEnumerable<RhinoObject> UnpackInstanceDefinition(InstanceDefinition definition)
+  {
+    var stack = new Stack<RhinoObject>();
+    foreach (var obj in definition.GetObjects())
+    {
+      stack.Push(obj);
+    }
+
+    while (stack.Count > 0)
+    {
+      var obj = stack.Pop();
+      if (obj is InstanceObject block)
+      {
+        foreach (var VARIABLE in block.InstanceDefinition.GetObjects())
+        {
+          stack.Push(VARIABLE);
+        }
+        continue;
+      }
+
+      yield return obj;
+    }
+  }
+}
+
+public class RhinoInstanceUnpacker
+{
+  public Dictionary<string, InstanceProxy> FlatBlocks { get; set; } = new();
+  public Dictionary<string, InstanceDefinitionProxy> FlatDefinitions { get; set; } = new();
+  public Dictionary<string, RhinoObject> FlatAtomicObjects { get; set; } = new();
+
+  public void Unpack(List<RhinoObject> objects)
+  {
+    foreach (var obj in objects)
+    {
+      if (obj is InstanceObject instanceObject)
+      {
+        UnpackInstance(instanceObject);
+      }
+      FlatAtomicObjects[obj.Id.ToString()] = obj;
+    }
+  }
+
+  private void UnpackInstance(InstanceObject instance, int depth = 0)
+  {
+    if (FlatBlocks.ContainsKey(instance.Id.ToString()))
+    {
+      FlatBlocks[instance.Id.ToString()].MaxDepth = depth;
+      return;
+    }
+
+    FlatBlocks[instance.Id.ToString()] = new InstanceProxy()
+    {
+      applicationId = instance.Id.ToString(),
+      DefinitionId = instance.InstanceDefinition.Id.ToString(),
+      Transform = XFormToMatrix(instance.InstanceXform),
+      MaxDepth = depth
+    };
+
+    if (FlatDefinitions.ContainsKey(instance.InstanceDefinition.Id.ToString()))
+    {
+      FlatDefinitions[instance.InstanceDefinition.Id.ToString()].MaxDepth = depth;
+      return;
+    }
+
+    var def = new InstanceDefinitionProxy
+    {
+      applicationId = instance.InstanceDefinition.Id.ToString(),
+      Objects = new List<string>()
+    };
+
+    FlatDefinitions[instance.InstanceDefinition.Id.ToString()] = def;
+
+    foreach (var obj in instance.InstanceDefinition.GetObjects())
+    {
+      def.Objects.Add(obj.Id.ToString());
+
+      if (obj is InstanceObject localInstance)
+      {
+        UnpackInstance(localInstance, depth + 1);
+      }
+      else
+      {
+        FlatAtomicObjects[obj.Id.ToString()] = obj;
+      }
+    }
+  }
+
+  private Matrix4x4 XFormToMatrix(Transform t) =>
+    new(t.M00, t.M01, t.M02, t.M03, t.M10, t.M11, t.M12, t.M13, t.M20, t.M21, t.M22, t.M23, t.M30, t.M31, t.M32, t.M33);
+}
+
+public class InstanceProxy : Base
+{
+  // public string Id { get; set; }
+  public string DefinitionId { get; set; }
+  public Matrix4x4 Transform { get; set; }
+  public int MaxDepth { get; set; } = 0;
+}
+
+public class InstanceDefinitionProxy : Base
+{
+  // public string Id { get; set; }
+  public List<string> Objects { get; set; }
+  public int MaxDepth { get; set; } = 0;
 }

--- a/ConnectorRhino/ConnectorRhinoWebUI/Utils/Utils.cs
+++ b/ConnectorRhino/ConnectorRhinoWebUI/Utils/Utils.cs
@@ -29,7 +29,7 @@ public class RhinoInstanceUnpacker
 {
   public Dictionary<string, InstanceProxy> InstanceProxies { get; set; } = new();
 
-  private readonly Dictionary<string, List<InstanceProxy>> _instanceProxiesByDefinitionId = new(); // TODO: max depth blocks needs to be set correctly
+  private readonly Dictionary<string, List<InstanceProxy>> _instanceProxiesByDefinitionId = new();
   public Dictionary<string, InstanceDefinitionProxy> DefinitionProxies { get; set; } = new();
   public Dictionary<string, RhinoObject> FlatAtomicObjects { get; set; } = new();
 
@@ -89,8 +89,11 @@ public class RhinoInstanceUnpacker
     {
       applicationId = instanceDefinitionId,
       Objects = new List<string>(),
-      MaxDepth = depth
+      MaxDepth = depth,
+      ["name"] = instance.InstanceDefinition.Name,
+      ["description"] = instance.InstanceDefinition.Description
     };
+
     DefinitionProxies[instance.InstanceDefinition.Id.ToString()] = definition;
 
     foreach (var obj in instance.InstanceDefinition.GetObjects())

--- a/Core/Core/Models/Extras.cs
+++ b/Core/Core/Models/Extras.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.DoubleNumerics;
 using System.Linq;
 using Speckle.Core.Models.Extensions;
 
@@ -66,6 +67,27 @@ public class ObjectReference : Base
   public string referencedId { get; set; }
 
   public Dictionary<string, int> closure { get; set; }
+}
+
+// POC: Probably should go in objects? These are some quick proxy classes for blocks/instances and definitions.
+public interface IInstanceComponent
+{
+  public int MaxDepth { get; set; }
+}
+
+// POC: Probably should go in objects? These are some quick proxy classes for blocks/instances and definitions.
+public class InstanceProxy : Base, IInstanceComponent
+{
+  public string DefinitionId { get; set; }
+  public Matrix4x4 Transform { get; set; }
+  public int MaxDepth { get; set; }
+}
+
+// POC: Probably should go in objects? These are some quick proxy classes for blocks/instances and definitions.
+public class InstanceDefinitionProxy : Base, IInstanceComponent
+{
+  public List<string> Objects { get; set; } // source app application ids for the objects
+  public int MaxDepth { get; set; }
 }
 
 public class ProgressEventArgs : EventArgs

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -404,11 +404,13 @@ public partial class ConverterRhinoGh
 
     // get the definition name
     var commitInfo = GetCommitInfo();
+
     string definitionName = definition is BlockDefinition blockDef
       ? blockDef.name
       : definition is RevitSymbolElementType revitDef
         ? $"{revitDef.family} - {revitDef.type} - {definition.id}"
         : definition.id;
+
     if (ReceiveMode == ReceiveMode.Create)
     {
       definitionName = $"{commitInfo} - " + definitionName;


### PR DESCRIPTION
It's a shift from the previous implementation. What we're doing: 

On Send: 
- converting atomic elements, and keeping them on their respective layers 
- creating proxies for instances (treated similarly as atomic objects) and instance definitions (held separately in the root object) 
- keeping track of the maximum depth at which an instance/instance definition is found

On Receive: 
- Stage 1: converting all atomic objects to their respective layers
- Stage 2: creating (connector bound) all required instance definitions and instances based on a simple sort order by their maximum depth, starting with definitions always

Works well :) Note the code is a mess and i'd want to port it to the new DI architecture as soon as we've got basic geometry receive conversions in. 
