### PR TITLE
fix: Save to file even when no models exist (covers edge-case where last model was removed)

### DIFF
--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -82,12 +82,6 @@ internal class RevitDocumentStore : DocumentModelStore
       return;
     }
 
-    // Don't even attempt to write anything if empty.
-    if (!Models.Any())
-    {
-      return;
-    }
-
     string serializedModels = Serialize();
 
     using Transaction t = new(doc, "Speckle Write State");

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.ExtensibleStorage;
 using Autodesk.Revit.UI;


### PR DESCRIPTION
Saving to file should be done even when no models exist.