### PR TITLE
CNX-9912 - Implement a display fallback for Revit Areas equivalent to the outline.

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertArea.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertArea.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
+using Objects.Geometry;
+using Speckle.Core.Models;
 using DB = Autodesk.Revit.DB;
 using Point = Objects.Geometry.Point;
 
@@ -44,13 +47,14 @@ public partial class ConverterRevit
   {
     var profiles = GetProfiles(revitArea);
 
-    var speckleArea = new BuiltElements.Area();
-
-    speckleArea.name = revitArea.get_Parameter(BuiltInParameter.ROOM_NAME).AsString();
-    speckleArea.number = revitArea.Number;
-    speckleArea.center = (Point)LocationToSpeckle(revitArea);
-    speckleArea.level = ConvertAndCacheLevel(revitArea, BuiltInParameter.ROOM_LEVEL_ID);
-    if (profiles.Any())
+    var speckleArea = new BuiltElements.Area
+    {
+      name = revitArea.get_Parameter(BuiltInParameter.ROOM_NAME).AsString(),
+      number = revitArea.Number,
+      center = (Point)LocationToSpeckle(revitArea),
+      level = ConvertAndCacheLevel(revitArea, BuiltInParameter.ROOM_LEVEL_ID)
+    };
+    if (profiles.Count != 0)
     {
       speckleArea.outline = profiles[0];
     }
@@ -63,8 +67,17 @@ public partial class ConverterRevit
 
     GetAllRevitParamsAndIds(speckleArea, revitArea);
 
-    //no mesh seems to be retriavable, not even using the SpatialElementGeometryCalculator
+    //no mesh seems to be retrievable, not even using the SpatialElementGeometryCalculator
     //speckleArea.displayValue = GetElementDisplayValue(revitArea);
+
+    var displayValue = new List<Base>();
+    if (profiles.Count != 0 && profiles[0] is Polycurve polyCurve)
+    {
+      displayValue.Add(polyCurve);
+    }
+
+    speckleArea.displayValue = displayValue;
+
     return speckleArea;
   }
 }

--- a/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/PartialClasses/ConvertContourPlate.cs
+++ b/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/PartialClasses/ConvertContourPlate.cs
@@ -3,6 +3,7 @@ using Objects.Geometry;
 using BE = Objects.BuiltElements;
 using Objects.BuiltElements.TeklaStructures;
 using System.Linq;
+using Speckle.Core.Models;
 using Tekla.Structures.Model;
 
 namespace Objects.Converter.TeklaStructures;
@@ -63,7 +64,15 @@ public partial class ConverterTeklaStructures
     GetAllUserProperties(specklePlate, plate);
 
     var solid = plate.GetSolid();
-    specklePlate.displayValue = new List<Mesh> { GetMeshFromSolid(solid) };
+    
+    var displayMesh = GetMeshFromSolid(solid);
+    if (displayMesh != null)
+    {
+        var displayValue = new List<Base>();
+        displayValue.Add(displayMesh);
+        specklePlate.displayValue = displayValue;
+    }
+    
     var rebars = plate.GetReinforcements();
     if (rebars != null)
     {

--- a/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/PartialClasses/ConvertContourPlate.cs
+++ b/Objects/Converters/ConverterTeklaStructures/ConverterTeklaStructuresShared/PartialClasses/ConvertContourPlate.cs
@@ -13,6 +13,7 @@ public partial class ConverterTeklaStructures
   public void ContourPlateToNative(BE.Area area)
   {
     if (!(area.outline is Polyline)) { }
+
     var ContourPlate = new ContourPlate();
     if (area is TeklaContourPlate)
     {
@@ -26,8 +27,10 @@ public partial class ConverterTeklaStructures
       {
         ContourPlate.AddContourPoint(ToTeklaContourPoint(cp));
       }
+
       SetPartProperties(ContourPlate, contour);
     }
+
     ContourPlate.Insert();
     //Model.CommitChanges();
   }
@@ -64,15 +67,15 @@ public partial class ConverterTeklaStructures
     GetAllUserProperties(specklePlate, plate);
 
     var solid = plate.GetSolid();
-    
+
     var displayMesh = GetMeshFromSolid(solid);
     if (displayMesh != null)
     {
-        var displayValue = new List<Base>();
-        displayValue.Add(displayMesh);
-        specklePlate.displayValue = displayValue;
+      var displayValue = new List<Base>();
+      displayValue.Add(displayMesh);
+      specklePlate.displayValue = displayValue;
     }
-    
+
     var rebars = plate.GetReinforcements();
     if (rebars != null)
     {
@@ -84,6 +87,7 @@ public partial class ConverterTeklaStructures
         }
       }
     }
+
     return specklePlate;
   }
 

--- a/Objects/Objects/BuiltElements/AdvanceSteel/AsteelPlate.cs
+++ b/Objects/Objects/BuiltElements/AdvanceSteel/AsteelPlate.cs
@@ -6,7 +6,8 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.AdvanceSteel;
 
-public class AsteelPlate : Area, IDisplayValue<List<Mesh>>, IHasArea, IHasVolume, IAsteelObject
+// TODO: This class really shouldn't inherit from Area, but we need to fix the inheritance chain in the future.
+public class AsteelPlate : Area, IDisplayValue<List<Base>>, IHasArea, IHasVolume, IAsteelObject
 {
   [DetachProperty]
   public StructuralMaterial? material { get; set; }

--- a/Objects/Objects/BuiltElements/AdvanceSteel/AsteelSlab.cs
+++ b/Objects/Objects/BuiltElements/AdvanceSteel/AsteelSlab.cs
@@ -6,7 +6,8 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.AdvanceSteel;
 
-public class AsteelSlab : Area, IDisplayValue<List<Mesh>>, IHasArea, IHasVolume, IAsteelObject
+// TODO: This class really shouldn't inherit from Area, but we need to fix the inheritance chain in the future.
+public class AsteelSlab : Area, IDisplayValue<List<Base>>, IHasArea, IHasVolume, IAsteelObject
 {
   [DetachProperty]
   public StructuralMaterial? material { get; set; }

--- a/Objects/Objects/BuiltElements/Area.cs
+++ b/Objects/Objects/BuiltElements/Area.cs
@@ -5,7 +5,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements;
 
-public class Area : Base, IHasArea, IHasVolume, IDisplayValue<List<Mesh>>
+public class Area : Base, IHasArea, IHasVolume, IDisplayValue<List<Base>>
 {
   public Area() { }
 
@@ -31,7 +31,7 @@ public class Area : Base, IHasArea, IHasVolume, IDisplayValue<List<Mesh>>
   public string units { get; set; }
 
   [DetachProperty]
-  public List<Mesh> displayValue { get; set; }
+  public List<Base> displayValue { get; set; }
 
   public double area { get; set; }
   public double volume { get; set; }

--- a/Objects/Objects/BuiltElements/TeklaStructures/TeklaContourPlate.cs
+++ b/Objects/Objects/BuiltElements/TeklaStructures/TeklaContourPlate.cs
@@ -7,6 +7,7 @@ using Speckle.Core.Models;
 
 namespace Objects.BuiltElements.TeklaStructures;
 
+// TODO: This class really shouldn't inherit from Area, but we need to fix the inheritance chain in the future.
 public class TeklaContourPlate : Area
 {
   [SchemaInfo("ContourPlate", "Creates a TeklaStructures contour plate.", "Tekla", "Structure")]


### PR DESCRIPTION
Implements `displayValue` to be the Area outline as there is no method to retrieve or generate a `Mesh`