### PR TITLE
DUI3-464: Separates root and raw converter registration

### DIFF
--- a/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/ArcGISConverterModule.cs
+++ b/DUI3-DX/Converters/ArcGIS/Speckle.Converters.ArcGIS3.DependencyInjection/ArcGISConverterModule.cs
@@ -10,8 +10,13 @@ public class ArcGISConverterModule : ISpeckleModule
 {
   public void Load(SpeckleContainerBuilder builder)
   {
+    // add single root converter
     //don't need a host specific RootToSpeckleConverter
-    builder.AddConverterCommon<RootToSpeckleConverter, ArcGISToSpeckleUnitConverter, Unit>();
+    builder.AddRootCommon<RootToSpeckleConverter>();
+
+    // add application converters
+    builder.AddApplicationConverters<ArcGISToSpeckleUnitConverter, Unit>();
+
     // most things should be InstancePerLifetimeScope so we get one per operation
     builder.AddScoped<IFeatureClassUtils, FeatureClassUtils>();
     builder.AddScoped<IArcGISFieldUtils, ArcGISFieldUtils>();

--- a/DUI3-DX/Converters/Autocad/2023/Speckle.Converters.Autocad2023.DependencyInjection/AutocadConverterModule.cs
+++ b/DUI3-DX/Converters/Autocad/2023/Speckle.Converters.Autocad2023.DependencyInjection/AutocadConverterModule.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.AutoCAD.ApplicationServices;
+using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 using Speckle.Autofac.DependencyInjection;
 using Speckle.Converters.Autocad;
@@ -11,9 +11,11 @@ public class AutocadConverterModule : ISpeckleModule
 {
   public void Load(SpeckleContainerBuilder builder)
   {
-    builder.AddConverterCommon<AutocadRootToHostConverter, AutocadToSpeckleUnitConverter, UnitsValue>();
+    // add single root converter
+    builder.AddRootCommon<AutocadRootToHostConverter>();
 
-    // single stack per conversion
+    // add application converters and context stack
+    builder.AddApplicationConverters<AutocadToSpeckleUnitConverter, UnitsValue>();
     builder.AddScoped<IConversionContextStack<Document, UnitsValue>, AutocadConversionContextStack>();
   }
 }

--- a/DUI3-DX/Converters/Autocad/2024/Speckle.Converters.Autocad2024.DependencyInjection/AutocadConverterModule.cs
+++ b/DUI3-DX/Converters/Autocad/2024/Speckle.Converters.Autocad2024.DependencyInjection/AutocadConverterModule.cs
@@ -11,9 +11,11 @@ public class AutocadConverterModule : ISpeckleModule
 {
   public void Load(SpeckleContainerBuilder builder)
   {
-    builder.AddConverterCommon<AutocadRootToHostConverter, AutocadToSpeckleUnitConverter, UnitsValue>();
+    // add single root converter
+    builder.AddRootCommon<AutocadRootToHostConverter>();
 
-    // single stack per conversion
+    // add application converters and context stack
+    builder.AddApplicationConverters<AutocadToSpeckleUnitConverter, UnitsValue>();
     builder.AddScoped<IConversionContextStack<Document, UnitsValue>, AutocadConversionContextStack>();
   }
 }

--- a/DUI3-DX/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/RevitConverterModule.cs
+++ b/DUI3-DX/Converters/Revit/Speckle.Converters.Revit2023.DependencyInjection/RevitConverterModule.cs
@@ -12,7 +12,12 @@ public class RevitConverterModule : ISpeckleModule
 {
   public void Load(SpeckleContainerBuilder builder)
   {
-    builder.AddConverterCommon<RevitRootToSpeckleConverter, RevitToSpeckleUnitConverter, ForgeTypeId>();
+    // Register single root
+    builder.AddRootCommon<RevitRootToSpeckleConverter>();
+
+    // register all application converters
+    builder.AddApplicationConverters<RevitToSpeckleUnitConverter, ForgeTypeId>();
+
     builder.AddSingleton(new RevitContext());
 
     // POC: do we need ToSpeckleScalingService as is, do we need to interface it out?

--- a/DUI3-DX/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/RhinoConverterModule.cs
+++ b/DUI3-DX/Converters/Rhino/Speckle.Converters.Rhino7.DependencyInjection/RhinoConverterModule.cs
@@ -9,8 +9,11 @@ public class RhinoConverterModule : ISpeckleModule
 {
   public void Load(SpeckleContainerBuilder builder)
   {
-    builder.AddConverterCommon<RootToSpeckleConverter, RhinoToSpeckleUnitConverter, UnitSystem>();
-    // single stack per conversion
+    // Register single root
+    builder.AddRootCommon<RootToSpeckleConverter>();
+
+    // register all application converters and context stacks
+    builder.AddApplicationConverters<RhinoToSpeckleUnitConverter, UnitSystem>();
     builder.AddScoped<IConversionContextStack<RhinoDoc, UnitSystem>, RhinoConversionContextStack>();
   }
 }

--- a/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ContainerRegistration.cs
+++ b/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ContainerRegistration.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Autofac.DependencyInjection;
+using Speckle.Autofac.DependencyInjection;
 using Speckle.Converters.Common.DependencyInjection.ToHost;
 using Speckle.Converters.Common.Objects;
 
@@ -6,14 +6,10 @@ namespace Speckle.Converters.Common.DependencyInjection;
 
 public static class ContainerRegistration
 {
-  public static void AddConverterCommon<TRootToSpeckleConverter, THostToSpeckleUnitConverter, THostUnit>(
-    this SpeckleContainerBuilder builder
-  )
+  public static void AddRootCommon<TRootToSpeckleConverter>(this SpeckleContainerBuilder builder)
     where TRootToSpeckleConverter : class, IRootToSpeckleConverter
-    where THostToSpeckleUnitConverter : class, IHostToSpeckleUnitConverter<THostUnit>
   {
     builder.AddScoped<IRootToSpeckleConverter, TRootToSpeckleConverter>();
-    builder.AddScoped<IHostToSpeckleUnitConverter<THostUnit>, THostToSpeckleUnitConverter>();
     /*
       POC: CNX-9267 Moved the Injection of converters into the converter module. Not sure if this is 100% right, as this doesn't just register the conversions within this converter, but any conversions found in any Speckle.*.dll file.
       This will require consolidating across other connectors.
@@ -29,8 +25,16 @@ public static class ContainerRegistration
 
     builder.AddScoped<IRootToHostConverter, ConverterWithFallback>();
 
-    builder.RegisterRawConversions();
     builder.InjectNamedTypes<IToSpeckleTopLevelConverter>();
     builder.InjectNamedTypes<IToHostTopLevelConverter>();
+  }
+
+  public static void AddApplicationConverters<THostToSpeckleUnitConverter, THostUnits>(
+    this SpeckleContainerBuilder builder
+  )
+    where THostToSpeckleUnitConverter : class, IHostToSpeckleUnitConverter<THostUnits>
+  {
+    builder.AddScoped<IHostToSpeckleUnitConverter<THostUnits>, THostToSpeckleUnitConverter>();
+    builder.RegisterRawConverters();
   }
 }

--- a/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ContainerRegistration.cs
+++ b/DUI3-DX/Sdk/Speckle.Converters.Common.DependencyInjection/ContainerRegistration.cs
@@ -35,6 +35,6 @@ public static class ContainerRegistration
     where THostToSpeckleUnitConverter : class, IHostToSpeckleUnitConverter<THostUnits>
   {
     builder.AddScoped<IHostToSpeckleUnitConverter<THostUnits>, THostToSpeckleUnitConverter>();
-    builder.RegisterRawConverters();
+    builder.RegisterRawConversions();
   }
 }


### PR DESCRIPTION
## Description & motivation

Separates root (top level) converter registration in the container registration from the raw application converters.
Updates all converter dependency injection projects to use this new registration
