### PR TITLE
Fix Autocad to Rhino Polycurves

### DIFF
--- a/DUI3-DX/Converters/Rhino/Speckle.Converters.Rhino7/ToHost/Raw/SpecklePolyCurveRawToHostConversion.cs
+++ b/DUI3-DX/Converters/Rhino/Speckle.Converters.Rhino7/ToHost/Raw/SpecklePolyCurveRawToHostConversion.cs
@@ -1,5 +1,6 @@
 ﻿using Objects;
 using Speckle.Converters.Common.Objects;
+using Speckle.Core.Kits;
 
 namespace Speckle.Converters.Rhino7.ToHost.Raw;
 
@@ -27,7 +28,11 @@ public class SpecklePolyCurveRawToHostConversion : IRawConversion<SOG.Polycurve,
     foreach (var segment in target.segments)
     {
       var childCurve = CurveConverter!.RawConvert(segment);
-      result.Append(childCurve);
+      bool success = result.AppendSegment(childCurve);
+      if (!success)
+      {
+        throw new ConversionException($"Failed to append segment {segment}");
+      }
     }
 
     result.Domain = _intervalConverter.RawConvert(target.domain);


### PR DESCRIPTION
The `.Append` function not only appends a segment to a polycurve, but it also moves the segment to align the start and end points with the previous segment.
This is fine for polycurves that fit that rule, Like most from rhino
But for Autocad polycurves, its common for segments to be in different orders, or segments to have their end and start point effectively reversed from the aforementioned expectation.

Rhino instead has a `AppendSegment` function, which apparently does a similar thing to `.Append`, but avoids attempting to match the start and end points.

In addition to this change, I also noticed that `AppendSegment` returns a bool indicating success.

---

Before:
Rhino would receive like this:
![image](https://github.com/specklesystems/speckle-sharp/assets/45512892/c090e193-7424-421d-afce-3faa30b1b372)


After:
Rhino receives like this: (pretty much as expected)
![image](https://github.com/specklesystems/speckle-sharp/assets/45512892/4a3a4315-e1a6-4aa6-a977-eea9f6288234)
