### PR TITLE
CNX-9303 define a top level error handling strategy for all connectors most likely in the i bridge

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -39,14 +39,15 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding, ICancelable
   {
     try
     {
-      // Init cancellation token source -> Manager also cancel it if exist before
-      CancellationTokenSource cts = _cancellationManager.InitCancellationTokenSource(modelCardId);
-
       // Get receiver card
       if (_store.GetModelById(modelCardId) is not ReceiverModelCard modelCard)
       {
+        // Handle as GLOBAL ERROR at BrowserBridge
         throw new InvalidOperationException("No download model card was found.");
       }
+
+      // Init cancellation token source -> Manager also cancel it if exist before
+      CancellationTokenSource cts = _cancellationManager.InitCancellationTokenSource(modelCardId);
 
       using IUnitOfWork<ReceiveOperation> unitOfWork = _unitOfWorkFactory.Resolve<ReceiveOperation>();
 
@@ -65,9 +66,11 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding, ICancelable
 
       Commands.SetModelReceiveResult(modelCardId, receivedObjectIds.ToList());
     }
-    catch (Exception e) when (!e.IsFatal()) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
+    // Catch here specific exceptions if they related to model card.
+    catch (OperationCanceledException)
     {
-      Commands.SetModelError(modelCardId, e);
+      // SWALLOW -> UI handles it immediately, so we do not need to handle anything
+      return;
     }
   }
 

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
@@ -3,19 +3,19 @@ using Speckle.Autofac.DependencyInjection;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.Utils.Cancellation;
-using Speckle.Core.Logging;
 using ICancelable = System.Reactive.Disposables.ICancelable;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.DUI.Settings;
-using Speckle.Connectors.Utils;
 using ArcGIS.Desktop.Mapping.Events;
 using ArcGIS.Desktop.Mapping;
 using Speckle.Connectors.ArcGIS.Filters;
 using ArcGIS.Desktop.Editing.Events;
 using ArcGIS.Desktop.Framework.Threading.Tasks;
 using ArcGIS.Core.Data;
+using Speckle.Connectors.DUI.Exceptions;
+using Speckle.Connectors.Utils;
 using Speckle.Connectors.Utils.Operations;
 using Speckle.Core.Models;
 
@@ -258,14 +258,14 @@ public sealed class ArcGISSendBinding : ISendBinding, ICancelable
     using IUnitOfWork<SendOperation<MapMember>> unitOfWork = _unitOfWorkFactory.Resolve<SendOperation<MapMember>>();
     try
     {
-      // 0 - Init cancellation token source -> Manager also cancel it if exist before
-      CancellationTokenSource cts = _cancellationManager.InitCancellationTokenSource(modelCardId);
-
-      // 1 - Get model
       if (_store.GetModelById(modelCardId) is not SenderModelCard modelCard)
       {
+        // Handle as GLOBAL ERROR at BrowserBridge
         throw new InvalidOperationException("No publish model card was found.");
       }
+
+      // Init cancellation token source -> Manager also cancel it if exist before
+      CancellationTokenSource cts = _cancellationManager.InitCancellationTokenSource(modelCardId);
 
       var sendInfo = new SendInfo(
         modelCard.AccountId.NotNull(),
@@ -285,6 +285,14 @@ public sealed class ArcGISSendBinding : ISendBinding, ICancelable
             .Select(id => (MapMember)MapView.Active.Map.FindLayer(id) ?? MapView.Active.Map.FindStandaloneTable(id))
             .Where(obj => obj != null)
             .ToList();
+
+          if (!mapMembers.Any())
+          {
+            // Handle as CARD ERROR in this function
+            throw new SpeckleSendFilterException(
+              "No objects were found to convert. Please update your publish filter!"
+            );
+          }
 
           var result = await unitOfWork.Service
             .Execute(
@@ -310,13 +318,15 @@ public sealed class ArcGISSendBinding : ISendBinding, ICancelable
 
       Commands.SetModelCreatedVersionId(modelCardId, sendResult.rootObjId);
     }
-    catch (OperationCanceledException)
-    {
-      return;
-    }
-    catch (Exception e) when (!e.IsFatal()) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
+    // Catch here specific exceptions if they related to model card.
+    catch (SpeckleSendFilterException e)
     {
       Commands.SetModelError(modelCardId, e);
+    }
+    catch (OperationCanceledException)
+    {
+      // SWALLOW -> UI handles it immediately, so we do not need to handle anything
+      return;
     }
   }
 

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Send/RootObjectBuilder.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Send/RootObjectBuilder.cs
@@ -26,12 +26,6 @@ public class RootObjectBuilder : IRootObjectBuilder<MapMember>
     CancellationToken ct = default
   )
   {
-    if (!objects.Any())
-    {
-      // POC: not sure if we would want to throw in here?
-      throw new InvalidOperationException("No objects were found. Please update your send filter!");
-    }
-
     // POC: does this feel like the right place? I am wondering if this should be called from within send/rcv?
     // begin the unit of work
     using var uow = _unitOfWorkFactory.Resolve<IRootToSpeckleConverter>();

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SendBinding.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SendBinding.cs
@@ -9,6 +9,7 @@ using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Autofac.DependencyInjection;
+using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.Utils.Operations;
 using Speckle.Core.Models;
@@ -72,10 +73,6 @@ internal sealed class SendBinding : RevitBaseBinding, ICancelable, ISendBinding
 
   private async Task HandleSend(string modelCardId)
   {
-    // POC: probably the CTS SHOULD be injected as InstancePerLifetimeScope and then
-    // it can be injected where needed instead of passing it around like a bomb :D
-    CancellationTokenSource cts = CancellationManager.InitCancellationTokenSource(modelCardId);
-
     // POC: this try catch pattern is coming from Rhino. I see there is a semi implemented "SpeckleTopLevelExceptionHandler"
     // above that wraps the call of this HandleSend, but it currently is not doing anything - resulting in all errors from here
     // bubbling up to the bridge.
@@ -83,8 +80,13 @@ internal sealed class SendBinding : RevitBaseBinding, ICancelable, ISendBinding
     {
       if (Store.GetModelById(modelCardId) is not SenderModelCard modelCard)
       {
+        // Handle as GLOBAL ERROR at BrowserBridge
         throw new InvalidOperationException("No publish model card was found.");
       }
+
+      // POC: probably the CTS SHOULD be injected as InstancePerLifetimeScope and then
+      // it can be injected where needed instead of passing it around like a bomb :D
+      CancellationTokenSource cts = CancellationManager.InitCancellationTokenSource(modelCardId);
 
       using IUnitOfWork<SendOperation<ElementId>> sendOperation = _unitOfWorkFactory.Resolve<
         SendOperation<ElementId>
@@ -95,6 +97,12 @@ internal sealed class SendBinding : RevitBaseBinding, ICancelable, ISendBinding
         .GetObjectIds()
         .Select(id => ElementId.Parse(id))
         .ToList();
+
+      if (!revitObjects.Any())
+      {
+        // Handle as CARD ERROR in this function
+        throw new SpeckleSendFilterException("No objects were found to convert. Please update your publish filter!");
+      }
 
       var sendInfo = new SendInfo(
         modelCard.AccountId.NotNull(),
@@ -125,13 +133,14 @@ internal sealed class SendBinding : RevitBaseBinding, ICancelable, ISendBinding
 
       Commands.SetModelCreatedVersionId(modelCardId, sendResult.rootObjId);
     }
+    // Catch here specific exceptions if they related to model card.
+    catch (SpeckleSendFilterException e)
+    {
+      Commands.SetModelError(modelCardId, e);
+    }
     catch (OperationCanceledException)
     {
       return;
-    }
-    catch (Exception e) when (!e.IsFatal()) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
-    {
-      Commands.SetModelError(modelCardId, e);
     }
   }
 

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -1,6 +1,7 @@
 using Speckle.Converters.Common;
 using Speckle.Core.Models;
 using Autodesk.Revit.DB;
+using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Converters.RevitShared.Helpers;
 using Speckle.Connectors.Utils.Builders;
 using Speckle.Connectors.Utils.Operations;
@@ -56,7 +57,7 @@ public class RevitRootObjectBuilder : IRootObjectBuilder<ElementId>
 
     if (revitElements.Count == 0)
     {
-      throw new InvalidOperationException("No objects were found. Please update your send filter!");
+      throw new SpeckleSendFilterException("No objects were found. Please update your send filter!");
     }
 
     var countProgress = 0; // because for(int i = 0; ...) loops are so last year

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoSendBinding.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoSendBinding.cs
@@ -6,10 +6,10 @@ using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.Rhino7.HostApp;
 using Speckle.Connectors.Utils.Cancellation;
-using Speckle.Core.Logging;
 using ICancelable = System.Reactive.Disposables.ICancelable;
 using Speckle.Autofac.DependencyInjection;
 using Rhino.DocObjects;
+using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.Utils.Operations;
 using Speckle.Core.Models;
@@ -137,14 +137,14 @@ public sealed class RhinoSendBinding : ISendBinding, ICancelable
     using var unitOfWork = _unitOfWorkFactory.Resolve<SendOperation<RhinoObject>>();
     try
     {
-      // 0 - Init cancellation token source -> Manager also cancel it if exist before
-      CancellationTokenSource cts = _cancellationManager.InitCancellationTokenSource(modelCardId);
-
-      // 1 - Get model
       if (_store.GetModelById(modelCardId) is not SenderModelCard modelCard)
       {
+        // Handle as GLOBAL ERROR at BrowserBridge
         throw new InvalidOperationException("No publish model card was found.");
       }
+
+      //  Init cancellation token source -> Manager also cancel it if exist before
+      CancellationTokenSource cts = _cancellationManager.InitCancellationTokenSource(modelCardId);
 
       List<RhinoObject> rhinoObjects = modelCard.SendFilter
         .NotNull()
@@ -152,6 +152,12 @@ public sealed class RhinoSendBinding : ISendBinding, ICancelable
         .Select(id => RhinoDoc.ActiveDoc.Objects.FindId(new Guid(id)))
         .Where(obj => obj != null)
         .ToList();
+
+      if (!rhinoObjects.Any())
+      {
+        // Handle as CARD ERROR in this function
+        throw new SpeckleSendFilterException("No objects were found to convert. Please update your publish filter!");
+      }
 
       var sendInfo = new SendInfo(
         modelCard.AccountId.NotNull(),
@@ -182,13 +188,15 @@ public sealed class RhinoSendBinding : ISendBinding, ICancelable
 
       Commands.SetModelCreatedVersionId(modelCardId, sendResult.rootObjId);
     }
-    catch (OperationCanceledException)
-    {
-      return;
-    }
-    catch (Exception e) when (!e.IsFatal()) // All exceptions should be handled here if possible, otherwise we enter "crashing the host app" territory.
+    // Catch here specific exceptions if they related to model card.
+    catch (SpeckleSendFilterException e)
     {
       Commands.SetModelError(modelCardId, e);
+    }
+    catch (OperationCanceledException)
+    {
+      // SWALLOW -> UI handles it immediately, so we do not need to handle anything
+      return;
     }
   }
 

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Operations/Send/RhinoRootObjectBuilder.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Operations/Send/RhinoRootObjectBuilder.cs
@@ -26,18 +26,7 @@ public class RhinoRootObjectBuilder : IRootObjectBuilder<RhinoObject>
     SendInfo sendInfo,
     Action<string, double?>? onOperationProgressed = null,
     CancellationToken ct = default
-  )
-  {
-    if (!objects.Any())
-    {
-      // POC: not sure if we would want to throw in here?
-      throw new InvalidOperationException("No objects were found. Please update your send filter!");
-    }
-
-    Base commitObject = ConvertObjects(objects, sendInfo, onOperationProgressed, ct);
-
-    return commitObject;
-  }
+  ) => ConvertObjects(objects, sendInfo, onOperationProgressed, ct);
 
   private Collection ConvertObjects(
     IReadOnlyList<RhinoObject> rhinoObjects,

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -256,6 +256,9 @@ public class BrowserBridge : IBridge
     }
   }
 
+  /// <summary>
+  /// Errors that not handled on bindings.
+  /// </summary>
   private void ReportUnhandledError(string requestId, Exception e)
   {
     var errorDetails = new

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -207,6 +207,7 @@ public class BrowserBridge : IBridge
         {
           continue;
         }
+
         typedArgs[i] = ccc;
       }
 
@@ -223,6 +224,8 @@ public class BrowserBridge : IBridge
       else // It's an async call
       {
         // See note at start of function. Do not asyncify!
+
+        // POC: "Reporting and Error Handling" -> Aggregate exception
         resultTypedTask.Wait();
 
         // If has a "Result" property return the value otherwise null (Task<void> etc)
@@ -241,6 +244,20 @@ public class BrowserBridge : IBridge
         _serializerOptions
       );
 
+      NotifyUIMethodCallResultReady(requestId, serializedError);
+    }
+    // POC: "Reporting and Error Handling" -> Unhandled errors in invoked method!
+    catch (TargetInvocationException e)
+    {
+      var errorDetails = new
+      {
+        Error = e.Message,
+        e.StackTrace,
+        InnerError = e.InnerException?.Message,
+        InnerStackTrace = e.InnerException?.StackTrace
+      };
+
+      var serializedError = JsonConvert.SerializeObject(errorDetails, _serializerOptions);
       NotifyUIMethodCallResultReady(requestId, serializedError);
     }
   }

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -247,31 +247,27 @@ public class BrowserBridge : IBridge
     // POC: ASYNC "Reporting and Error Handling" -> Unhandled errors in invoked method for async functions!
     catch (AggregateException e)
     {
-      var errorDetails = new
-      {
-        Error = e.Message,
-        e.StackTrace,
-        InnerError = e.InnerException?.Message,
-        InnerStackTrace = e.InnerException?.StackTrace
-      };
-
-      var serializedError = JsonConvert.SerializeObject(errorDetails, _serializerOptions);
-      NotifyUIMethodCallResultReady(requestId, serializedError);
+      ReportUnhandledError(requestId, e);
     }
     // POC: SYNC "Reporting and Error Handling" -> Unhandled errors in invoked method for sync functions!
     catch (TargetInvocationException e)
     {
-      var errorDetails = new
-      {
-        Error = e.Message,
-        e.StackTrace,
-        InnerError = e.InnerException?.Message,
-        InnerStackTrace = e.InnerException?.StackTrace
-      };
-
-      var serializedError = JsonConvert.SerializeObject(errorDetails, _serializerOptions);
-      NotifyUIMethodCallResultReady(requestId, serializedError);
+      ReportUnhandledError(requestId, e);
     }
+  }
+
+  private void ReportUnhandledError(string requestId, Exception e)
+  {
+    var errorDetails = new
+    {
+      Error = e.Message,
+      e.StackTrace,
+      InnerError = e.InnerException?.Message,
+      InnerStackTrace = e.InnerException?.StackTrace
+    };
+
+    var serializedError = JsonConvert.SerializeObject(errorDetails, _serializerOptions);
+    NotifyUIMethodCallResultReady(requestId, serializedError);
   }
 
   /// <summary>

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Exceptions/SpeckleSendFilterException.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Exceptions/SpeckleSendFilterException.cs
@@ -1,0 +1,12 @@
+﻿namespace Speckle.Connectors.DUI.Exceptions;
+
+public class SpeckleSendFilterException : Exception
+{
+  public SpeckleSendFilterException() { }
+
+  public SpeckleSendFilterException(string message)
+    : base(message) { }
+
+  public SpeckleSendFilterException(string message, Exception innerException)
+    : base(message, innerException) { }
+}


### PR DESCRIPTION
With this figma board we investigated back and forth handle which exception where.
https://www.figma.com/board/8QiaBt4QfxSa4DbNjnAdto/DUI3-Reporting-and-Error-Handling?node-id=0-1&t=caf8txRzgoEt2C1p-0

Then decided to BE SPECIFIC for exceptions on bindings methods (i.e. Send), and handle unhandled errors at the `BrowserBridge` level.

We will handle exceptions;
- on binding method if we want to show message on model card
- on bridge `ExecuteMethod` method if we want to show message as global toast

We might need to test it extensively to find potential gaps.