### PR TITLE
Fixes integration tests

### DIFF
--- a/Core/Tests/Speckle.Core.Tests.Integration/ServerTransportTests.cs
+++ b/Core/Tests/Speckle.Core.Tests.Integration/ServerTransportTests.cs
@@ -46,6 +46,7 @@ public class ServerTransportTests : IDisposable
 
   private void CleanData()
   {
+    _transport?.Dispose();
     if (Directory.Exists(_basePath))
     {
       Directory.Delete(_basePath, true);
@@ -73,7 +74,7 @@ public class ServerTransportTests : IDisposable
     // NOTE: used to debug diffing
     // await Operations.Send(myObject, new List<ITransport> { transport });
 
-    var receivedObject = await Operations.Receive(sentObjectId, _transport);
+    var receivedObject = await Operations.Receive(sentObjectId, _transport, new MemoryTransport());
 
     var allFiles = Directory
       .GetFiles(_transport.BlobStorageFolder)
@@ -104,7 +105,7 @@ public class ServerTransportTests : IDisposable
     var memTransport = new MemoryTransport();
     var sentObjectId = await Operations.Send(myObject, new List<ITransport> { _transport, memTransport });
 
-    var receivedObject = await Operations.Receive(sentObjectId, _transport);
+    var receivedObject = await Operations.Receive(sentObjectId, _transport, new MemoryTransport());
 
     var allFiles = Directory
       .GetFiles(_transport.BlobStorageFolder)


### PR DESCRIPTION
Our server transport tests were failing locally because a local SQLite DB was failing to be cleaned up.
However, these tests were not designed to run with a local SQLite DB.
We were explicitly not sending data to a SQLite transport, but we weren't explicitly opting out on the Receive side.

This PR opts us out by specifying a clean MemoryTransport for receives.