### PR TITLE
Swallow an exception specific for .NET Core and other plugins

### DIFF
--- a/ConnectorCore/DllConflictManagement/DllConflictManager.cs
+++ b/ConnectorCore/DllConflictManagement/DllConflictManager.cs
@@ -157,6 +157,11 @@ public sealed class DllConflictManager
       // is core which will be checked as a dependency of many other libraries.
       // there are a couple other random types that will trigger this exception as well
     }
+    catch (FileLoadException)
+    {
+      // this is new for .NET Core and is invalid for Speckle assemblies.  Not catching causes other issues
+      // with other plugins so swallowing is the best we can do.
+    }
     return null;
   }
 


### PR DESCRIPTION
This seems to fix the issue with Revit 2025 and AIT mentioned here: https://speckle.community/t/issue-with-revit-2025-will-not-load/12445/26

AIT produces this exception with the conflict manager but isn't a conflict for the speckle plugin on Revit 2025.  The exception is new with .NET Core so swallowing should be safe for v2.