### PR TITLE
fix(civil3d): added units to civil classes missing them

### DIFF
--- a/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
+++ b/Objects/Converters/ConverterAutocadCivil/ConverterAutocadCivilShared/ConverterAutocadCivil.Civil.cs
@@ -148,7 +148,8 @@ public partial class ConverterAutocadCivil
       stationEquationDirections = directions,
       offset = alignment.IsOffsetAlignment ? alignment.OffsetAlignmentInfo.NominalOffset : 0,
       site = alignment.SiteName ?? "",
-      style = alignment.StyleName ?? ""
+      style = alignment.StyleName ?? "",
+      units = ModelUnits
     };
 
     AddNameAndDescriptionProperty(alignment.Name, alignment.Description, speckleAlignment);
@@ -542,7 +543,8 @@ public partial class ConverterAutocadCivil
       offset = profile.Offset,
       style = profile.StyleName ?? "",
       startStation = profile.StartingStation,
-      endStation = profile.EndingStation
+      endStation = profile.EndingStation,
+      units = ModelUnits
     };
 
     AddNameAndDescriptionProperty(profile.Name, profile.Description, speckleProfile);
@@ -614,8 +616,6 @@ public partial class ConverterAutocadCivil
     {
       speckleProfile.displayValue = PolylineToSpeckle(pvis, profile.Closed);
     }
-
-    speckleProfile.units = ModelUnits;
 
     return speckleProfile;
   }
@@ -1136,6 +1136,7 @@ public partial class ConverterAutocadCivil
   private CivilDataField AppliedSubassemblyParamToSpeckle(IAppliedSubassemblyParam param)
   {
     CivilDataField baseParam = new(param.KeyName, param.ValueType.Name, param.ValueAsObject, null, null, param.DisplayName);
+
     return baseParam;
   }
 
@@ -1155,7 +1156,11 @@ public partial class ConverterAutocadCivil
     Point soePoint = PointToSpeckle(appliedSubassembly.OriginStationOffsetElevationToBaseline);
     List<CivilDataField> speckleParameters = appliedSubassembly.Parameters.Select(p => AppliedSubassemblyParamToSpeckle(p)).ToList();
 
-    CivilAppliedSubassembly speckleAppliedSubassembly = new(appliedSubassembly.SubassemblyId.ToString(), subassembly.Name, speckleShapes, soePoint, speckleParameters);
+    CivilAppliedSubassembly speckleAppliedSubassembly = new(appliedSubassembly.SubassemblyId.ToString(), subassembly.Name, speckleShapes, soePoint, speckleParameters)
+    {
+      units = ModelUnits
+    };
+
     return speckleAppliedSubassembly;
   }
 
@@ -1201,7 +1206,11 @@ public partial class ConverterAutocadCivil
     }
 
     // create the speckle region
-    CivilBaselineRegion speckleRegion = new(region.Name, region.StartStation, region.EndStation, assembly.Id.ToString(), assembly.Name, speckleAppliedAssemblies);
+    CivilBaselineRegion speckleRegion = new(region.Name, region.StartStation, region.EndStation, assembly.Id.ToString(), assembly.Name, speckleAppliedAssemblies)
+    {
+      units = ModelUnits
+    };
+
     return speckleRegion;
   }
 
@@ -1229,7 +1238,11 @@ public partial class ConverterAutocadCivil
       specklePoints.Add(specklePoint);
     }
 
-    CivilCalculatedLink speckleLink = new(codes, specklePoints);
+    CivilCalculatedLink speckleLink = new(codes, specklePoints)
+    {
+      units = ModelUnits
+    };
+
     return speckleLink;
   }
 
@@ -1240,7 +1253,11 @@ public partial class ConverterAutocadCivil
     Vector normalBaseline = VectorToSpeckle(point.NormalToBaseline);
     Vector normalSubAssembly = VectorToSpeckle(point.NormalToSubassembly);
     Point soePoint = PointToSpeckle(point.StationOffsetElevationToBaseline);
-    CivilCalculatedPoint speckleCalculatedPoint = new(specklePoint, codes, normalBaseline, normalSubAssembly, soePoint);
+    CivilCalculatedPoint speckleCalculatedPoint = new(specklePoint, codes, normalBaseline, normalSubAssembly, soePoint)
+    {
+      units = ModelUnits
+    };
+
     return speckleCalculatedPoint;
   }
 
@@ -1269,7 +1286,10 @@ public partial class ConverterAutocadCivil
       var profile = Trans.GetObject(baseline.ProfileId, OpenMode.ForRead) as CivilDB.Profile;
       CivilProfile speckleProfile = ProfileToSpeckle(profile);
 
-      speckleBaseline = new(baseline.Name, speckleRegions, baseline.SortedStations().ToList(), baseline.StartStation, baseline.EndStation, speckleAlignment, speckleProfile);
+      speckleBaseline = new(baseline.Name, speckleRegions, baseline.SortedStations().ToList(), baseline.StartStation, baseline.EndStation, speckleAlignment, speckleProfile)
+      {
+        units = ModelUnits
+      };
     }
     else
     {
@@ -1277,7 +1297,10 @@ public partial class ConverterAutocadCivil
       var featureline = Trans.GetObject(baseline.FeatureLineId, OpenMode.ForRead) as CivilDB.FeatureLine;
       Featureline speckleFeatureline = FeaturelineToSpeckle(featureline);
 
-      speckleBaseline = new(baseline.Name, speckleRegions, baseline.SortedStations().ToList(), baseline.StartStation, baseline.EndStation, speckleFeatureline);
+      speckleBaseline = new(baseline.Name, speckleRegions, baseline.SortedStations().ToList(), baseline.StartStation, baseline.EndStation, speckleFeatureline)
+      {
+        units = ModelUnits
+      };
     }
     
     return speckleBaseline;

--- a/Objects/Objects/BuiltElements/Baseline.cs
+++ b/Objects/Objects/BuiltElements/Baseline.cs
@@ -32,6 +32,8 @@ public abstract class Baseline : Base
   public Featureline? featureline { get; internal set; }
 
   public bool isFeaturelineBased { get; set; }
+
+  public string units { get; set; }
 }
 
 /// <summary>

--- a/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilAppliedSubassembly.cs
@@ -34,4 +34,6 @@ public class CivilAppliedSubassembly : Base
 
   [DetachProperty]
   public List<CivilDataField> parameters { get; set; }
+
+  public string units { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Civil/CivilBaselineRegion.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilBaselineRegion.cs
@@ -42,4 +42,6 @@ public class CivilBaselineRegion : Base
 
   [DetachProperty]
   public List<CivilAppliedAssembly> appliedAssemblies { get; set; }
+
+  public string units { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Civil/CivilCalculatedLink.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilCalculatedLink.cs
@@ -17,4 +17,6 @@ public class CivilCalculatedLink : Base, ICivilCalculatedObject
 
   [DetachProperty]
   public List<CivilCalculatedPoint> points { get; set; }
+
+  public string units { get; set; }
 }

--- a/Objects/Objects/BuiltElements/Civil/CivilCalculatedPoint.cs
+++ b/Objects/Objects/BuiltElements/Civil/CivilCalculatedPoint.cs
@@ -32,4 +32,6 @@ public class CivilCalculatedPoint : Base, ICivilCalculatedObject
   public Vector normalToSubassembly { get; set; }
 
   public Point stationOffsetElevationToBaseline { get; set; }
+
+  public string units { get; set; }
 }


### PR DESCRIPTION
adds units to some civil classes added in 2.20 that were msising them, as well as the civil3d conversions.
