### PR TITLE
Removed vulnerable packages

### DIFF
--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -49,8 +49,6 @@
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.3.0" />
-    <PackageReference Include="Serilog.Enrichers.GlobalLogContext" Version="3.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />

--- a/Core/Core/Logging/SpeckleLog.cs
+++ b/Core/Core/Logging/SpeckleLog.cs
@@ -182,10 +182,7 @@ public static class SpeckleLog
 
     if (logConfiguration.EnhancedLogContext)
     {
-      serilogLogConfiguration = serilogLogConfiguration.Enrich
-        .WithClientAgent()
-        .Enrich.WithClientIp()
-        .Enrich.WithExceptionDetails();
+      serilogLogConfiguration = serilogLogConfiguration.Enrich.WithExceptionDetails();
     }
 
     if (logConfiguration.LogToFile && canLogToFile)


### PR DESCRIPTION
Removed `Serilog.Enrichers.ClientInfo`

The CVE reported https://github.com/advisories/GHSA-5x5q-cqf6-gj8r is not critical for us, any log IP addresses are not trusted.
But for the sake of us not having to supress warning categories, its easy enough for us just to remove these dependencies.

---

also removed `Serilog.Enrichers.GlobalLogContext` since we aren't using it, and haven't been for several releases