### PR TITLE
CNX-9199 implement opening revit and dui3 when double clicking a file

### DIFF
--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.Events;
 using Autodesk.Revit.DB.ExtensibleStorage;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Events;

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Events;
 using Autodesk.Revit.DB.ExtensibleStorage;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Events;
@@ -45,6 +46,8 @@ internal class RevitDocumentStore : DocumentModelStore
 
     uiApplication.Application.DocumentOpening += (_, _) => IsDocumentInit = false;
     uiApplication.Application.DocumentOpened += (_, _) => IsDocumentInit = false;
+
+    ReadFromFile(); // Smells... there is no event that we can hook here for double-click file open... This line push ReadFromFile immediately.
   }
 
   /// <summary>
@@ -52,6 +55,7 @@ internal class RevitDocumentStore : DocumentModelStore
   /// </summary>
   private void OnViewActivated(object sender, ViewActivatedEventArgs e)
   {
+    TaskDialog.Show("a", "a");
     if (e.Document == null)
     {
       return;
@@ -70,7 +74,6 @@ internal class RevitDocumentStore : DocumentModelStore
 
     IsDocumentInit = true;
     ReadFromFile();
-    OnDocumentChanged();
   }
 
   private void WriteToFileWithDoc(Document doc)
@@ -114,6 +117,7 @@ internal class RevitDocumentStore : DocumentModelStore
 
       string modelsString = stateEntity.Get<string>("contents");
       Models = Deserialize(modelsString);
+      OnDocumentChanged();
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -47,7 +47,9 @@ internal class RevitDocumentStore : DocumentModelStore
     uiApplication.Application.DocumentOpening += (_, _) => IsDocumentInit = false;
     uiApplication.Application.DocumentOpened += (_, _) => IsDocumentInit = false;
 
-    ReadFromFile(); // Smells... there is no event that we can hook here for double-click file open... This line push ReadFromFile immediately.
+    // There is no event that we can hook here for double-click file open...
+    // It is kind of harmless since we create this object as "SingleInstance".
+    ReadFromFile();
   }
 
   /// <summary>

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -50,6 +50,7 @@ internal class RevitDocumentStore : DocumentModelStore
     // There is no event that we can hook here for double-click file open...
     // It is kind of harmless since we create this object as "SingleInstance".
     ReadFromFile();
+    OnDocumentChanged();
   }
 
   /// <summary>
@@ -75,6 +76,7 @@ internal class RevitDocumentStore : DocumentModelStore
 
     IsDocumentInit = true;
     ReadFromFile();
+    OnDocumentChanged();
   }
 
   private void WriteToFileWithDoc(Document doc)
@@ -118,7 +120,6 @@ internal class RevitDocumentStore : DocumentModelStore
 
       string modelsString = stateEntity.Get<string>("contents");
       Models = Deserialize(modelsString);
-      OnDocumentChanged();
     }
     catch (Exception ex) when (!ex.IsFatal())
     {

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/HostApp/RevitDocumentStore.cs
@@ -55,7 +55,6 @@ internal class RevitDocumentStore : DocumentModelStore
   /// </summary>
   private void OnViewActivated(object sender, ViewActivatedEventArgs e)
   {
-    TaskDialog.Show("a", "a");
     if (e.Document == null)
     {
       return;

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitPlugin.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitPlugin.cs
@@ -45,9 +45,9 @@ internal class RevitPlugin : IRevitPlugin
 
   public void Initialise()
   {
-    _uIControlledApplication.ControlledApplication.ApplicationInitialized += OnApplicationInitialized;
-
     CreateTabAndRibbonPanel(_uIControlledApplication);
+    RegisterPanelAndInitializePlugin();
+    _uIControlledApplication.ControlledApplication.ApplicationInitialized += OnApplicationInitialized;
   }
 
   public void Shutdown()
@@ -107,19 +107,11 @@ internal class RevitPlugin : IRevitPlugin
     // POC: might be worth to interface this out, we shall see...
     RevitTask.Initialize(uiApplication);
 
-    RegisterPanelAndInitializePlugin();
+    PostApplicationInit();
   }
 
-  private void RegisterPanelAndInitializePlugin()
+  private void PostApplicationInit()
   {
-    CefSharpSettings.ConcurrentTaskExecution = true;
-
-    _uIControlledApplication.RegisterDockablePane(
-      RevitExternalApplication.DoackablePanelId,
-      _revitSettings.RevitPanelName,
-      _cefSharpPanel
-    );
-
     // binding the bindings to each bridge
     foreach (IBinding binding in _bindings.Select(x => x.Value))
     {
@@ -168,6 +160,17 @@ internal class RevitPlugin : IRevitPlugin
               CefSharpPanel.Browser.Load("http://localhost:8082");
 #endif
     };
+  }
+
+  private void RegisterPanelAndInitializePlugin()
+  {
+    CefSharpSettings.ConcurrentTaskExecution = true;
+
+    _uIControlledApplication.RegisterDockablePane(
+      RevitExternalApplication.DoackablePanelId,
+      _revitSettings.RevitPanelName,
+      _cefSharpPanel
+    );
   }
 
   private ImageSource? LoadPngImgSource(string sourceName, string path)

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitPlugin.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitPlugin.cs
@@ -45,9 +45,9 @@ internal class RevitPlugin : IRevitPlugin
 
   public void Initialise()
   {
-    // Create and register panels before app initialized. this was needed for double-click file open
+    // Create and register panels before app initialized. this is needed for double-click file open
     CreateTabAndRibbonPanel(_uIControlledApplication);
-    RegisterPanelAndInitializePlugin();
+    RegisterDockablePane();
     _uIControlledApplication.ControlledApplication.ApplicationInitialized += OnApplicationInitialized;
   }
 
@@ -112,7 +112,7 @@ internal class RevitPlugin : IRevitPlugin
   }
 
   /// <summary>
-  /// Actions to run after UiApplication initialized. This was needed for double-click file open issue.
+  /// Actions to run after UiApplication initialized. This is needed for double-click file open issue.
   /// </summary>
   private void PostApplicationInit()
   {
@@ -166,10 +166,12 @@ internal class RevitPlugin : IRevitPlugin
     };
   }
 
-  private void RegisterPanelAndInitializePlugin()
+  private void RegisterDockablePane()
   {
     CefSharpSettings.ConcurrentTaskExecution = true;
 
+    // Registering dockable pane should happen before UiApplication is initialized with RevitTask.
+    // Otherwise pane cannot be registered for double-click file open.
     _uIControlledApplication.RegisterDockablePane(
       RevitExternalApplication.DoackablePanelId,
       _revitSettings.RevitPanelName,

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitPlugin.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Plugin/RevitPlugin.cs
@@ -45,6 +45,7 @@ internal class RevitPlugin : IRevitPlugin
 
   public void Initialise()
   {
+    // Create and register panels before app initialized. this was needed for double-click file open
     CreateTabAndRibbonPanel(_uIControlledApplication);
     RegisterPanelAndInitializePlugin();
     _uIControlledApplication.ControlledApplication.ApplicationInitialized += OnApplicationInitialized;
@@ -107,9 +108,12 @@ internal class RevitPlugin : IRevitPlugin
     // POC: might be worth to interface this out, we shall see...
     RevitTask.Initialize(uiApplication);
 
-    PostApplicationInit();
+    PostApplicationInit(); // for double-click file open
   }
 
+  /// <summary>
+  /// Actions to run after UiApplication initialized. This was needed for double-click file open issue.
+  /// </summary>
   private void PostApplicationInit()
   {
     // binding the bindings to each bridge


### PR DESCRIPTION
I have couple of findings on double-click file open issue,

### Problems
1. Docable pane didn't register successfully if we try to do registration after `RevitTask.Initialize(uiApplication)`
2. Cef binding registirations didn't catch if we do it before `RevitTask.Initialize(uiApplication)` (causes black screen of UI)
3. There are no Revit event that we can trigger `ReadFromFile` and `OnDocumentChanged` functions after double-click open

![image](https://github.com/specklesystems/speckle-sharp/assets/45078678/d85c4864-47c5-4642-8c8c-0bc491849274)

### Solutions
1. Creating and registration of ribbons, buttons and panes done as first pass
2. Cef binding registrations done in `PostApplicationInit` function
3. `ReadFromFile` and `OnDocumentChanged` called in the constructor on `RevitDocumentStore`. Even if I don't like it, I couldn't find any other event or way for now

### Tests
- [x] Double-click file opens the pane
- [x] After double click open we can read the saved model cards
- [x] Non-double-click file opens work as before (switching docs, opening new docs etc..)

Comments welcome!