### PR TITLE
D ui3 123 receiving non native attributes revit params gh attributes etc

### DIFF
--- a/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
+++ b/DUI3-DX/Connectors/ArcGIS/Speckle.Connectors.ArcGIS3/Operations/Receive/HostObjectBuilder.cs
@@ -135,6 +135,9 @@ public class ArcGISHostObjectBuilder : IHostObjectBuilder
         // add layer URI to bakedIds
         bakedObjectIds.Add(trackerItem.MappedLayerURI == null ? "" : trackerItem.MappedLayerURI);
 
+        // mark dataset as already created
+        bakedMapMembers[trackerItem.DatasetId] = mapMember;
+
         // add report item
         AddResultsFromTracker(trackerItem, results);
       }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -136,7 +136,25 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
     if (field.Value is Base attributeBase)
     {
       // only traverse Base if it's Rhino userStrings, or Revit parameter, or Base containing Revit parameters
-      if (field.Key == "parameters" || field.Key == "userStrings")
+      if (field.Key == "parameters")
+      {
+        foreach (KeyValuePair<string, object?> attributField in attributeBase.GetMembers(DynamicBaseMemberType.Dynamic))
+        {
+          // only iterate through elements if they are actually Revit Parameters or parameter IDs
+          if (
+            attributField.Value is Objects.BuiltElements.Revit.Parameter
+            || attributField.Key == "applicationId"
+            || attributField.Key == "id"
+          )
+          {
+            KeyValuePair<string, object?> newAttributField =
+              new($"{field.Key}.{attributField.Key}", attributField.Value);
+            Func<Base, object?> functionAdded = x => (function(x) as Base)?[attributField.Key];
+            TraverseAttributes(newAttributField, functionAdded, fieldsAndFunctions, fieldAdded);
+          }
+        }
+      }
+      else if (field.Key == "userStrings")
       {
         foreach (KeyValuePair<string, object?> attributField in attributeBase.GetMembers(DynamicBaseMemberType.Dynamic))
         {

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -32,31 +32,24 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
         string key = field.AliasName; // use Alias, as Name is simplified to alphanumeric
         FieldType fieldType = field.FieldType;
         var value = attributes[key];
-        if (value is not null)
+
+        try
         {
-          // POC: get all values in a correct format
-          try
-          {
-            rowBuffer[key] = GISAttributeFieldType.SpeckleValueToNativeFieldType(fieldType, value);
-          }
-          catch (GeodatabaseFeatureException)
-          {
-            //'The value type is incompatible.'
-            // log error!
-            rowBuffer[key] = null;
-          }
-          catch (GeodatabaseFieldException)
-          {
-            // non-editable Field, do nothing
-          }
+          rowBuffer[key] = GISAttributeFieldType.SpeckleValueToNativeFieldType(fieldType, value);
         }
-        else
+        catch (GeodatabaseFeatureException)
         {
-          try
-          {
-            rowBuffer[key] = null;
-          }
-          catch (GeodatabaseGeneralException) { } // The index passed was not within the valid range. // unclear reason of the error
+          //'The value type is incompatible.'
+          // log error!
+          rowBuffer[key] = null;
+        }
+        catch (GeodatabaseFieldException)
+        {
+          // non-editable Field, do nothing
+        }
+        catch (GeodatabaseGeneralException)
+        {
+          // The index passed was not within the valid range. // unclear reason of the error
         }
       }
     }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -130,19 +130,19 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
         foreach (KeyValuePair<string, object?> attributField in attributeBase.GetMembers(DynamicBaseMemberType.Dynamic))
         {
           KeyValuePair<string, object?> newAttributField = new($"{field.Key}.{attributField.Key}", attributField.Value);
-          Func<Base, object?> addedFunction = x => (function(x) as KeyValuePair<string, object?>?)?.Value;
-          function = addedFunction;
-          TraverseAttributes(newAttributField, function, fieldsAndFunctions, fieldAdded);
+          Func<Base, object?> functionAdded = x => (function(x) as KeyValuePair<string, object?>?)?.Value;
+          TraverseAttributes(newAttributField, functionAdded, fieldsAndFunctions, fieldAdded);
         }
       }
       else if (field.Value is Objects.BuiltElements.Revit.Parameter)
       {
-        foreach (KeyValuePair<string, object?> attributField in attributeBase.GetMembers(DynamicBaseMemberType.Dynamic))
+        foreach (
+          KeyValuePair<string, object?> attributField in attributeBase.GetMembers(DynamicBaseMemberType.Instance)
+        )
         {
           KeyValuePair<string, object?> newAttributField = new($"{field.Key}.{attributField.Key}", attributField.Value);
-          Func<Base, object?> addedFunction = x => (function(x) as KeyValuePair<string, object?>?)?.Value;
-          function = addedFunction;
-          TraverseAttributes(newAttributField, function, fieldsAndFunctions, fieldAdded);
+          Func<Base, object?> functionAdded = x => (function(x) as KeyValuePair<string, object?>?)?.Value;
+          TraverseAttributes(newAttributField, functionAdded, fieldsAndFunctions, fieldAdded);
         }
       }
     }
@@ -152,9 +152,8 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
       foreach (var attributField in attributeList)
       {
         KeyValuePair<string, object?> newAttributField = new($"{field.Key}[{count}]", attributField);
-        Func<Base, object?> addedFunction = x => (function(x) as List<object?>)?[count];
-        function = addedFunction;
-        TraverseAttributes(newAttributField, function, fieldsAndFunctions, fieldAdded);
+        Func<Base, object?> functionAdded = x => (function(x) as List<object?>)?[count];
+        TraverseAttributes(newAttributField, functionAdded, fieldsAndFunctions, fieldAdded);
         count += 1;
       }
     }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -106,10 +106,14 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
     foreach (var baseObj in target)
     {
       // get all members by default, but only Dynamic ones from the basic geometry
-      var members = baseObj.GetMembers(DynamicBaseMemberType.All);
+      Dictionary<string, object?> members = new();
       if (baseObj.speckle_type.StartsWith("Objects.Geometry"))
       {
         members = baseObj.GetMembers(DynamicBaseMemberType.Dynamic);
+      }
+      else
+      {
+        members = baseObj.GetMembers(DynamicBaseMemberType.All);
       }
 
       foreach (KeyValuePair<string, object?> field in members)
@@ -151,6 +155,10 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
           Func<Base, object?> functionAdded = x => (function(x) as Base)?[attributField.Key];
           TraverseAttributes(newAttributField, functionAdded, fieldsAndFunctions, fieldAdded);
         }
+      }
+      else
+      {
+        // for now, ignore all other properties of Base type
       }
     }
     else if (field.Value is IList attributeList)

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -105,8 +105,9 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
 
     foreach (var baseObj in target)
     {
+      Dictionary<string, object?> members = new();
       // get all members by default, but only Dynamic ones from the basic geometry
-      Dictionary<string, object?> members = baseObj.GetMembers(DynamicBaseMemberType.Instance);
+      // Dictionary<string, object?> members = baseObj.GetMembers(DynamicBaseMemberType.Dynamic);
 
       foreach (KeyValuePair<string, object?> field in members)
       {

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using ArcGIS.Core.Data;
 using ArcGIS.Core.Data.Exceptions;
 using Objects.GIS;

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -107,7 +107,15 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
     foreach (var baseObj in target)
     {
       // get all members by default, but only Dynamic ones from the basic geometry
-      Dictionary<string, object?> members = baseObj.GetMembers(DynamicBaseMemberType.Instance);
+      Dictionary<string, object?> members = new();
+      if (baseObj.speckle_type.StartsWith("Objects.Geometry"))
+      {
+        members = baseObj.GetMembers(DynamicBaseMemberType.Dynamic);
+      }
+      else
+      {
+        members = baseObj.GetMembers(DynamicBaseMemberType.All);
+      }
 
       foreach (KeyValuePair<string, object?> field in members)
       {
@@ -143,9 +151,6 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
   {
     if (field.Value is Base attributeBase)
     {
-      // ignore all properties of Base type, until we find a common approach for host apps to send them
-      return;
-      /*
       // only traverse Base if it's Rhino userStrings, or Revit parameter, or Base containing Revit parameters
       if (field.Key == "parameters")
       {
@@ -189,10 +194,7 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
       {
         // for now, ignore all other properties of Base type
       }
-      */
     }
-    // also ignore lists before we find a strategy for hostApps to send properties in a common way
-    /*
     else if (field.Value is IList attributeList)
     {
       int count = 0;
@@ -204,7 +206,6 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
         count += 1;
       }
     }
-    */
     else
     {
       TryAddField(field, function, fieldsAndFunctions, fieldAdded);

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using ArcGIS.Core.Data;
 using ArcGIS.Core.Data.Exceptions;
 using Objects.GIS;

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -107,15 +107,7 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
     foreach (var baseObj in target)
     {
       // get all members by default, but only Dynamic ones from the basic geometry
-      Dictionary<string, object?> members = new();
-      if (baseObj.speckle_type.StartsWith("Objects.Geometry"))
-      {
-        members = baseObj.GetMembers(DynamicBaseMemberType.Dynamic);
-      }
-      else
-      {
-        members = baseObj.GetMembers(DynamicBaseMemberType.All);
-      }
+      Dictionary<string, object?> members = baseObj.GetMembers(DynamicBaseMemberType.Instance);
 
       foreach (KeyValuePair<string, object?> field in members)
       {
@@ -151,6 +143,9 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
   {
     if (field.Value is Base attributeBase)
     {
+      // ignore all properties of Base type, until we find a common approach for host apps to send them
+      return;
+      /*
       // only traverse Base if it's Rhino userStrings, or Revit parameter, or Base containing Revit parameters
       if (field.Key == "parameters")
       {
@@ -194,7 +189,10 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
       {
         // for now, ignore all other properties of Base type
       }
+      */
     }
+    // also ignore lists before we find a strategy for hostApps to send properties in a common way
+    /*
     else if (field.Value is IList attributeList)
     {
       int count = 0;
@@ -206,6 +204,7 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
         count += 1;
       }
     }
+    */
     else
     {
       TryAddField(field, function, fieldsAndFunctions, fieldAdded);

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -108,6 +108,9 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
     {
       // get all members by default, but only Dynamic ones from the basic geometry
       Dictionary<string, object?> members = new();
+
+      // leave out until we decide which properties to support on Receive
+      /*
       if (baseObj.speckle_type.StartsWith("Objects.Geometry"))
       {
         members = baseObj.GetMembers(DynamicBaseMemberType.Dynamic);
@@ -116,6 +119,7 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
       {
         members = baseObj.GetMembers(DynamicBaseMemberType.All);
       }
+      */
 
       foreach (KeyValuePair<string, object?> field in members)
       {

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/ArcGISFieldUtils.cs
@@ -105,9 +105,8 @@ public class ArcGISFieldUtils : IArcGISFieldUtils
 
     foreach (var baseObj in target)
     {
-      Dictionary<string, object?> members = new();
       // get all members by default, but only Dynamic ones from the basic geometry
-      // Dictionary<string, object?> members = baseObj.GetMembers(DynamicBaseMemberType.Dynamic);
+      Dictionary<string, object?> members = baseObj.GetMembers(DynamicBaseMemberType.Instance);
 
       foreach (KeyValuePair<string, object?> field in members)
       {

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/FeatureClassUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/FeatureClassUtils.cs
@@ -99,7 +99,7 @@ public class FeatureClassUtils : IFeatureClassUtils
         foreach ((FieldDescription field, Func<Base, object?> function) in fieldsAndFunctions)
         {
           string key = field.AliasName;
-          attributes[key] = function(baseObj)?.ToString();
+          attributes[key] = function(baseObj);
         }
         // newFeatureClass.CreateRow(rowBuffer).Dispose(); // without extra attributes
         newFeatureClass

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
@@ -94,6 +94,7 @@ public static class GISAttributeFieldType
     {
       try
       {
+        static T? GetValue<T>(string? s, Func<string, T> func) => s is null ? default : func(s);
         return fieldType switch
         {
           FieldType.String => Convert.ToString(value),
@@ -102,9 +103,9 @@ public static class GISAttributeFieldType
           FieldType.BigInteger => Convert.ToInt64(value),
           FieldType.SmallInteger => Convert.ToInt16(value),
           FieldType.Double => Convert.ToDouble(value),
-          FieldType.Date => DateTime.Parse((string)value, null),
-          FieldType.DateOnly => DateOnly.Parse((string)value),
-          FieldType.TimeOnly => TimeOnly.Parse((string)value),
+          FieldType.Date => GetValue(value.ToString(), s => DateTime.Parse(s, null)),
+          FieldType.DateOnly => GetValue(value.ToString(), s => DateOnly.Parse(s, null)),
+          FieldType.TimeOnly => GetValue(value.ToString(), s => TimeOnly.Parse(s, null)),
           _ => value,
         };
       }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
@@ -116,4 +116,23 @@ public static class GISAttributeFieldType
 
     return value;
   }
+
+  public static FieldType GetFieldTypeFromRawValue(object? value)
+  {
+    // using "Blob" as a placeholder for unrecognized values/nulls.
+    // Once all elements are iterated, FieldType.Blob will be replaced with FieldType.String if no better type found
+    if (value is not null)
+    {
+      return value switch
+      {
+        string => FieldType.String,
+        int => FieldType.Integer,
+        long => FieldType.BigInteger,
+        double => FieldType.Double,
+        _ => FieldType.Blob,
+      };
+    }
+
+    return FieldType.Blob;
+  }
 }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
@@ -96,7 +96,7 @@ public static class GISAttributeFieldType
       {
         return fieldType switch
         {
-          FieldType.String => value.ToString(),
+          FieldType.String => Convert.ToString(value),
           FieldType.Single => Convert.ToSingle(value),
           FieldType.Integer => Convert.ToInt32(value), // need this step because sent "ints" seem to be received as "longs"
           FieldType.BigInteger => Convert.ToInt64(value),

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
@@ -90,11 +90,11 @@ public static class GISAttributeFieldType
         return value;
     }
 
-    if (value is not null)
+    if (value != null)
     {
       try
       {
-        static T? GetValue<T>(string? s, Func<string, T> func) => s is null ? default : func(s);
+        static object? GetValue(string? s, Func<string, object> func) => s is null ? null : func(s);
         return fieldType switch
         {
           FieldType.String => Convert.ToString(value),
@@ -109,13 +109,15 @@ public static class GISAttributeFieldType
           _ => value,
         };
       }
-      catch (InvalidCastException)
+      catch (Exception ex) when (ex is InvalidCastException or FormatException or ArgumentNullException)
       {
-        return value;
+        return null;
       }
     }
-
-    return value;
+    else
+    {
+      return null;
+    }
   }
 
   public static FieldType GetFieldTypeFromRawValue(object? value)

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/GISAttributeFieldType.cs
@@ -96,7 +96,7 @@ public static class GISAttributeFieldType
       {
         return fieldType switch
         {
-          FieldType.String => (string)value,
+          FieldType.String => value.ToString(),
           FieldType.Single => Convert.ToSingle(value),
           FieldType.Integer => Convert.ToInt32(value), // need this step because sent "ints" seem to be received as "longs"
           FieldType.BigInteger => Convert.ToInt64(value),

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IArcGISFieldUtils.cs
@@ -1,11 +1,18 @@
 using ArcGIS.Core.Data;
 using Objects.GIS;
+using Speckle.Core.Models;
 using FieldDescription = ArcGIS.Core.Data.DDL.FieldDescription;
 
 namespace Speckle.Converters.ArcGIS3.Utils;
 
 public interface IArcGISFieldUtils
 {
-  public RowBuffer AssignFieldValuesToRow(RowBuffer rowBuffer, List<FieldDescription> fields, GisFeature feat);
+  public RowBuffer AssignFieldValuesToRow(
+    RowBuffer rowBuffer,
+    List<FieldDescription> fields,
+    Dictionary<string, object?> attributes
+  );
   public List<FieldDescription> GetFieldsFromSpeckleLayer(VectorLayer target);
+
+  public List<FieldDescription> CreateFieldsFromListOfBase(List<Base> target);
 }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IArcGISFieldUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IArcGISFieldUtils.cs
@@ -14,5 +14,5 @@ public interface IArcGISFieldUtils
   );
   public List<FieldDescription> GetFieldsFromSpeckleLayer(VectorLayer target);
 
-  public List<FieldDescription> CreateFieldsFromListOfBase(List<Base> target);
+  public List<(FieldDescription, Func<Base, object?>)> CreateFieldsFromListOfBase(List<Base> target);
 }

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IFeatureClassUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IFeatureClassUtils.cs
@@ -16,7 +16,7 @@ public interface IFeatureClassUtils
   );
   void AddNonGISFeaturesToFeatureClass(
     FeatureClass newFeatureClass,
-    List<ACG.Geometry> features,
+    List<(Base baseObj, ACG.Geometry convertedGeom)> featuresTuples,
     List<FieldDescription> fields
   );
   void AddFeaturesToTable(Table newFeatureClass, List<GisFeature> gisFeatures, List<FieldDescription> fields);

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IFeatureClassUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/IFeatureClassUtils.cs
@@ -17,7 +17,7 @@ public interface IFeatureClassUtils
   void AddNonGISFeaturesToFeatureClass(
     FeatureClass newFeatureClass,
     List<(Base baseObj, ACG.Geometry convertedGeom)> featuresTuples,
-    List<FieldDescription> fields
+    List<(FieldDescription, Func<Base, object?>)> fieldsAndFunctions
   );
   void AddFeaturesToTable(Table newFeatureClass, List<GisFeature> gisFeatures, List<FieldDescription> fields);
   public ACG.GeometryType GetLayerGeometryType(VectorLayer target);

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
@@ -162,6 +162,7 @@ public class NonNativeFeaturesUtils : INonNativeFeaturesUtils
     catch (ArgumentException ex)
     {
       // if name has invalid characters/combinations
+      // or 'The table contains multiple fields with the same name.:
       throw new ArgumentException($"{ex.Message}: {featureClassName}", ex);
     }
     bool buildStatus = schemaBuilder.Build();

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
@@ -126,27 +126,29 @@ public class NonNativeFeaturesUtils : INonNativeFeaturesUtils
     );
 
     // delete FeatureClass if already exists
-    foreach (FeatureClassDefinition fClassDefinition in geodatabase.GetDefinitions<FeatureClassDefinition>())
+    try
     {
-      // will cause GeodatabaseCatalogDatasetException if doesn't exist in the database
-      if (fClassDefinition.GetName() == featureClassName)
-      {
-        FeatureClassDescription existingDescription = new(fClassDefinition);
-        schemaBuilder.Delete(existingDescription);
-        schemaBuilder.Build();
-      }
+      FeatureClassDefinition fClassDefinition = geodatabase.GetDefinition<FeatureClassDefinition>(featureClassName);
+      FeatureClassDescription existingDescription = new(fClassDefinition);
+      schemaBuilder.Delete(existingDescription);
+      schemaBuilder.Build();
+    }
+    catch (GeodatabaseTableException)
+    {
+      // "The table was not found.", do nothing
     }
 
     // delete Table if already exists
-    foreach (TableDefinition fClassDefinition in geodatabase.GetDefinitions<TableDefinition>())
+    try
     {
-      // will cause GeodatabaseCatalogDatasetException if doesn't exist in the database
-      if (fClassDefinition.GetName() == featureClassName)
-      {
-        TableDescription existingDescription = new(fClassDefinition);
-        schemaBuilder.Delete(existingDescription);
-        schemaBuilder.Build();
-      }
+      TableDefinition fClassDefinition = geodatabase.GetDefinition<TableDefinition>(featureClassName);
+      TableDescription existingDescription = new(fClassDefinition);
+      schemaBuilder.Delete(existingDescription);
+      schemaBuilder.Build();
+    }
+    catch (GeodatabaseTableException)
+    {
+      // "The table was not found.", do nothing
     }
 
     // Create FeatureClass

--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3/Utils/NonNativeFeaturesUtils.cs
@@ -133,22 +133,21 @@ public class NonNativeFeaturesUtils : INonNativeFeaturesUtils
       schemaBuilder.Delete(existingDescription);
       schemaBuilder.Build();
     }
-    catch (GeodatabaseTableException)
+    catch (Exception ex) when (!ex.IsFatal()) //(GeodatabaseTableException)
     {
-      // "The table was not found.", do nothing
-    }
-
-    // delete Table if already exists
-    try
-    {
-      TableDefinition fClassDefinition = geodatabase.GetDefinition<TableDefinition>(featureClassName);
-      TableDescription existingDescription = new(fClassDefinition);
-      schemaBuilder.Delete(existingDescription);
-      schemaBuilder.Build();
-    }
-    catch (GeodatabaseTableException)
-    {
-      // "The table was not found.", do nothing
+      // "The table was not found."
+      // delete Table if already exists
+      try
+      {
+        TableDefinition fClassDefinition = geodatabase.GetDefinition<TableDefinition>(featureClassName);
+        TableDescription existingDescription = new(fClassDefinition);
+        schemaBuilder.Delete(existingDescription);
+        schemaBuilder.Build();
+      }
+      catch (Exception ex2) when (!ex2.IsFatal()) //(GeodatabaseTableException)
+      {
+        // "The table was not found.", do nothing
+      }
     }
 
     // Create FeatureClass


### PR DESCRIPTION
UPD: receiving of non-native properties has been turned into a placeholder until we find better strategy for sending props from host apps. 

Purpose is to preserve objects properties when placing them into GIS layers(tables).
Current approach is to iterate through all objects that will be placed under the same layer and collect their property names and their Type (e.g. string, int) while defaulting to string if nothing better fits).
The opinionated choice of non-native properties to receive is:
- all properties that are not Base: Dynamic for "Objects.Geometry" and Typed for everything else
- Base properties if its Revit "properties" or Rhino "userStrings"

P.S. atm the following exception is being generated inconsistently, needs better understanding. Thrown during "Conversion" step, so likely not a problem with the current PR: 
![image](https://github.com/specklesystems/speckle-sharp/assets/89912278/f3f9772e-3e9f-4525-8de3-91750fa17c70)

![image](https://github.com/specklesystems/speckle-sharp/assets/89912278/5806d263-b9f3-435e-9738-63fbe66a25d1)

