### PR TITLE
CNX-9499 Save model cards into metadata and read/write on map init/switch

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Utils/ArcGisDocumentStore.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Utils/ArcGisDocumentStore.cs
@@ -1,5 +1,10 @@
+using System.Xml.Linq;
+using ArcGIS.Desktop.Core.Events;
+using ArcGIS.Desktop.Framework.Threading.Tasks;
+using ArcGIS.Desktop.Mapping;
 using ArcGIS.Desktop.Mapping.Events;
 using Speckle.Connectors.DUI.Models;
+using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Newtonsoft.Json;
 
 namespace Speckle.Connectors.ArcGIS.Utils;
@@ -9,22 +14,81 @@ public class ArcGISDocumentStore : DocumentModelStore
   public ArcGISDocumentStore(JsonSerializerSettings serializerOption)
     : base(serializerOption)
   {
-    // POC: Subscribe here document related events like OnSave, OnClose, OnOpen etc...
     ActiveMapViewChangedEvent.Subscribe(OnMapViewChanged);
+    ProjectSavingEvent.Subscribe(OnProjectSaving);
+    ProjectClosingEvent.Subscribe(OnProjectClosing);
   }
 
+  private Task OnProjectClosing(ProjectClosingEventArgs arg)
+  {
+    if (MapView.Active is null)
+    {
+      return Task.CompletedTask;
+    }
+
+    WriteToFile();
+    return Task.CompletedTask;
+  }
+
+  private Task OnProjectSaving(ProjectEventArgs arg)
+  {
+    if (MapView.Active is null)
+    {
+      return Task.CompletedTask;
+    }
+
+    WriteToFile();
+    return Task.CompletedTask;
+  }
+
+  /// <summary>
+  /// On map view switch, this event trigger twice, first for outgoing view, second for incoming view.
+  /// </summary>
   private void OnMapViewChanged(ActiveMapViewChangedEventArgs args)
   {
-    OnDocumentChanged();
+    if (args.OutgoingView is not null)
+    {
+      WriteToFileWithMap(args.OutgoingView.Map);
+    }
+
+    if (args.IncomingView is not null)
+    {
+      IsDocumentInit = true;
+      ReadFromFile();
+      OnDocumentChanged();
+    }
   }
 
-  public override void WriteToFile()
+  private void WriteToFileWithMap(Map map)
   {
-    // Implement the logic to save it to file
+    string serializedModels = Serialize();
+
+    XDocument xmlDocument = new(new XElement("metadata", new XElement("SpeckleModelCards", serializedModels)));
+
+    QueuedTask.Run(() =>
+    {
+      map.SetMetadata(xmlDocument.ToString());
+    });
   }
+
+  public override void WriteToFile() => WriteToFileWithMap(MapView.Active.Map);
 
   public override void ReadFromFile()
   {
-    // Implement the logic to read it from file
+    Map map = MapView.Active.Map;
+    QueuedTask.Run(() =>
+    {
+      var metadata = map.GetMetadata();
+      var root = XDocument.Parse(metadata).Root;
+      var element = root?.Element("SpeckleModelCards");
+      if (element is null)
+      {
+        Models = new List<ModelCard>();
+        return;
+      }
+
+      string modelsString = element.Value;
+      Models = Deserialize(modelsString);
+    });
   }
 }


### PR DESCRIPTION
The way we can store metadata is writing it as XML. I do read/write metadata with `SpeckleModelCards` element into root metadata XML.

Tested and seems work fine but would be nice double-triple tests.