### PR TITLE
fix(core/http): log message should not duplicate path separator

### DIFF
--- a/Core/Core/Helpers/Http.cs
+++ b/Core/Core/Helpers/Http.cs
@@ -225,7 +225,7 @@ public sealed class SpeckleHttpClientHandler : HttpClientHandler
       SpeckleLog.Logger
         .ForContext("ExceptionType", policyResult.FinalException?.GetType())
         .Information(
-          "Execution of http request to {httpScheme}://{hostUrl}/{relativeUrl} {resultStatus} with {httpStatusCode} after {elapsed} seconds and {retryCount} retries",
+          "Execution of http request to {httpScheme}://{hostUrl}{relativeUrl} {resultStatus} with {httpStatusCode} after {elapsed} seconds and {retryCount} retries",
           request.RequestUri.Scheme,
           request.RequestUri.Host,
           request.RequestUri.PathAndQuery,


### PR DESCRIPTION


We don't want to see duplicated `/` in uris, like this:
<img width="1070" alt="Screenshot 2024-07-15 at 17 59 52" src="https://github.com/user-attachments/assets/4b51e9c1-8ed3-4410-8712-ae707faec514">

As described in the documentation, the Uri.PathAndQuery will return the leading path separator so the formatting context should not introduce another one: https://learn.microsoft.com/en-us/dotnet/api/system.uri?view=net-8.0#examples