### PR TITLE
bug(Archicad): Properties not showing in viewer

### DIFF
--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementBaseData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementBaseData.cs
@@ -7,7 +7,7 @@ using ConnectorArchicad.Communication.Commands;
 
 namespace Archicad.Communication.Commands;
 
-sealed internal class GetElementBaseData : GetDataBase, ICommand<IEnumerable<DirectShape>>
+sealed internal class GetElementBaseData : GetDataBase, ICommand<Speckle.Newtonsoft.Json.Linq.JArray>
 {
   [JsonObject(MemberSerialization.OptIn)]
   private sealed class Result
@@ -19,17 +19,13 @@ sealed internal class GetElementBaseData : GetDataBase, ICommand<IEnumerable<Dir
   public GetElementBaseData(IEnumerable<string> applicationIds, bool sendProperties, bool sendListingParameters)
     : base(applicationIds, sendProperties, sendListingParameters) { }
 
-  public async Task<IEnumerable<DirectShape>> Execute()
+  public async Task<Speckle.Newtonsoft.Json.Linq.JArray> Execute()
   {
-    Result result = await HttpCommandExecutor.Execute<Parameters, Result>(
+    dynamic result = await HttpCommandExecutor.Execute<Parameters, dynamic>(
       "GetElementBaseData",
       new Parameters(ApplicationIds, SendProperties, SendListingParameters)
     );
-    foreach (var directShape in result.Datas)
-    {
-      directShape.units = Units.Meters;
-    }
 
-    return result.Datas;
+    return (Speckle.Newtonsoft.Json.Linq.JArray)result["elements"];
   }
 }

--- a/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementBaseData.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Communication/Commands/Command_GetElementBaseData.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Speckle.Core.Kits;
-using Speckle.Newtonsoft.Json;
-using Objects.BuiltElements.Archicad;
 using ConnectorArchicad.Communication.Commands;
+using Objects.BuiltElements.Archicad;
+using Speckle.Newtonsoft.Json;
 
 namespace Archicad.Communication.Commands;
 

--- a/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
+++ b/ConnectorArchicad/ConnectorArchicad/Converters/Converters/Utils.cs
@@ -180,7 +180,8 @@ public static class Utils
 
     if (level != null)
     {
-      PropertyInfo propLevel = speckleObject.GetType().GetProperty("archicadLevel");
+      PropertyInfo propLevel =
+        speckleObject.GetType().GetProperty("archicadLevel") ?? speckleObject.GetType().GetProperty("level");
       propLevel.SetValue(speckleObject, level);
     }
 

--- a/Objects/Objects/BuiltElements/Archicad/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Archicad/DirectShape.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using Objects.Geometry;
 using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
 
 namespace Objects.BuiltElements.Archicad;
 
@@ -16,7 +18,10 @@ public class DirectShape : Base
 
   // Element base
   public string elementType { get; set; }
+
   public List<Classification> classifications { get; set; }
+  public Base? elementProperties { get; set; }
+  public Base? componentProperties { get; set; }
 
   public ArchicadLevel level { get; set; }
 

--- a/Objects/Objects/BuiltElements/Archicad/DirectShape.cs
+++ b/Objects/Objects/BuiltElements/Archicad/DirectShape.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using Objects.Geometry;
 using Speckle.Core.Models;
-using Speckle.Newtonsoft.Json;
 
 namespace Objects.BuiltElements.Archicad;
 


### PR DESCRIPTION
## Description & motivation

Fix of #3471.

## Changes:

`elementProperties` and `componentProperites` properties added to `Archicad.DirectShape` class
`GetElementBaseData` changed to be able to work with JSON raw data.


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

