### PR TITLE
DUI3-173: adds send and receive cancellation on document switch

### DIFF
--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
@@ -120,9 +120,20 @@ public sealed class AutocadSendBinding : ISendBinding, ICancelable
   {
     try
     {
+      Application.DocumentManager.DocumentActivated += (sender, args) =>
+      {
+        CancelSend(modelCardId);
+        Commands.SetModelError(
+          modelCardId,
+          new OperationCanceledException("Another document was activated during this operation.")
+        );
+        return;
+      };
+
       if (_store.GetModelById(modelCardId) is not SenderModelCard modelCard)
       {
         // Handle as GLOBAL ERROR at BrowserBridge
+        // TODO: this will crash autocad
         throw new InvalidOperationException("No publish model card was found.");
       }
 


### PR DESCRIPTION
## Description & motivation
Cancels an ongoing send/receive operation on a document activation event (creation/switch).

