### PR TITLE
CNX-9158 - Replace `BinaryFormatter` with UTF-8 encoded bytes for SHA256 hash function

### DIFF
--- a/Core/Core/Helpers/Crypt.cs
+++ b/Core/Core/Helpers/Crypt.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -20,12 +18,11 @@ public static class Crypt
   [Pure]
   public static string Sha256(string input, string? format = "x2", int startIndex = 0, int length = 64)
   {
-    using MemoryStream ms = new();
+    var inputBytes = Encoding.UTF8.GetBytes(input);
 
-    new BinaryFormatter().Serialize(ms, input);
+    using var sha256 = SHA256.Create();
+    byte[] hash = sha256.ComputeHash(inputBytes);
 
-    using SHA256 sha = SHA256.Create();
-    var hash = sha.ComputeHash(ms.ToArray());
     StringBuilder sb = new(64);
     foreach (byte b in hash)
     {

--- a/Core/Tests/Speckle.Core.Tests.Unit/Models/UtilitiesTests.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Models/UtilitiesTests.cs
@@ -18,8 +18,8 @@ public sealed class UtilitiesTests
     Assert.That(upper, Is.EqualTo(expected.ToUpper()));
   }
 
-  [TestCase("fxFB14cBcXvoENN", "a6b48b2514a3ded45ad2cbea9e325c25c7ddc998247f2aff9bdd0e2694f5d5d4")]
-  [TestCase("tgWsOH8frdAwJT7", "82ac4675b283bae908fd110095252eca87dc6080244fc2014cf61bd9e45d37fc")]
+  [TestCase("fxFB14cBcXvoENN", "887db9349afa455f957a95f9dbacbb3c10697749cf4d4afc5c6398932a596fbc")]
+  [TestCase("tgWsOH8frdAwJT7", "e486224ded0dcb1452d69d0d005a6dcbc52087f6e8c66e04803e1337a192abb4")]
   [TestOf(nameof(Crypt.Sha256))]
   public void Sha256(string input, string expected)
   {


### PR DESCRIPTION
I have this as an alternative to #3282

Unlike #3282, this PR does introduce a breaking change, in that the same input will yield a different output.

This is because (as described by @secretlyagoblin the `BinaryFormatter` gives us more than just the char[] bytes, but also several bytes of type information) With this implementation, I've aligned the hashing behaviour with our Python SDK, which simply gets the UTF-8 encoded bytes.

I think we should consider accepting this breaking change, the implementation here is much simpler than having to patch in prefix as specified here https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrbf/eb503ca5-e1f6-4271-a7ee-c4ca38d07996, is already exactly what we're doing in Python SDK, and means there is less code for us to maintain.

---

I have benchmarked it against our current implementation, and it is a tad faster with both "small" and "long" data sets.

|          Method |                input |       Mean |    Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|---------------- |--------------------- |-----------:|---------:|---------:|-------:|-------:|----------:|
| BinaryFormatter |  long(...)8o7y [471] | 1,463.3 ns | 18.65 ns | 16.54 ns | 0.2975 | 0.0019 |    4992 B |
|            Utf8 |  long(...)8o7y [471] |   956.4 ns | 10.23 ns |  9.57 ns | 0.1259 |      - |    2112 B |
| BinaryFormatter | small(...)0sdfa [50] | 1,199.7 ns | 20.45 ns | 18.13 ns | 0.2403 |      - |    4032 B |
|            Utf8 | small(...)0sdfa [50] |   703.1 ns |  8.39 ns |  7.01 ns | 0.1011 |      - |    1696 B |

---

The remaining thing for us to decide, are we happy to make this breaking change (maybe in a 2.19 release)
The biggest effect of this is diffing in the viewer will not be useful between prior and post change versions.
Or, We can make this change in a later release where we can communicate a breaking change clearer (e.g. in the DUI3 connectors release). We can always publish a nuget in the interim to unblock the Net8 users who can't 