### PR TITLE
fix(ci): Install <8.0.300 everywhere

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -418,7 +418,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 
   build-connector-dotnet-mac:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:8.0
+      - image: mcr.microsoft.com/dotnet/sdk:7.0
     parameters:
       slnname:
         type: string

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -81,7 +81,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0.100
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.100
             $HOME/.dotnet/dotnet --version
       - run:
           name: Enforce formatting
@@ -129,7 +129,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0.100
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.100
             $HOME/.dotnet/dotnet --version
       - run:
           name: Startup the Speckle Server
@@ -310,7 +310,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0.100
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.100
 
             $HOME/.dotnet/dotnet --version
             $HOME/.dotnet/dotnet --list-runtimes

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -81,7 +81,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.100
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.204
             $HOME/.dotnet/dotnet --version
       - run:
           name: Enforce formatting
@@ -129,7 +129,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.100
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.204
             $HOME/.dotnet/dotnet --version
       - run:
           name: Startup the Speckle Server
@@ -310,7 +310,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.100
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 8.0.204
 
             $HOME/.dotnet/dotnet --version
             $HOME/.dotnet/dotnet --list-runtimes

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -81,7 +81,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0.100
             $HOME/.dotnet/dotnet --version
       - run:
           name: Enforce formatting
@@ -129,7 +129,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0.100
             $HOME/.dotnet/dotnet --version
       - run:
           name: Startup the Speckle Server
@@ -310,7 +310,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
           name: Install dotnet
           command: |
             curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel sts
-            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0.100
 
             $HOME/.dotnet/dotnet --version
             $HOME/.dotnet/dotnet --list-runtimes

--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -418,7 +418,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 
   build-connector-dotnet-mac:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
     parameters:
       slnname:
         type: string

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil.sln
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil.sln
@@ -69,6 +69,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorAutocad2025", "Con
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConverterAutocad2025", "..\Objects\Converters\ConverterAutocadCivil\ConverterAutocad2025\ConverterAutocad2025.csproj", "{5A4FB6D3-CAC0-43BC-BB4A-BED3845C79DA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectorCivil2025", "ConnectorCivil2025\ConnectorCivil2025.csproj", "{DD5EF30C-6000-4B8A-8ECC-6F6D5C3B0CEE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterCivil2025", "..\Objects\Converters\ConverterAutocadCivil\ConverterCivil2025\ConverterCivil2025.csproj", "{A8950613-B16B-461E-9549-331408DE7821}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -179,6 +183,14 @@ Global
 		{5A4FB6D3-CAC0-43BC-BB4A-BED3845C79DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A4FB6D3-CAC0-43BC-BB4A-BED3845C79DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A4FB6D3-CAC0-43BC-BB4A-BED3845C79DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD5EF30C-6000-4B8A-8ECC-6F6D5C3B0CEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD5EF30C-6000-4B8A-8ECC-6F6D5C3B0CEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD5EF30C-6000-4B8A-8ECC-6F6D5C3B0CEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD5EF30C-6000-4B8A-8ECC-6F6D5C3B0CEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8950613-B16B-461E-9549-331408DE7821}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8950613-B16B-461E-9549-331408DE7821}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8950613-B16B-461E-9549-331408DE7821}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8950613-B16B-461E-9549-331408DE7821}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -210,6 +222,8 @@ Global
 		{572B1D77-83BA-4E96-A70A-7D000D2AC220} = {A07071D5-E197-487D-B543-28639AC3C719}
 		{6B147D7E-4F94-43EC-A982-340E98B37656} = {A07071D5-E197-487D-B543-28639AC3C719}
 		{5A4FB6D3-CAC0-43BC-BB4A-BED3845C79DA} = {8AFDB1E6-D3E7-45EA-BCDC-F3554BDDEF1E}
+		{DD5EF30C-6000-4B8A-8ECC-6F6D5C3B0CEE} = {A07071D5-E197-487D-B543-28639AC3C719}
+		{A8950613-B16B-461E-9549-331408DE7821} = {8AFDB1E6-D3E7-45EA-BCDC-F3554BDDEF1E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EAFBA51C-7222-435F-8BDF-8C15B27A34C8}

--- a/Objects/Converters/ConverterAutocadCivil/ConverterCivil2025/ConverterCivil2025.csproj
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterCivil2025/ConverterCivil2025.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <AssemblyName>Objects.Converter.Civil2025</AssemblyName>
+    <AssemblyName>Objects.Converter.Civil3D2025</AssemblyName>
     <RootNamespace>Objects.Converter.Civil</RootNamespace>
     <DefineConstants>$(DefineConstants);CIVIL2025;CIVIL;CIVIL2021_OR_GREATER;CIVIL2022_OR_GREATER;CIVIL2023_OR_GREATER;CIVIL2024_OR_GREATER;CIVIL2025_OR_GREATER</DefineConstants>
     <PackageId>Speckle.Objects.Converter.Civil2025</PackageId>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.0",
+    "version": "8.0.0",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.0",
-    "rollForward": "latestMinor",
+    "version": "7.0.0",
+    "rollForward": "latestMajor",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "disable",
+    "version": "7.0.0",
+    "rollForward": "latestMinor",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.0",
-    "rollForward": "latestMajor",
+    "version": "8.0.100",
+    "rollForward": "disable",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Prevents dotnet from rolling forward to untested versions. These could (and do) bring in more analyser fixes and edge-cases covered; which means more warnings/errors in code that previously was OK.

The current fix is not really the ideal solution, but rather a temporary measure to prevent CI from running on the latest version of dotnet.

Ideal fix will be described in an incoming ticket (INSERT CODE HERE) but TLDR:
- We should lock our `global.json` version with no rollForward policy, and instead actively choose to upgrade at will.
- We should build all our projects in net8 (where possible, Rhino 8 uses Net7 🤦🏼‍♂️)

**Sneaky addition**
Includes some changes in civil SLN file (was missing some projects) and a typo fix on the converter assembly name to align with the rest of versions