### PR TITLE
fix(autocad): polyline3d splines had incorrect displayvalue

### DIFF
--- a/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
+++ b/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/Polyline2dToSpeckleConverter.cs
@@ -156,7 +156,7 @@ public class Polyline2dToSpeckleConverter : IHostObjectToSpeckleConversion
       }
     }
 
-    // for splines, convert the spline curve and display value and add to the segments list and
+    // for splines, convert the spline curve and display value and add to the segments list
     if (isSpline)
     {
       SOG.Curve spline = _splineConverter.RawConvert(target.Spline);


### PR DESCRIPTION
Fixes the polyline3d spline display value.
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/9a3483ff-bc3d-4ba8-b337-9f2030459db8)