### PR TITLE
perf(civil): CNX-9178 Civil: Optimised ToSpeckle conversion performance of Tin Surfaces

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -731,7 +731,7 @@ public partial class ConverterAutocadCivil
 
     return speckleFeatureline;
   }
-  
+
   // surfaces
   public Mesh SurfaceToSpeckle(TinSurface surface)
   {
@@ -966,12 +966,10 @@ public partial class ConverterAutocadCivil
         {
           continue;
         }
-
-        // TODO: This foreach loop is unacceptably expensive... probably FindVertexAtXY is the culprit, we should avoid using it.
         
         var a1 = surface.FindVertexAtXY(edgeStart.X, edgeStart.Y);
         var a2 = surface.FindVertexAtXY(vertexToAdd.X, vertexToAdd.Y);
-        surface.AddLine(a1, a2); 
+        surface.AddLine(a1, a2);
         a1.Dispose();
         a2.Dispose();
       }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -745,14 +745,6 @@ public partial class ConverterAutocadCivil
     {
       try
       {
-#if CIVIL2023 || CIVIL2024 // skip any triangles that are hidden in the surface!
-        if (!triangle.IsVisible)
-        {
-          //TODO: why are we skipping trianlges like this, are we not excluding them already in our call to GetTriangles(false) ?
-          continue;
-        }
-#endif
-        
         Point3d[] triangleVertices = { triangle.Vertex1.Location, triangle.Vertex2.Location, triangle.Vertex3.Location };
         foreach (Point3d p in triangleVertices)
         {

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -57,12 +57,9 @@ public partial class ConverterAutocadCivil
 
   public Point3d PointToNative(Point point)
   {
-    var _point = new Point3d(
-      ScaleToNative(point.x, point.units),
-      ScaleToNative(point.y, point.units),
-      ScaleToNative(point.z, point.units)
-    );
-    var intPt = ToInternalCoordinates(_point);
+    var scaleFactor = Units.GetConversionFactor(point.units, ModelUnits); 
+    var scaledPoint = new Point3d(point.x * scaleFactor, point.y * scaleFactor, point.z * scaleFactor);
+    var intPt = ToInternalCoordinates(scaledPoint);
     return intPt;
   }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Geometry.cs
@@ -57,7 +57,7 @@ public partial class ConverterAutocadCivil
 
   public Point3d PointToNative(Point point)
   {
-    var scaleFactor = Units.GetConversionFactor(point.units, ModelUnits); 
+    var scaleFactor = Units.GetConversionFactor(point.units, ModelUnits);
     var scaledPoint = new Point3d(point.x * scaleFactor, point.y * scaleFactor, point.z * scaleFactor);
     var intPt = ToInternalCoordinates(scaledPoint);
     return intPt;

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ What is Speckle? Check our ![YouTube Video Views](https://img.shields.io/youtube
 
 Give Speckle a try in no time by:
 
-- [![speckle XYZ](https://img.shields.io/badge/https://-speckle.xyz-0069ff?style=flat-square&logo=hackthebox&logoColor=white)](https://speckle.xyz) ⇒ creating an account at
+- [![speckle](https://img.shields.io/badge/https://-app.speckle.systems-0069ff?style=flat-square&logo=hackthebox&logoColor=white)](https://app.speckle.systems) ⇒ creating an account
 - [![create a droplet](https://img.shields.io/badge/Create%20a%20Droplet-0069ff?style=flat-square&logo=digitalocean&logoColor=white)](https://marketplace.digitalocean.com/apps/speckle-server?refcode=947a2b5d7dc1) ⇒ deploying an instance in 1 click
 
 ### Resources


### PR DESCRIPTION
Tested with the small surface test files, and no regressions (object ids perfectly match)

I'm not able to test any large surfaces, due to receive performance being awful still. 