### PR TITLE
WEB-961 Update `Automate.SDK` to match new `AutomationRunData` shape

### DIFF
--- a/Automate/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/Automate/Speckle.Automate.Sdk/AutomationContext.cs
@@ -107,14 +107,6 @@ public class AutomationContext
   /// The reason is to prevent circular run loop in automation. </exception>
   public async Task<string> CreateNewVersionInProject(Base rootObject, string modelName, string versionMessage = "")
   {
-    // if (modelName == AutomationRunData.BranchName)
-    // {
-    //   throw new ArgumentException(
-    //     $"The target model: {modelName} cannot match the model that triggered this automation: {AutomationRunData.ModelId}/{AutomationRunData.BranchName}",
-    //     nameof(modelName)
-    //   );
-    // }
-
     string rootObjectId = await Operations
       .Send(rootObject, new List<ITransport> { _serverTransport, _memoryTransport })
       .ConfigureAwait(false);

--- a/Automate/Speckle.Automate.Sdk/AutomationContext.cs
+++ b/Automate/Speckle.Automate.Sdk/AutomationContext.cs
@@ -258,54 +258,29 @@ public class AutomationContext
       {
         Query =
           @"
-            mutation ReportFunctionRunStatus(
-                $automationId: String!,
-                $automationRevisionId: String!,
-                $automationRunId: String!,
-                $versionId: String!,
-                $functionId: String!,
-                $functionName: String!,
-                $functionLogo: String,
-                $runStatus: AutomationRunStatus!
-                $elapsed: Float!
-                $resultVersionIds: [String!]!
+            mutation AutomateFunctionRunStatusReport(
+                $functionRunId: String!
+                $status: AutomateRunStatus!
                 $statusMessage: String
-                $objectResults: JSONObject
+                $results: JSONObject
+                $contextView: String
             ){
-              automationMutations {
-                functionRunStatusReport(input: {
-                  automationId: $automationId
-                  automationRevisionId: $automationRevisionId
-                  automationRunId: $automationRunId
-                  versionId: $versionId
-                  functionRuns: [{
-                    functionId: $functionId,
-                    functionName: $functionName,
-                    functionLogo: $functionLogo,
-                    status: $runStatus,
-                    elapsed: $elapsed,
-                    resultVersionIds: $resultVersionIds,
-                    statusMessage: $statusMessage,
-                    results: $objectResults,
-                  }]
+                automateFunctionRunStatusReport(input: {
+                    functionRunId: $functionRunId
+                    status: $status
+                    statusMessage: $statusMessage
+                    contextView: $contextView
+                    results: $results
                 })
-              }
             }
         ",
         Variables = new
         {
-          automationId = AutomationRunData.AutomationId,
-          automationRevisionId = AutomationRunData.AutomationRevisionId,
-          automationRunId = AutomationRunData.AutomationRunId,
-          versionId = AutomationRunData.VersionId,
-          functionId = AutomationRunData.FunctionId,
-          functionName = AutomationRunData.FunctionName,
-          functionLogo = AutomationRunData.FunctionLogo,
-          runStatus = RunStatus,
+          functionRunId = AutomationRunData.FunctionRunId,
+          status = RunStatus,
           statusMessage = AutomationResult.StatusMessage,
-          elapsed = Elapsed.TotalSeconds,
-          resultVersionIds = AutomationResult.ResultVersions,
-          objectResults,
+          contextView = ContextView,
+          results = objectResults,
         }
       };
     await SpeckleClient.ExecuteGraphQLRequest<Dictionary<string, object>>(request).ConfigureAwait(false);

--- a/Automate/Speckle.Automate.Sdk/Schema/AutomationRunData.cs
+++ b/Automate/Speckle.Automate.Sdk/Schema/AutomationRunData.cs
@@ -1,20 +1,16 @@
+using Speckle.Automate.Sdk.Schema.Triggers;
+
 namespace Speckle.Automate.Sdk.Schema;
 
 ///<summary>
-///Values of the project, model and automation that triggered this function run.
+/// Values of the project, model and automation that triggered this function run.
 ///</summary>
 public struct AutomationRunData
 {
   public string ProjectId { get; set; }
-  public string ModelId { get; set; }
-  public string BranchName { get; set; }
-  public string VersionId { get; set; }
   public string SpeckleServerUrl { get; set; }
   public string AutomationId { get; set; }
-  public string AutomationRevisionId { get; set; }
   public string AutomationRunId { get; set; }
-  public string FunctionId { get; set; }
-  public string FunctionRelease { get; set; }
-  public string FunctionName { get; set; }
-  public string? FunctionLogo { get; set; }
+  public string FunctionRunId { get; set; }
+  public List<AutomationRunTriggerBase> Triggers { get; set; }
 }

--- a/Automate/Speckle.Automate.Sdk/Schema/ObjectResults.cs
+++ b/Automate/Speckle.Automate.Sdk/Schema/ObjectResults.cs
@@ -2,6 +2,6 @@ namespace Speckle.Automate.Sdk.Schema;
 
 public struct ObjectResults
 {
-  public readonly string Version => "1.0.0";
+  public readonly int Version => 1;
   public ObjectResultValues Values { get; set; }
 }

--- a/Automate/Speckle.Automate.Sdk/Schema/Triggers/AutomationRunTriggerBase.cs
+++ b/Automate/Speckle.Automate.Sdk/Schema/Triggers/AutomationRunTriggerBase.cs
@@ -1,0 +1,6 @@
+namespace Speckle.Automate.Sdk.Schema.Triggers;
+
+public class AutomationRunTriggerBase
+{
+  public string TriggerType { get; set; }
+}

--- a/Automate/Speckle.Automate.Sdk/Schema/Triggers/VersionCreationTrigger.cs
+++ b/Automate/Speckle.Automate.Sdk/Schema/Triggers/VersionCreationTrigger.cs
@@ -1,5 +1,8 @@
 namespace Speckle.Automate.Sdk.Schema.Triggers;
 
+/// <summary>
+/// Represents a single version creation trigger for the automation run.
+/// </summary>
 public class VersionCreationTrigger : AutomationRunTriggerBase
 {
   public VersionCreationTriggerPayload Payload { get; set; }
@@ -11,6 +14,9 @@ public class VersionCreationTrigger : AutomationRunTriggerBase
   }
 }
 
+/// <summary>
+/// Represents the version creation trigger payload.
+/// </summary>
 public class VersionCreationTriggerPayload
 {
   public string ModelId { get; set; }

--- a/Automate/Speckle.Automate.Sdk/Schema/Triggers/VersionCreationTrigger.cs
+++ b/Automate/Speckle.Automate.Sdk/Schema/Triggers/VersionCreationTrigger.cs
@@ -1,0 +1,18 @@
+namespace Speckle.Automate.Sdk.Schema.Triggers;
+
+public class VersionCreationTrigger : AutomationRunTriggerBase
+{
+  public VersionCreationTriggerPayload Payload { get; set; }
+
+  public VersionCreationTrigger(string modelId, string versionId)
+  {
+    TriggerType = "versionCreation";
+    Payload = new VersionCreationTriggerPayload() { ModelId = modelId, VersionId = versionId };
+  }
+}
+
+public class VersionCreationTriggerPayload
+{
+  public string ModelId { get; set; }
+  public string VersionId { get; set; }
+}


### PR DESCRIPTION
## Description & motivation

The shape of the Automate API is changing wrt status reporting and "triggers" for automate runs. The SDK should reflect these changes.

## Changes:

- `AutomationRunData` struct updated to match new shape
- References to `AutomationRunData.VersionId` and `AutomationRunData.ModelId` replaced with references in trigger(s)
- Use `switch` statements to handle "union" of types of possible triggers (only 1 currently available)
- Update gql operation in `ReportRunStatus`

