### PR TITLE
feat(autocad): CNX-9417 ACAD align Speckle command name

### DIFF
--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Plugin/AutocadCommand.cs
@@ -21,7 +21,7 @@ public class AutocadCommand
 
   public AutofacContainer? Container { get; private set; }
 
-  [CommandMethod("SpeckleDUI3DX")]
+  [CommandMethod("SpeckleNewUI")]
   public void Command()
   {
     if (PaletteSet != null)

--- a/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
+++ b/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/PolycurveToHostConverter.cs
@@ -8,7 +8,7 @@ namespace Speckle.Converters.AutocadShared.ToHost.Geometry;
 
 /// <summary>
 /// A polycurve has segments as list and it can contain different kind of ICurve objects like Arc, Line, Polyline, Curve etc..
-/// If polycurve segments is consist of only with Arcs and Lines, it can be represented as Polyline in Autucad.
+/// If polycurve segments are planar and only of type <see cref="SOG.Line"/> and <see cref="SOG.Arc"/>, it can be represented as Polyline in Autocad.
 /// Otherwise we convert it as spline (list of ADB.Entity) that switch cases according to each segment type.
 /// </summary>
 [NameAndRankValue(nameof(SOG.Polycurve), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
@@ -45,13 +45,12 @@ public class PolycurveToHostConverter : ISpeckleObjectToHostConversion
   private bool IsPolycurvePlanar(SOG.Polycurve polycurve)
   {
     double? z = null;
-    foreach (var segment in polycurve.segments)
+    foreach (Objects.ICurve segment in polycurve.segments)
     {
       switch (segment)
       {
         case SOG.Line o:
           z ??= o.start.z;
-
           if (o.start.z != z || o.end.z != z)
           {
             return false;
@@ -60,7 +59,6 @@ public class PolycurveToHostConverter : ISpeckleObjectToHostConversion
           break;
         case SOG.Arc o:
           z ??= o.startPoint.z;
-
           if (o.startPoint.z != z || o.midPoint.z != z || o.endPoint.z != z)
           {
             return false;
@@ -69,7 +67,6 @@ public class PolycurveToHostConverter : ISpeckleObjectToHostConversion
           break;
         case SOG.Curve o:
           z ??= o.points[2];
-
           for (int i = 2; i < o.points.Count; i += 3)
           {
             if (o.points[i] != z)
@@ -81,7 +78,6 @@ public class PolycurveToHostConverter : ISpeckleObjectToHostConversion
           break;
         case SOG.Spiral o:
           z ??= o.startPoint.z;
-
           if (o.startPoint.z != z || o.endPoint.z != z)
           {
             return false;


### PR DESCRIPTION
Changes the Speckle DUI3 command in Autocad to "SpeckleNewUI" to align with other connectors