### PR TITLE
fix: Update receive node with proper tracking

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/ComponentTracker.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/BaseComponents/ComponentTracker.cs
@@ -61,9 +61,15 @@ public class ComponentTracker
     Speckle.Core.Logging.Analytics.TrackEvent(acc, Speckle.Core.Logging.Analytics.Events.Send, customProperties);
   }
 
-  public void TrackNodeReceive(Account acc, bool auto)
+  public void TrackNodeReceive(Account acc, bool auto, bool isMultiplayer, string sourceHostApp)
   {
-    var properties = new Dictionary<string, object> { { "auto", auto } };
+    var properties = new Dictionary<string, object>
+    {
+      { "auto", auto },
+      { "isMultiplayer", isMultiplayer },
+      { "sourceHostApp", HostApplications.GetHostAppFromString(sourceHostApp).Slug },
+      { "sourceHostAppVersion", sourceHostApp },
+    };
     AppendHostAppInfoToProperties(properties);
     Speckle.Core.Logging.Analytics.TrackEvent(acc, Speckle.Core.Logging.Analytics.Events.Receive, properties);
   }

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -12,7 +11,6 @@ using Rhino;
 using Speckle.Core.Api;
 using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
-using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Transports;
@@ -254,17 +252,7 @@ public class SyncReceiveComponent : SelectKitTaskCapableComponentBase<Base>
             return null;
           }
 
-          Speckle.Core.Logging.Analytics.TrackEvent(
-            acc,
-            Speckle.Core.Logging.Analytics.Events.Receive,
-            new Dictionary<string, object>
-            {
-              { "sync", true },
-              { "sourceHostApp", HostApplications.GetHostAppFromString(myCommit.sourceApplication).Slug },
-              { "sourceHostAppVersion", myCommit.sourceApplication },
-              { "isMultiplayer", myCommit.authorId != acc.userInfo.id }
-            }
-          );
+          Tracker.TrackNodeReceive(acc, AutoReceive, myCommit.authorId != acc.userInfo.id, myCommit.sourceApplication);
 
           var totalObjectCount = 1;
 

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -523,7 +523,6 @@ public class VariableInputReceiveComponent : SelectKitAsyncComponentBase, IGH_Va
 
     StreamWrapper = wrapper;
 
-    //ResetApiClient(wrapper);
     Task.Run(async () =>
     {
       ApiResetTask = ResetApiClient(StreamWrapper);
@@ -722,16 +721,11 @@ public class VariableInputReceiveComponentWorker : WorkerInstance
         }
 
         ReceivedCommit = myCommit;
-        Speckle.Core.Logging.Analytics.TrackEvent(
+        receiveComponent.Tracker.TrackNodeReceive(
           acc,
-          Speckle.Core.Logging.Analytics.Events.Receive,
-          new Dictionary<string, object>
-          {
-            { "auto", receiveComponent.AutoReceive },
-            { "sourceHostApp", HostApplications.GetHostAppFromString(myCommit.sourceApplication).Slug },
-            { "sourceHostAppVersion", myCommit.sourceApplication },
-            { "isMultiplayer", myCommit.authorId != acc.userInfo.id }
-          }
+          receiveComponent.AutoReceive,
+          myCommit.authorId != acc.userInfo.id,
+          myCommit.sourceApplication
         );
 
         if (CancellationToken.IsCancellationRequested)

--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.VariableInputReceiveComponent.cs
@@ -24,7 +24,6 @@ using Speckle.Core.Api;
 using Speckle.Core.Api.SubscriptionModels;
 using Speckle.Core.Credentials;
 using Speckle.Core.Helpers;
-using Speckle.Core.Kits;
 using Speckle.Core.Logging;
 using Speckle.Core.Models;
 using Speckle.Core.Models.Extensions;


### PR DESCRIPTION
Fixes tracking in the receive node to use the tracker that has the proper host app and host app versions overloaded

Update tracker class to allow all properties tracked on receive

<img width="1606" alt="Screenshot 2024-08-30 at 15 45 37" src="https://github.com/user-attachments/assets/fcb07113-b642-4a78-9acc-5c98a336fe18">
