### PR TITLE
CNX-9315 resolve warning singular in arc gis d ui3 dx connector

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Config.daml
@@ -17,7 +17,7 @@
    limitations under the License.
 
 -->
-<ArcGIS defaultAssembly="Speckle.Connectors.ArcGIS3.dll" defaultNamespace="Speckle.Connectors.ArcGIS.HostApp" xmlns="http://schemas.esri.com/DADF/Registry" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.esri.com/DADF/Registry file:///C:/Program%20Files/ArcGIS/Pro/bin/ArcGIS.Desktop.Framework.xsd">
+<ArcGIS defaultAssembly="Speckle.Connectors.ArcGIS3.dll" defaultNamespace="Speckle.Connectors.ArcGIS" xmlns="http://schemas.esri.com/DADF/Registry" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.esri.com/DADF/Registry file:///C:/Program%20Files/ArcGIS/Pro/bin/ArcGIS.Desktop.Framework.xsd">
 	<AddInInfo id="{6CB1D25C-B8BF-4A33-9099-C1F8D1B32EFC}" version="1.0" desktopVersion="3.0.34047">
 		<Name>Speckle</Name>
 		<Description>Speckle connector for ArcGIS</Description>

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/SpeckleDUI3ViewModel.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/SpeckleDUI3ViewModel.cs
@@ -1,7 +1,7 @@
 using ArcGIS.Desktop.Framework;
 using ArcGIS.Desktop.Framework.Contracts;
 
-namespace Speckle.Connectors.ArcGIS.HostApp;
+namespace Speckle.Connectors.ArcGIS;
 
 internal class SpeckleDUI3ViewModel : DockPane
 {

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/SpeckleDUI3Wrapper.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/SpeckleDUI3Wrapper.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
+using Speckle.Connectors.ArcGIS.HostApp;
 
-namespace Speckle.Connectors.ArcGIS.HostApp;
+namespace Speckle.Connectors.ArcGIS;
 
 public class SpeckleDUI3Wrapper : UserControl
 {

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/SpeckleModule.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/SpeckleModule.cs
@@ -5,12 +5,13 @@ using Autofac;
 using Speckle.Autofac.DependencyInjection;
 using Speckle.Autofac.Files;
 using Speckle.Connectors.ArcGIS.DependencyInjection;
+using Speckle.Connectors.ArcGIS.HostApp;
 using Speckle.Converters.Common.Objects;
 using Speckle.Core.Kits;
 using Speckle.Converters.Common.DependencyInjection;
 using Module = ArcGIS.Desktop.Framework.Contracts.Module;
 
-namespace Speckle.Connectors.ArcGIS.HostApp;
+namespace Speckle.Connectors.ArcGIS;
 
 /// <summary>
 /// This sample shows how to implement pane that contains an Edge WebView2 control using the built-in ArcGIS Pro SDK's WebBrowser control.  For details on how to utilize the WebBrowser control in an add-in see here: https://github.com/Esri/arcgis-pro-sdk/wiki/ProConcepts-Framework#webbrowser  For details on how to utilize the Microsoft Edge web browser control in an add-in see here: https://github.com/Esri/arcgis-pro-sdk/wiki/ProConcepts-Framework#webbrowser-control


### PR DESCRIPTION
The Esri template build targets would raise a msbuild warning that the namespace defined in the DAML file was misaligned with the default namespace of the project.
```
24>Esri.ArcGISPro.Extensions30.targets(327,6): Warning  : Your value of 'Speckle.Connectors.ArcGIS.HostApp' for the 'defaultNamespace' attribute in the Config.daml does not match the default namespace 'Speckle.Connectors.ArcGIS' set for your project.
```
 This was introduced when we moved a couple of the connector UI files into the `HostApp` folder.

This PR moves the required files (the ones referenced in the daml) back into the root of the project, and sets the namespace in the daml file back to the root.

What this means for us: No more build warning for ArcGIS (reducing noise + pathing the way for us to enforce msbuild warnings in CI)