### PR TITLE
suppress warning dialog for potential dll conflicts

### DIFF
--- a/ConnectorRevit/ConnectorRevit/Entry/App.cs
+++ b/ConnectorRevit/ConnectorRevit/Entry/App.cs
@@ -76,7 +76,6 @@ public class App : IExternalApplication
       APIContext.Initialize(application);
 
       InitializeUiPanel(application);
-      conflictNotifier.WarnUserOfPossibleConflicts();
 
       return Result.Succeeded;
     }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

We've decided that the warning message for dll conflicts may not be necessary because we can rely on only notifying the user when a conflict happens such that an exception is thrown and the Speckle connector cannot be used.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->
