### PR TITLE
CNX-9752 add parts data to pipes and structures

### DIFF
--- a/Objects/Objects/Other/Civil/CivilDataField.cs
+++ b/Objects/Objects/Other/Civil/CivilDataField.cs
@@ -1,0 +1,20 @@
+namespace Objects.Other.Civil;
+
+public class CivilDataField : DataField
+{
+  public CivilDataField() { }
+
+  public CivilDataField(string name, string type, string units, string context, object? value = null)
+  {
+    this.name = name;
+    this.type = type;
+    this.units = units;
+    this.context = context;
+    this.value = value;
+  }
+
+  /// <summary>
+  /// The context type of the Civil3D part
+  /// </summary>
+  public string context { get; set; }
+}

--- a/Objects/Objects/Other/DataField.cs
+++ b/Objects/Objects/Other/DataField.cs
@@ -1,0 +1,27 @@
+using Speckle.Core.Models;
+
+namespace Objects.Other;
+
+/// <summary>
+/// Generic class for a data field
+/// </summary>
+public class DataField : Base
+{
+  public DataField() { }
+
+  public DataField(string name, string type, string units, object? value = null)
+  {
+    this.name = name;
+    this.type = type;
+    this.units = units;
+    this.value = value;
+  }
+
+  public string name { get; set; }
+
+  public string type { get; set; }
+
+  public object? value { get; set; }
+
+  public string units { get; set; }
+}


### PR DESCRIPTION
## Description & motivation

Adds parts data to pipes and structures.
This implementation introduces 2 new classes: `DataField` (which functions as a generic `Parameter` class) and `CivilDataField:DataField` which includes civil3d-specific properties.

## Changes:

- Objects
- Civil3D converter


## Screenshots:

[https://speckle.xyz/streams/b53a53697a/commits/99b6ae2a03](https://speckle.xyz/streams/b53a53697a/commits/99b6ae2a03)
![image](https://github.com/specklesystems/speckle-sharp/assets/16748799/cd0c9f45-1a9b-415f-a904-8699ae6ef6ba)

