### PR TITLE
fix: if headless use original material

### DIFF
--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -224,7 +224,7 @@ public partial class ConverterRhinoGh
       matToUse.CopyFrom(material);
       matToUse.ToPhysicallyBased();
     }
-    using (var rm = RenderMaterial.FromMaterial(matToUse, Doc))
+    using (var rm = RenderMaterial.FromMaterial(matToUse, null))
     {
       RH.PhysicallyBasedMaterial pbrMaterial = rm.ConvertToPhysicallyBased(RenderTexture.TextureGeneration.Allow);
       renderMaterial.diffuse = pbrMaterial.BaseColor.AsSystemColor().ToArgb();

--- a/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
+++ b/Objects/Converters/ConverterRhinoGh/ConverterRhinoGhShared/ConverterRhinoGh.Other.cs
@@ -218,13 +218,13 @@ public partial class ConverterRhinoGh
     }
 #else
     RH.Material matToUse = material;
-    if (!material.IsPhysicallyBased)
+    if (!material.IsPhysicallyBased && !Doc.IsHeadless)
     {
       matToUse = new RH.Material();
       matToUse.CopyFrom(material);
       matToUse.ToPhysicallyBased();
     }
-    using (var rm = RenderMaterial.FromMaterial(matToUse, null))
+    using (var rm = RenderMaterial.FromMaterial(matToUse, Doc))
     {
       RH.PhysicallyBasedMaterial pbrMaterial = rm.ConvertToPhysicallyBased(RenderTexture.TextureGeneration.Allow);
       renderMaterial.diffuse = pbrMaterial.BaseColor.AsSystemColor().ToArgb();


### PR DESCRIPTION
## Description & motivation
Running headless, the copy of the RH.Material yields null when passed to RenderMaterial.FromMaterial(material, Doc), which results the conversion throwing since the following calls assume a non nullable Material.

## Changes:
I have tried to make the minimum intervention.
- Check if headless, and if so do not use the copy of the material but the original.

## Screenshots:
Before and after 💯

![image](https://github.com/specklesystems/speckle-sharp/assets/61347148/358013a1-cade-40e9-83d5-f49e2629d741)

## References

https://developer.rhino3d.com/api/rhinocommon/rhino.render.rendermaterial/frommaterial
