### PR TITLE
fix: Do not pack RevitAPI nor Cef in Revit Connector

### DIFF
--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.Revit2023/Speckle.Connectors.Revit2023.csproj
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.Revit2023/Speckle.Connectors.Revit2023.csproj
@@ -34,11 +34,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CefSharp.Wpf" Version="92.0.260" />
+    <PackageReference Include="CefSharp.Wpf" Version="92.0.260" IncludeAssets="compile" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Revit.Async" Version="2.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Speckle.Revit.API" Version="2023.0.0" />
+    <PackageReference Include="Speckle.Revit.API" Version="2023.0.0" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <Target AfterTargets="Clean" Name="CleanAddinFolder">


### PR DESCRIPTION
Revit connector should not include the RevitAPI.dll nor any of the Cef stuff.

I tested it and it worked just fine, but at least another person verifying this would be great.