### PR TITLE
fix(civil3d): prop sets & changes name to definition name

### DIFF
--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/UI/ConnectorBindingsAutocadCivil.Receive.cs
@@ -545,12 +545,15 @@ public partial class ConnectorBindingsAutocad : ConnectorBindings
 
             // add property sets if this is Civil3D
 #if CIVIL
-            if (obj["propertySets"] is IReadOnlyList<object> list)
+            if (obj["propertySets"] is Base propertySetsBase)
             {
               List<Dictionary<string, object>> propertySets = new();
-              foreach (var listObj in list)
+              foreach (object baseObj in propertySetsBase.GetMembers(DynamicBaseMemberType.Dynamic).Values)
               {
-                propertySets.Add(listObj as Dictionary<string, object>);
+                if (baseObj is Dictionary<string, object> propertySet)
+                {
+                  propertySets.Add(propertySet);
+                }
               }
 
               try

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Utils.cs
@@ -509,7 +509,7 @@ public static class Utils
 
       if (setDictionary.Count > 0)
       {
-        propertySets[propertySet.Name] = CleanDictionary(setDictionary);
+        propertySets[propertySet.PropertySetDefinitionName] = CleanDictionary(setDictionary);
       }
     }
 


### PR DESCRIPTION
Fixes community reported bug on receiving property sets due to change of type to `Base`. 
sample commit: [https://app.speckle.systems/projects/b53a53697a/models/899753a050](https://app.speckle.systems/projects/b53a53697a/models/899753a050)
Also changes the name of property sets to use the definition name instead of the applied set name.
![image](https://github.com/user-attachments/assets/e52069ea-6828-4aba-b1a5-6e9b4250fa9a)

