### PR TITLE
Feature [Revit]: Excel parameter updater support for shared type parameters

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertView.Schedule.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertView.Schedule.cs
@@ -257,10 +257,22 @@ public partial class ConverterRevit
     }
     else if (info.field.FieldType == ScheduleFieldType.Instance)
     {
+      // All shared parameters also use this type, regardless of whether they are instance or type parameters.
+      // ref: https://www.revitapidocs.com/2024/9888db7d-00d0-4fd7-a1a9-cdd1fb5fce16.htm
       if (firstElement != null)
       {
         param = firstElement.get_Parameter(builtInParameter);
-        columnMetadata["IsReadOnly"] = param?.IsReadOnly;
+
+        
+
+        // if the parameter is shared, we need to check the type parameterer too
+        Parameter typeParam = null;
+        if (firstType != null)
+        {
+          typeParam = firstType.get_Parameter(builtInParameter);
+        }
+
+        columnMetadata["IsReadOnly"] = (param?.IsReadOnly ?? false) && (typeParam?.IsReadOnly ?? false);
       }
     }
     else

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertView.Schedule.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertView.Schedule.cs
@@ -246,11 +246,10 @@ public partial class ConverterRevit
     var columnMetadata = new Base();
     columnMetadata["BuiltInParameterInteger"] = info.field.ParameterId.IntegerValue;
     string fieldType = info.field.FieldType.ToString();
-    
+
     Parameter param;
     if (info.field.FieldType == ScheduleFieldType.ElementType)
     {
-      
       if (firstType != null)
       {
         param = firstType.get_Parameter(builtInParameter);
@@ -270,7 +269,7 @@ public partial class ConverterRevit
         if (firstType != null)
         {
           typeParam = firstType.get_Parameter(builtInParameter);
-          
+
           // If the parameter is readonly in the element but not in the type, is a type parameter
           if (typeParam != null && !typeParam.IsReadOnly && param != null && param.IsReadOnly)
           {


### PR DESCRIPTION
## Description & motivation

I opened a thread in the community some days ago because I couldn't update some parameters in the Revit schedules using the Excel Connector. Here is the original post:

https://speckle.community/t/revit-excel-parameter-updater-graying-out-custom-parameters-in-excel/11613

The problem was that Revit considers shared parameters as ScheduleField.Instance instead of ScheduleField.ElementType. Therefore, if the parameter was a "Type Parameter" and was obtained from the element, it would always be considered as "ReadOnly."

The solution was to obtain the parameter from the "Type" rather than from the element. Because of this, I added some logic in the code to handle Shared Parameters.

Reference: https://www.revitapidocs.com/2024/9888db7d-00d0-4fd7-a1a9-cdd1fb5fce16.htm

## Changes:

`ConvertView.Schedule -> AddColumnMetadataToDataTable`

## Screenshots:

Using the sample Architecture Project add a shared type parameter to the planting category:
![image](https://github.com/specklesystems/speckle-sharp/assets/23631382/1c7be263-8f18-4966-ae58-969d30ff1399)

Add the type and the shared parameters to the existing schedule and sort by type (not itemize every instance)
![image](https://github.com/specklesystems/speckle-sharp/assets/23631382/02b77c01-17e3-46db-bbf6-9070baf4abe3)

Then:
 1. Send to Speckle
 2. Receive from Excel
 3. Edit in Excel
 4. Send To Speckle
 5. Receive in Revit


## Checklist:

- [x ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

