### PR TITLE
CNX-9443 Rhino Compute units set as mm

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
@@ -28,6 +28,7 @@ public static class Utilities
   /// </summary>
   /// <remarks>If running in Rhino >7, Rhino7 will be used as fallback.</remarks>
   /// <returns><see cref="VersionedHostApplications.Grasshopper7"/> when Rhino 7 is running, <see cref="VersionedHostApplications.Grasshopper8"/> when Rhino 8 is running, <see cref="VersionedHostApplications.Grasshopper6"/> otherwise.</returns>
+  [Obsolete("Use Loader.GetGrasshopperHostAppVersion instead")]
   public static string GetVersionedAppName() => Loader.GetGrasshopperHostAppVersion();
 
   public static ISpeckleConverter GetDefaultConverter()

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
@@ -10,7 +10,6 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using Microsoft.CSharp.RuntimeBinder;
-using Rhino;
 using Rhino.Display;
 using Rhino.Geometry;
 using Speckle.Core.Kits;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
@@ -27,17 +27,8 @@ public static class Utilities
   /// Gets the appropriate Grasshopper App name depending on the Version of Rhino currently running.
   /// </summary>
   /// <remarks>If running in Rhino >7, Rhino7 will be used as fallback.</remarks>
-  /// <returns><see cref="VersionedHostApplications.Grasshopper7"/> when Rhino 7 is running, <see cref="VersionedHostApplications.Grasshopper6"/> otherwise.</returns>
-  public static string GetVersionedAppName()
-  {
-    var version = HostApplications.Grasshopper.GetVersion(HostAppVersion.v6);
-    if (RhinoApp.Version.Major >= 7)
-    {
-      version = HostApplications.Grasshopper.GetVersion(HostAppVersion.v7);
-    }
-
-    return version;
-  }
+  /// <returns><see cref="VersionedHostApplications.Grasshopper7"/> when Rhino 7 is running, <see cref="VersionedHostApplications.Grasshopper8"/> when Rhino 8 is running, <see cref="VersionedHostApplications.Grasshopper6"/> otherwise.</returns>
+  public static string GetVersionedAppName() => Loader.GetGrasshopperHostAppVersion();
 
   public static ISpeckleConverter GetDefaultConverter()
   {

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
@@ -49,6 +49,7 @@ public class Loader : GH_AssemblyPriority
     Setup.Init(GetRhinoHostAppVersion(), HostApplications.Rhino.Slug, logConfig);
 
     Instances.CanvasCreated += OnCanvasCreated;
+
 #if RHINO7_OR_GREATER
     if (Instances.RunningHeadless)
     {
@@ -510,7 +511,8 @@ public class Loader : GH_AssemblyPriority
 
     _headlessDoc = RhinoDoc.CreateHeadless(null);
     Console.WriteLine(
-      $"Headless run with doc '{_headlessDoc.Name ?? "Untitled"}'\n    with template: '{_headlessDoc.TemplateFileUsed ?? "No template"}'\n    with units: {_headlessDoc.ModelUnitSystem}");
+      $"Speckle - Backup headless doc is ready: '{_headlessDoc.Name ?? "Untitled"}'\n    with template: '{_headlessDoc.TemplateFileUsed ?? "No template"}'\n    with units: {_headlessDoc.ModelUnitSystem}");
+    Console.WriteLine("Speckle - To modify the units in a headless run, you can override the 'RhinoDoc.ActiveDoc' in the '.gh' file using a c#/python script.");
 #endif
   }
 
@@ -522,13 +524,17 @@ public class Loader : GH_AssemblyPriority
   public static RhinoDoc GetCurrentDocument()
   {
 #if RHINO7_OR_GREATER
-    if (Instances.RunningHeadless && RhinoDoc.ActiveDoc == null)
+    if (Instances.RunningHeadless && RhinoDoc.ActiveDoc == null && _headlessDoc != null)
     {
+      // Running headless, with no ActiveDoc override and _headlessDoc was correctly initialised.
+      // Only time the _headlessDoc is not set is upon document opening, where the components will
+      // check for this as their normal initialisation routine, but the document will be refreshed on every solution run.
       Console.WriteLine(
-        $"Fetching headless doc '{_headlessDoc.Name ?? "Untitled"}'\n    with template: '{_headlessDoc.TemplateFileUsed ?? "No template"}'");
+        $"Speckle - Fetching headless doc '{_headlessDoc?.Name ?? "Untitled"}'\n    with template: '{_headlessDoc.TemplateFileUsed ?? "No template"}'");
       Console.WriteLine("    Model units:" + _headlessDoc.ModelUnitSystem);
       return _headlessDoc;
     }
+    
     return RhinoDoc.ActiveDoc;
 #else
     return RhinoDoc.ActiveDoc;

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Loader.cs
@@ -49,7 +49,7 @@ public class Loader : GH_AssemblyPriority
     Setup.Init(GetRhinoHostAppVersion(), HostApplications.Rhino.Slug, logConfig);
 
     Instances.CanvasCreated += OnCanvasCreated;
-#if RHINO7
+#if RHINO7_OR_GREATER
     if (Instances.RunningHeadless)
     {
       // If GH is running headless, we listen for document added/removed events.
@@ -492,7 +492,7 @@ public class Loader : GH_AssemblyPriority
 
   public static void DisposeHeadlessDoc()
   {
-#if RHINO7
+#if RHINO7_OR_GREATER
     _headlessDoc?.Dispose();
 #endif
     _headlessDoc = null;
@@ -500,7 +500,7 @@ public class Loader : GH_AssemblyPriority
 
   public static void SetupHeadlessDoc()
   {
-#if RHINO7
+#if RHINO7_OR_GREATER
     // var templatePath = Path.Combine(Helpers.UserApplicationDataPath, "Speckle", "Templates",
     //   SpeckleGHSettings.HeadlessTemplateFilename);
     // Console.WriteLine($"Setting up doc. Looking for '{templatePath}'");
@@ -521,7 +521,7 @@ public class Loader : GH_AssemblyPriority
   /// <returns></returns>
   public static RhinoDoc GetCurrentDocument()
   {
-#if RHINO7
+#if RHINO7_OR_GREATER
     if (Instances.RunningHeadless && RhinoDoc.ActiveDoc == null)
     {
       Console.WriteLine(

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObject.cs
@@ -186,7 +186,7 @@ public class CreateSchemaObject : SelectKitComponentBase, IGH_VariableParameterC
         break;
       }
       (Params.Output[0] as SpeckleBaseParam).UseSchemaTag = UseSchemaTag;
-#if RHINO7
+#if RHINO7_OR_GREATER
       if (!Instances.RunningHeadless)
       {
         (Params.Output[0] as SpeckleBaseParam).ExpirePreview(true);

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/SchemaBuilder/CreateSchemaObjectBase.cs
@@ -243,7 +243,7 @@ public abstract class CreateSchemaObjectBase : SelectKitComponentBase, IGH_Varia
     }
 
     ((SpeckleBaseParam)Params.Output[0]).UseSchemaTag = UseSchemaTag;
-#if RHINO7
+#if RHINO7_OR_GREATER
     if (!Instances.RunningHeadless)
     {
       (Params.Output[0] as SpeckleBaseParam).ExpirePreview(true);


### PR DESCRIPTION
> [!IMPORTANT]
> This PR targets `main` and should be released as part of the next hotfix `2.19.1`


https://spockle.atlassian.net/browse/CNX-9443

- Adds RHINO7_OR_GREATER to grasshopper
- Fixes GetVersionedAppName to use Loader equivalent. Did not delete it but flagged it as obsolete
- Fixed exception on initial open event in headless document run.