### PR TITLE
DUI3-295 track non native received objects for the full report

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/BasicConnectorBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/BasicConnectorBinding.cs
@@ -171,6 +171,12 @@ public class BasicConnectorBinding : IBasicConnectorBinding
       }
     }
     MapView.Active.SelectLayers(layers);
-    // MapView.Active.SelectStandaloneTables(tables); // clears previous selection, not clear how to ADD selection instead
+
+    // this step clears previous selection, not clear how to ADD selection instead
+    // this is why, activating it only if no layers are selected
+    if (layers.Count == 0)
+    {
+      MapView.Active.SelectStandaloneTables(tables);
+    }
   }
 }

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
@@ -43,6 +43,11 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
 
     Uri uri = new($"{_contextStack.Current.Document.SpeckleDatabasePath.AbsolutePath.Replace('/', '\\')}\\{datasetId}");
     Map map = _contextStack.Current.Document.Map;
+
+    // Most of the Speckle-written datasets will be containing geometry and added as Layers
+    // although, some datasets might be just tables (e.g. native GIS Tables, in the future maybe Revit schedules etc.
+    // We can create a connection to the dataset in advance and determine its type, but this will be more
+    // expensive, than assuming by default that it's a layer with geometry (which in most cases it's expected to be)
     try
     {
       var layer = LayerFactory.Instance.CreateLayer(uri, map, layerName: nestedLayerName);

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
@@ -36,30 +36,6 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
     _traverseFunction = traverseFunction;
   }
 
-  private MapMember AddDatasetsToMap(ObjectConversionTracker trackerItem)
-  {
-    string? datasetId = trackerItem.DatasetId; // should not ne null here
-    string nestedLayerName = trackerItem.NestedLayerName;
-
-    Uri uri = new($"{_contextStack.Current.Document.SpeckleDatabasePath.AbsolutePath.Replace('/', '\\')}\\{datasetId}");
-    Map map = _contextStack.Current.Document.Map;
-
-    // Most of the Speckle-written datasets will be containing geometry and added as Layers
-    // although, some datasets might be just tables (e.g. native GIS Tables, in the future maybe Revit schedules etc.
-    // We can create a connection to the dataset in advance and determine its type, but this will be more
-    // expensive, than assuming by default that it's a layer with geometry (which in most cases it's expected to be)
-    try
-    {
-      var layer = LayerFactory.Instance.CreateLayer(uri, map, layerName: nestedLayerName);
-      return layer;
-    }
-    catch (ArgumentException)
-    {
-      var table = StandaloneTableFactory.Instance.CreateStandaloneTable(uri, map, tableName: nestedLayerName);
-      return table;
-    }
-  }
-
   public HostObjectBuilderResult Build(
     Base rootObject,
     string projectName,
@@ -181,6 +157,30 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
           trackerItem.HostAppMapMember?.GetType().ToString()
         )
       );
+    }
+  }
+
+  private MapMember AddDatasetsToMap(ObjectConversionTracker trackerItem)
+  {
+    string? datasetId = trackerItem.DatasetId; // should not ne null here
+    string nestedLayerName = trackerItem.NestedLayerName;
+
+    Uri uri = new($"{_contextStack.Current.Document.SpeckleDatabasePath.AbsolutePath.Replace('/', '\\')}\\{datasetId}");
+    Map map = _contextStack.Current.Document.Map;
+
+    // Most of the Speckle-written datasets will be containing geometry and added as Layers
+    // although, some datasets might be just tables (e.g. native GIS Tables, in the future maybe Revit schedules etc.
+    // We can create a connection to the dataset in advance and determine its type, but this will be more
+    // expensive, than assuming by default that it's a layer with geometry (which in most cases it's expected to be)
+    try
+    {
+      var layer = LayerFactory.Instance.CreateLayer(uri, map, layerName: nestedLayerName);
+      return layer;
+    }
+    catch (ArgumentException)
+    {
+      var table = StandaloneTableFactory.Instance.CreateStandaloneTable(uri, map, tableName: nestedLayerName);
+      return table;
     }
   }
 

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
@@ -3,6 +3,10 @@ using Speckle.Core.Models;
 
 namespace Speckle.Converters.ArcGIS3.Utils;
 
+/// <summary>
+/// Container connecting the received Base object, converted hostApp object, dataset it was written to,
+/// URI of the layer mapped from the dataset and, if applicable, feature/row id.
+/// </summary>
 public struct ObjectConversionTracker
 {
   public Base Base { get; set; }
@@ -43,12 +47,24 @@ public struct ObjectConversionTracker
     MappedLayerURI = layerURIstring;
   }
 
+  /// <summary>
+  /// Initializes a new instance of <see cref="ObjectConversionTracker"/>.
+  /// </summary>
+  /// <param name="baseObj">Original received Base object.</param>
+  /// <param name="nestedLayerName">String with the full traversed path to the object. Will be used to create nested layer structure in the TOC.</param>
   public ObjectConversionTracker(Base baseObj, string nestedLayerName)
   {
     Base = baseObj;
     NestedLayerName = nestedLayerName;
   }
 
+  /// <summary>
+  /// Constructor for received non-GIS geometries.
+  /// Initializes a new instance of <see cref="ObjectConversionTracker"/>, accepting converted hostApp geometry.
+  /// </summary>
+  /// <param name="baseObj">Original received Base object.</param>
+  /// <param name="nestedLayerName">String with the full traversed path to the object. Will be used to create nested layer structure in the TOC.</param>
+  /// <param name="hostAppGeom">Converted ArcGIS.Core.Geometry.</param>
   public ObjectConversionTracker(Base baseObj, string nestedLayerName, ACG.Geometry hostAppGeom)
   {
     Base = baseObj;
@@ -56,6 +72,13 @@ public struct ObjectConversionTracker
     HostAppGeom = hostAppGeom;
   }
 
+  /// <summary>
+  /// Constructor for received native GIS layers.
+  /// Initializes a new instance of <see cref="ObjectConversionTracker"/>, accepting datasetID of a coverted Speckle layer.
+  /// </summary>
+  /// <param name="baseObj">Original received Base object.</param>
+  /// <param name="nestedLayerName">String with the full traversed path to the object. Will be used to create nested layer structure in the TOC.</param>
+  /// <param name="datasetId">ID of the locally written dataset, created from received Speckle layer.</param>
   public ObjectConversionTracker(Base baseObj, string nestedLayerName, string datasetId)
   {
     Base = baseObj;

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
@@ -1,3 +1,4 @@
+using ArcGIS.Desktop.Mapping;
 using Speckle.Core.Models;
 
 namespace Speckle.Converters.ArcGIS3.Utils;
@@ -7,6 +8,7 @@ public struct ObjectConversionTracker
   public Base Base { get; set; }
   public string NestedLayerName { get; set; }
   public ACG.Geometry? HostAppGeom { get; set; }
+  public MapMember? HostAppMapMember { get; set; }
   public string? DatasetId { get; set; }
   public int? DatasetRow { get; set; }
   public string? MappedLayerURI { get; set; }
@@ -29,6 +31,16 @@ public struct ObjectConversionTracker
   public void AddDatasetRow(int datasetRow)
   {
     DatasetRow = datasetRow;
+  }
+
+  public void AddConvertedMapMember(MapMember mapMember)
+  {
+    HostAppMapMember = mapMember;
+  }
+
+  public void AddLayerURI(string layerURIstring)
+  {
+    MappedLayerURI = layerURIstring;
   }
 
   public ObjectConversionTracker(Base baseObj, string nestedLayerName)

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
@@ -21,6 +21,16 @@ public struct ObjectConversionTracker
     MappedLayerURI = null;
   }
 
+  public void AddDatasetId(string datasetId)
+  {
+    DatasetId = datasetId;
+  }
+
+  public void AddDatasetRow(int datasetRow)
+  {
+    DatasetRow = datasetRow;
+  }
+
   public ObjectConversionTracker(Base baseObj, string nestedLayerName)
   {
     Base = baseObj;

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ConversionTracker.cs
@@ -1,0 +1,43 @@
+using Speckle.Core.Models;
+
+namespace Speckle.Converters.ArcGIS3.Utils;
+
+public struct ObjectConversionTracker
+{
+  public Base Base { get; set; }
+  public string NestedLayerName { get; set; }
+  public ACG.Geometry? HostAppGeom { get; set; }
+  public string? DatasetId { get; set; }
+  public int? DatasetRow { get; set; }
+  public string? MappedLayerURI { get; set; }
+  public Exception? Exception { get; set; }
+
+  public void AddException(Exception ex)
+  {
+    Exception = ex;
+    HostAppGeom = null;
+    DatasetId = null;
+    DatasetRow = null;
+    MappedLayerURI = null;
+  }
+
+  public ObjectConversionTracker(Base baseObj, string nestedLayerName)
+  {
+    Base = baseObj;
+    NestedLayerName = nestedLayerName;
+  }
+
+  public ObjectConversionTracker(Base baseObj, string nestedLayerName, ACG.Geometry hostAppGeom)
+  {
+    Base = baseObj;
+    NestedLayerName = nestedLayerName;
+    HostAppGeom = hostAppGeom;
+  }
+
+  public ObjectConversionTracker(Base baseObj, string nestedLayerName, string datasetId)
+  {
+    Base = baseObj;
+    NestedLayerName = nestedLayerName;
+    DatasetId = datasetId;
+  }
+}

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/INonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/INonNativeFeaturesUtils.cs
@@ -4,7 +4,5 @@ namespace Speckle.Converters.ArcGIS3.Utils;
 
 public interface INonNativeFeaturesUtils
 {
-  public List<(string parentPath, string converted)> WriteGeometriesToDatasets(
-    Dictionary<TraversalContext, (string parentPath, ACG.Geometry geom)> convertedObjs
-  );
+  public void WriteGeometriesToDatasets(Dictionary<TraversalContext, ObjectConversionTracker> conversionTracker);
 }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
@@ -60,6 +60,10 @@ public class NonNativeFeaturesUtils : INonNativeFeaturesUtils
           trackerItem.AddDatasetRow(geometryGroups[uniqueKey].Count - 1);
           conversionTracker[item.Key] = trackerItem;
         }
+        else if (geom == null && datasetId != null) // GIS layers, already written to a dataset
+        {
+          continue;
+        }
         else
         {
           throw new ArgumentException($"Unexpected geometry and datasetId values: {geom}, {datasetId}");

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
@@ -83,7 +83,7 @@ public class NonNativeFeaturesUtils : INonNativeFeaturesUtils
       catch (GeodatabaseGeometryException ex)
       {
         // do nothing if writing of some geometry groups fails
-        // record in a conversionTracker:
+        // only record in conversionTracker:
         foreach (var conversionItem in conversionTracker)
         {
           if (conversionItem.Value.DatasetId == uniqueKey)

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
@@ -53,6 +53,14 @@ public class NonNativeFeaturesUtils : INonNativeFeaturesUtils
           }
 
           geometryGroups[uniqueKey].Add(geom);
+
+          // record changes in conversion tracker
+          conversionTracker[item.Key].AddDatasetId(uniqueKey);
+          conversionTracker[item.Key].AddDatasetRow(geometryGroups[uniqueKey].Count - 1);
+        }
+        else
+        {
+          throw new ArgumentException($"Unexpected geometry and datasetId values: {geom}, {datasetId}");
         }
       }
       catch (Exception ex) when (!ex.IsFatal())


### PR DESCRIPTION
Restructuring HostObjectBuilder to track Base object ID -> MapLayerURI (including feature index, if applicable)
Visual explanation: https://www.notion.so/speckle/ArcGIS-explainers-e3c2571d0208409fa98fe87d41247c2d?pvs=4

Currenly, report Selection is selecting the entire layer with that feature, not considering the individual feature ID:
![image](https://github.com/specklesystems/speckle-sharp/assets/89912278/37f0b7be-3adc-490a-90f5-65e1d519aa22)
