### PR TITLE
CNX-9753: Add assembly and subassembly objects to Corridors

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.cs
@@ -206,7 +206,7 @@ public partial class ConverterAutocadCivil : ISpeckleConverter
               @base = CorridorToSpeckle(o);
               break;
             case CivilDB.FeatureLine o:
-              @base = FeatureLineToSpeckle(o);
+              @base = FeaturelineToSpeckle(o);
               break;
             case CivilDB.Structure o:
               @base = StructureToSpeckle(o);

--- a/Objects/Objects/BuiltElements/Baseline.cs
+++ b/Objects/Objects/BuiltElements/Baseline.cs
@@ -7,9 +7,10 @@ public abstract class Baseline : Base
 {
   public Baseline() { }
 
-  public Baseline(string name)
+  public Baseline(string name, bool isFeaturelineBased)
   {
     this.name = name;
+    this.isFeaturelineBased = isFeaturelineBased;
   }
 
   /// <summary>
@@ -20,12 +21,17 @@ public abstract class Baseline : Base
   /// <summary>
   /// The horizontal component of this baseline
   /// </summary>
-  public abstract Alignment alignment { get; internal set; }
+  public abstract Alignment? alignment { get; internal set; }
 
   /// <summary>
   /// The vertical component of this baseline
   /// </summary>
-  public abstract Profile profile { get; internal set; }
+  public abstract Profile? profile { get; internal set; }
+
+  [DetachProperty]
+  public Featureline? featureline { get; internal set; }
+
+  public bool isFeaturelineBased { get; set; }
 }
 
 /// <summary>
@@ -35,16 +41,18 @@ public abstract class Baseline<TA, TP> : Baseline
   where TA : Alignment
   where TP : Profile
 {
-  protected Baseline(string name, TA alignment, TP profile)
-    : base(name)
+  protected Baseline(string name, TA alignment, TP profile, Featureline? featureline, bool isFeaturelineBased)
+    : base(name, isFeaturelineBased)
   {
     this.name = name;
     typedAlignment = alignment;
     typedProfile = profile;
+    this.featureline = featureline;
+    this.isFeaturelineBased = isFeaturelineBased;
   }
 
   protected Baseline()
-    : base(string.Empty) { }
+    : base(string.Empty, false) { }
 
   [JsonIgnore]
   public TA typedAlignment { get; set; }
@@ -53,7 +61,7 @@ public abstract class Baseline<TA, TP> : Baseline
   public TP typedProfile { get; set; }
 
   [DetachProperty]
-  public override Alignment alignment
+  public override Alignment? alignment
   {
     get => typedAlignment;
     internal set
@@ -66,7 +74,7 @@ public abstract class Baseline<TA, TP> : Baseline
   }
 
   [DetachProperty]
-  public override Profile profile
+  public override Profile? profile
   {
     get => typedProfile;
     internal set

--- a/Objects/Objects/BuiltElements/Baseline.cs
+++ b/Objects/Objects/BuiltElements/Baseline.cs
@@ -1,0 +1,80 @@
+using Speckle.Core.Models;
+using Speckle.Newtonsoft.Json;
+
+namespace Objects.BuiltElements;
+
+public abstract class Baseline : Base
+{
+  public Baseline() { }
+
+  public Baseline(string name)
+  {
+    this.name = name;
+  }
+
+  /// <summary>
+  /// The name of this baseline
+  /// </summary>
+  public string name { get; set; }
+
+  /// <summary>
+  /// The horizontal component of this baseline
+  /// </summary>
+  public abstract Alignment alignment { get; internal set; }
+
+  /// <summary>
+  /// The vertical component of this baseline
+  /// </summary>
+  public abstract Profile profile { get; internal set; }
+}
+
+/// <summary>
+/// Generic instance class
+/// </summary>
+public abstract class Baseline<TA, TP> : Baseline
+  where TA : Alignment
+  where TP : Profile
+{
+  protected Baseline(string name, TA alignment, TP profile)
+    : base(name)
+  {
+    this.name = name;
+    typedAlignment = alignment;
+    typedProfile = profile;
+  }
+
+  protected Baseline()
+    : base(string.Empty) { }
+
+  [JsonIgnore]
+  public TA typedAlignment { get; set; }
+
+  [JsonIgnore]
+  public TP typedProfile { get; set; }
+
+  [DetachProperty]
+  public override Alignment alignment
+  {
+    get => typedAlignment;
+    internal set
+    {
+      if (value is TA typeA)
+      {
+        typedAlignment = typeA;
+      }
+    }
+  }
+
+  [DetachProperty]
+  public override Profile profile
+  {
+    get => typedProfile;
+    internal set
+    {
+      if (value is TP typeP)
+      {
+        typedProfile = typeP;
+      }
+    }
+  }
+}

--- a/Objects/Objects/BuiltElements/Baseline.cs
+++ b/Objects/Objects/BuiltElements/Baseline.cs
@@ -5,9 +5,9 @@ namespace Objects.BuiltElements;
 
 public abstract class Baseline : Base
 {
-  public Baseline() { }
+  protected Baseline() { }
 
-  public Baseline(string name, bool isFeaturelineBased)
+  protected Baseline(string name, bool isFeaturelineBased)
   {
     this.name = name;
     this.isFeaturelineBased = isFeaturelineBased;

--- a/Objects/Objects/BuiltElements/Civil/CivilAppliedAssembly.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilAppliedAssembly.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Speckle.Core.Models;
+
+namespace Objects.BuiltElements.Civil;
+
+public class CivilAppliedAssembly : Base
+{
+  public CivilAppliedAssembly() { }
+
+  public CivilAppliedAssembly(
+    List<CivilAppliedSubassembly> appliedSubassemblies,
+    double adjustedElevation,
+    string units
+  )
+  {
+    this.appliedSubassemblies = appliedSubassemblies;
+    this.adjustedElevation = adjustedElevation;
+    this.units = units;
+  }
+
+  public List<CivilAppliedSubassembly> appliedSubassemblies { get; set; }
+
+  public double adjustedElevation { get; set; }
+
+  public string units { get; set; }
+}

--- a/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Speckle.Core.Models;
+
+namespace Objects.BuiltElements.Civil;
+
+public class CivilAppliedSubassembly : Base
+{
+  public CivilAppliedSubassembly() { }
+
+  public CivilAppliedSubassembly(List<CivilCalculatedShape> shapes, List<Base> parameters)
+  {
+    this.shapes = shapes;
+    this.parameters = parameters;
+  }
+
+  [DetachProperty]
+  public List<Base> parameters { get; set; }
+
+  public List<CivilCalculatedShape> shapes { get; set; }
+}

--- a/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Objects.Geometry;
+using Objects.Other.Civil;
 using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.Civil;
@@ -11,12 +13,14 @@ public class CivilAppliedSubassembly : Base
     string subassemblyId,
     string subassemblyName,
     List<CivilCalculatedShape> shapes,
-    List<Base> parameters
+    Point stationOffsetElevationToBaseline,
+    List<CivilDataField> parameters
   )
   {
     this.subassemblyId = subassemblyId;
     this.subassemblyName = subassemblyName;
     this.shapes = shapes;
+    this.stationOffsetElevationToBaseline = stationOffsetElevationToBaseline;
     this.parameters = parameters;
   }
 
@@ -24,8 +28,10 @@ public class CivilAppliedSubassembly : Base
 
   public string subassemblyName { get; set; }
 
-  [DetachProperty]
-  public List<Base> parameters { get; set; }
-
   public List<CivilCalculatedShape> shapes { get; set; }
+
+  public Point stationOffsetElevationToBaseline { get; set; }
+
+  [DetachProperty]
+  public List<CivilDataField> parameters { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.Civil;
@@ -7,11 +8,22 @@ public class CivilAppliedSubassembly : Base
 {
   public CivilAppliedSubassembly() { }
 
-  public CivilAppliedSubassembly(List<CivilCalculatedShape> shapes, List<Base> parameters)
+  public CivilAppliedSubassembly(
+    string subassemblyId,
+    string subassemblyName,
+    List<CivilCalculatedShape> shapes,
+    List<Base> parameters
+  )
   {
+    this.subassemblyId = subassemblyId;
+    this.subassemblyName = subassemblyName;
     this.shapes = shapes;
     this.parameters = parameters;
   }
+
+  public string subassemblyId { get; set; }
+
+  public string subassemblyName { get; set; }
 
   [DetachProperty]
   public List<Base> parameters { get; set; }

--- a/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.Civil;

--- a/Objects/Objects/BuiltElements/Civil/CivilBaseline.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilBaseline.cs
@@ -23,6 +23,25 @@ public class CivilBaseline : Baseline<CivilAlignment, CivilProfile>
     this.endStation = endStation;
     this.alignment = alignment;
     this.profile = profile;
+    isFeaturelineBased = false;
+  }
+
+  public CivilBaseline(
+    string name,
+    List<CivilBaselineRegion> regions,
+    List<double> stations,
+    double startStation,
+    double endStation,
+    Featureline featureline
+  )
+  {
+    this.name = name;
+    this.regions = regions;
+    this.stations = stations;
+    this.startStation = startStation;
+    this.endStation = endStation;
+    this.featureline = featureline;
+    isFeaturelineBased = true;
   }
 
   public List<CivilBaselineRegion> regions { get; set; }

--- a/Objects/Objects/BuiltElements/Civil/CivilBaseline.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilBaseline.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Objects.BuiltElements.Civil;
+
+public class CivilBaseline : Baseline<CivilAlignment, CivilProfile>
+{
+  public CivilBaseline() { }
+
+  public CivilBaseline(
+    string name,
+    List<CivilBaselineRegion> regions,
+    List<double> stations,
+    double startStation,
+    double endStation,
+    CivilAlignment alignment,
+    CivilProfile profile
+  )
+  {
+    this.name = name;
+    this.regions = regions;
+    this.stations = stations;
+    this.startStation = startStation;
+    this.endStation = endStation;
+    this.alignment = alignment;
+    this.profile = profile;
+  }
+
+  public List<CivilBaselineRegion> regions { get; set; }
+
+  public List<double> stations { get; set; }
+
+  public double startStation { get; set; }
+
+  public double endStation { get; set; }
+}

--- a/Objects/Objects/BuiltElements/Civil/CivilBaselineRegion.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilBaselineRegion.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Speckle.Core.Models;
+
+namespace Objects.BuiltElements.Civil;
+
+public class CivilBaselineRegion : Base
+{
+  public CivilBaselineRegion() { }
+
+  public CivilBaselineRegion(
+    string name,
+    double startStation,
+    double endStation,
+    string assemblyId,
+    string? assemblyName,
+    List<CivilAppliedAssembly> appliedAssemblies
+  )
+  {
+    this.name = name;
+    this.startStation = startStation;
+    this.endStation = endStation;
+    this.assemblyId = assemblyId;
+    this.assemblyName = assemblyName;
+    this.appliedAssemblies = appliedAssemblies;
+  }
+
+  /// <summary>
+  /// The name of the region
+  /// </summary>
+  public string name { get; set; }
+
+  /// <summary>
+  /// The id of the assembly of the region
+  /// </summary>
+  public string assemblyId { get; set; }
+
+  public string? assemblyName { get; set; }
+
+  public double startStation { get; set; }
+
+  public double endStation { get; set; }
+
+  [DetachProperty]
+  public List<CivilAppliedAssembly> appliedAssemblies { get; set; }
+}

--- a/Objects/Objects/BuiltElements/Civil/CivilCalculatedLink.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilCalculatedLink.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Speckle.Core.Models;
+
+namespace Objects.BuiltElements.Civil;
+
+public class CivilCalculatedLink : Base, ICivilCalculatedObject
+{
+  public CivilCalculatedLink() { }
+
+  public CivilCalculatedLink(List<string> codes, List<CivilCalculatedPoint> points)
+  {
+    this.codes = codes;
+    this.points = points;
+  }
+
+  public List<string> codes { get; set; }
+
+  [DetachProperty]
+  public List<CivilCalculatedPoint> points { get; set; }
+}

--- a/Objects/Objects/BuiltElements/Civil/CivilCalculatedPoint.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilCalculatedPoint.cs
@@ -8,12 +8,19 @@ public class CivilCalculatedPoint : Base, ICivilCalculatedObject
 {
   public CivilCalculatedPoint() { }
 
-  public CivilCalculatedPoint(Point point, List<string> codes, Vector normalToBaseline, Vector normalToSubassembly)
+  public CivilCalculatedPoint(
+    Point point,
+    List<string> codes,
+    Vector normalToBaseline,
+    Vector normalToSubassembly,
+    Point stationOffsetElevationToBaseline
+  )
   {
     this.point = point;
     this.codes = codes;
     this.normalToBaseline = normalToBaseline;
     this.normalToSubassembly = normalToSubassembly;
+    this.stationOffsetElevationToBaseline = stationOffsetElevationToBaseline;
   }
 
   public Point point { get; set; }
@@ -23,4 +30,6 @@ public class CivilCalculatedPoint : Base, ICivilCalculatedObject
   public Vector normalToBaseline { get; set; }
 
   public Vector normalToSubassembly { get; set; }
+
+  public Point stationOffsetElevationToBaseline { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Civil/CivilCalculatedPoint.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilCalculatedPoint.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Objects.Geometry;
+using Speckle.Core.Models;
+
+namespace Objects.BuiltElements.Civil;
+
+public class CivilCalculatedPoint : Base, ICivilCalculatedObject
+{
+  public CivilCalculatedPoint() { }
+
+  public CivilCalculatedPoint(Point point, List<string> codes, Vector normalToBaseline, Vector normalToSubassembly)
+  {
+    this.point = point;
+    this.codes = codes;
+    this.normalToBaseline = normalToBaseline;
+    this.normalToSubassembly = normalToSubassembly;
+  }
+
+  public Point point { get; set; }
+
+  public List<string> codes { get; set; }
+
+  public Vector normalToBaseline { get; set; }
+
+  public Vector normalToSubassembly { get; set; }
+}

--- a/Objects/Objects/BuiltElements/Civil/CivilCalculatedShape.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilCalculatedShape.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Speckle.Core.Models;
+
+namespace Objects.BuiltElements.Civil;
+
+public class CivilCalculatedShape : Base, ICivilCalculatedObject
+{
+  public CivilCalculatedShape() { }
+
+  public CivilCalculatedShape(List<string> codes, List<CivilCalculatedLink> links, double area, string units)
+  {
+    this.codes = codes;
+    this.links = links;
+    this.area = area;
+    this.units = units;
+  }
+
+  public List<string> codes { get; set; }
+
+  [DetachProperty]
+  public List<CivilCalculatedLink> links { get; set; }
+
+  public double area { get; set; }
+
+  public string units { get; set; }
+}

--- a/Objects/Objects/Interfaces.cs
+++ b/Objects/Objects/Interfaces.cs
@@ -110,5 +110,16 @@ public interface IDisplayValue<T>
   T displayValue { get; set; }
 }
 
+/// <summary>
+/// Represents a calculated object for civil disciplines
+/// </summary>
+public interface ICivilCalculatedObject
+{
+  /// <summary>
+  /// <see cref="codes"/> for this calculated object.
+  /// </summary>
+  List<string> codes { get; set; }
+}
+
 
 #endregion

--- a/Objects/Objects/Other/Civil/CivilDataField.cs
+++ b/Objects/Objects/Other/Civil/CivilDataField.cs
@@ -4,17 +4,27 @@ public class CivilDataField : DataField
 {
   public CivilDataField() { }
 
-  public CivilDataField(string name, string type, string units, string context, object? value = null)
+  public CivilDataField(
+    string name,
+    string type,
+    object? value,
+    string? units = null,
+    string? context = null,
+    string? displayName = null
+  )
   {
     this.name = name;
     this.type = type;
+    this.value = value;
     this.units = units;
     this.context = context;
-    this.value = value;
+    this.displayName = displayName;
   }
 
   /// <summary>
   /// The context type of the Civil3D part
   /// </summary>
-  public string context { get; set; }
+  public string? context { get; set; }
+
+  public string? displayName { get; set; }
 }

--- a/Objects/Objects/Other/DataField.cs
+++ b/Objects/Objects/Other/DataField.cs
@@ -9,12 +9,12 @@ public class DataField : Base
 {
   public DataField() { }
 
-  public DataField(string name, string type, string units, object? value = null)
+  public DataField(string name, string type, object? value, string? units = null)
   {
     this.name = name;
     this.type = type;
-    this.units = units;
     this.value = value;
+    this.units = units;
   }
 
   public string name { get; set; }
@@ -23,5 +23,5 @@ public class DataField : Base
 
   public object? value { get; set; }
 
-  public string units { get; set; }
+  public string? units { get; set; }
 }


### PR DESCRIPTION
## Description & motivation
This pr adds quite a few new `civil` classes and restructures how `corridor`s are sent from Civil3D:
- CivilBaseline
- CivilBaselineRegion
- CivilAppliedAssembly
- CivilAppliedSubassembly
- CivilCalculatedShape
- CivilCalculatedLink
- CivilCalculatedPoint
- ICivilCalculatedObject interface

Closes #3265

## Changes:

- Objects
- Civil converter

## Screenshots:
 sample corridor commit: [https://app.speckle.systems/projects/bff55266ce/models/763d2dadb7](https://app.speckle.systems/projects/bff55266ce/models/763d2dadb7)

