### PR TITLE
chore: Temporarily silence warnings that are not errors in Core and Objects

### DIFF
--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -17,8 +17,8 @@
 
   <PropertyGroup Condition="'$(IsDesktopBuild)' == false">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>
-      $(WarningsNotAsErrors);
+    <NoWarn>
+      $(NoWarn);
       CA1000; CA1001; CA1003; CA1024; CA1033; CA1034; CA1051; CA1055; CA1063; CA1065;
       CA1502; CA1506;
       CA1708; CA1710; CA1711; CA1716; CA1720; CA1721; CA1724;
@@ -27,12 +27,12 @@
       CS0419; CS0618; CS0659; CS0809;
       CS8600; CS8602; CS8603; CS8604;
       IDE0032; IDE0059; IDE0130; IDE1006;
-    </WarningsNotAsErrors>
+    </NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <InternalsVisibleTo Include="Speckle.Core.Tests.Unit" />
-    <InternalsVisibleTo Include="Speckle.Core.Tests.Integration" />
+    <InternalsVisibleTo Include="Speckle.Core.Tests.Unit"/>
+    <InternalsVisibleTo Include="Speckle.Core.Tests.Integration"/>
   </ItemGroup>
 
   <!--Do
@@ -42,28 +42,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Client" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="Sentry" Version="3.33.0" />
-    <PackageReference Include="Sentry.Serilog" Version="3.33.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.3.0" />
-    <PackageReference Include="Serilog.Enrichers.GlobalLogContext" Version="3.0.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
-    <PackageReference Include="SerilogTimings" Version="3.0.1" />
-    <PackageReference Include="Speckle.Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5" />
-    <PackageReference Include="System.DoubleNumerics" Version="3.1.3" />
+    <PackageReference Include="GraphQL.Client" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+    <PackageReference Include="Polly" Version="7.2.3"/>
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1"/>
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0"/>
+    <PackageReference Include="Sentry" Version="3.33.0"/>
+    <PackageReference Include="Sentry.Serilog" Version="3.33.0"/>
+    <PackageReference Include="Serilog" Version="2.12.0"/>
+    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.3.0"/>
+    <PackageReference Include="Serilog.Enrichers.GlobalLogContext" Version="3.0.0"/>
+    <PackageReference Include="Serilog.Exceptions" Version="8.4.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2"/>
+    <PackageReference Include="SerilogTimings" Version="3.0.1"/>
+    <PackageReference Include="Speckle.Newtonsoft.Json" Version="13.0.2"/>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5"/>
+    <PackageReference Include="System.DoubleNumerics" Version="3.1.3"/>
   </ItemGroup>
 
-<!--  Ensure-->
+  <!--  Ensure-->
   <Target Name="husky" BeforeTargets="Restore" Condition="$(IsDesktopBuild) == 'true'">
-    <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
-    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(RepositoryRoot)" />
+    <Exec Command="dotnet tool restore" StandardOutputImportance="Low"
+      StandardErrorImportance="High"/>
+    <Exec Command="dotnet husky install" StandardOutputImportance="Low"
+      StandardErrorImportance="High" WorkingDirectory="$(RepositoryRoot)"/>
   </Target>
 </Project>

--- a/Objects/Objects/Objects.csproj
+++ b/Objects/Objects/Objects.csproj
@@ -15,15 +15,15 @@
 
   <PropertyGroup Condition="'$(IsDesktopBuild)' == false">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>
-      $(WarningsNotAsErrors);
+    <NoWarn>
+      $(NoWarn);
       CA1008; CA1024; CA1034; CA1065;
       CA1708; CA1711; CA1716; CA1724; CA1725;
       CA1819; CS8618;
       CA2201; CA2225;
       CS0659; CS0661; CS0728;
       IDE0041; IDE0060; IDE1006;
-    </WarningsNotAsErrors>
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our CI now picks up on warnings and displays them in the PR, this leads to 1000s of warnings we don't consider errors being reported.

I'm disabling them for now. This only applies to CI builds so local builds will still see these warnings.