### PR TITLE
DUI3-174 Cancel ops on doc swap

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISReceiveBinding.cs
@@ -6,11 +6,10 @@ using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.Utils;
 using Speckle.Connectors.Utils.Cancellation;
 using Speckle.Connectors.Utils.Operations;
-using ICancelable = System.Reactive.Disposables.ICancelable;
 
 namespace Speckle.Connectors.ArcGIS.Bindings;
 
-public sealed class ArcGISReceiveBinding : IReceiveBinding, ICancelable
+public sealed class ArcGISReceiveBinding : IReceiveBinding
 {
   public string Name { get; } = "receiveBinding";
   private readonly CancellationManager _cancellationManager;
@@ -84,11 +83,4 @@ public sealed class ArcGISReceiveBinding : IReceiveBinding, ICancelable
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
-
-  public void Dispose()
-  {
-    IsDisposed = true;
-  }
-
-  public bool IsDisposed { get; private set; }
 }

--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Bindings/ArcGISSendBinding.cs
@@ -3,7 +3,6 @@ using Speckle.Autofac.DependencyInjection;
 using Speckle.Connectors.DUI.Bindings;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.Utils.Cancellation;
-using ICancelable = System.Reactive.Disposables.ICancelable;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
@@ -21,7 +20,7 @@ using Speckle.Connectors.Utils.Operations;
 
 namespace Speckle.Connectors.ArcGIS.Bindings;
 
-public sealed class ArcGISSendBinding : ISendBinding, ICancelable
+public sealed class ArcGISSendBinding : ISendBinding
 {
   public string Name => "sendBinding";
   public SendBindingUICommands Commands { get; }
@@ -364,11 +363,4 @@ public sealed class ArcGISSendBinding : ISendBinding, ICancelable
   {
     Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress));
   }
-
-  public void Dispose()
-  {
-    IsDisposed = true;
-  }
-
-  public bool IsDisposed { get; private set; }
 }

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -32,7 +32,6 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
     _unitOfWorkFactory = unitOfWorkFactory;
     Parent = parent;
     Commands = new ReceiveBindingUICommands(parent);
-    _store.DocumentChanged += (_, _) => OnDocumentChanged();
   }
 
   public void CancelReceive(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
@@ -78,21 +77,5 @@ public sealed class AutocadReceiveBinding : IReceiveBinding
   private void OnSendOperationProgress(string modelCardId, string status, double? progress)
   {
     Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress));
-  }
-
-  // POC: Will be re-addressed later with better UX with host apps that are friendly on async doc operations.
-  // That's why don't bother for now how to get rid of from dup logic in other bindings.
-  private void OnDocumentChanged()
-  {
-    if (_cancellationManager.NumberOfOperations > 0)
-    {
-      _cancellationManager.CancelAllOperations();
-      // POC: Will be readdressed later with better UX with host apps which are friendly on async doc operations.
-      Commands.SetGlobalNotification(
-        ToastNotificationType.INFO,
-        "Document Switch",
-        "Operations cancelled because of document swap!"
-      );
-    }
   }
 }

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadReceiveBinding.cs
@@ -6,11 +6,10 @@ using Speckle.Connectors.Utils.Cancellation;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.Utils;
 using Speckle.Connectors.Utils.Operations;
-using ICancelable = System.Reactive.Disposables.ICancelable;
 
 namespace Speckle.Connectors.Autocad.Bindings;
 
-public sealed class AutocadReceiveBinding : IReceiveBinding, ICancelable
+public sealed class AutocadReceiveBinding : IReceiveBinding
 {
   public string Name => "receiveBinding";
   public IBridge Parent { get; }
@@ -81,24 +80,19 @@ public sealed class AutocadReceiveBinding : IReceiveBinding, ICancelable
     Commands.SetModelProgress(modelCardId, new ModelCardProgress(modelCardId, status, progress));
   }
 
+  // POC: Will be re-addressed later with better UX with host apps that are friendly on async doc operations.
+  // That's why don't bother for now how to get rid of from dup logic in other bindings.
   private void OnDocumentChanged()
   {
     if (_cancellationManager.NumberOfOperations > 0)
     {
       _cancellationManager.CancelAllOperations();
       // POC: Will be readdressed later with better UX with host apps which are friendly on async doc operations.
-      Commands.SendGlobalNotification(
+      Commands.SetGlobalNotification(
         ToastNotificationType.INFO,
         "Document Switch",
         "Operations cancelled because of document swap!"
       );
     }
   }
-
-  public void Dispose()
-  {
-    IsDisposed = true;
-  }
-
-  public bool IsDisposed { get; private set; }
 }

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
@@ -63,6 +63,8 @@ public sealed class AutocadSendBinding : ISendBinding, ICancelable
       // catches the case when autocad just opens up with a blank new doc
       SubscribeToObjectChanges(Application.DocumentManager.CurrentDocument);
     }
+
+    _store.DocumentChanged += (_, _) => OnDocumentChanged();
   }
 
   private readonly List<string> _docSubsTracker = new();
@@ -178,6 +180,20 @@ public sealed class AutocadSendBinding : ISendBinding, ICancelable
   }
 
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
+
+  private void OnDocumentChanged()
+  {
+    if (_cancellationManager.NumberOfOperations > 0)
+    {
+      _cancellationManager.CancelAllOperations();
+      // POC: Will be readdressed later with better UX with host apps which are friendly on async doc operations.
+      Commands.SendGlobalNotification(
+        ToastNotificationType.INFO,
+        "Document Switch",
+        "Operations cancelled because of document swap!"
+      );
+    }
+  }
 
   public void Dispose()
   {

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
@@ -10,14 +10,13 @@ using Speckle.Autofac.DependencyInjection;
 using Speckle.Connectors.Autocad.Operations.Send;
 using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.Utils.Operations;
-using ICancelable = System.Reactive.Disposables.ICancelable;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
 using Speckle.Connectors.Utils;
 using Speckle.Connectors.Utils.Caching;
 
 namespace Speckle.Connectors.Autocad.Bindings;
 
-public sealed class AutocadSendBinding : ISendBinding, ICancelable
+public sealed class AutocadSendBinding : ISendBinding
 {
   public string Name { get; } = "sendBinding";
   public SendBindingUICommands Commands { get; }
@@ -181,24 +180,19 @@ public sealed class AutocadSendBinding : ISendBinding, ICancelable
 
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
 
+  // POC: Will be re-addressed later with better UX with host apps that are friendly on async doc operations.
+  // That's why don't bother for now how to get rid of from dup logic in other bindings.
   private void OnDocumentChanged()
   {
     if (_cancellationManager.NumberOfOperations > 0)
     {
       _cancellationManager.CancelAllOperations();
       // POC: Will be readdressed later with better UX with host apps which are friendly on async doc operations.
-      Commands.SendGlobalNotification(
+      Commands.SetGlobalNotification(
         ToastNotificationType.INFO,
         "Document Switch",
         "Operations cancelled because of document swap!"
       );
     }
   }
-
-  public void Dispose()
-  {
-    IsDisposed = true;
-  }
-
-  public bool IsDisposed { get; private set; }
 }

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/Bindings/AutocadSendBinding.cs
@@ -62,8 +62,6 @@ public sealed class AutocadSendBinding : ISendBinding
       // catches the case when autocad just opens up with a blank new doc
       SubscribeToObjectChanges(Application.DocumentManager.CurrentDocument);
     }
-
-    _store.DocumentChanged += (_, _) => OnDocumentChanged();
   }
 
   private readonly List<string> _docSubsTracker = new();
@@ -179,20 +177,4 @@ public sealed class AutocadSendBinding : ISendBinding
   }
 
   public void CancelSend(string modelCardId) => _cancellationManager.CancelOperation(modelCardId);
-
-  // POC: Will be re-addressed later with better UX with host apps that are friendly on async doc operations.
-  // That's why don't bother for now how to get rid of from dup logic in other bindings.
-  private void OnDocumentChanged()
-  {
-    if (_cancellationManager.NumberOfOperations > 0)
-    {
-      _cancellationManager.CancelAllOperations();
-      // POC: Will be readdressed later with better UX with host apps which are friendly on async doc operations.
-      Commands.SetGlobalNotification(
-        ToastNotificationType.INFO,
-        "Document Switch",
-        "Operations cancelled because of document swap!"
-      );
-    }
-  }
 }

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -48,6 +48,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBin
     // TODO expiry events
     // TODO filters need refresh events
     revitContext.UIApplication.NotNull().Application.DocumentChanged += (_, e) => DocChangeHandler(e);
+    Store.DocumentChanged += (_, _) => OnDocumentChanged();
   }
 
   public List<ISendFilter> GetSendFilters()
@@ -177,5 +178,19 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBin
 
     Commands.SetModelsExpired(expiredSenderIds);
     ChangedObjectIds = new HashSet<string>();
+  }
+
+  // POC: Will be re-addressed later with better UX with host apps that are friendly on async doc operations.
+  private void OnDocumentChanged()
+  {
+    if (CancellationManager.NumberOfOperations > 0)
+    {
+      CancellationManager.CancelAllOperations();
+      Commands.SendGlobalNotification(
+        ToastNotificationType.INFO,
+        "Document Switch",
+        "Operations cancelled because of document swap!"
+      );
+    }
   }
 }

--- a/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
+++ b/DUI3-DX/Connectors/Revit/Speckle.Connectors.RevitShared/Bindings/RevitSendBinding.cs
@@ -1,6 +1,5 @@
 using Autodesk.Revit.DB;
 using Speckle.Connectors.DUI.Models.Card.SendFilter;
-using Speckle.Connectors.Utils.Cancellation;
 using Speckle.Connectors.DUI.Bridge;
 using Speckle.Connectors.Revit.Plugin;
 using Speckle.Connectors.Utils;
@@ -11,20 +10,21 @@ using Speckle.Autofac.DependencyInjection;
 using Speckle.Connectors.DUI.Exceptions;
 using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.Utils.Caching;
+using Speckle.Connectors.Utils.Cancellation;
 using Speckle.Connectors.Utils.Operations;
 
 namespace Speckle.Connectors.Revit.Bindings;
 
-internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBinding
+internal sealed class RevitSendBinding : RevitBaseBinding, ISendBinding
 {
   // POC:does it need injecting?
-  public CancellationManager CancellationManager { get; } = new();
 
   // POC: does it need injecting?
   private HashSet<string> ChangedObjectIds { get; set; } = new();
 
   private readonly RevitSettings _revitSettings;
   private readonly IRevitIdleManager _idleManager;
+  private readonly CancellationManager _cancellationManager;
   private readonly IUnitOfWorkFactory _unitOfWorkFactory;
   private readonly ISendConversionCache _sendConversionCache;
 
@@ -32,6 +32,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBin
     IRevitIdleManager idleManager,
     RevitContext revitContext,
     DocumentModelStore store,
+    CancellationManager cancellationManager,
     IBridge bridge,
     IUnitOfWorkFactory unitOfWorkFactory,
     RevitSettings revitSettings,
@@ -40,6 +41,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBin
     : base("sendBinding", store, bridge, revitContext)
   {
     _idleManager = idleManager;
+    _cancellationManager = cancellationManager;
     _unitOfWorkFactory = unitOfWorkFactory;
     _revitSettings = revitSettings;
     _sendConversionCache = sendConversionCache;
@@ -58,7 +60,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBin
 
   public void CancelSend(string modelCardId)
   {
-    CancellationManager.CancelOperation(modelCardId);
+    _cancellationManager.CancelOperation(modelCardId);
   }
 
   public SendBindingUICommands Commands { get; }
@@ -76,7 +78,7 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBin
 
       // POC: probably the CTS SHOULD be injected as InstancePerLifetimeScope and then
       // it can be injected where needed instead of passing it around like a bomb :D
-      CancellationTokenSource cts = CancellationManager.InitCancellationTokenSource(modelCardId);
+      CancellationTokenSource cts = _cancellationManager.InitCancellationTokenSource(modelCardId);
 
       using IUnitOfWork<SendOperation<ElementId>> sendOperation = _unitOfWorkFactory.Resolve<
         SendOperation<ElementId>
@@ -181,12 +183,13 @@ internal sealed class RevitSendBinding : RevitBaseBinding, ICancelable, ISendBin
   }
 
   // POC: Will be re-addressed later with better UX with host apps that are friendly on async doc operations.
+  // That's why don't bother for now how to get rid of from dup logic in other bindings.
   private void OnDocumentChanged()
   {
-    if (CancellationManager.NumberOfOperations > 0)
+    if (_cancellationManager.NumberOfOperations > 0)
     {
-      CancellationManager.CancelAllOperations();
-      Commands.SendGlobalNotification(
+      _cancellationManager.CancelAllOperations();
+      Commands.SetGlobalNotification(
         ToastNotificationType.INFO,
         "Document Switch",
         "Operations cancelled because of document swap!"

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoSendBinding.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/Bindings/RhinoSendBinding.cs
@@ -5,7 +5,6 @@ using Speckle.Connectors.DUI.Models;
 using Speckle.Connectors.DUI.Models.Card;
 using Speckle.Connectors.Rhino7.HostApp;
 using Speckle.Connectors.Utils.Cancellation;
-using ICancelable = System.Reactive.Disposables.ICancelable;
 using Speckle.Autofac.DependencyInjection;
 using Rhino.DocObjects;
 using Speckle.Connectors.DUI.Exceptions;
@@ -17,7 +16,7 @@ using Speckle.Connectors.Utils.Caching;
 
 namespace Speckle.Connectors.Rhino7.Bindings;
 
-public sealed class RhinoSendBinding : ISendBinding, ICancelable
+public sealed class RhinoSendBinding : ISendBinding
 {
   public string Name { get; } = "sendBinding";
   public SendBindingUICommands Commands { get; }
@@ -213,11 +212,4 @@ public sealed class RhinoSendBinding : ISendBinding, ICancelable
     Commands.SetModelsExpired(expiredSenderIds);
     ChangedObjectIds = new HashSet<string>();
   }
-
-  public void Dispose()
-  {
-    IsDisposed = true;
-  }
-
-  public bool IsDisposed { get; private set; }
 }

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/IBasicConnectorBinding.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/IBasicConnectorBinding.cs
@@ -56,7 +56,14 @@ public class BasicConnectorBindingCommands
 
   public void NotifyDocumentChanged() => Bridge.Send(NOTIFY_DOCUMENT_CHANGED_EVENT_NAME);
 
-  public void SendGlobalNotification(ToastNotificationType type, string title, string message) =>
+  /// <summary>
+  /// Use it whenever you want to send global toast notification to UI.
+  /// </summary>
+  /// <param name="type"> Level of notification, see <see cref="ToastNotificationType"/> for types</param>
+  /// <param name="title"> Title of the notification</param>
+  /// <param name="message"> Message in the toast notification.</param>
+  /// <param name="autoClose"> Closes toast notification in set timeout in UI. Default is true.</param>
+  public void SetGlobalNotification(ToastNotificationType type, string title, string message, bool autoClose = true) =>
     Bridge.Send(
       SET_GLOBAL_NOTIFICATION,
       new
@@ -64,7 +71,7 @@ public class BasicConnectorBindingCommands
         type,
         title,
         description = message,
-        autoClose = true
+        autoClose
       }
     );
 

--- a/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/IBasicConnectorBinding.cs
+++ b/DUI3-DX/DUI3/Speckle.Connectors.DUI/Bindings/IBasicConnectorBinding.cs
@@ -32,11 +32,20 @@ public static class BasicConnectorBindingEvents
   public const string DOCUMENT_CHANGED = "documentChanged";
 }
 
+public enum ToastNotificationType
+{
+  SUCCESS,
+  WARNING,
+  DANGER,
+  INFO
+}
+
 public class BasicConnectorBindingCommands
 {
   private const string NOTIFY_DOCUMENT_CHANGED_EVENT_NAME = "documentChanged";
   private const string SET_MODEL_PROGRESS_UI_COMMAND_NAME = "setModelProgress";
   private const string SET_MODEL_ERROR_UI_COMMAND_NAME = "setModelError";
+  private const string SET_GLOBAL_NOTIFICATION = "setGlobalNotification";
 
   protected IBridge Bridge { get; }
 
@@ -46,6 +55,18 @@ public class BasicConnectorBindingCommands
   }
 
   public void NotifyDocumentChanged() => Bridge.Send(NOTIFY_DOCUMENT_CHANGED_EVENT_NAME);
+
+  public void SendGlobalNotification(ToastNotificationType type, string title, string message) =>
+    Bridge.Send(
+      SET_GLOBAL_NOTIFICATION,
+      new
+      {
+        type,
+        title,
+        description = message,
+        autoClose = true
+      }
+    );
 
   public void SetModelProgress(string modelCardId, ModelCardProgress progress) =>
     Bridge.Send(SET_MODEL_PROGRESS_UI_COMMAND_NAME, new { modelCardId, progress });

--- a/DUI3-DX/Sdk/Speckle.Connectors.Utils/Cancellation/CancellationManager.cs
+++ b/DUI3-DX/Sdk/Speckle.Connectors.Utils/Cancellation/CancellationManager.cs
@@ -10,6 +10,8 @@ public class CancellationManager
   /// </summary>
   private readonly Dictionary<string, CancellationTokenSource> _operationsInProgress = new();
 
+  public int NumberOfOperations => _operationsInProgress.Count;
+
   /// <summary>
   /// Get token with registered id.
   /// </summary>
@@ -28,6 +30,16 @@ public class CancellationManager
   public bool IsExist(string id)
   {
     return _operationsInProgress.ContainsKey(id);
+  }
+
+  public void CancelAllOperations()
+  {
+    foreach (var operation in _operationsInProgress)
+    {
+      operation.Value.Cancel();
+      operation.Value.Dispose();
+    }
+    _operationsInProgress.Clear();
   }
 
   /// <summary>


### PR DESCRIPTION
UI implementation is ready to merge -> https://github.com/specklesystems/speckle-server/pull/2363

- We have command for each binding to set any message to UI as global toast notification
- I removed all old `ICancelable` interface from send and receive bindings. Which was something talking with @JR-Morgan
- I aligned naming of `_cancellationManager` in bindings. Some of still was having setter on `CancellationManager`
- I have dup code now on RevitSendBinding, AutocadSendBinding and AutocadReceiveBinding for document switch logic to cancel out all active operations and then tell UI to show message.
- Feel free to suggest better "message" on doc switch 🙂

Also would like to sync @clairekuang before merging in!