### PR TITLE
CNX-9509 RHN opening up plugin panel again results in error

### DIFF
--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/DependencyInjection/AutofacRhinoModule.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/DependencyInjection/AutofacRhinoModule.cs
@@ -63,7 +63,6 @@ public class AutofacRhinoModule : Module
 
     // binding dependencies
     builder.RegisterType<CancellationManager>().InstancePerDependency();
-    builder.RegisterType<ServerTransport>().As<ITransport>().InstancePerDependency();
 
     // register send filters
     builder.RegisterType<RhinoSelectionFilter>().As<ISendFilter>().InstancePerDependency();

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/HostApp/SpeckleRhinoPanelHost.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/HostApp/SpeckleRhinoPanelHost.cs
@@ -1,4 +1,7 @@
 using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Controls;
+using Rhino.UI;
 using Speckle.Connectors.DUI.WebView;
 using Speckle.Connectors.Rhino7.Plugin;
 
@@ -8,10 +11,29 @@ namespace Speckle.Connectors.Rhino7.HostApp;
 public class SpeckleRhinoPanelHost : RhinoWindows.Controls.WpfElementHost
 {
   private readonly uint _docSn;
+  private readonly DUI3ControlWebView? _webView;
 
   public SpeckleRhinoPanelHost(uint docSn)
     : base(SpeckleConnectorsRhino7Plugin.Instance.Container?.Resolve<DUI3ControlWebView>(), null)
   {
     _docSn = docSn;
+    _webView = SpeckleConnectorsRhino7Plugin.Instance.Container?.Resolve<DUI3ControlWebView>();
+    Panels.Closed += PanelsOnClosed;
+  }
+
+  private void PanelsOnClosed(object sender, PanelEventArgs e)
+  {
+    if (e.PanelId == typeof(SpeckleRhinoPanelHost).GUID)
+    {
+      // Disconnect UIElement from WpfElementHost. Otherwise, we can't reinit panel with same DUI3ControlWebView
+      if (_webView != null)
+      {
+        // Since WpfHost inherited from Border, find the parent as border and set null it's Child.
+        if (LogicalTreeHelper.GetParent(_webView) is Border border)
+        {
+          border.Child = null;
+        }
+      }
+    }
   }
 }

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/HostApp/SpeckleRhinoPanelHost.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/HostApp/SpeckleRhinoPanelHost.cs
@@ -25,6 +25,20 @@ public class SpeckleRhinoPanelHost : RhinoWindows.Controls.WpfElementHost
   {
     if (e.PanelId == typeof(SpeckleRhinoPanelHost).GUID)
     {
+      // This check comes from behavioral difference on closing Rhino Panels.
+      // IsPanelVisible returns;
+      //  - True, when docked Panel closed from the list on right click on panel tab,
+      // whenever it is closed with this way, Rhino.Panels tries to reinit this object and expect the different UIElement, that's why we disconnect Child.
+      //  - False, when detached Panel is closed by 'X' close button.
+      // whenever it is closed with this way, Rhino.Panels don't create this object, that's why we do not disconnect Child UIElement.
+      if (!Panels.IsPanelVisible(typeof(SpeckleRhinoPanelHost).GUID))
+      {
+        return;
+      }
+
+      // Unsubscribe from the event to prevent growing registrations.
+      Panels.Closed -= PanelsOnClosed;
+
       // Disconnect UIElement from WpfElementHost. Otherwise, we can't reinit panel with same DUI3ControlWebView
       if (_webView != null)
       {


### PR DESCRIPTION
It was painful to spot the problem and solution. Because there is a different behavior on closing and reopening Panels in Rhino.

###  First behavior -> Close via list. If it is closed/disabled via list
On re-open --> It creates `SpeckleRhinoPanelHost` object and expects UIElement under `RhinoWindows.Controls.WpfElementHost` is not identical as before or empty. That was the problem before because we register `DUI3ControlWebView` as `SingleInstance` on Autofac. To fix this I've subscribed `Panels.Closed` event to Disconnect previous UIElement from `WpfHostElement`.

### Second behavior -> Close via ❌ button on detached panel.
On re-open --> It doesn't try to create `SpeckleRhinoPanelHost`

To distinguish these two behaviors, we have static `Panels.IsPanelVisible` function. According to this flag either I disconnect UIElement or not.

Hopefully it is clear enough, otherwise you know my Discord address..