### PR TITLE
fix(revit): exclude element params which are not visible

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -333,6 +333,13 @@ public partial class ConverterRevit
         continue;
       }
 
+      //ignore parameters that are not visible by the end users
+      //these could be set by plugins, and historically have conflited with our send operation
+      if (param.Definition is InternalDefinition internalDef && !internalDef.Visible)
+      {
+        continue;
+      }
+
       var speckleParam = ParameterToSpeckle(param, internalName, isTypeParameter);
       paramDict[internalName] = speckleParam;
     }


### PR DESCRIPTION
https://speckle.community/t/transferring-problem/10462

Debugging this community-reported bug, I noticed we're sending to Spekcle also any hidden element parameter; in this case, there are hundreds of huge parameters attached to some elements (maybe images or something else?) added, most likely via an adding.

I think we should ignore these props.

Ideally this PR would be released as hotfix sometime soon.

![image](https://github.com/specklesystems/speckle-sharp/assets/2679513/f7792937-7657-49dd-9eb5-5c717b9ddac2)
