### PR TITLE
CNX-9441-ETABS-to-Revit-Scaling-Issue

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/ConverterCSIUtils.cs
@@ -4,6 +4,7 @@ using CSiAPIv1;
 using Objects.Structural.CSI.Analysis;
 using System.Linq;
 using System;
+using Speckle.Core.Logging;
 
 namespace Objects.Converter.CSI;
 
@@ -26,14 +27,18 @@ public partial class ConverterCSI
       return _modelUnits;
     }
 
-    var units = Model.GetPresentUnits();
-    if (units != 0)
+    eForce forceUnits = eForce.NotApplicable;
+    eLength lengthUnits = eLength.NotApplicable;
+    eTemperature temperatureUnits = eTemperature.NotApplicable;
+    _ = Model.GetPresentUnits_2(ref forceUnits, ref lengthUnits, ref temperatureUnits);
+
+    if (lengthUnits == eLength.NotApplicable)
     {
-      string[] unitsCat = units.ToString().Split('_');
-      _modelUnits = unitsCat[1];
-      return _modelUnits;
+      throw new SpeckleException("Unable to retreive valid length units from the ETABS document");
     }
-    return null;
+
+    _modelUnits = lengthUnits.ToString();
+    return _modelUnits;
   }
 
   public double ScaleToNative(double value, string units)


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Conversation on forum (https://speckle.community/t/revit-etabs-connection-scaling-issue/9916/15) revealed that etabs units were not being retreived correctly when the units were a mix of metric and imperial. This is because we were using Model.GetPresentUnits() which returned the following enum
![image](https://github.com/specklesystems/speckle-sharp/assets/43247197/e93cf5e3-a098-4787-9b93-52fd8ade5de2)

Clearly, there are no options corresponding to mixed unit values such as imperial length and metric temperature. Now, I have switched the database unit retrieval method to Model.GetPresentUnits_2() which separates the units individually.

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
