### PR TITLE
Fix: AppliedAssembly.AdjustedElevation error, and  Single Point Featureline error

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -702,7 +702,7 @@ public partial class ConverterAutocadCivil
       var point = featureline.FeatureLinePoints[i];
       baseCurvePoints.Add(point.XYZ);
       if (!point.IsBreak) { polylinePoints.Add(point.XYZ); }
-      if (polylinePoints.Count > 0 && (i == featureline.FeatureLinePoints.Count - 1 || point.IsBreak ))
+      if (polylinePoints.Count > 1 && (i == featureline.FeatureLinePoints.Count - 1 || point.IsBreak ))
       {
         var polyline = PolylineToSpeckle(new Polyline3d(Poly3dType.SimplePoly, polylinePoints, false));
         polylines.Add(polyline);
@@ -1168,7 +1168,18 @@ public partial class ConverterAutocadCivil
       speckleSubassemblies.Add(speckleSubassembly);
     }
 
-    CivilAppliedAssembly speckleAppliedAssembly = new(speckleSubassemblies, appliedAssembly.AdjustedElevation, ModelUnits);
+    var adjustedElevation = double.MinValue;
+    try
+    {
+      adjustedElevation = appliedAssembly.AdjustedElevation;
+    }
+    catch (ArgumentException e) when (!e.IsFatal())
+    {
+      // Do nothing. Leave the value as NaN
+    }
+
+    CivilAppliedAssembly speckleAppliedAssembly = new(speckleSubassemblies, adjustedElevation, ModelUnits);
+
     return speckleAppliedAssembly;
   }
 

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -1168,7 +1168,7 @@ public partial class ConverterAutocadCivil
       speckleSubassemblies.Add(speckleSubassembly);
     }
 
-    var adjustedElevation = double.MinValue;
+    var adjustedElevation = double.NaN;
     try
     {
       adjustedElevation = appliedAssembly.AdjustedElevation;


### PR DESCRIPTION
## Description & motivation

Fixes #3516 

## Changes:

If accessing the Civil3D AppliedAssembly.AdjustedElevation property throws an error, then Speckle fails to send the whole corridor. Now defaults to sending double.NaN for this value if this occurs

If a featureline only has one point, then trying to get the spline representation of it would throw an error. Adjust code to check the featureline has more than one point, rather than more than zero.

## To-do before merge:

There is no issue with the corridors now being saved in Speckle, and being able to view the corridors in the web viewer.
However, the Excel connector and the python connectors seem to 

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests. - N/A
- [x] I have updated or added relevant documentation. - N/A


