### PR TITLE
Brings CreateNewVersionInProject up to parity with SpeckePy

### DIFF
--- a/Automate/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/Automate/Speckle.Automate.Sdk/AutomationContext.cs
@@ -134,6 +134,12 @@ public class AutomationContext
         }
       )
       .ConfigureAwait(false);
+
+    if (!string.IsNullOrEmpty(versionId))
+    {
+      AutomationResult.ResultVersions.Add(versionId);
+    }
+
     return versionId;
   }
 


### PR DESCRIPTION
Per the issue logged in the Automate Bug reports in February:

https://speckle.community/t/automate-bug-reports/9136/20

The functionality in this PR wasn't hooked up - you can compare it to the same lines in Specklepy: https://github.com/specklesystems/specklepy/blob/6469b6f757f00bb93041a835c04da71ceff1d3d6/src/speckle_automate/automation_context.py#L162 

So the Resulting Models subsection in for automations isn't populating in C#