### PR TITLE
better fallback reporting

### DIFF
--- a/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ToHost/ConverterWithFallback.cs
+++ b/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ToHost/ConverterWithFallback.cs
@@ -1,4 +1,5 @@
-﻿using Speckle.Converters.Common.Objects;
+using System.Collections;
+using Speckle.Converters.Common.Objects;
 using Speckle.Core.Models;
 using Speckle.Core.Models.Extensions;
 
@@ -49,6 +50,10 @@ public sealed class ConverterWithFallback : IRootToHostConverter
     var displayValue = target.TryGetDisplayValue<Base>();
     if (displayValue != null)
     {
+      if (displayValue is IEnumerable && !displayValue.Any())
+      {
+        throw new NotSupportedException($"No display value found for {type}");
+      }
       return FallbackToDisplayValue(displayValue);
     }
 

--- a/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ToHost/ConverterWithFallback.cs
+++ b/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ToHost/ConverterWithFallback.cs
@@ -50,7 +50,7 @@ public sealed class ConverterWithFallback : IRootToHostConverter
     var displayValue = target.TryGetDisplayValue<Base>();
     if (displayValue != null)
     {
-      if (displayValue is IEnumerable && !displayValue.Any())
+      if (displayValue is IList && !displayValue.Any())
       {
         throw new NotSupportedException($"No display value found for {type}");
       }


### PR DESCRIPTION
If we don't throw exception here, later in the hostApp converter we won't be able to tell which object was it initially and report properly. 