### PR TITLE
CNX-9295 Speckle Connector doesn't initialize on Mac

### DIFF
--- a/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
+++ b/ConnectorRhino/ConnectorRhino/ConnectorRhinoShared/Entry/Plugin.cs
@@ -184,7 +184,7 @@ public class SpeckleRhinoConnectorPlugin : PlugIn
 
       var hostAppName = HostApplications.Rhino.Slug;
       var hostAppVersion = Utils.GetRhinoHostAppVersion();
-      SpeckleLog.Initialize(HostApplications.Rhino.Slug, Utils.GetRhinoHostAppVersion());
+      SpeckleLog.Initialize(HostApplications.Rhino.Slug, Utils.GetRhinoHostAppVersion(), logConfig);
       SpeckleLog.Logger.Information(
         "Loading Speckle Plugin for host app {hostAppName} version {hostAppVersion}",
         hostAppName,

--- a/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
+++ b/ConnectorRhino/ConnectorRhino7/ConnectorRhino7.csproj
@@ -5,14 +5,14 @@
     <Title>SpeckleRhino</Title>
     <Description>Description of SpeckleRhino</Description>
     <TargetExt>.rhp</TargetExt>
-    <RhinoMacLauncher>/Applications/Rhino 7.app</RhinoMacLauncher>
+    <RhinoMacLauncher>7</RhinoMacLauncher>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AssemblyName>SpeckleConnectorRhino</AssemblyName>
     <Configurations>Debug;Release;Debug Mac;Release Mac</Configurations>
     <RootNamespace>SpeckleRhino</RootNamespace>
     <Product>ConnectorRhino7</Product>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-
+    <RhinoPluginType>grasshopper</RhinoPluginType>
     <!--NOTE-->
     <!--
     Since Rhino uses mono we build for win-x64 also on mac
@@ -25,6 +25,7 @@
     <UseWpf>true</UseWpf>
     <DefineConstants>$(DefineConstants);RHINO7;RHINO6_OR_GREATER;RHINO7_OR_GREATER</DefineConstants>
     <OutputType>Library</OutputType>
+    <RhinoPluginType>rhp</RhinoPluginType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug Mac' OR '$(Configuration)'=='Release Mac'">


### PR DESCRIPTION
https://spockle.atlassian.net/browse/CNX-9295
Fixes error initialising Rhino 7 on mac due to loggerConfiguration not being passed down to the Initialize call.

Additionally, adds `RhinoPluginType` to the csproj as `rhp`, which turns out is absolutely necessary for Debug on Mac.