### PR TITLE
Add hosted element area to parameters in Revit.

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
@@ -24,12 +24,6 @@
     <PackageReference Include="Speckle.Revit.API" Version="2023.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="RevitAPIIFC">
-      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files\Autodesk\Revit 2023\RevitAPIIFC.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
   <Target Name="CopyTemplatesToKitfolder" AfterTargets="CopyToKitFolder" Condition="'$(IsDesktopBuild)' == true">
     <Message Text="Copying templates to kit folder" />
     <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(MSBuildProjectDirectory)\..\Templates\2023&quot; &quot;$(AppData)\Speckle\Kits\Objects\Templates\Revit\2023\&quot;" />

--- a/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
+++ b/Objects/Converters/ConverterRevit/ConverterRevit2023/ConverterRevit2023.csproj
@@ -24,6 +24,12 @@
     <PackageReference Include="Speckle.Revit.API" Version="2023.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="RevitAPIIFC">
+      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files\Autodesk\Revit 2023\RevitAPIIFC.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
   <Target Name="CopyTemplatesToKitfolder" AfterTargets="CopyToKitFolder" Condition="'$(IsDesktopBuild)' == true">
     <Message Text="Copying templates to kit folder" />
     <Exec Condition="$([MSBuild]::IsOsPlatform('Windows'))" Command="xcopy /Y /S &quot;$(MSBuildProjectDirectory)\..\Templates\2023&quot; &quot;$(AppData)\Speckle\Kits\Objects\Templates\Revit\2023\&quot;" />

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -152,11 +152,15 @@ public partial class ConverterRevit
 #else
     double area_transformed = UnitUtils.ConvertFromInternalUnits(area, UnitTypeId.SquareMeters);
 #endif
-            Base parameters = (Base)obj["parameters"];
-            if (parameters != null)
+            var paramObject = obj["parameters"];
+            if( paramObject != null )
             {
-              Objects.BuiltElements.Revit.Parameter hostedAreaParameter = new Parameter("Cutout Area", area_transformed, "m²");
-              parameters["Cutout Area"] = hostedAreaParameter;
+              Base parameters = (Base)paramObject;
+              if (parameters != null)
+              {
+                Objects.BuiltElements.Revit.Parameter hostedAreaParameter = new Parameter("Cutout Area", area_transformed, "m²");
+                parameters["Cutout Area"] = hostedAreaParameter;
+              }
             }
             convertedHostedElements.Add(obj);
             ConvertedObjects.Add(obj.applicationId);

--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/ConversionUtils.cs
@@ -153,9 +153,11 @@ public partial class ConverterRevit
     double area_transformed = UnitUtils.ConvertFromInternalUnits(area, UnitTypeId.SquareMeters);
 #endif
             Base parameters = (Base)obj["parameters"];
-            Objects.BuiltElements.Revit.Parameter mmmm = new Parameter("Cutout Area", area_transformed, "m²");
-            parameters["Cutout Area"] = mmmm;
-
+            if (parameters != null)
+            {
+              Objects.BuiltElements.Revit.Parameter hostedAreaParameter = new Parameter("Cutout Area", area_transformed, "m²");
+              parameters["Cutout Area"] = hostedAreaParameter;
+            }
             convertedHostedElements.Add(obj);
             ConvertedObjects.Add(obj.applicationId);
           }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Refers to Issue #3530 
This change adds the area of hosted elements within a host to a parameter. So far, there is no such parameter available. This becomes especially important for windows and doors where the area of removed elements can be essential. For instance, prefabricated timber elements are normally produced as a whole and then these parts are removed, thus, are somewhat waste (even though they may be re-used).

Others will benefit from this change as such essential information is not yet available in Speckle.


## Changes:

- Add a method to get the Area of a Hosted element in a Host
- Add the area as a new Parameter to the Base object

## To-do before merge:

- [ ] The code requires the RevitAPIIFC.dll




## Validation of changes:
The contribution has been verified with several Revit models where windows and doors are added to walls.

## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
