### PR TITLE
chore(civil3d): changes property sets and parts data to be a `Base`

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Send.cs
@@ -246,8 +246,7 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
 #if CIVIL
             // add property sets if this is Civil3D
-            var propertySets = obj.GetPropertySets(tr);
-            if (propertySets.Count > 0)
+            if (obj.TryGetPropertySets(tr, out Base propertySets))
             {
               converted["propertySets"] = propertySets;
             }

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -476,7 +476,7 @@ public static class Utils
       return false;
     }
 
-    if (propertySetIds is null)
+    if (propertySetIds is null || propertySetIds.Count == 0)
     {
       return false;
     }

--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -702,7 +702,7 @@ public partial class ConverterAutocadCivil
       var point = featureline.FeatureLinePoints[i];
       baseCurvePoints.Add(point.XYZ);
       if (!point.IsBreak) { polylinePoints.Add(point.XYZ); }
-      if (polylinePoints.Count > 0 && (i == featureline.FeatureLinePoints.Count - 1 || point.IsBreak ))
+      if (polylinePoints.Count > 1 && (i == featureline.FeatureLinePoints.Count - 1 || point.IsBreak ))
       {
         var polyline = PolylineToSpeckle(new Polyline3d(Poly3dType.SimplePoly, polylinePoints, false));
         polylines.Add(polyline);
@@ -1029,17 +1029,18 @@ public partial class ConverterAutocadCivil
   /// <summary>
   /// Converts PartData into a list of DataField
   /// </summary>
-  private List<CivilDataField> PartDataRecordToSpeckle(PartDataRecord partData)
+  private Base PartDataRecordToSpeckle(PartDataRecord partData)
   {
+    Base partDataBase = new();
     List<CivilDataField> fields = new();
 
     foreach (PartDataField partField in partData.GetAllDataFields())
     {
       CivilDataField field = new(partField.Name, partField.DataType.ToString(), partField.Value, partField.Units.ToString(),partField.Context.ToString(), null);
-      fields.Add(field);
+      partDataBase[partField.Name] = field;
     }
 
-    return fields;
+    return partDataBase;
   }
 
 #if CIVIL2022_OR_GREATER


### PR DESCRIPTION
community thread: [https://speckle.community/t/property-set-grayed-when-exporting-data-from-civil-3d/12512/4](https://speckle.community/t/property-set-grayed-when-exporting-data-from-civil-3d/12512/4)

This pr changes property sets and parts data on civil3d objects to be sent as `Base` instead of `List`. This better aligns with how we are sending parameters from other applications, and allows for contents to be displayed in the default viewer object explorer mode.

Sample commit: [https://app.speckle.systems/projects/b53a53697a/models/719612f9da](https://app.speckle.systems/projects/b53a53697a/models/719612f9da)