### PR TITLE
Cnx 9502 agis object tracking change detection

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
@@ -17,7 +17,7 @@ public class ArcGISSelectionBinding : ISelectionBinding
     Parent = parent;
 
     // example: https://github.com/Esri/arcgis-pro-sdk-community-samples/blob/master/Map-Authoring/QueryBuilderControl/DefinitionQueryDockPaneViewModel.cs
-    MapViewEventArgs args = new(MapView.Active);
+    // MapViewEventArgs args = new(MapView.Active);
     TOCSelectionChangedEvent.Subscribe(OnSelectionChanged, true);
   }
 

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSelectionBinding.cs
@@ -7,8 +7,6 @@ namespace Speckle.Connectors.ArcGIS.Bindings;
 
 public class ArcGISSelectionBinding : ISelectionBinding
 {
-  private const string SELECTION_EVENT = "setSelection";
-
   public string Name { get; } = "selectionBinding";
   public IBridge Parent { get; set; }
 
@@ -24,7 +22,7 @@ public class ArcGISSelectionBinding : ISelectionBinding
   private void OnSelectionChanged(MapViewEventArgs args)
   {
     SelectionInfo selInfo = GetSelection();
-    Parent?.Send(SELECTION_EVENT, selInfo);
+    Parent?.Send(SelectionBindingEvents.SET_SELECTION, selInfo);
   }
 
   public SelectionInfo GetSelection()


### PR DESCRIPTION
Currently the change detection only works for the change of the map elements, their properties and names, but NOT the change in the data source (actual features /data rows in the table). This requires dynamic subscription to every new layer on the map, and it is tricky to extract the layer id from the feature-changed event. 