### PR TITLE
Added support for IReadOnlyList deserialization

### DIFF
--- a/Core/Core/Serialisation/SerializationUtilities/ValueConverter.cs
+++ b/Core/Core/Serialisation/SerializationUtilities/ValueConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.DoubleNumerics;
 using System.Drawing;
 using System.Globalization;
@@ -158,15 +159,16 @@ internal static class ValueConverter
     }
 
     // Handle List<?>
-    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+    if (type.IsGenericType && IsGenericList(type))
     {
       if (value is not List<object> valueList)
       {
         return false;
       }
 
+      var targetType = typeof(List<>).MakeGenericType(type.GenericTypeArguments);
       Type listElementType = type.GenericTypeArguments[0];
-      IList ret = Activator.CreateInstance(type, valueList.Count) as IList;
+      IList ret = Activator.CreateInstance(targetType, valueList.Count) as IList;
       foreach (object inputListElement in valueList)
       {
         if (!ConvertValue(listElementType, inputListElement, out object? convertedListElement))
@@ -310,5 +312,22 @@ internal static class ValueConverter
     }
 
     return false;
+  }
+
+  /// <summary>
+  /// Tests that the given <paramref name="type"/> is assignable from a generic type def <see cref="List{T}"/>
+  /// </summary>
+  /// <param name="type"></param>
+  /// <returns></returns>
+  [Pure]
+  private static bool IsGenericList(Type type)
+  {
+    if (!type.IsGenericType)
+    {
+      return false;
+    }
+
+    Type typeDef = type.GetGenericTypeDefinition();
+    return typeDef == typeof(List<>) || typeDef == typeof(IList<>) || typeDef == typeof(IReadOnlyList<>);
   }
 }

--- a/Core/Core/Serialisation/SerializationUtilities/ValueConverter.cs
+++ b/Core/Core/Serialisation/SerializationUtilities/ValueConverter.cs
@@ -158,7 +158,7 @@ internal static class ValueConverter
       #endregion
     }
 
-    // Handle List<?>
+    // Handle List<>, IList<>, and IReadOnlyList<>
     if (type.IsGenericType && IsGenericList(type))
     {
       if (value is not List<object> valueList)

--- a/Core/Tests/Speckle.Core.Tests.Unit/Serialisation/SerializerBreakingChanges.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Serialisation/SerializerBreakingChanges.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using Speckle.Core.Logging;
 using Speckle.Core.Serialisation;
 
 namespace Speckle.Core.Tests.Unit.Serialisation;

--- a/Core/Tests/Speckle.Core.Tests.Unit/Serialisation/SerializerNonBreakingChanges.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Serialisation/SerializerNonBreakingChanges.cs
@@ -87,6 +87,24 @@ public class SerializerNonBreakingChanges : PrimitiveTestFixture
     Assert.That(res.value, Is.EquivalentTo(testCase));
   }
 
+  [Test, TestCaseSource(nameof(s_arrayTestCases))]
+  public void ListToIList(double[] testCase)
+  {
+    var from = new ListDoubleValueMock { value = testCase.ToList() };
+
+    var res = from.SerializeAsTAndDeserialize<IReadOnlyListDoubleValueMock>();
+    Assert.That(res.value, Is.EquivalentTo(testCase));
+  }
+
+  [Test, TestCaseSource(nameof(s_arrayTestCases))]
+  public void ListToIReadOnlyList(double[] testCase)
+  {
+    var from = new ListDoubleValueMock { value = testCase.ToList() };
+
+    var res = from.SerializeAsTAndDeserialize<IListDoubleValueMock>();
+    Assert.That(res.value, Is.EquivalentTo(testCase));
+  }
+
   [Test, TestCaseSource(nameof(MyEnums))]
   public void EnumToInt(MyEnum testCase)
   {
@@ -169,6 +187,16 @@ public class TValueMock<T> : SerializerMock
 public class ListDoubleValueMock : SerializerMock
 {
   public List<double> value { get; set; }
+}
+
+public class IListDoubleValueMock : SerializerMock
+{
+  public IList<double> value { get; set; }
+}
+
+public class IReadOnlyListDoubleValueMock : SerializerMock
+{
+  public IReadOnlyList<double> value { get; set; }
 }
 
 public class ArrayDoubleValueMock : SerializerMock

--- a/Core/Tests/Speckle.Core.Tests.Unit/Serialisation/SerializerNonBreakingChanges.cs
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Serialisation/SerializerNonBreakingChanges.cs
@@ -105,6 +105,24 @@ public class SerializerNonBreakingChanges : PrimitiveTestFixture
     Assert.That(res.value, Is.EquivalentTo(testCase));
   }
 
+  [Test, TestCaseSource(nameof(s_arrayTestCases))]
+  public void IListToList(double[] testCase)
+  {
+    var from = new IListDoubleValueMock { value = testCase.ToList() };
+
+    var res = from.SerializeAsTAndDeserialize<ListDoubleValueMock>();
+    Assert.That(res.value, Is.EquivalentTo(testCase));
+  }
+
+  [Test, TestCaseSource(nameof(s_arrayTestCases))]
+  public void IReadOnlyListToList(double[] testCase)
+  {
+    var from = new IReadOnlyListDoubleValueMock { value = testCase.ToList() };
+
+    var res = from.SerializeAsTAndDeserialize<ListDoubleValueMock>();
+    Assert.That(res.value, Is.EquivalentTo(testCase));
+  }
+
   [Test, TestCaseSource(nameof(MyEnums))]
   public void EnumToInt(MyEnum testCase)
   {

--- a/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
+++ b/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
@@ -47,9 +47,7 @@ public class ModelPropertySupportedTypes
       typeof(Guid),
       typeof(Color),
       typeof(List<>),
-      typeof(Array),
       typeof(Nullable<>),
-      typeof(Enum),
       typeof(IList<>),
       typeof(IReadOnlyList<>),
       typeof(Dictionary<,>),
@@ -60,7 +58,6 @@ public class ModelPropertySupportedTypes
       typeof(Matrix4x4),
     };
 
-  //[TestCase(typeof(Wall))]
   [Test]
   [TestCaseSource(typeof(GenericTests), nameof(GenericTests.AvailableTypesInKit))]
   public void TestObjects(Type t)

--- a/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
+++ b/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using Speckle.Core.Models;
 using Speckle.Core.Serialisation;
+using Speckle.Core.Tests.Unit.Serialisation;
 using Speckle.Newtonsoft.Json;
 
 namespace Objects.Tests.Unit;
@@ -26,6 +27,7 @@ public class ModelPropertySupportedTypes
   /// Check the <see cref="Speckle.Core.Serialisation.SerializationUtilities.ValueConverter"/>
   /// Check the <see cref="BaseObjectSerializerV2"/>
   /// (or is an interface where all concrete types are supported)
+  /// You should also consider adding a test in SerializerNonBreakingChanges
   /// </remarks>
   private HashSet<Type> allowedTypes =
     new()
@@ -49,8 +51,8 @@ public class ModelPropertySupportedTypes
       typeof(Array),
       typeof(Nullable<>),
       typeof(Enum),
-      //typeof(IList<>),
-      //typeof(IReadOnlyList<>),
+      typeof(IList<>),
+      typeof(IReadOnlyList<>),
       typeof(Dictionary<,>),
       //typeof(IDictionary<,>),
       //typeof(IReadOnlyDictionary<,>),

--- a/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
+++ b/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.DoubleNumerics;
+using System.Drawing;
+using System.Linq;
+using NUnit.Framework;
+using Speckle.Core.Models;
+using Speckle.Core.Serialisation;
+using Speckle.Newtonsoft.Json;
+
+namespace Objects.Tests.Unit;
+
+/// <summary>
+/// Tests that all Base object models in the kit have properties that are an allowed type
+/// This test is not exhaustive, there are plenty of generic arg combinations that will pass this test,
+/// but still not work / are not defined behaviour. This test will just catch many types that definitely won't work
+/// </summary>
+public class ModelPropertySupportedTypes
+{
+  /// <summary>
+  /// Lists of types that we support in Base objects
+  /// If it's not in the list, or is commented out, it's not supported by our serializer!
+  /// </summary>
+  /// <remarks>
+  /// If you're tempted to add to this list, please ensure both our serializer and deserializer support properties of this type
+  /// Check the <see cref="Speckle.Core.Serialisation.SerializationUtilities.ValueConverter"/>
+  /// Check the <see cref="BaseObjectSerializerV2"/>
+  /// (or is an interface where all concrete types are supported)
+  /// </remarks>
+  private HashSet<Type> allowedTypes =
+    new()
+    {
+      typeof(Boolean),
+      typeof(Byte),
+      typeof(UInt32),
+      typeof(UInt64),
+      typeof(Int16),
+      typeof(Int32),
+      typeof(Int64),
+      //typeof(Half),
+      typeof(Single),
+      typeof(Double),
+      typeof(Char),
+      typeof(string),
+      typeof(DateTime),
+      typeof(Guid),
+      typeof(Color),
+      typeof(List<>),
+      typeof(Array),
+      typeof(Nullable<>),
+      typeof(Enum),
+      //typeof(IList<>),
+      //typeof(IReadOnlyList<>),
+      typeof(Dictionary<,>),
+      //typeof(IDictionary<,>),
+      //typeof(IReadOnlyDictionary<,>),
+      typeof(ICurve),
+      typeof(Object),
+      typeof(Matrix4x4),
+    };
+
+  //[TestCase(typeof(Wall))]
+  [Test]
+  [TestCaseSource(typeof(GenericTests), nameof(GenericTests.AvailableTypesInKit))]
+  public void TestObjects(Type t)
+  {
+    var members = DynamicBase.GetInstanceMembers(t).Where(p => !p.IsDefined(typeof(JsonIgnoreAttribute), true));
+
+    foreach (var prop in members)
+    {
+      if (prop.PropertyType.IsAssignableTo(typeof(Base)))
+        continue;
+      if (prop.PropertyType.IsEnum)
+        continue;
+      if (prop.PropertyType.IsSZArray)
+        continue;
+
+      Type propType = prop.PropertyType;
+      Type typeDef = propType.IsGenericType ? propType.GetGenericTypeDefinition() : propType;
+      Assert.That(allowedTypes, Does.Contain(typeDef), $"{typeDef} was not in allowedTypes");
+    }
+  }
+}

--- a/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
+++ b/Objects/Tests/Objects.Tests.Unit/ModelPropertySupportedTypes.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using NUnit.Framework;
 using Speckle.Core.Models;
 using Speckle.Core.Serialisation;
-using Speckle.Core.Tests.Unit.Serialisation;
 using Speckle.Newtonsoft.Json;
 
 namespace Objects.Tests.Unit;
@@ -19,7 +18,7 @@ namespace Objects.Tests.Unit;
 public class ModelPropertySupportedTypes
 {
   /// <summary>
-  /// Lists of types that we support in Base objects
+  /// Set of types that we support in Base objects
   /// If it's not in the list, or is commented out, it's not supported by our serializer!
   /// </summary>
   /// <remarks>
@@ -29,7 +28,7 @@ public class ModelPropertySupportedTypes
   /// (or is an interface where all concrete types are supported)
   /// You should also consider adding a test in SerializerNonBreakingChanges
   /// </remarks>
-  private HashSet<Type> allowedTypes =
+  private readonly HashSet<Type> _allowedTypes =
     new()
     {
       typeof(Boolean),
@@ -79,7 +78,7 @@ public class ModelPropertySupportedTypes
 
       Type propType = prop.PropertyType;
       Type typeDef = propType.IsGenericType ? propType.GetGenericTypeDefinition() : propType;
-      Assert.That(allowedTypes, Does.Contain(typeDef), $"{typeDef} was not in allowedTypes");
+      Assert.That(_allowedTypes, Does.Contain(typeDef), $"{typeDef} was not in allowedTypes");
     }
   }
 }


### PR DESCRIPTION
https://github.com/specklesystems/speckle-sharp/pull/3451 introduced an issue where we were successfully serializing, but not  successfully deserializing `IReadOnlyList` properties.

This somehow got through my round of testing.... my bad! but thanks @gjedlicska for spotting this while 2.20 is still in wip! 🙌

---

### In This PR
1. Added support in our deserializer for `IList` and `IReadOnlyList` typed properties
2. Added a unit test for said support
3. Added a test in `Objects.Tests` to test that object model properties are one of the types supported by both our serializer and Deserializer (hard coded right now). Hopefully this will help ensure we never introduce this type of issue again.