### PR TITLE
Document.Document & IRevitConversionContextStack

### DIFF
--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -72,7 +72,6 @@ internal class BasicConnectorBindingRevit : IBasicConnectorBinding
     }
 
     // POC: Notify user here if document is null.
-
     return new DocumentInfo
     {
       Name = doc.Title,

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RootObjectBuilder.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RootObjectBuilder.cs
@@ -17,14 +17,14 @@ public class RootObjectBuilder : IRootObjectBuilder<ElementId>
   // POC: SendSelection and RevitConversionContextStack should be interfaces, former needs interfaces
   private readonly ISpeckleConverterToSpeckle _converter;
   private readonly ToSpeckleConvertedObjectsCache _convertedObjectsCache;
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly Dictionary<string, Collection> _collectionCache;
   private readonly Collection _rootObject;
 
   public RootObjectBuilder(
     ISpeckleConverterToSpeckle converter,
     ToSpeckleConvertedObjectsCache convertedObjectsCache,
-    RevitConversionContextStack contextStack
+    IRevitConversionContextStack contextStack
   )
   {
     _converter = converter;
@@ -36,7 +36,7 @@ public class RootObjectBuilder : IRootObjectBuilder<ElementId>
     _collectionCache = new Dictionary<string, Collection>();
     _rootObject = new Collection()
     {
-      name = _contextStack.Current.Document.Document.PathName.Split('\\').Last().Split('.').First()
+      name = _contextStack.Current.Document.PathName.Split('\\').Last().Split('.').First()
     };
   }
 
@@ -47,18 +47,18 @@ public class RootObjectBuilder : IRootObjectBuilder<ElementId>
     CancellationToken ct = default
   )
   {
-    var doc = _contextStack.Current.Document.Document; // POC: Document.Document is funny
+    var doc = _contextStack.Current.Document; // POC: Document.Document is funny
 
     if (doc.IsFamilyDocument)
     {
       throw new SpeckleException("Family Environment documents are not supported.");
     }
 
-    var revitElements = new List<Element>(); // = _contextStack.Current.Document.Document.GetElements(sendSelection.SelectedItems).ToList();
+    var revitElements = new List<Element>(); // = _contextStack.Current.Document.GetElements(sendSelection.SelectedItems).ToList();
 
     foreach (var id in objects)
     {
-      var el = _contextStack.Current.Document.Document.GetElement(id);
+      var el = _contextStack.Current.Document.GetElement(id);
       if (el != null)
       {
         revitElements.Add(el);

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RootObjectBuilder.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RootObjectBuilder.cs
@@ -47,7 +47,7 @@ public class RootObjectBuilder : IRootObjectBuilder<ElementId>
     CancellationToken ct = default
   )
   {
-    var doc = _contextStack.Current.Document; // POC: Document.Document is funny
+    var doc = _contextStack.Current.Document;
 
     if (doc.IsFamilyDocument)
     {

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/AutofacRevitConverterModule.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/AutofacRevitConverterModule.cs
@@ -33,11 +33,7 @@ public class AutofacRevitConverterModule : Module
     builder.RegisterType<ScalingServiceToSpeckle>().AsSelf().InstancePerLifetimeScope();
 
     // POC: the concrete type can come out if we remove all the reference to it
-    builder
-      .RegisterType<RevitConversionContextStack>()
-      .As<IRevitConversionContextStack>()
-      .AsSelf()
-      .InstancePerLifetimeScope();
+    builder.RegisterType<RevitConversionContextStack>().As<IRevitConversionContextStack>().InstancePerLifetimeScope();
 
     builder
       .RegisterType<RevitToSpeckleUnitConverter>()

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/GlobalUsings.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/GlobalUsings.cs
@@ -1,6 +1,5 @@
 global using DB = Autodesk.Revit.DB;
 global using DBA = Autodesk.Revit.DB.Architecture;
-global using UI = Autodesk.Revit.UI;
 global using SOG = Objects.Geometry;
 global using SOBR = Objects.BuiltElements.Revit;
 global using SOBE = Objects.BuiltElements;

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Helpers/IRevitConversionContextStack.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Helpers/IRevitConversionContextStack.cs
@@ -10,4 +10,4 @@ namespace Speckle.Converters.RevitShared.Helpers;
 )]
 // POC: so this should *probably* be Document and NOT UI.UIDocument, the former is Conversion centric
 // and the latter is more for connector
-public interface IRevitConversionContextStack : IConversionContextStack<UI.UIDocument, ForgeTypeId> { }
+public interface IRevitConversionContextStack : IConversionContextStack<Document, ForgeTypeId> { }

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Helpers/RevitConversionContextStack.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Helpers/RevitConversionContextStack.cs
@@ -10,9 +10,7 @@ namespace Speckle.Converters.RevitShared.Helpers;
 )]
 // POC: so this should *probably* be Document and NOT UI.UIDocument, the former is Conversion centric
 // and the latter is more for connector
-public class RevitConversionContextStack
-  : ConversionContextStack<UI.UIDocument, ForgeTypeId>,
-    IRevitConversionContextStack
+public class RevitConversionContextStack : ConversionContextStack<Document, ForgeTypeId>, IRevitConversionContextStack
 {
   public const double TOLERANCE = 0.0164042; // 5mm in ft
 
@@ -22,7 +20,7 @@ public class RevitConversionContextStack
       // so should this perpetuate or do we assume this is valid?
       // relting on the context.UIApplication?.ActiveUIDocument is not right
       // this should be some IActiveDocument I suspect?
-      context.UIApplication?.ActiveUIDocument
+      context.UIApplication?.ActiveUIDocument?.Document
         ?? throw new SpeckleConversionException("Active UI document could not be determined"),
       context.UIApplication.ActiveUIDocument.Document.GetUnits().GetFormatOptions(SpecTypeId.Length).GetUnitTypeId(),
       unitConverter

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/ColumnConversionToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/ColumnConversionToSpeckle.cs
@@ -16,7 +16,7 @@ public class ColumnConversionToSpeckle : IRawConversion<DB.FamilyInstance, Revit
   private readonly IRawConversion<Level, RevitLevel> _levelConverter;
   private readonly ParameterValueExtractor _parameterValueExtractor;
   private readonly DisplayValueExtractor _displayValueExtractor;
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly ParameterObjectAssigner _parameterObjectAssigner;
 
   public ColumnConversionToSpeckle(
@@ -24,7 +24,7 @@ public class ColumnConversionToSpeckle : IRawConversion<DB.FamilyInstance, Revit
     IRawConversion<Level, RevitLevel> levelConverter,
     ParameterValueExtractor parameterValueExtractor,
     DisplayValueExtractor displayValueExtractor,
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     ParameterObjectAssigner parameterObjectAssigner
   )
   {

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/CurveArrayConversionToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/CurveArrayConversionToSpeckle.cs
@@ -9,12 +9,12 @@ namespace Speckle.Converters.RevitShared.ToSpeckle;
 
 public sealed class CurveArrayConversionToSpeckle : IRawConversion<DB.CurveArray, SOG.Polycurve>
 {
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly ScalingServiceToSpeckle _scalingService;
   private readonly IRawConversion<DB.Curve, ICurve> _curveConverter;
 
   public CurveArrayConversionToSpeckle(
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     ScalingServiceToSpeckle scalingService,
     IRawConversion<DB.Curve, ICurve> curveConverter
   )

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/LineConversionToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/LineConversionToSpeckle.cs
@@ -7,12 +7,12 @@ namespace Speckle.Converters.RevitShared.ToSpeckle;
 
 public class LineConversionToSpeckle : IRawConversion<DB.Line, SOG.Line>
 {
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly IRawConversion<DB.XYZ, SOG.Point> _xyzToPointConverter;
   private readonly ScalingServiceToSpeckle _scalingService;
 
   public LineConversionToSpeckle(
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     IRawConversion<DB.XYZ, SOG.Point> xyzToPointConverter,
     ScalingServiceToSpeckle scalingService
   )

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/MeshByMaterialDictionaryToSpeckle.cs
@@ -6,13 +6,13 @@ namespace Speckle.Converters.RevitShared.ToSpeckle;
 
 public class MeshByMaterialDictionaryToSpeckle : IRawConversion<Dictionary<DB.ElementId, List<DB.Mesh>>, List<SOG.Mesh>>
 {
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly IRawConversion<DB.XYZ, SOG.Point> _xyzToPointConverter;
   private readonly IRawConversion<DB.Material, RenderMaterial> _materialConverter;
 
   public MeshByMaterialDictionaryToSpeckle(
     IRawConversion<DB.Material, RenderMaterial> materialConverter,
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     IRawConversion<DB.XYZ, SOG.Point> xyzToPointConverter
   )
   {
@@ -53,7 +53,7 @@ public class MeshByMaterialDictionaryToSpeckle : IRawConversion<Dictionary<DB.El
         units: _contextStack.Current.SpeckleUnits
       );
 
-      var doc = _contextStack.Current.Document.Document;
+      var doc = _contextStack.Current.Document;
       if (doc.GetElement(materialId) is DB.Material material)
       {
         speckleMesh["renderMaterial"] = _materialConverter.RawConvert(material);

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/MeshConversionToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/MeshConversionToSpeckle.cs
@@ -8,10 +8,10 @@ public class MeshConversionToSpeckle : IRawConversion<DB.Mesh, SOG.Mesh>
 {
   private readonly IRawConversion<DB.XYZ, SOG.Point> _xyzToPointConverter;
   private readonly IRawConversion<DB.Material, RenderMaterial> _materialConverter;
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
 
   public MeshConversionToSpeckle(
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     IRawConversion<DB.XYZ, SOG.Point> xyzToPointConverter,
     IRawConversion<DB.Material, RenderMaterial> materialConverter
   )
@@ -23,7 +23,7 @@ public class MeshConversionToSpeckle : IRawConversion<DB.Mesh, SOG.Mesh>
 
   public SOG.Mesh RawConvert(DB.Mesh target)
   {
-    var doc = _contextStack.Current.Document.Document;
+    var doc = _contextStack.Current.Document;
 
     List<double> vertices = GetSpeckleMeshVertexData(target);
     List<int> faces = GetSpeckleMeshFaceData(target);

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/XyzConversionToPoint.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/Geometry/XyzConversionToPoint.cs
@@ -7,9 +7,12 @@ namespace Speckle.Converters.RevitShared.ToSpeckle;
 public class XyzConversionToPoint : IRawConversion<DB.XYZ, SOG.Point>
 {
   private readonly ScalingServiceToSpeckle _toSpeckleScalingService;
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
 
-  public XyzConversionToPoint(ScalingServiceToSpeckle toSpeckleScalingService, RevitConversionContextStack contextStack)
+  public XyzConversionToPoint(
+    ScalingServiceToSpeckle toSpeckleScalingService,
+    IRevitConversionContextStack contextStack
+  )
   {
     _toSpeckleScalingService = toSpeckleScalingService;
     _contextStack = contextStack;

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/ModelCurveArrayToSpeckleConverter.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Raw/ModelCurveArrayToSpeckleConverter.cs
@@ -8,12 +8,12 @@ namespace Speckle.Converters.RevitShared.Raw;
 
 internal class ModelCurveArrayToSpeckleConverter : IRawConversion<DB.ModelCurveArray, SOG.Polycurve>
 {
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly ScalingServiceToSpeckle _scalingService;
   private readonly IRawConversion<DB.Curve, ICurve> _curveConverter;
 
   public ModelCurveArrayToSpeckleConverter(
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     ScalingServiceToSpeckle scalingService,
     IRawConversion<DB.Curve, ICurve> curveConverter
   )

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ReferencePointConverter.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ReferencePointConverter.cs
@@ -29,7 +29,7 @@ public class ReferencePointConverter : IReferencePointConverter
   // doc can change during the lifeycycle of the conversions. This may need some looking into
   public DB.XYZ ConvertToExternalCoordindates(DB.XYZ inbound, bool isPoint)
   {
-    var rpt = GetDocReferencePointTransform(_contextStack.Current.Document.Document);
+    var rpt = GetDocReferencePointTransform(_contextStack.Current.Document);
     return isPoint ? rpt.OfPoint(inbound) : rpt.OfVector(inbound);
   }
 
@@ -60,7 +60,7 @@ public class ReferencePointConverter : IReferencePointConverter
 
     // POC: bogus disposal below
 #pragma warning disable CA2000
-    var points = new DB.FilteredElementCollector(_contextStack.Current.Document.Document)
+    var points = new DB.FilteredElementCollector(_contextStack.Current.Document)
       .OfClass(typeof(DB.BasePoint))
       .Cast<DB.BasePoint>()
       .ToList();

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Services/ScalingServiceToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Services/ScalingServiceToSpeckle.cs
@@ -10,10 +10,10 @@ public sealed class ScalingServiceToSpeckle
   private readonly double _defaultLengthConversionFactor;
 
   // POC: this seems like the reverse relationship
-  public ScalingServiceToSpeckle(RevitConversionContextStack contextStack)
+  public ScalingServiceToSpeckle(IRevitConversionContextStack contextStack)
   {
     // POC: this is accurate for the current context stack
-    Units documentUnits = contextStack.Current.Document.Document.GetUnits();
+    Units documentUnits = contextStack.Current.Document.GetUnits();
     FormatOptions formatOptions = documentUnits.GetFormatOptions(SpecTypeId.Length);
     var lengthUnitsTypeId = formatOptions.GetUnitTypeId();
     _defaultLengthConversionFactor = ScaleStatic(1, lengthUnitsTypeId);

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/DirectShapeConversionToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/DirectShapeConversionToSpeckle.cs
@@ -9,13 +9,13 @@ namespace Speckle.Converters.Revit2023.ToSpeckle;
 [NameAndRankValue(nameof(DB.DirectShape), NameAndRankValueAttribute.SPECKLE_DEFAULT_RANK)]
 public class DirectShapeConversionToSpeckle : BaseConversionToSpeckle<DB.DirectShape, SOBR.DirectShape>
 {
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly ParameterObjectAssigner _parameterObjectAssigner;
   private readonly DisplayValueExtractor _displayValueExtractor;
 
   public DirectShapeConversionToSpeckle(
     ParameterObjectAssigner parameterObjectAssigner,
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     DisplayValueExtractor displayValueExtractor
   )
   {

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/HostedElementConversionToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/HostedElementConversionToSpeckle.cs
@@ -13,12 +13,12 @@ public class HostedElementConversionToSpeckle
 {
   private readonly ToSpeckleConvertedObjectsCache _convertedObjectsCache;
   private readonly ISpeckleConverterToSpeckle _converter;
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
 
   public HostedElementConversionToSpeckle(
     ToSpeckleConvertedObjectsCache convertedObjectsCache,
     ISpeckleConverterToSpeckle converter,
-    RevitConversionContextStack contextStack
+    IRevitConversionContextStack contextStack
   )
   {
     _convertedObjectsCache = convertedObjectsCache;
@@ -30,7 +30,7 @@ public class HostedElementConversionToSpeckle
   {
     foreach (var elemId in hostedElementIds)
     {
-      Element element = _contextStack.Current.Document.Document.GetElement(elemId);
+      Element element = _contextStack.Current.Document.GetElement(elemId);
 
       Base @base;
       try

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/WallConversionToSpeckle.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ToSpeckle/WallConversionToSpeckle.cs
@@ -18,7 +18,7 @@ public class WallConversionToSpeckle : BaseConversionToSpeckle<DB.Wall, SOBR.Rev
   private readonly IRawConversion<DB.Level, SOBR.RevitLevel> _levelConverter;
   private readonly IRawConversion<DB.CurveArrArray, List<SOG.Polycurve>> _curveArrArrayConverter;
   private readonly ParameterValueExtractor _parameterValueExtractor;
-  private readonly RevitConversionContextStack _contextStack;
+  private readonly IRevitConversionContextStack _contextStack;
   private readonly DisplayValueExtractor _displayValueExtractor;
   private readonly ParameterObjectAssigner _parameterObjectAssigner;
   private readonly ISpeckleConverterToSpeckle _converter;
@@ -27,7 +27,7 @@ public class WallConversionToSpeckle : BaseConversionToSpeckle<DB.Wall, SOBR.Rev
     IRawConversion<DB.Curve, ICurve> curveConverter,
     IRawConversion<DB.Level, SOBR.RevitLevel> levelConverter,
     IRawConversion<DB.CurveArrArray, List<SOG.Polycurve>> curveArrArrayConverter,
-    RevitConversionContextStack contextStack,
+    IRevitConversionContextStack contextStack,
     ParameterValueExtractor parameterValueExtractor,
     DisplayValueExtractor displayValueExtractor,
     ParameterObjectAssigner parameterObjectAssigner,
@@ -124,7 +124,7 @@ public class WallConversionToSpeckle : BaseConversionToSpeckle<DB.Wall, SOBR.Rev
   {
     foreach (DB.ElementId elementId in elementIds)
     {
-      yield return _converter.Convert(_contextStack.Current.Document.Document.GetElement(elementId));
+      yield return _converter.Convert(_contextStack.Current.Document.GetElement(elementId));
     }
   }
 


### PR DESCRIPTION
Fixed Document.Document and also changed to always reference stack to always use IRevitConversionContextStack

We were using the UIDocument in the context and NO conversions should care about this document. I've changed this to inject Document instead of UIDocument so we don't have the somewhat silly Document.Document everywhere.

Additionally we added the IRevitConversionContextStack interface some time back to allow conversions to reference this interface instead of the concrete Revit type. I've updated all references and registrations now so they are correct and we now MUST reference IRevitConversionContextStack.