### PR TITLE
fix(dui3): corrects IRootObjectBuilder registration

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/ArcGISConnectorModule.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/DependencyInjection/ArcGISConnectorModule.cs
@@ -55,7 +55,7 @@ public class ArcGISConnectorModule : ISpeckleModule
     // register send operation and dependencies
     builder.AddScoped<SendOperation<MapMember>>();
     builder.AddScoped<ArcGISRootObjectBuilder>();
-    builder.AddSingleton<IRootObjectBuilder<MapMember>, ArcGISRootObjectBuilder>();
+    builder.AddScoped<IRootObjectBuilder<MapMember>, ArcGISRootObjectBuilder>();
 
     // register send conversion cache
     builder.AddSingleton<ISendConversionCache, SendConversionCache>();

--- a/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/AutocadConnectorModule.cs
+++ b/DUI3-DX/Connectors/Autocad/Speckle.Connectors.AutocadShared/DependencyInjection/AutocadConnectorModule.cs
@@ -44,7 +44,7 @@ public class AutocadConnectorModule : ISpeckleModule
 
     // Object Builders
     builder.AddScoped<IHostObjectBuilder, AutocadHostObjectBuilder>();
-    builder.AddSingleton<IRootObjectBuilder<AutocadRootObject>, AutocadRootObjectBuilder>();
+    builder.AddScoped<IRootObjectBuilder<AutocadRootObject>, AutocadRootObjectBuilder>();
 
     // Register bindings
 

--- a/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/DependencyInjection/RhinoConnectorModule.cs
+++ b/DUI3-DX/Connectors/Rhino/Speckle.Connectors.Rhino7/DependencyInjection/RhinoConnectorModule.cs
@@ -70,6 +70,6 @@ public class RhinoConnectorModule : ISpeckleModule
     builder.AddScoped<SendOperation<RhinoObject>>();
     builder.AddSingleton(DefaultTraversal.CreateTraversalFunc());
 
-    builder.AddSingleton<IRootObjectBuilder<RhinoObject>, RhinoRootObjectBuilder>();
+    builder.AddScoped<IRootObjectBuilder<RhinoObject>, RhinoRootObjectBuilder>();
   }
 }


### PR DESCRIPTION
Expected behaviour: get a new root object builder every time we click "send". Reality: we didn't - this fixes that

Previously these components were registered as `InstancePerLifetimeScope` IIRC, they accidentaly became registed as singletons (`SingleInstance`), reverting back to `Scoped` (= `InstancePerLifetimeScope`)

