### PR TITLE
feat(Archicad): Add support for openings

### DIFF
--- a/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/AddOnMain.cpp
@@ -18,6 +18,7 @@
 #include "Commands/GetElementBaseData.hpp"
 #include "Commands/GetGridElementData.hpp"
 #include "Commands/GetObjectData.hpp"
+#include "Commands/GetOpeningData.hpp"
 #include "Commands/GetSlabData.hpp"
 #include "Commands/GetRoofData.hpp"
 #include "Commands/GetShellData.hpp"
@@ -31,6 +32,7 @@
 #include "Commands/CreateColumn.hpp"
 #include "Commands/CreateGridElement.hpp"
 #include "Commands/CreateObject.hpp"
+#include "Commands/CreateOpening.hpp"
 #include "Commands/CreateRoof.hpp"
 #include "Commands/CreateSkylight.hpp"
 #include "Commands/CreateSlab.hpp"
@@ -200,6 +202,7 @@ static GSErrCode RegisterAddOnCommands ()
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::GetElementBaseData> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::GetGridElementData> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::GetObjectData> ()));
+	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::GetOpeningData> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::GetRoofData> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::GetShellData> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::GetSkylightData> ()));
@@ -213,6 +216,7 @@ static GSErrCode RegisterAddOnCommands ()
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::CreateGridElement> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::CreateColumn> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::CreateObject> ()));
+	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::CreateOpening> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::CreateRoof> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::CreateShell> ()));
 	CHECKERROR (ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (NewOwned<AddOnCommands::CreateSkylight> ()));

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpening.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpening.cpp
@@ -1,0 +1,373 @@
+#include "CreateOpening.hpp"
+#include "ResourceIds.hpp"
+#include "ObjectState.hpp"
+#include "Utility.hpp"
+#include "Objects/Point.hpp"
+#include "Objects/Vector.hpp"
+#include "RealNumber.h"
+#include "DGModule.hpp"
+#include "LibpartImportManager.hpp"
+#include "APIHelper.hpp"
+#include "FieldNames.hpp"
+#include "OnExit.hpp"
+#include "ExchangeManager.hpp"
+#include "TypeNameTables.hpp"
+#include "Database.hpp"
+#include "BM.hpp"
+
+
+using namespace FieldNames;
+
+
+namespace AddOnCommands
+{
+
+
+GS::String CreateOpening::GetFieldName () const
+{
+	return FieldNames::Openings;
+}
+
+
+GS::UniString CreateOpening::GetUndoableCommandName () const
+{
+	return "CreateSpeckleOpening";
+}
+
+
+GS::ErrCode CreateOpening::GetElementFromObjectState (const GS::ObjectState& os,
+		API_Element& element,
+		API_Element& elementMask,
+		API_ElementMemo& memo,
+		GS::UInt64& /*memoMask*/,
+		API_SubElement** /*marker*/,
+		AttributeManager& /*attributeManager*/,
+		LibpartImportManager& /*libpartImportManager*/,
+		GS::Array<GS::UniString>& log) const
+{
+	GS::ErrCode err = NoError;
+
+	Utility::SetElementType (element.header, API_OpeningID);
+
+	err = Utility::GetBaseElementData (element, &memo, nullptr, log);
+	if (err != NoError)
+		return err;
+
+	err = GetElementBaseFromObjectState (os, element, elementMask);
+	if (err != NoError)
+		return err;
+
+	if (!CheckEnvironment (os, element))
+		return Error;
+
+	if (os.Contains (Opening::FloorPlanDisplayMode)) {
+		GS::UniString floorPlanDisplayModeName;
+		os.Get (Opening::FloorPlanDisplayMode, floorPlanDisplayModeName);
+
+		GS::Optional<API_OpeningFloorPlanDisplayModeTypeID> type = openingFloorPlanDisplayModeNames.FindValue (floorPlanDisplayModeName);
+		if (type.HasValue ()) {
+			element.opening.floorPlanParameters.floorPlanDisplayMode = type.Get ();
+			ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.floorPlanDisplayMode);
+		}
+	}
+
+	if (os.Contains (Opening::ConnectionMode)) {
+		GS::UniString connectionModeName;
+		os.Get (Opening::ConnectionMode, connectionModeName);
+
+		GS::Optional<API_OpeningFloorPlanConnectionModeTypeID> type = openingFloorPlanConnectionModeNames.FindValue (connectionModeName);
+		if (type.HasValue ()) {
+			element.opening.floorPlanParameters.connectionMode = type.Get ();
+			ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.connectionMode);
+		}
+	}
+
+	if (os.Contains (Opening::CutSurfacesUseLineOfCutElements)) {
+		os.Get (Opening::CutSurfacesUseLineOfCutElements, element.opening.floorPlanParameters.cutSurfacesParameters.useLineOfCutElements);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.cutSurfacesParameters.useLineOfCutElements);
+	}
+
+	if (os.Contains (Opening::CutSurfacesLinePenIndex)) {
+		os.Get (Opening::CutSurfacesLinePenIndex, element.opening.floorPlanParameters.cutSurfacesParameters.linePenIndex);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.cutSurfacesParameters.linePenIndex);
+	}
+
+	GS::UniString attributeName;
+	if (os.Contains (Opening::CutSurfacesLineIndex)) {
+
+		os.Get (Opening::CutSurfacesLineIndex, attributeName);
+
+		if (!attributeName.IsEmpty ()) {
+				API_Attribute attrib;
+				BNZeroMemory (&attrib, sizeof (API_Attribute));
+				attrib.header.typeID = API_LinetypeID;
+				CHCopyC (attributeName.ToCStr (), attrib.header.name);
+
+				if (NoError == ACAPI_Attribute_Get (&attrib)) {
+					element.opening.floorPlanParameters.cutSurfacesParameters.lineIndex = attrib.header.index;
+					ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.cutSurfacesParameters.lineIndex);
+			}
+		}
+	}
+
+	if (os.Contains (Opening::OutlinesStyle)) {
+		GS::UniString outlinesStyleName;
+		os.Get (Opening::OutlinesStyle, outlinesStyleName);
+
+		GS::Optional<API_OpeningFloorPlanOutlinesStyleTypeID> type = openingOutlinesStyleNames.FindValue (outlinesStyleName);
+		if (type.HasValue ()) {
+			element.opening.floorPlanParameters.outlinesParameters.outlinesStyle = type.Get ();
+			ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.outlinesParameters.outlinesStyle);
+		}
+	}
+
+	if (os.Contains (Opening::OutlinesUseLineOfCutElements)) {
+		os.Get (Opening::OutlinesUseLineOfCutElements, element.opening.floorPlanParameters.outlinesParameters.useLineOfCutElements);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.outlinesParameters.useLineOfCutElements);
+	}
+
+	if (os.Contains (Opening::OutlinesUncutLineIndex)) {
+
+		os.Get (Opening::OutlinesUncutLineIndex, attributeName);
+
+		if (!attributeName.IsEmpty ()) {
+			API_Attribute attrib;
+			BNZeroMemory (&attrib, sizeof (API_Attribute));
+			attrib.header.typeID = API_LinetypeID;
+			CHCopyC (attributeName.ToCStr (), attrib.header.name);
+
+			if (NoError == ACAPI_Attribute_Get (&attrib)) {
+				element.opening.floorPlanParameters.outlinesParameters.uncutLineIndex = attrib.header.index;
+				ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.outlinesParameters.uncutLineIndex);
+			}
+		}
+	}
+
+	if (os.Contains (Opening::OutlinesOverheadLineIndex)) {
+
+		os.Get (Opening::OutlinesOverheadLineIndex, attributeName);
+
+		if (!attributeName.IsEmpty ()) {
+			API_Attribute attrib;
+			BNZeroMemory (&attrib, sizeof (API_Attribute));
+			attrib.header.typeID = API_LinetypeID;
+			CHCopyC (attributeName.ToCStr (), attrib.header.name);
+
+			if (NoError == ACAPI_Attribute_Get (&attrib)) {
+				element.opening.floorPlanParameters.outlinesParameters.overheadLineIndex = attrib.header.index;
+				ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.outlinesParameters.overheadLineIndex);
+			}
+		}
+	}
+
+	if (os.Contains (Opening::OutlinesOverheadLinePenIndex)) {
+		os.Get (Opening::OutlinesOverheadLinePenIndex, element.opening.floorPlanParameters.outlinesParameters.overheadLinePenIndex);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.outlinesParameters.overheadLinePenIndex);
+	}
+
+	if (os.Contains (Opening::UseCoverFills)) {
+		os.Get (Opening::UseCoverFills, element.opening.floorPlanParameters.coverFillsParameters.useCoverFills);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillsParameters.useCoverFills);
+	}
+
+	if (os.Contains (Opening::UseFillsOfCutElements)) {
+		os.Get (Opening::UseFillsOfCutElements, element.opening.floorPlanParameters.coverFillsParameters.useFillsOfCutElements);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillsParameters.useFillsOfCutElements);
+	}
+
+	if (os.Contains (Opening::CoverFillIndex)) {
+
+		os.Get (Opening::CoverFillIndex, attributeName);
+
+		if (!attributeName.IsEmpty ()) {
+			API_Attribute attrib;
+			BNZeroMemory (&attrib, sizeof (API_Attribute));
+			attrib.header.typeID = API_FilltypeID;
+			CHCopyC (attributeName.ToCStr (), attrib.header.name);
+
+			if (NoError == ACAPI_Attribute_Get (&attrib)) {
+				element.opening.floorPlanParameters.coverFillsParameters.coverFillIndex = attrib.header.index;
+				ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillsParameters.coverFillIndex);
+			}
+		}
+	}
+
+	if (os.Contains (Opening::CoverFillPenIndex)) {
+		os.Get (Opening::CoverFillPenIndex, element.opening.floorPlanParameters.coverFillsParameters.coverFillPenIndex);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillsParameters.coverFillPenIndex);
+	}
+
+	if (os.Contains (Opening::CoverFillBackgroundPenIndex)) {
+		os.Get (Opening::CoverFillBackgroundPenIndex, element.opening.floorPlanParameters.coverFillsParameters.coverFillBackgroundPenIndex);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillsParameters.coverFillBackgroundPenIndex);
+	}
+
+	if (os.Contains (Opening::CoverFillOrientation)) {
+		os.Get (Opening::CoverFillOrientation, element.opening.floorPlanParameters.coverFillsParameters.coverFillOrientation);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillsParameters.coverFillOrientation);
+	}
+
+	if (os.Contains (Opening::CoverFillTransformationOrigoX)) {
+		os.Get (Opening::CoverFillTransformationOrigoX, element.opening.floorPlanParameters.coverFillTransformation.origo.x);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillTransformation.origo.x);
+	}
+
+	if (os.Contains (Opening::CoverFillTransformationOrigoY)) {
+		os.Get (Opening::CoverFillTransformationOrigoY, element.opening.floorPlanParameters.coverFillTransformation.origo.y);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillTransformation.origo.y);
+	}
+
+	if (os.Contains (Opening::CoverFillTransformationXAxisX)) {
+		os.Get (Opening::CoverFillTransformationXAxisX, element.opening.floorPlanParameters.coverFillTransformation.xAxis.x);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillTransformation.xAxis.x);
+	}
+
+	if (os.Contains (Opening::CoverFillTransformationXAxisY)) {
+		os.Get (Opening::CoverFillTransformationXAxisY, element.opening.floorPlanParameters.coverFillTransformation.xAxis.y);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillTransformation.xAxis.y);
+	}
+
+	if (os.Contains (Opening::CoverFillTransformationYAxisX)) {
+		os.Get (Opening::CoverFillTransformationYAxisX, element.opening.floorPlanParameters.coverFillTransformation.yAxis.x);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillTransformation.yAxis.x);
+	}
+
+	if (os.Contains (Opening::CoverFillTransformationYAxisY)) {
+		os.Get (Opening::CoverFillTransformationYAxisY, element.opening.floorPlanParameters.coverFillTransformation.yAxis.y);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.coverFillTransformation.yAxis.y);
+	}
+
+	if (os.Contains (Opening::ShowReferenceAxis)) {
+		os.Get (Opening::ShowReferenceAxis, element.opening.floorPlanParameters.referenceAxisParameters.showReferenceAxis);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.referenceAxisParameters.showReferenceAxis);
+	}
+
+	if (os.Contains (Opening::ReferenceAxisPenIndex)) {
+		os.Get (Opening::ReferenceAxisPenIndex, element.opening.floorPlanParameters.referenceAxisParameters.referenceAxisPenIndex);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.referenceAxisParameters.referenceAxisPenIndex);
+	}
+
+	if (os.Contains (Opening::ReferenceAxisLineTypeIndex)) {
+
+		os.Get (Opening::ReferenceAxisLineTypeIndex, attributeName);
+
+		if (!attributeName.IsEmpty ()) {
+			API_Attribute attrib;
+			BNZeroMemory (&attrib, sizeof (API_Attribute));
+			attrib.header.typeID = API_LinetypeID;
+			CHCopyC (attributeName.ToCStr (), attrib.header.name);
+
+			if (NoError == ACAPI_Attribute_Get (&attrib)) {
+				element.opening.floorPlanParameters.referenceAxisParameters.referenceAxisLineTypeIndex = attrib.header.index;
+				ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.referenceAxisParameters.referenceAxisLineTypeIndex);
+			}
+		}
+	}
+
+	if (os.Contains (Opening::ReferenceAxisOverhang)) {
+		os.Get (Opening::ReferenceAxisOverhang, element.opening.floorPlanParameters.referenceAxisParameters.referenceAxisOverhang);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, floorPlanParameters.referenceAxisParameters.referenceAxisOverhang);
+	}
+
+	Objects::Point3D basePoint;
+	if (os.Contains (Opening::ExtrusionGeometryBasePoint)) {
+		os.Get (Opening::ExtrusionGeometryBasePoint, basePoint);
+		element.opening.extrusionGeometryData.frame.basePoint = basePoint.ToAPI_Coord3D ();
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.frame.basePoint);
+	}
+
+	Objects::Vector3D axisX;
+	if (os.Contains (Opening::ExtrusionGeometryXAxis)) {
+		os.Get (Opening::ExtrusionGeometryXAxis, axisX);
+		element.opening.extrusionGeometryData.frame.axisX = axisX.ToAPI_Vector3D ();
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.frame.axisX);
+	}
+
+	Objects::Vector3D axisY;
+	if (os.Contains (Opening::ExtrusionGeometryYAxis)) {
+		os.Get (Opening::ExtrusionGeometryYAxis, axisY);
+		element.opening.extrusionGeometryData.frame.axisY = axisY.ToAPI_Vector3D ();
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.frame.axisY);
+	}
+
+	Objects::Vector3D axisZ;
+	if (os.Contains (Opening::ExtrusionGeometryZAxis)) {
+		os.Get (Opening::ExtrusionGeometryZAxis, axisZ);
+		element.opening.extrusionGeometryData.frame.axisZ = axisZ.ToAPI_Vector3D ();
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.frame.axisZ);
+	}
+
+	if (os.Contains (Opening::BasePolygonType)) {
+		GS::UniString basePolygonTypeName;
+		os.Get (Opening::BasePolygonType, basePolygonTypeName);
+
+		GS::Optional<API_OpeningBasePolygonTypeTypeID> type = openingBasePolygonTypeNames.FindValue (basePolygonTypeName);
+		if (type.HasValue ()) {
+			element.opening.extrusionGeometryData.parameters.basePolygonType = type.Get ();
+			ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.basePolygonType);
+		}
+	}
+
+	if (os.Contains (Opening::Width)) {
+		os.Get (Opening::Width, element.opening.extrusionGeometryData.parameters.width);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.width);
+
+		element.opening.extrusionGeometryData.parameters.linkedStatus = API_OpeningNotLinked;
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.linkedStatus);
+	}
+
+	if (os.Contains (Opening::Height)) {
+		os.Get (Opening::Height, element.opening.extrusionGeometryData.parameters.height);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.height);
+
+		element.opening.extrusionGeometryData.parameters.linkedStatus = API_OpeningNotLinked;
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.linkedStatus);
+	}
+
+	if (os.Contains (Opening::Constraint)) {
+		os.Get (Opening::Constraint, element.opening.extrusionGeometryData.parameters.constraint);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.constraint);
+	}
+
+	if (os.Contains (Opening::AnchorIndex)) {
+		os.Get (Opening::AnchorIndex, element.opening.extrusionGeometryData.parameters.anchor);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.anchor);
+	}
+
+	if (os.Contains (Opening::AnchorAltitude)) {
+		os.Get (Opening::AnchorAltitude, element.opening.extrusionGeometryData.parameters.anchorAltitude);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.anchorAltitude);
+	}
+
+	if (os.Contains (Opening::LimitType)) {
+		GS::UniString limitTypeName;
+		os.Get (Opening::LimitType, limitTypeName);
+
+		GS::Optional<API_OpeningLimitTypeTypeID> type = openingLimitTypeNames.FindValue (limitTypeName);
+		if (type.HasValue ()) {
+			element.opening.extrusionGeometryData.parameters.limitType = type.Get ();
+			ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.limitType);
+		}
+	}
+
+	if (os.Contains (Opening::ExtrusionStartOffSet)) {
+		os.Get (Opening::ExtrusionStartOffSet, element.opening.extrusionGeometryData.parameters.extrusionStartOffset);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.extrusionStartOffset);
+	}
+
+	if (os.Contains (Opening::FiniteBodyLength)) {
+		os.Get (Opening::FiniteBodyLength, element.opening.extrusionGeometryData.parameters.finiteBodyLength);
+		ACAPI_ELEMENT_MASK_SET (elementMask, API_OpeningType, extrusionGeometryData.parameters.finiteBodyLength);
+	}
+
+	return err;
+}
+
+
+GS::String CreateOpening::GetName () const
+{
+	return CreateOpeningCommandName;
+}
+
+
+}

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpening.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpening.hpp
@@ -1,0 +1,33 @@
+#ifndef CREATE_OPENING_HPP
+#define CREATE_OPENING_HPP
+
+#include "CreateOpeningBase.hpp"
+#include "FieldNames.hpp"
+
+
+namespace AddOnCommands {
+
+
+class CreateOpening : public CreateOpeningBase {
+	GS::String			GetFieldName () const override;
+	GS::UniString		GetUndoableCommandName () const override;
+
+	GSErrCode			GetElementFromObjectState (const GS::ObjectState& os,
+							API_Element& element,
+							API_Element& elementMask,
+							API_ElementMemo& memo,
+							GS::UInt64& memoMask,
+							API_SubElement** marker,
+							AttributeManager& attributeManager,
+							LibpartImportManager& libpartImportManager,
+							GS::Array<GS::UniString>& log) const override;
+
+public:
+	virtual GS::String	GetName () const override;
+};
+
+
+}
+
+
+#endif // !CREATE_OPENING_HPP

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpeningBase.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/CreateOpeningBase.cpp
@@ -29,7 +29,8 @@ bool CreateOpeningBase::CheckEnvironment (const GS::ObjectState& os, API_Element
 	bool isParentWall = Utility::GetElementType (parentArchicadId) == API_WallID;
 	bool isParentRoof = Utility::GetElementType (parentArchicadId) == API_RoofID;
 	bool isParentShell = Utility::GetElementType (parentArchicadId) == API_ShellID;
-	if (!(parentExists && (isParentWall || isParentRoof || isParentShell))) {
+	bool isParentSlab = Utility::GetElementType (parentArchicadId) == API_SlabID;
+	if (!(parentExists && (isParentWall || isParentRoof || isParentShell || isParentSlab))) {
 		return false;
 	}
 
@@ -45,6 +46,8 @@ bool CreateOpeningBase::CheckEnvironment (const GS::ObjectState& os, API_Element
 		Utility::SetElementType (elem.header, API_RoofID);
 	} else if (isParentShell) {
 		Utility::SetElementType (elem.header, API_ShellID);
+	} else if (isParentSlab) {
+		Utility::SetElementType (elem.header, API_SlabID);
 	}
 
 	elem.header.guid = parentArchicadId;
@@ -61,6 +64,10 @@ bool CreateOpeningBase::CheckEnvironment (const GS::ObjectState& os, API_Element
 		element.window.owner = parentArchicadId;
 	} else if (elementType == API_SkylightID) {
 		element.skylight.owner = parentArchicadId;
+	} else if (elementType == API_OpeningID) {
+		element.opening.owner = parentArchicadId;
+	} else if (elementType == API_SlabID) {
+		element.opening.owner = parentArchicadId;
 	}
 
 	return true;

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDoorData.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetDoorData.hpp
@@ -1,5 +1,5 @@
-#ifndef GET_OPENING_DATA_HPP
-#define GET_OPENING_DATA_HPP
+#ifndef GET_DOOR_DATA_HPP
+#define GET_DOOR_DATA_HPP
 
 #include "GetDataCommand.hpp"
 

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetOpeningData.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetOpeningData.cpp
@@ -1,0 +1,156 @@
+#include "GetOpeningData.hpp"
+#include "ResourceIds.hpp"
+#include "ObjectState.hpp"
+#include "Utility.hpp"
+#include "Objects/Point.hpp"
+#include "Objects/Vector.hpp"
+#include "RealNumber.h"
+#include "FieldNames.hpp"
+#include "TypeNameTables.hpp"
+using namespace FieldNames;
+
+
+namespace AddOnCommands {
+
+
+GS::String GetOpeningData::GetFieldName () const
+{
+	return Openings;
+}
+
+
+API_ElemTypeID GetOpeningData::GetElemTypeID () const
+{
+	return API_OpeningID;
+}
+
+
+GS::ErrCode GetOpeningData::SerializeElementType (const API_Element& element,
+  const API_ElementMemo& /*memo*/,
+  GS::ObjectState& os) const
+{
+	os.Add (ElementBase::ParentElementId, APIGuidToString (element.opening.owner));
+
+	API_Attribute attrib;
+
+	// Opening Floor Parameters
+	os.Add (Opening::FloorPlanDisplayMode, openingFloorPlanDisplayModeNames.Get (element.opening.floorPlanParameters.floorPlanDisplayMode));
+	os.Add (Opening::ConnectionMode, openingFloorPlanConnectionModeNames.Get (element.opening.floorPlanParameters.connectionMode));
+
+	// Opening Floor Plan Parameters - Cut Surfaces
+	os.Add (Opening::CutSurfacesUseLineOfCutElements, element.opening.floorPlanParameters.cutSurfacesParameters.useLineOfCutElements);
+	os.Add (Opening::CutSurfacesLinePenIndex, element.opening.floorPlanParameters.cutSurfacesParameters.linePenIndex);
+	BNZeroMemory (&attrib, sizeof (API_Attribute));
+	attrib.header.typeID = API_LinetypeID;
+	attrib.header.index = element.opening.floorPlanParameters.cutSurfacesParameters.lineIndex;
+
+	if (NoError == ACAPI_Attribute_Get (&attrib)) {
+		os.Add (Opening::CutSurfacesLineIndex, GS::UniString{attrib.header.name});
+	}
+
+	// Opening Floor Plan Parameters - Outlines Parameters
+	os.Add (Opening::OutlinesStyle, openingOutlinesStyleNames.Get (element.opening.floorPlanParameters.outlinesParameters.outlinesStyle));
+	os.Add (Opening::OutlinesUseLineOfCutElements, element.opening.floorPlanParameters.outlinesParameters.useLineOfCutElements);
+
+	BNZeroMemory (&attrib, sizeof (API_Attribute));
+	attrib.header.typeID = API_LinetypeID;
+	attrib.header.index = element.opening.floorPlanParameters.outlinesParameters.uncutLineIndex;
+
+	if (NoError == ACAPI_Attribute_Get (&attrib)) {
+		os.Add (Opening::OutlinesUncutLineIndex, GS::UniString{attrib.header.name});
+	}
+
+	BNZeroMemory (&attrib, sizeof (API_Attribute));
+	attrib.header.typeID = API_LinetypeID;
+	attrib.header.index = element.opening.floorPlanParameters.outlinesParameters.overheadLineIndex;
+
+	if (NoError == ACAPI_Attribute_Get (&attrib)) {
+		os.Add (Opening::OutlinesOverheadLineIndex, GS::UniString{attrib.header.name});
+	}
+
+	BNZeroMemory (&attrib, sizeof (API_Attribute));
+	attrib.header.typeID = API_LinetypeID;
+	attrib.header.index = element.opening.floorPlanParameters.outlinesParameters.uncutLineIndex;
+
+	if (NoError == ACAPI_Attribute_Get (&attrib)) {
+		os.Add (Opening::OutlinesUncutLineIndex, GS::UniString{attrib.header.name});
+	}
+	os.Add (Opening::OutlinesOverheadLinePenIndex, element.opening.floorPlanParameters.outlinesParameters.overheadLinePenIndex);
+
+	// Opening Floor Plan Parameters - Cover Fills
+	os.Add (Opening::UseCoverFills, element.opening.floorPlanParameters.coverFillsParameters.useCoverFills);
+	if (element.opening.floorPlanParameters.coverFillsParameters.useCoverFills) {
+		os.Add (Opening::UseFillsOfCutElements, element.opening.floorPlanParameters.coverFillsParameters.useFillsOfCutElements);
+
+		BNZeroMemory (&attrib, sizeof (API_Attribute));
+		attrib.header.typeID = API_FilltypeID;
+		attrib.header.index = element.opening.floorPlanParameters.coverFillsParameters.coverFillIndex;
+
+		if (NoError == ACAPI_Attribute_Get (&attrib)) {
+			os.Add (Opening::CoverFillIndex, GS::UniString{attrib.header.name});
+		}
+
+		os.Add (Opening::CoverFillPenIndex, element.opening.floorPlanParameters.coverFillsParameters.coverFillPenIndex);
+		os.Add (Opening::CoverFillBackgroundPenIndex, element.opening.floorPlanParameters.coverFillsParameters.coverFillBackgroundPenIndex);
+		os.Add (Opening::CoverFillOrientation, element.opening.floorPlanParameters.coverFillsParameters.coverFillOrientation);
+	}
+	
+	// Opening Floor Plan Parameters - Cover Fill Transformation
+	os.Add (Opening::CoverFillTransformationOrigoX, element.opening.floorPlanParameters.coverFillTransformation.origo.x);
+	os.Add (Opening::CoverFillTransformationOrigoY, element.opening.floorPlanParameters.coverFillTransformation.origo.y);
+	os.Add (Opening::CoverFillTransformationXAxisX, element.opening.floorPlanParameters.coverFillTransformation.xAxis.x);
+	os.Add (Opening::CoverFillTransformationXAxisY, element.opening.floorPlanParameters.coverFillTransformation.xAxis.y);
+	os.Add (Opening::CoverFillTransformationYAxisX, element.opening.floorPlanParameters.coverFillTransformation.yAxis.x);
+	os.Add (Opening::CoverFillTransformationYAxisY, element.opening.floorPlanParameters.coverFillTransformation.yAxis.y);
+
+	// Opening Floor Plan Parameters - Reference Axis
+	os.Add (Opening::ShowReferenceAxis, element.opening.floorPlanParameters.referenceAxisParameters.showReferenceAxis);
+	if (element.opening.floorPlanParameters.referenceAxisParameters.showReferenceAxis) {
+		os.Add (Opening::ReferenceAxisPenIndex, element.opening.floorPlanParameters.referenceAxisParameters.referenceAxisPenIndex);
+
+		BNZeroMemory (&attrib, sizeof (API_Attribute));
+		attrib.header.typeID = API_LinetypeID;
+		attrib.header.index = element.opening.floorPlanParameters.referenceAxisParameters.referenceAxisLineTypeIndex;
+
+		if (NoError == ACAPI_Attribute_Get (&attrib)) {
+			os.Add (Opening::ReferenceAxisLineTypeIndex, GS::UniString{attrib.header.name});
+		}
+
+		os.Add (Opening::ReferenceAxisOverhang, element.opening.floorPlanParameters.referenceAxisParameters.referenceAxisOverhang);
+	}
+
+	// Extrusion Geometry
+	os.Add (Opening::ExtrusionGeometryBasePoint, Objects::Point3D (element.opening.extrusionGeometryData.frame.basePoint));
+	os.Add (Opening::ExtrusionGeometryXAxis, Objects::Vector3D(element.opening.extrusionGeometryData.frame.axisX));
+	os.Add (Opening::ExtrusionGeometryYAxis, Objects::Vector3D (element.opening.extrusionGeometryData.frame.axisY));
+	os.Add (Opening::ExtrusionGeometryZAxis, Objects::Vector3D (element.opening.extrusionGeometryData.frame.axisZ));
+
+	// Extrusion Geometry - Opening Extrusion Parameters
+	os.Add (Opening::BasePolygonType, openingBasePolygonTypeNames.Get (element.opening.extrusionGeometryData.parameters.basePolygonType));
+	os.Add (Opening::Width, element.opening.extrusionGeometryData.parameters.width);
+	os.Add (Opening::Height, element.opening.extrusionGeometryData.parameters.height);
+	os.Add (Opening::Constraint, element.opening.extrusionGeometryData.parameters.constraint);
+	os.Add (Opening::Anchor, openingAnchorNames.Get (element.opening.extrusionGeometryData.parameters.anchor));
+	os.Add (Opening::AnchorIndex, (element.opening.extrusionGeometryData.parameters.anchor));
+	os.Add (Opening::AnchorAltitude, element.opening.extrusionGeometryData.parameters.anchorAltitude);
+	os.Add (Opening::LimitType, openingLimitTypeNames.Get (element.opening.extrusionGeometryData.parameters.limitType));
+	os.Add (Opening::ExtrusionStartOffSet, element.opening.extrusionGeometryData.parameters.extrusionStartOffset);
+	os.Add (Opening::FiniteBodyLength, element.opening.extrusionGeometryData.parameters.finiteBodyLength);
+	os.Add (Opening::LinkedStatus, openingLinkedStatusNames.Get (element.opening.extrusionGeometryData.parameters.linkedStatus));
+
+	// Extrusion Geometry - Custom Base Polygon
+	if (element.opening.extrusionGeometryData.parameters.basePolygonType == API_OpeningBasePolygonCustom) {
+		// Reserved for future use
+	}
+
+	return NoError;
+}
+
+
+GS::String GetOpeningData::GetName () const
+{
+	return GetOpeningDataCommandName;
+}
+
+
+} // namespace AddOnCommands

--- a/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetOpeningData.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/Commands/GetOpeningData.hpp
@@ -1,0 +1,24 @@
+#ifndef GET_OPENING_DATA_HPP
+#define GET_OPENING_DATA_HPP
+
+#include "GetDataCommand.hpp"
+
+namespace AddOnCommands {
+
+
+class GetOpeningData : public GetDataCommand {
+		GS::String				GetFieldName() const override;
+		API_ElemTypeID			GetElemTypeID() const override;
+		GS::ErrCode				SerializeElementType(const API_Element& elem,
+									const API_ElementMemo& memo,
+									GS::ObjectState& os) const override;
+
+public:
+	virtual GS::String		GetName() const override;
+};
+
+
+}
+
+
+#endif // GET_OPENING_DATA_HPP

--- a/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/FieldNames.hpp
@@ -83,6 +83,7 @@ static const char* Slabs = "slabs";
 static const char* Walls = "walls";
 static const char* Windows = "windows";
 static const char* Zones = "zones";
+static const char* Openings = "openings";
 
 static const char* Models = "models";
 static const char* SubelementModels = "subelementModels";
@@ -473,6 +474,73 @@ namespace Object
 static const char* pos = "pos";
 static const char* transform = "transform";
 }
+
+
+namespace Opening
+{
+// Floor Plan Parameters
+static const char* FloorPlanDisplayMode = "floorPlanDisplayMode";
+static const char* ConnectionMode = "connectionMode";
+
+// Cut Surfaces Parameters
+static const char* CutSurfacesUseLineOfCutElements = "cutsurfacesUseLineOfCutElements";
+static const char* CutSurfacesLinePenIndex = "cutsurfacesLinePenIndex";
+static const char* CutSurfacesLineIndex = "cutsurfacesLineIndex";
+
+// Outlines Parameters
+static const char* OutlinesStyle = "outlinesStyle";
+static const char* OutlinesUseLineOfCutElements = "outlinesUseLineOfCutElements"; // => Cut Surfaces Parameters-ben is megtalálható
+static const char* OutlinesUncutLineIndex = "outlinesUncutLineIndex";
+static const char* OutlinesOverheadLineIndex = "outlinesOverheadLineIndex";
+static const char* OutlinesUncutLinePenIndex = "outlinesUncutLinePenIndex";
+static const char* OutlinesOverheadLinePenIndex = "outlinesOverheadLinePenIndex";
+
+// Opening Cover Fills Parameters
+static const char* UseCoverFills = "useCoverFills";
+static const char* UseFillsOfCutElements = "useFillsOfCutElements";
+static const char* CoverFillIndex = "coverFillIndex";
+static const char* CoverFillPenIndex = "coverFillPenIndex";
+static const char* CoverFillBackgroundPenIndex = "coverFillBackgroundPenIndex";
+static const char* CoverFillOrientation = "coverFillOrientation";
+
+// Cover Fill Transformation Parameters
+static const char* CoverFillTransformationOrigoX = "coverFillTransformationOrigoX";
+static const char* CoverFillTransformationOrigoY = "coverFillTransformationOrigoY";
+static const char* CoverFillTransformationOrigoZ = "coverFillTransformationOrigoZ";
+static const char* CoverFillTransformationXAxisX = "coverFillTransformationXAxisX";
+static const char* CoverFillTransformationXAxisY = "coverFillTransformationXAxisY";
+static const char* CoverFillTransformationXAxisZ = "coverFillTransformationXAxisZ";
+static const char* CoverFillTransformationYAxisX = "coverFillTransformationYAxisX";
+static const char* CoverFillTransformationYAxisY = "coverFillTransformationYAxisY";
+static const char* CoverFillTransformationYAxisZ = "coverFillTransformationYAxisZ";
+
+// Reference Axis Parameters
+static const char* ShowReferenceAxis = "showReferenceAxis";
+static const char* ReferenceAxisPenIndex = "referenceAxisPenIndex";
+static const char* ReferenceAxisLineTypeIndex = "referenceAxisLineTypeIndex";
+static const char* ReferenceAxisOverhang = "referenceAxisOverhang";
+
+// Extrusion Geometry Parameters
+static const char* ExtrusionGeometryBasePoint = "extrusionGeometryBasePoint";
+static const char* ExtrusionGeometryXAxis = "extrusionGeometryXAxis";
+static const char* ExtrusionGeometryYAxis = "extrusionGeometryYAxis";
+static const char* ExtrusionGeometryZAxis = "extrusionGeometryZAxis";
+static const char* BasePolygonType = "basePolygonType";
+static const char* Width = "width";
+static const char* Height = "height";
+static const char* Constraint = "constraint";
+static const char* Anchor = "anchor";
+static const char* AnchorIndex = "anchorIndex";
+static const char* AnchorAltitude = "anchorAltitude";
+static const char* LimitType = "limitType";
+static const char* ExtrusionStartOffSet = "extrusionStartOffSet";
+static const char* FiniteBodyLength = "finiteBodyLength";
+static const char* LinkedStatus = "linkedStatus";
+static const char* NCoords = "nCoords";
+static const char* NSubPolys = "nSubPolys";
+static const char* NArcs = "nArcs";
+}
+
 
 namespace GridElement
 {

--- a/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/ResourceIds.hpp
@@ -24,6 +24,7 @@
 #define GetElementBaseDataCommandName			"GetElementBaseData";
 #define GetGridElementCommandName				"GetGridElementData";
 #define GetObjectDataCommandName				"GetObjectData";
+#define GetOpeningDataCommandName				"GetOpeningData";
 #define GetSlabDataCommandName					"GetSlabData";
 #define GetRoomDataCommandName					"GetRoomData";
 #define GetRoofDataCommandName					"GetRoofData";
@@ -38,6 +39,7 @@
 #define CreateColumnCommandName					"CreateColumn";
 #define CreateGridElementCommandName			"CreateGridElement";
 #define CreateObjectCommandName					"CreateObject";
+#define CreateOpeningCommandName				"CreateOpening";
 #define CreateSlabCommandName					"CreateSlab";
 #define CreateSkylightCommandName				"CreateSkylight";
 #define CreateRoofCommandName					"CreateRoof";

--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.cpp
@@ -301,3 +301,63 @@ const GS::HashTable<short, GS::UniString> coreSymbolTypeNames
 	{ 3,		"X"},
 	{ 4,		"CrossHair"}
 };
+
+
+const GS::HashTable<API_OpeningFloorPlanDisplayModeTypeID, GS::UniString> openingFloorPlanDisplayModeNames
+{
+	{ API_OpeningSymbolic,			"Symbolic"},
+	{ API_OpeningSymbolicCut,		"Symbolic Cut"},
+	{ API_OpeningSymbolicOverhead,	"Symbolic Overhead"}
+};
+
+
+const GS::HashTable<API_OpeningFloorPlanConnectionModeTypeID, GS::UniString> openingFloorPlanConnectionModeNames
+{
+	{ API_OpeningDisconnected,		"Disconnected"},
+	{ API_OpeningConnected,			"Connected"}
+};
+
+
+const GS::HashTable<API_OpeningFloorPlanOutlinesStyleTypeID, GS::UniString> openingOutlinesStyleNames
+{
+	{ API_OpeningHideBorder,			"Hide Border"},
+	{ API_OpeningShowUncutBorder,		"Show Uncut Border"},
+	{ API_OpeningShowOverheadBorder,	"Show Overhead Border"}
+};
+
+
+const GS::HashTable<API_OpeningBasePolygonTypeTypeID, GS::UniString> openingBasePolygonTypeNames
+{
+	{ API_OpeningBasePolygonRectangular,	"Rectangular"},
+	{ API_OpeningBasePolygonCircular,		"Circular"},
+	{ API_OpeningBasePolygonCustom,			"Custom"}
+};
+
+
+const GS::HashTable<API_AnchorID, GS::UniString> openingAnchorNames
+{
+	{ APIAnc_LT,		"Left Top"},
+	{ APIAnc_MT,		"Middle Top"},
+	{ APIAnc_RT,		"Right Top"},
+	{ APIAnc_LM,		"Left Middle"},
+	{ APIAnc_MM,		"Middle Middle"},
+	{ APIAnc_RM,		"Right Middle"},
+	{ APIAnc_LB,		"Left Bottom"},
+	{ APIAnc_MB,		"Middle Bottom"},
+	{ APIAnc_RB,		"Right Bottom"}
+};
+
+
+const GS::HashTable<API_OpeningLimitTypeTypeID, GS::UniString> openingLimitTypeNames
+{
+	{ API_OpeningLimitInfinite,		"Infinite"},
+	{ API_OpeningLimitFinite,		"Finite"},
+	{ API_OpeningLimitHalfInfinite,	"Half Infinite"}
+};
+
+
+const GS::HashTable<API_OpeningLinkedStatusTypeID, GS::UniString> openingLinkedStatusNames
+{
+	{ API_OpeningLinked,		"Linked"},
+	{ API_OpeningNotLinked,		"Not Linked"}
+};

--- a/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.hpp
+++ b/ConnectorArchicad/AddOn/Sources/AddOn/TypeNameTables.hpp
@@ -45,4 +45,12 @@ extern const GS::HashTable<API_VeneerTypeID, GS::UniString> venTypeNames;
 
 extern const GS::HashTable<short, GS::UniString> coreSymbolTypeNames;
 
+extern const GS::HashTable<API_OpeningFloorPlanDisplayModeTypeID, GS::UniString> openingFloorPlanDisplayModeNames;
+extern const GS::HashTable<API_OpeningFloorPlanConnectionModeTypeID, GS::UniString> openingFloorPlanConnectionModeNames;
+extern const GS::HashTable<API_OpeningFloorPlanOutlinesStyleTypeID, GS::UniString> openingOutlinesStyleNames;
+extern const GS::HashTable<API_OpeningBasePolygonTypeTypeID, GS::UniString> openingBasePolygonTypeNames;
+extern const GS::HashTable<API_AnchorID, GS::UniString> openingAnchorNames;
+
+extern const GS::HashTable<API_OpeningLimitTypeTypeID, GS::UniString> openingLimitTypeNames;
+extern const GS::HashTable<API_OpeningLinkedStatusTypeID, GS::UniString> openingLinkedStatusNames;
 #endif

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateOpening.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_CreateOpening.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
+using Objects.BuiltElements.Archicad;
+
+namespace Archicad.Communication.Commands;
+
+sealed internal class CreateOpening : ICommand<IEnumerable<ApplicationObject>>
+{
+  [JsonObject(MemberSerialization.OptIn)]
+  public sealed class Parameters
+  {
+    [JsonProperty("openings")]
+    private IEnumerable<ArchicadOpening> Datas { get; }
+
+    public Parameters(IEnumerable<ArchicadOpening> datas)
+    {
+      Datas = datas;
+    }
+  }
+
+  [JsonObject(MemberSerialization.OptIn)]
+  private sealed class Result
+  {
+    [JsonProperty("applicationObjects")]
+    public IEnumerable<ApplicationObject> ApplicationObjects { get; private set; }
+  }
+
+  private IEnumerable<ArchicadOpening> Datas { get; }
+
+  public CreateOpening(IEnumerable<ArchicadOpening> datas)
+  {
+    Datas = datas;
+  }
+
+  public async Task<IEnumerable<ApplicationObject>> Execute()
+  {
+    var result = await HttpCommandExecutor.Execute<Parameters, Result>("CreateOpening", new Parameters(Datas));
+    return result == null ? null : result.ApplicationObjects;
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetOpening.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetOpening.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ConnectorArchicad.Communication.Commands;
+
+namespace Archicad.Communication.Commands;
+
+sealed internal class GetOpeningData : GetDataBase, ICommand<Speckle.Newtonsoft.Json.Linq.JArray>
+{
+  public GetOpeningData(IEnumerable<string> applicationIds, bool sendProperties, bool sendListingParameters)
+    : base(applicationIds, sendProperties, sendListingParameters) { }
+
+  public async Task<Speckle.Newtonsoft.Json.Linq.JArray> Execute()
+  {
+    dynamic result = await HttpCommandExecutor.Execute<Parameters, dynamic>(
+      "GetOpeningData",
+      new Parameters(ApplicationIds, SendProperties, SendListingParameters)
+    );
+
+    return (Speckle.Newtonsoft.Json.Linq.JArray)result["openings"];
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ConverterArchicad.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ConverterArchicad.cs
@@ -68,6 +68,7 @@ public partial class ConverterArchicad : ISpeckleConverter
       Objects.BuiltElements.Roof _ => true,
       Objects.BuiltElements.Room _ => true,
       Objects.BuiltElements.Wall _ => true,
+      Objects.BuiltElements.Opening _ => true,
 
       // Archicad elements
       Objects.BuiltElements.Archicad.ArchicadDoor _ => true,

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/OpeningConverter.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/OpeningConverter.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Archicad.Communication;
+using Archicad.Model;
+using Speckle.Core.Kits;
+using Speckle.Core.Logging;
+using Speckle.Core.Models;
+using Speckle.Core.Models.GraphTraversal;
+
+namespace Archicad.Converters;
+
+public sealed class OpeningConverter : IConverter
+{
+  public Type Type => typeof(Objects.BuiltElements.Opening);
+
+  public Task<List<ApplicationObject>> ConvertToArchicad(
+    IEnumerable<TraversalContext> elements,
+    CancellationToken token
+  )
+  {
+    var openings = new List<Objects.BuiltElements.Archicad.ArchicadOpening>();
+
+    var context = Archicad.Helpers.Timer.Context.Peek;
+    using (
+      context?.cumulativeTimer?.Begin(ConnectorArchicad.Properties.OperationNameTemplates.ConvertToNative, Type.Name)
+    )
+    {
+      foreach (var tc in elements)
+      {
+        token.ThrowIfCancellationRequested();
+
+        switch (tc.current)
+        {
+          case Objects.BuiltElements.Archicad.ArchicadOpening archicadOpening:
+            archicadOpening.parentApplicationId = tc.parent.current.id;
+            Archicad.Converters.Utils.ConvertToArchicadDTOs<Objects.BuiltElements.Archicad.ArchicadOpening>(
+              archicadOpening
+            );
+            openings.Add(archicadOpening);
+            break;
+          case Objects.BuiltElements.Opening opening:
+            try
+            {
+              Objects.Geometry.Vector extrusionBasePoint,
+                extrusionXAxis,
+                extrusionYAxis,
+                extrusionZAxis;
+              double width,
+                height;
+              Operations.ModelConverter.GetExtrusionParametersFromOutline(
+                opening.outline,
+                out extrusionBasePoint,
+                out extrusionXAxis,
+                out extrusionYAxis,
+                out extrusionZAxis,
+                out width,
+                out height
+              );
+              openings.Add(
+                new Objects.BuiltElements.Archicad.ArchicadOpening
+                {
+                  id = opening.id,
+                  applicationId = opening.applicationId,
+                  parentApplicationId = tc.parent.current.id,
+                  extrusionGeometryBasePoint = new Objects.Geometry.Point(extrusionBasePoint),
+                  extrusionGeometryXAxis = extrusionXAxis,
+                  extrusionGeometryYAxis = extrusionYAxis,
+                  extrusionGeometryZAxis = extrusionZAxis,
+                  width = width,
+                  height = height,
+                  anchorIndex = 4,
+                }
+              );
+            }
+            catch (SpeckleException ex)
+            {
+              SpeckleLog.Logger.Error(ex.Message);
+            }
+            break;
+        }
+      }
+
+      IEnumerable<ApplicationObject> result;
+      result = AsyncCommandProcessor.Execute(new Communication.Commands.CreateOpening(openings), token).Result;
+
+      return Task.FromResult(result is null ? new List<ApplicationObject>() : result.ToList());
+    }
+  }
+
+  public async Task<List<Base>> ConvertToSpeckle(
+    IEnumerable<ElementModelData> elements,
+    CancellationToken token,
+    ConversionOptions conversionOptions
+  )
+  {
+    var elementModels = elements as ElementModelData[] ?? elements.ToArray();
+
+    Speckle.Newtonsoft.Json.Linq.JArray jArray = await AsyncCommandProcessor.Execute(
+      new Communication.Commands.GetOpeningData(
+        elementModels.Select(e => e.applicationId),
+        conversionOptions.SendProperties,
+        conversionOptions.SendListingParameters
+      ),
+      token
+    );
+
+    List<Base> openings = new();
+    if (jArray is null)
+    {
+      return openings;
+    }
+
+    var context = Archicad.Helpers.Timer.Context.Peek;
+    using (
+      context?.cumulativeTimer?.Begin(ConnectorArchicad.Properties.OperationNameTemplates.ConvertToNative, Type.Name)
+    )
+    {
+      foreach (Speckle.Newtonsoft.Json.Linq.JToken jToken in jArray)
+      {
+        Objects.BuiltElements.Archicad.ArchicadOpening opening =
+          Archicad.Converters.Utils.ConvertToSpeckleDTOs<Objects.BuiltElements.Archicad.ArchicadOpening>(jToken);
+        {
+          opening.outline = Operations.ModelConverter.CreateOpeningOutline(opening);
+          opening.units = Units.Meters;
+        }
+        openings.Add(opening);
+      }
+    }
+
+    return openings;
+  }
+}

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
@@ -68,6 +68,14 @@ public static class Utils
     };
   }
 
+  public static Vector ScaleToNative(Vector vector, string? units = null)
+  {
+    units ??= vector.units;
+    var scale = Units.GetConversionFactor(units, Units.Meters);
+
+    return new Vector(vector.x * scale, vector.y * scale, vector.z * scale);
+  }
+
   public static Polycurve PolycurveToSpeckle(ElementShape.Polyline archiPolyline)
   {
     var poly = new Polycurve

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementConverterManager.cs
@@ -13,6 +13,7 @@ using Ceiling = Objects.BuiltElements.Ceiling;
 using Column = Objects.BuiltElements.Column;
 using Door = Objects.BuiltElements.Archicad.ArchicadDoor;
 using Fenestration = Objects.BuiltElements.Archicad.ArchicadFenestration;
+using Opening = Objects.BuiltElements.Opening;
 using Floor = Objects.BuiltElements.Floor;
 using Roof = Objects.BuiltElements.Roof;
 using Wall = Objects.BuiltElements.Wall;
@@ -20,6 +21,7 @@ using Window = Objects.BuiltElements.Archicad.ArchicadWindow;
 using Skylight = Objects.BuiltElements.Archicad.ArchicadSkylight;
 using GridLine = Objects.BuiltElements.GridLine;
 using DesktopUI2.Models;
+using Objects.BuiltElements.Archicad;
 
 namespace Archicad;
 
@@ -95,13 +97,24 @@ public sealed partial class ElementConverterManager
       allObjects.AddRange(objects);
 
       // subelements translated into "elements" property of the parent
-      if (typeof(Fenestration).IsAssignableFrom(elemenType))
+      if (typeof(Fenestration).IsAssignableFrom(elemenType) || typeof(Opening).IsAssignableFrom(elemenType))
       {
         Collection elementCollection = null;
 
         foreach (Base item in objects)
         {
-          Base parent = allObjects.Find(x => x.applicationId == ((Fenestration)item).parentApplicationId);
+          string parentApplicationId = null;
+
+          if (item is Fenestration fenestration)
+          {
+            parentApplicationId = fenestration.parentApplicationId;
+          }
+          else if (item is ArchicadOpening opening)
+          {
+            parentApplicationId = opening.parentApplicationId;
+          }
+
+          Base parent = allObjects.Find(x => x.applicationId == parentApplicationId);
 
           if (parent == null)
           {
@@ -245,6 +258,11 @@ public sealed partial class ElementConverterManager
     if (elementType.IsSubclassOf(typeof(Roof)))
     {
       return Converters[typeof(Roof)];
+    }
+
+    if (elementType.IsSubclassOf(typeof(Opening)))
+    {
+      return Converters[typeof(Opening)];
     }
 
     if (elementType.IsAssignableFrom(typeof(Objects.BuiltElements.Room)))

--- a/ConnectorArchicad/ConnectorArchicad/Converters/ElementTypeProvider.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/ElementTypeProvider.cs
@@ -10,6 +10,7 @@ using Shell = Objects.BuiltElements.Archicad.ArchicadShell;
 using Wall = Objects.BuiltElements.Archicad.ArchicadWall;
 using Window = Objects.BuiltElements.Archicad.ArchicadWindow;
 using Skylight = Objects.BuiltElements.Archicad.ArchicadSkylight;
+using Opening = Objects.BuiltElements.Archicad.ArchicadOpening;
 
 namespace Archicad;
 
@@ -28,7 +29,8 @@ public static class ElementTypeProvider
       { "Door", typeof(Door) },
       { "Window", typeof(Window) },
       { "Skylight", typeof(Skylight) },
-      { "GridElement", typeof(GridElement) }
+      { "GridElement", typeof(GridElement) },
+      { "Opening", typeof(Opening) }
     };
 
   public static Type GetTypeByName(string name)

--- a/Objects/Objects/BuiltElements/Archicad/ArchicadOpening.cs
+++ b/Objects/Objects/BuiltElements/Archicad/ArchicadOpening.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Speckle.Core.Kits;
+using Speckle.Core.Models;
+using Objects.Geometry;
+
+namespace Objects.BuiltElements.Archicad;
+
+public class ArchicadOpening : Opening
+{
+  [SchemaInfo("ArchicadOpening", "Creates an Archicad opening.", "Archicad", "Structure")]
+  public ArchicadOpening() { }
+
+  public string parentApplicationId { get; set; }
+
+  // Element base
+  public string? elementType { get; set; } /*APINullabe*/
+
+  public List<Classification>? classifications { get; set; } /*APINullabe*/
+  public Base? elementProperties { get; set; }
+  public Base? componentProperties { get; set; }
+
+  // Floor Plan Parameters
+  public string? floorPlanDisplayMode { get; set; } /*APINullabe*/
+  public string? connectionMode { get; set; } /*APINullabe*/
+
+  // Cut Surfaces Parameters
+  public bool? cutsurfacesUseLineOfCutElements { get; set; } /*APINullabe*/
+  public short? cutsurfacesLinePenIndex { get; set; } /*APINullabe*/
+  public string? cutsurfacesLineIndex { get; set; } /*APINullabe*/
+
+  // Outlines Parameters
+  public string? outlinesStyle { get; set; } /*APINullabe*/
+  public bool? outlinesUseLineOfCutElements { get; set; } /*APINullabe*/
+  public string? outlinesUncutLineIndex { get; set; } /*APINullabe*/
+  public string? outlinesOverheadLineIndex { get; set; } /*APINullabe*/
+  public short? outlinesUncutLinePenIndex { get; set; } /*APINullabe*/
+  public short? outlinesOverheadLinePenIndex { get; set; } /*APINullabe*/
+
+  // Opening Cover Fills Parameters
+  public bool? useCoverFills { get; set; } /*APINullabe*/
+  public bool? useFillsOfCutElements { get; set; } /*APINullabe*/
+  public string? coverFillIndex { get; set; } /*APINullabe*/
+  public short? coverFillPenIndex { get; set; } /*APINullabe*/
+  public short? coverFillBackgroundPenIndex { get; set; } /*APINullabe*/
+  public string? coverFillOrientation { get; set; } /*APINullabe*/ // Kérdéses..
+
+  // Cover Fill Transformation Parameters
+  public double? coverFillTransformationOrigoX { get; set; }
+  public double? coverFillTransformationOrigoY { get; set; }
+  public double? coverFillTransformationOrigoZ { get; set; }
+  public double? coverFillTransformationXAxisX { get; set; }
+  public double? coverFillTransformationXAxisY { get; set; }
+  public double? coverFillTransformationXAxisZ { get; set; }
+  public double? coverFillTransformationYAxisX { get; set; }
+  public double? coverFillTransformationYAxisY { get; set; }
+  public double? coverFillTransformationYAxisZ { get; set; }
+
+  // Reference Axis Parameters
+  public bool? showReferenceAxis { get; set; } /*APINullabe*/
+  public short? referenceAxisPenIndex { get; set; } /*APINullabe*/
+  public string? referenceAxisLineTypeIndex { get; set; } /*APINullabe*/
+  public double? referenceAxisOverhang { get; set; } /*APINullabe*/
+
+  // Extrusion Geometry Parameters
+  // Plane Frame
+  public Point extrusionGeometryBasePoint { get; set; }
+  public Vector extrusionGeometryXAxis { get; set; }
+  public Vector extrusionGeometryYAxis { get; set; }
+  public Vector extrusionGeometryZAxis { get; set; }
+
+  // Opening Extrustion Parameters
+  public string? basePolygonType { get; set; } /*APINullabe*/
+  public double? width { get; set; } /*APINullabe*/
+  public double? height { get; set; } /*APINullabe*/
+  public string? constraint { get; set; } /*APINullabe*/
+  public string? anchor { get; set; } /*APINullabe */
+  public int? anchorIndex { get; set; } /*APINullabe*/
+  public double? anchorAltitude { get; set; } /*APINullabe*/
+  public string? limitType { get; set; } /*APINullabe*/
+  public double? extrusionStartOffSet { get; set; } /*APINullabe*/
+  public double? finiteBodyLength { get; set; } /*APINullabe*/
+  public string? linkedStatus { get; set; } /*APINullabe*/
+}


### PR DESCRIPTION
## Description & motivation

Support for Archicad Openings (#3267):
* Sending Archicad Openings to Speckle
  * openings are sent via the `elements` list of the parent element
  * only rectangular and circular openings can be handled by Archicad API
  * generating `outline` property for the common Speckle Opening class
* Receiving Archicad Openings from Speckle
  * Either from `ArchicadOpening`
  * or from Speckle `Opening` using the `outline` property
* Archicad to Revit workflow
  * rectangular openings can go through
* Revit to Archicad workflow
  * rectangular openings can go through (only rectangular openings are supported in Revit)

## Changes:

Objects:
* `ArchicadOpening` has been introduced

C# Connector:
* Opening converters added

C++ add-on:
* `GetOpening` ommand and `CreateOpening` commands added

## Screenshots:

<img width="1333" alt="image" src="https://github.com/specklesystems/speckle-sharp/assets/50739844/4e6942c7-33fa-4c8b-8e65-2fce9a725726">


## Validation of changes:

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
  - `objects.pln` has been updated with openings, I can provide it to you 
- [ ] I have updated or added relevant documentation.