### PR TITLE
Fix (autocad): CNX-9346 autocad document states are broken

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/AutofacArcGISModule.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/AutofacArcGISModule.cs
@@ -22,6 +22,11 @@ using Speckle.Connectors.Utils.Operations;
 using ArcGIS.Core.Geometry;
 using Speckle.Connectors.ArcGIS.Filters;
 
+// POC: This is a temp reference to root object senders to tweak CI failing after having generic interfaces into common project.
+// This should go whenever it is aligned.
+using IRootObjectSender = Speckle.Connectors.ArcGis.Operations.Send.IRootObjectSender;
+using RootObjectSender = Speckle.Connectors.ArcGis.Operations.Send.RootObjectSender;
+
 namespace Speckle.Connectors.ArcGIS.DependencyInjection;
 
 public class AutofacArcGISModule : Module

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSelectionBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSelectionBinding.cs
@@ -19,10 +19,16 @@ public class AutocadSelectionBinding : ISelectionBinding
   {
     Parent = parent;
 
+    // POC: Use here Context for doc. In converters it's OK but we are still lacking to use context into bindings.
+    // It is with the case of if binding created with already a document
+    // This is valid when user opens acad file directly double clicking
+    TryRegisterDocumentForSelection(Application.DocumentManager.MdiActiveDocument);
     Application.DocumentManager.DocumentActivated += (sender, e) => OnDocumentChanged(e.Document);
   }
 
-  private void OnDocumentChanged(Document document)
+  private void OnDocumentChanged(Document document) => TryRegisterDocumentForSelection(document);
+
+  private void TryRegisterDocumentForSelection(Document document)
   {
     if (document == null)
     {

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadDocumentModelStore.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/HostApp/AutocadDocumentModelStore.cs
@@ -23,6 +23,12 @@ public class AutocadDocumentStore : DocumentModelStore
     if (Application.DocumentManager.MdiActiveDocument != null)
     {
       IsDocumentInit = true;
+      // POC: this logic might go when we have document management in context
+      // It is with the case of if binding created with already a document
+      // This is valid when user opens acad file directly double clicking
+      _previousDocName = Application.DocumentManager.MdiActiveDocument.Name;
+      _saveToDocSubTracker.Add(Application.DocumentManager.MdiActiveDocument.Name);
+      OnDocumentChanged();
     }
 
     Application.DocumentManager.DocumentToBeDestroyed += (_, _) => WriteToFile();


### PR DESCRIPTION
The previous assumption was that always will have a null doc whenever Bindings are created. But whenever we had a document opened already before bindings were created, we were missing track on the first doc and that's why it was failing to follow selections and feedback to UI with empty state if we're switching to the main screen in AutoCAD.

Another PR on UI side is -> https://github.com/specklesystems/speckle-server/pull/2231

Before
![acad_XZBmXXlu4W](https://github.com/specklesystems/speckle-sharp/assets/45078678/0959bcb9-664e-4383-8abb-6c43c26b73fd)
