### PR TITLE
add null check around assembly & location

### DIFF
--- a/ConnectorCore/DllConflictManagement/DllConflictManager.cs
+++ b/ConnectorCore/DllConflictManagement/DllConflictManager.cs
@@ -101,11 +101,16 @@ public sealed class DllConflictManager
     }
   }
 
-  private bool ShouldSkipCheckingConflictBecauseOfAssemblyLocation(Assembly loadedAssembly)
+  private bool ShouldSkipCheckingConflictBecauseOfAssemblyLocation(Assembly? loadedAssembly)
   {
+    if (string.IsNullOrWhiteSpace(loadedAssembly?.Location))
+    {
+      return false;
+    }
+    string location = loadedAssembly!.Location;
     foreach (var exactPath in _exactAssemblyPathsToIgnore)
     {
-      if (Path.GetDirectoryName(loadedAssembly.Location) == exactPath)
+      if (Path.GetDirectoryName(location) == exactPath)
       {
         return true;
       }
@@ -113,7 +118,7 @@ public sealed class DllConflictManager
 
     foreach (var pathFragment in _assemblyPathFragmentsToIgnore)
     {
-      if (loadedAssembly.Location.Contains(pathFragment))
+      if (location.Contains(pathFragment))
       {
         return true;
       }

--- a/ConnectorCore/DllConflictManagement/DllConflictManager.cs
+++ b/ConnectorCore/DllConflictManagement/DllConflictManager.cs
@@ -101,6 +101,16 @@ public sealed class DllConflictManager
     }
   }
 
+
+  private static bool PathIsValid(string path)
+  {
+    if (path.Any(x => Path.GetInvalidPathChars().Contains(x)))
+    {
+      return false;
+    }
+    return true;
+  }
+
   private bool ShouldSkipCheckingConflictBecauseOfAssemblyLocation(Assembly? loadedAssembly)
   {
     if (string.IsNullOrWhiteSpace(loadedAssembly?.Location))
@@ -108,6 +118,10 @@ public sealed class DllConflictManager
       return false;
     }
     string location = loadedAssembly!.Location;
+    if (!PathIsValid(location))
+    {
+      return false;
+    }
     foreach (var exactPath in _exactAssemblyPathsToIgnore)
     {
       if (Path.GetDirectoryName(location) == exactPath)

--- a/ConnectorCore/DllConflictManagement/DllConflictManager.cs
+++ b/ConnectorCore/DllConflictManagement/DllConflictManager.cs
@@ -101,7 +101,6 @@ public sealed class DllConflictManager
     }
   }
 
-
   private static bool PathIsValid(string path)
   {
     if (path.Any(x => Path.GetInvalidPathChars().Contains(x)))


### PR DESCRIPTION
As found here: https://speckle.community/t/dllconflictmanager-throwing-error-in-revit/12589