### PR TITLE
CNX-9163 type mapping dialog not picking up loaded families

### DIFF
--- a/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
+++ b/ConnectorRevit/ConnectorRevit/TypeMapping/ElementTypeMapper.cs
@@ -272,6 +272,9 @@ internal sealed class ElementTypeMapper
     var groupedElementTypeCache = revitDocumentAggregateCache.GetOrInitializeWithDefaultFactory<List<ElementType>>();
     var elementTypeCache = revitDocumentAggregateCache.GetOrInitializeWithDefaultFactory<ElementType>();
 
+    // add all element types from the document to the cache
+    groupedElementTypeCache.GetOrAddGroupOfTypes(RevitSharedResources.Helpers.Categories.Undefined);
+
     foreach (var @base in speckleElements)
     {
       var incomingType = typeRetriever.GetElementType(@base);


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

As some users have reported, the element type mapper in Revit is not picking up all of the types in the document, only all of the types for the category of incoming object. This works well most of the time, but sometimes incoming types are incorrectly categorized. In this case, a use will not be able to map the type of the incoming object to the desired document type.

For example, foundation slabs in Revit are sent to Revit as floors. On receive, the element type mapper will pull all of the floor types from the document. However, foundation slabs use foundation types, not floor types. For this and other edge cases, this PR attempts to solve the issue by pulling all types from the document instead of just the detected category types.

I was initially worried about the performance of querying the document for hundreds of types, but after some brief testing on heavy models, it doesn't seem to be a noticeable change.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

The type mapping dialog will populate a dropdown with all of the types in the category that the type mapper THINKS the element is. However, if no types are found that match a user's query string, the type mapper will expand it's query to use all types in the document

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

Before this PR
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/7e491386-227e-4d6d-9537-30ca0a7556af)

After this PR
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/9c5b7d88-679a-4426-a3b9-55ac4b3a80dc)


<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
