### PR TITLE
fix(autocad): CNX-9497 adds trim domains to ellipse conversions

### DIFF
--- a/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/EllipseToHostConverter.cs
+++ b/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Geometry/EllipseToHostConverter.cs
@@ -41,6 +41,25 @@ public class EllipseToHostConverter : ISpeckleObjectToHostConversion, IRawConver
 
     AG.Vector3d majorAxis = f * (double)target.firstRadius * xAxis.GetNormal();
     double radiusRatio = (double)target.secondRadius / (double)target.firstRadius;
-    return new(origin, normal, majorAxis, radiusRatio, 0, 2 * Math.PI);
+
+    // get trim
+    double startAngle = 0;
+    double endAngle = Math.PI * 2;
+    if (
+      target.domain.start is double domainStart
+      && target.domain.end is double domainEnd
+      && target.trimDomain is SOP.Interval trim
+      && trim.start is double start
+      && trim.end is double end
+    )
+    {
+      // normalize the start and end trim values to [0,2pi]
+      startAngle = (start - domainStart) / (domainEnd - domainStart) * Math.PI * 2;
+      endAngle = (end - domainStart) / (domainEnd - domainStart) * Math.PI * 2;
+    }
+
+    ADB.Ellipse ellipse = new(origin, normal, majorAxis, radiusRatio, startAngle, endAngle);
+
+    return ellipse;
   }
 }

--- a/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/EllipseToSpeckleConverter.cs
+++ b/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToSpeckle/Geometry/EllipseToSpeckleConverter.cs
@@ -29,10 +29,14 @@ public class DBEllipseToSpeckleConverter : IHostObjectToSpeckleConversion
     SOG.Plane plane = _planeConverter.RawConvert(new AG.Plane(target.Center, target.MajorAxis, target.MinorAxis));
     SOG.Box bbox = _boxConverter.RawConvert(target.GeometricExtents);
 
+    // the start and end param corresponds to start and end angle in radians
+    SOP.Interval trim = new(target.StartAngle, target.EndAngle);
+
     SOG.Ellipse ellipse =
       new(plane, target.MajorRadius, target.MinorRadius, _contextStack.Current.SpeckleUnits)
       {
-        domain = new SOP.Interval(target.StartParam, target.EndParam),
+        domain = new(0, Math.PI * 2),
+        trimDomain = trim,
         length = target.GetDistanceAtParameter(target.EndParam),
         bbox = bbox
       };


### PR DESCRIPTION
Autocad Ellipse conversions were not taking into account trim domains before, resulting in incorrect elliptical arc conversions.
NOTE: viewer does not render trims on ellipses correctly: [https://app.speckle.systems/projects/b53a53697a/models/66aca735ab#threadId=29e9388ee4](https://app.speckle.systems/projects/b53a53697a/models/66aca735ab#threadId=29e9388ee4)

Receiving in Autocad:
![incorrectarcs](https://github.com/specklesystems/speckle-sharp/assets/16748799/45d7ee1c-d409-41b9-a053-c1e23380cdf9)

Receiving in Rhino:
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/e83bb047-872a-42f9-8f64-c2b7ba615e03)

