### PR TITLE
Remove Cancellation Swallowing and re-Lazied the binding registration

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -64,11 +64,6 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding, ICancelable
 
       Commands.SetModelReceiveResult(modelCardId, receivedObjectIds.ToList());
     }
-    catch (OperationCanceledException)
-    {
-      // POC: not sure here need to handle anything. UI already aware it cancelled operation visually.
-      return;
-    }
     catch (Exception e) when (!e.IsFatal()) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
     {
       Commands.SetModelError(modelCardId, e);

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -66,13 +66,6 @@ public sealed class AutocadReceiveBinding : IReceiveBinding, ICancelable
 
       Commands.SetModelReceiveResult(modelCardId, receivedObjectIds.ToList());
     }
-    catch (OperationCanceledException)
-    {
-      // POC: not sure here need to handle anything. UI already aware it cancelled operation visually.
-      // POC: JEDD: We should not update the UI until this exception is caught, we don't want to show the UI as cancelled
-      // until the actual operation is cancelled (thrown exception).
-      return;
-    }
     catch (Exception e) when (!e.IsFatal()) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
     {
       Commands.SetModelError(modelCardId, e);
@@ -84,6 +77,9 @@ public sealed class AutocadReceiveBinding : IReceiveBinding, ICancelable
     Commands.SetModelProgress(modelCardId, new ModelCardProgress { Status = status, Progress = progress });
   }
 
+  // POC: JEDD: We should not update the UI until a OperationCancelledException is caught, we don't want to show the UI as cancelled
+  // until the actual operation is cancelled (thrown exception).
+  // I think there's room for us to introduce a cancellation pattern for bindings to do this and avoid this _cancellationManager
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
 
   public void Dispose()

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoReceiveBinding.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoReceiveBinding.cs
@@ -70,10 +70,6 @@ public class RhinoReceiveBinding : IReceiveBinding, ICancelable
       // POC: Here we can't set receive result if ReceiveOperation throws an error.
       Commands.SetModelReceiveResult(modelCardId, receivedObjectIds.ToList());
     }
-    catch (OperationCanceledException)
-    {
-      // POC: not sure here need to handle anything. UI already aware it cancelled operation visually.
-    }
     catch (Exception e) when (!e.IsFatal()) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
     {
       Commands.SetModelError(modelCardId, e);

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI.WebView/DUI3ControlWebView.xaml.cs
@@ -9,9 +9,9 @@ namespace Speckle.Connectors.DUI.WebView;
 
 public sealed partial class DUI3ControlWebView : UserControl
 {
-  private readonly IReadOnlyCollection<IBinding> _bindings;
+  private readonly IEnumerable<Lazy<IBinding>> _bindings;
 
-  public DUI3ControlWebView(IReadOnlyCollection<IBinding> bindings)
+  public DUI3ControlWebView(IEnumerable<Lazy<IBinding>> bindings)
   {
     _bindings = bindings;
     InitializeComponent();
@@ -32,10 +32,22 @@ public sealed partial class DUI3ControlWebView : UserControl
 
   private void OnInitialized(object? sender, CoreWebView2InitializationCompletedEventArgs e)
   {
-    foreach (IBinding binding in _bindings)
+    if (e.IsSuccess == false)
     {
-      binding.Parent.AssociateWithBinding(binding, ExecuteScriptAsyncMethod, Browser, ShowDevToolsMethod);
-      Browser.CoreWebView2.AddHostObjectToScript(binding.Name, binding.Parent);
+      //POC: avoid silently accepting webview failures handle...
     }
+
+    // We use Lazy here to delay creating the binding until after the Browser is fully initialized.
+    // Otherwise the Browser cannot respond to any requests to ExecuteScriptAsyncMethod
+    foreach (Lazy<IBinding> lazyBinding in _bindings)
+    {
+      SetupBinding(lazyBinding.Value);
+    }
+  }
+
+  private void SetupBinding(IBinding binding)
+  {
+    binding.Parent.AssociateWithBinding(binding, ExecuteScriptAsyncMethod, Browser, ShowDevToolsMethod);
+    Browser.CoreWebView2.AddHostObjectToScript(binding.Name, binding.Parent);
   }
 }


### PR DESCRIPTION
- Reintroduced lazy bindings to avoid a race condition (was very common in Rhino) where the document finishes loading before webview
- Removed cancellation swallowing so that DUI3 never gets into a state where the model cards were not updated with either a result or an exception

todo:
- [x] Test In Rhino
- [x] Test In AutoCAD
- [ ] Test In ArcGIS