### PR TITLE
CNX-9373 saved model cards doesn t show correct state on latest version state

### DIFF
--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Models/Card/ReceiverModelCard.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Models/Card/ReceiverModelCard.cs
@@ -6,4 +6,5 @@ public class ReceiverModelCard : ModelCard
   public string ModelName { get; set; }
   public string SelectedVersionId { get; set; }
   public string LatestVersionId { get; set; }
+  public bool HasDismissedUpdateWarning { get; set; }
 }


### PR DESCRIPTION
We were seeing this error unnecessarily even if on latest version for saved receiver cards
![image](https://github.com/specklesystems/speckle-sharp/assets/45078678/21817722-3469-4309-9a86-08111dc7b810) 