### PR TITLE
Retry Fixes

### DIFF
--- a/Core/Core/Api/GraphQL/Client.cs
+++ b/Core/Core/Api/GraphQL/Client.cs
@@ -92,15 +92,6 @@ public sealed partial class Client : ISpeckleGraphQLClient, IDisposable
 
   internal async Task<T> ExecuteWithResiliencePolicies<T>(Func<Task<T>> func)
   {
-    // TODO: handle these in the HttpClient factory with a custom RequestHandler class
-    // 408 Request Timeout
-    // 425 Too Early
-    // 429 Too Many Requests
-    // 500 Internal Server Error
-    // 502 Bad Gateway
-    // 503 Service Unavailable
-    // 504 Gateway Timeout
-
     var delay = Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(1), 5);
     var graphqlRetry = Policy
       .Handle<SpeckleGraphQLInternalErrorException>()

--- a/Core/Core/Transports/ServerUtils/ServerAPI.cs
+++ b/Core/Core/Transports/ServerUtils/ServerAPI.cs
@@ -28,7 +28,6 @@ public sealed class ServerApi : IDisposable, IServerApi
   private const int MAX_REQUEST_SIZE = 100_000_000;
 
   private const int RETRY_COUNT = 3;
-  private static readonly HashSet<int> s_retryCodes = new() { 408, 502, 503, 504 };
   private static readonly char[] s_separator = { '\t' };
   private static readonly string[] s_filenameSeparator = { "filename=" };
 
@@ -77,13 +76,9 @@ public sealed class ServerApi : IDisposable, IServerApi
       Method = HttpMethod.Get
     };
 
-    HttpResponseMessage rootHttpResponse;
-    do
-    {
-      rootHttpResponse = await _client
-        .SendAsync(rootHttpMessage, HttpCompletionOption.ResponseContentRead, CancellationToken)
-        .ConfigureAwait(false);
-    } while (ShouldRetry(rootHttpResponse));
+    HttpResponseMessage rootHttpResponse = await _client
+      .SendAsync(rootHttpMessage, HttpCompletionOption.ResponseContentRead, CancellationToken)
+      .ConfigureAwait(false);
 
     rootHttpResponse.EnsureSuccessStatusCode();
 
@@ -256,11 +251,7 @@ public sealed class ServerApi : IDisposable, IServerApi
 
     try
     {
-      HttpResponseMessage response;
-      do
-      {
-        response = await _client.SendAsync(message, CancellationToken).ConfigureAwait(false);
-      } while (ShouldRetry(response)); //TODO: can we get rid of this now we have polly?
+      HttpResponseMessage response = await _client.SendAsync(message, CancellationToken).ConfigureAwait(false);
 
       response.EnsureSuccessStatusCode();
 
@@ -335,13 +326,9 @@ public sealed class ServerApi : IDisposable, IServerApi
     childrenHttpMessage.Content = new StringContent(serializedPayload, Encoding.UTF8, "application/json");
     childrenHttpMessage.Headers.Add("Accept", "text/plain");
 
-    HttpResponseMessage childrenHttpResponse;
-    do
-    {
-      childrenHttpResponse = await _client
-        .SendAsync(childrenHttpMessage, HttpCompletionOption.ResponseHeadersRead, CancellationToken)
-        .ConfigureAwait(false);
-    } while (ShouldRetry(childrenHttpResponse));
+    HttpResponseMessage childrenHttpResponse = await _client
+      .SendAsync(childrenHttpMessage, HttpCompletionOption.ResponseHeadersRead, CancellationToken)
+      .ConfigureAwait(false);
 
     childrenHttpResponse.EnsureSuccessStatusCode();
 
@@ -370,12 +357,8 @@ public sealed class ServerApi : IDisposable, IServerApi
     string serializedPayload = JsonConvert.SerializeObject(payload);
     var uri = new Uri($"/api/diff/{streamId}", UriKind.Relative);
 
-    HttpResponseMessage response;
     using StringContent stringContent = new(serializedPayload, Encoding.UTF8, "application/json");
-    do
-    {
-      response = await _client.PostAsync(uri, stringContent, CancellationToken).ConfigureAwait(false);
-    } while (ShouldRetry(response));
+    HttpResponseMessage response = await _client.PostAsync(uri, stringContent, CancellationToken).ConfigureAwait(false);
 
     response.EnsureSuccessStatusCode();
 
@@ -434,11 +417,7 @@ public sealed class ServerApi : IDisposable, IServerApi
       }
     }
     message.Content = multipart;
-    HttpResponseMessage response;
-    do
-    {
-      response = await _client.SendAsync(message, CancellationToken).ConfigureAwait(false);
-    } while (ShouldRetry(response));
+    HttpResponseMessage response = await _client.SendAsync(message, CancellationToken).ConfigureAwait(false);
 
     response.EnsureSuccessStatusCode();
 
@@ -454,12 +433,7 @@ public sealed class ServerApi : IDisposable, IServerApi
 
     using StringContent stringContent = new(payload, Encoding.UTF8, "application/json");
 
-    //TODO: can we get rid of this now we have polly?
-    HttpResponseMessage response;
-    do
-    {
-      response = await _client.PostAsync(uri, stringContent, CancellationToken).ConfigureAwait(false);
-    } while (ShouldRetry(response));
+    HttpResponseMessage response = await _client.PostAsync(uri, stringContent, CancellationToken).ConfigureAwait(false);
 
     response.EnsureSuccessStatusCode();
 
@@ -471,28 +445,6 @@ public sealed class ServerApi : IDisposable, IServerApi
     }
 
     return parsed;
-  }
-
-  //TODO: can we get rid of this now we have polly?
-  private bool ShouldRetry(HttpResponseMessage? serverResponse)
-  {
-    if (serverResponse == null)
-    {
-      return true;
-    }
-
-    if (!s_retryCodes.Contains((int)serverResponse.StatusCode))
-    {
-      return false;
-    }
-
-    if (RetriedCount >= RETRY_COUNT)
-    {
-      return false;
-    }
-
-    RetriedCount += 1;
-    return true;
   }
 
   private sealed class BlobUploadResult

--- a/Core/Core/Transports/ServerUtils/ServerAPI.cs
+++ b/Core/Core/Transports/ServerUtils/ServerAPI.cs
@@ -27,7 +27,6 @@ public sealed class ServerApi : IDisposable, IServerApi
 
   private const int MAX_REQUEST_SIZE = 100_000_000;
 
-  private const int RETRY_COUNT = 3;
   private static readonly char[] s_separator = { '\t' };
   private static readonly string[] s_filenameSeparator = { "filename=" };
 


### PR DESCRIPTION
- Fixed reporting of retries: 
   - We were never incrementing the retry number given to the logger, so it was allways reporting as 0 even if it had retried.
   - Looks like a regression introduced by https://github.com/specklesystems/speckle-sharp/pull/2305 when we commented out some logging.
   - Also fixed the headers which previously were appending new correlation ids with every retry.
- Removed ancient flawed retries loop in ServerAPI
    - Clients already retry with proper backoff policy, this naive loop was only causes problems for the server.