### PR TITLE
fix: Warnings picked up in net8.0

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
@@ -286,7 +286,7 @@ public sealed class ArcGISSendBinding : ISendBinding, ICancelable
             .Where(obj => obj != null)
             .ToList();
 
-          if (!mapMembers.Any())
+          if (mapMembers.Count == 0)
           {
             // Handle as CARD ERROR in this function
             throw new SpeckleSendFilterException(

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
@@ -82,7 +82,8 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
   private string[] GetLayerPath(TraversalContext context)
   {
     string[] collectionBasedPath = context.GetAscendantOfType<Collection>().Select(c => c.name).ToArray();
-    string[] reverseOrderPath = collectionBasedPath.Any() ? collectionBasedPath : context.GetPropertyPath().ToArray();
+    string[] reverseOrderPath =
+      collectionBasedPath.Length != 0 ? collectionBasedPath : context.GetPropertyPath().ToArray();
     return reverseOrderPath.Reverse().ToArray();
   }
 
@@ -180,10 +181,7 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
     // 3. add layer and tables to the Table Of Content
     foreach ((string, string) databaseObj in convertedGISObjects)
     {
-      if (cancellationToken.IsCancellationRequested)
-      {
-        throw new OperationCanceledException(cancellationToken);
-      }
+      cancellationToken.ThrowIfCancellationRequested();
       // BAKE OBJECTS HERE
       // POC: QueuedTask
       var task = QueuedTask.Run(() =>

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Operations/Receive/AutocadHostObjectBuilder.cs
@@ -103,7 +103,7 @@ public class AutocadHostObjectBuilder : IHostObjectBuilder
   private string GetLayerPath(TraversalContext context, string baseLayerPrefix)
   {
     string[] collectionBasedPath = context.GetAscendantOfType<Collection>().Select(c => c.name).ToArray();
-    string[] path = collectionBasedPath.Any() ? collectionBasedPath : context.GetPropertyPath().ToArray();
+    string[] path = collectionBasedPath.Length != 0 ? collectionBasedPath : context.GetPropertyPath().ToArray();
 
     return _autocadLayerManager.LayerFullName(baseLayerPrefix, string.Join("-", path)); //TODO: reverse path?
   }

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/BasicConnectorBindingRevit.cs
@@ -91,7 +91,7 @@ internal sealed class BasicConnectorBindingRevit : IBasicConnectorBinding
     SenderModelCard model = (SenderModelCard)_store.GetModelById(modelCardId);
 
     var elementIds = model.SendFilter.NotNull().GetObjectIds().Select(ElementId.Parse).ToList();
-    if (elementIds.Any())
+    if (elementIds.Count != 0)
     {
       Commands.SetModelError(modelCardId, new InvalidOperationException("No objects found to highlight."));
       return;

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SendBinding.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/SendBinding.cs
@@ -98,7 +98,7 @@ internal sealed class SendBinding : RevitBaseBinding, ICancelable, ISendBinding
         .Select(id => ElementId.Parse(id))
         .ToList();
 
-      if (!revitObjects.Any())
+      if (revitObjects.Count == 0)
       {
         // Handle as CARD ERROR in this function
         throw new SpeckleSendFilterException("No objects were found to convert. Please update your publish filter!");

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Operations/Send/RevitRootObjectBuilder.cs
@@ -122,9 +122,9 @@ public class RevitRootObjectBuilder : IRootObjectBuilder<ElementId>
     {
       flatPathName += pathItem;
       Collection childCollection;
-      if (_collectionCache.ContainsKey(flatPathName))
+      if (_collectionCache.TryGetValue(flatPathName, out Collection? collection))
       {
-        childCollection = _collectionCache[flatPathName];
+        childCollection = collection;
       }
       else
       {

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoSendBinding.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoSendBinding.cs
@@ -153,7 +153,7 @@ public sealed class RhinoSendBinding : ISendBinding, ICancelable
         .Where(obj => obj != null)
         .ToList();
 
-      if (!rhinoObjects.Any())
+      if (rhinoObjects.Count == 0)
       {
         // Handle as CARD ERROR in this function
         throw new SpeckleSendFilterException("No objects were found to convert. Please update your publish filter!");

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Operations/Receive/RhinoHostObjectBuilder.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Operations/Receive/RhinoHostObjectBuilder.cs
@@ -194,7 +194,8 @@ public class RhinoHostObjectBuilder : IHostObjectBuilder
   private string[] GetLayerPath(TraversalContext context)
   {
     string[] collectionBasedPath = context.GetAscendantOfType<Collection>().Select(c => c.name).ToArray();
-    string[] reverseOrderPath = collectionBasedPath.Any() ? collectionBasedPath : context.GetPropertyPath().ToArray();
+    string[] reverseOrderPath =
+      collectionBasedPath.Length != 0 ? collectionBasedPath : context.GetPropertyPath().ToArray();
     return reverseOrderPath.Reverse().ToArray();
   }
 }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
@@ -49,12 +49,13 @@ public class NonNativeFeaturesUtils : INonNativeFeaturesUtils
         (string parentPath, ACG.Geometry geom, string? parentId) = item.Value;
 
         // add dictionnary item if doesn't exist yet
-        if (!geometryGroups.ContainsKey(parentPath))
+        if (!geometryGroups.TryGetValue(parentPath, out var value))
         {
-          geometryGroups[parentPath] = (new List<ACG.Geometry>(), parentId);
+          value = (new List<ACG.Geometry>(), parentId);
+          geometryGroups[parentPath] = value;
         }
 
-        geometryGroups[parentPath].geometries.Add(geom);
+        value.geometries.Add(geom);
       }
       catch (Exception ex) when (!ex.IsFatal())
       {

--- a/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/PolycurveToHostPolylineRawConverter.cs
+++ b/DUI3-DX/Converters/Autocad/Speckle.Converters.AutocadShared/ToHost/Raw/PolycurveToHostPolylineRawConverter.cs
@@ -49,7 +49,7 @@ public class PolycurveToHostPolylineRawConverter : ITypedConverter<SOG.Polycurve
           angle = angle < 0 ? angle + 2 * Math.PI : angle;
           if (angle is null)
           {
-            throw new ArgumentNullException(nameof(arc), "Cannot convert arc without angle value.");
+            throw new ArgumentNullException(nameof(target), "Cannot convert arc without angle value.");
           }
 
           var bulge = Math.Tan((double)angle / 4) * BulgeDirection(arc.startPoint, arc.midPoint, arc.endPoint);

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/Helpers/DisplayValueExtractor.cs
@@ -51,12 +51,13 @@ public sealed class DisplayValueExtractor
     foreach (var mesh in meshes)
     {
       var materialId = mesh.MaterialElementId;
-      if (!meshesByMaterial.ContainsKey(materialId))
+      if (!meshesByMaterial.TryGetValue(materialId, out List<DB.Mesh>? value))
       {
-        meshesByMaterial[materialId] = new List<DB.Mesh>();
+        value = new List<DB.Mesh>();
+        meshesByMaterial[materialId] = value;
       }
 
-      meshesByMaterial[materialId].Add(mesh);
+      value.Add(mesh);
     }
 
     foreach (var solid in solids)
@@ -64,12 +65,13 @@ public sealed class DisplayValueExtractor
       foreach (DB.Face face in solid.Faces)
       {
         var materialId = face.MaterialElementId;
-        if (!meshesByMaterial.ContainsKey(materialId))
+        if (!meshesByMaterial.TryGetValue(materialId, out List<DB.Mesh>? value))
         {
-          meshesByMaterial[materialId] = new List<DB.Mesh>();
+          value = new List<DB.Mesh>();
+          meshesByMaterial[materialId] = value;
         }
 
-        meshesByMaterial[materialId].Add(face.Triangulate());
+        value.Add(face.Triangulate());
       }
     }
 

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ReferencePointConverter.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.RevitShared/ReferencePointConverter.cs
@@ -42,16 +42,17 @@ public class ReferencePointConverter : IReferencePointConverter
     //if the current doc is unsaved it will not, but then it'll be the only one :)
     var id = doc.PathName;
 
-    if (!_docTransforms.ContainsKey(id))
+    if (!_docTransforms.TryGetValue(id, out DB.Transform? transform))
     {
       // get from settings
       var referencePointSetting = _revitSettings.TryGetSettingString("reference-point", out string value)
         ? value
         : string.Empty;
-      _docTransforms[id] = GetReferencePointTransform(referencePointSetting);
+      transform = GetReferencePointTransform(referencePointSetting);
+      _docTransforms[id] = transform;
     }
 
-    return _docTransforms[id];
+    return transform;
   }
 
   [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]


### PR DESCRIPTION
In preparation for updating to net8 as our default SDK, there were a bunch of new warnings that appeared in 8.0.300 that needed to be adressed.

These are simple fixes:
- Use TryGetvalue in dictionaries
- Use Length != 0 instead of Any()

