### PR TITLE
Chore (dui3): error message from inner exception on sync functions

### DIFF
--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -255,7 +255,12 @@ public class BrowserBridge : IBridge
   /// </summary>
   private void ReportUnhandledError(string requestId, Exception e)
   {
-    var errorDetails = new { e.Message, Error = e.ToString() };
+    var message = e.Message;
+    if (e is TargetInvocationException tie) // Exception on SYNC function calls. Message should be passed from inner exception since it is wrapped.
+    {
+      message = tie.InnerException?.Message;
+    }
+    var errorDetails = new { Message = message, Error = e.ToString() };
 
     var serializedError = JsonConvert.SerializeObject(errorDetails, _serializerOptions);
     NotifyUIMethodCallResultReady(requestId, serializedError);

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bridge/BrowserBridge.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks.Dataflow;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Speckle.Connectors.Utils;
+using Speckle.Core.Models.Extensions;
 
 namespace Speckle.Connectors.DUI.Bridge;
 
@@ -260,7 +261,12 @@ public class BrowserBridge : IBridge
     {
       message = tie.InnerException?.Message;
     }
-    var errorDetails = new { Message = message, Error = e.ToString() };
+    var errorDetails = new
+    {
+      Message = message, // Topmost message
+      Error = e.ToFormattedString(), // All messages from exceptions
+      StackTrace = e.ToString()
+    };
 
     var serializedError = JsonConvert.SerializeObject(errorDetails, _serializerOptions);
     NotifyUIMethodCallResultReady(requestId, serializedError);


### PR DESCRIPTION
Otherwise error message is rendered wrong on UI.
@JR-Morgan happy to consider if you have alternative.

Before
![image](https://github.com/specklesystems/speckle-sharp/assets/45078678/d89c8fe5-dc24-4510-9649-22e1a90bdea0)


After
![image](https://github.com/specklesystems/speckle-sharp/assets/45078678/a09e3f1c-bce7-49e7-a12e-6c9f4541fbc7)
