### PR TITLE
bjorn/cnx-396-etabs-structure-layout

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Models/ETABSGridLineDefinitionTable.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Models/ETABSGridLineDefinitionTable.cs
@@ -191,9 +191,6 @@ internal class ETABSGridLineDefinitionTable : DatabaseTableWrapper
     var systemName = GetUniqueGridSystemName();
     _ = cSapModel.GridSys.SetGridSys(systemName, 0, 0, gridRotation * 180 / Math.PI);
 
-    // when a grid system is created, it doesn't show up unless it has at least one grid in each direction
-    AddCartesian(systemName, XGridLineType, "Default0", 0, "No");
-    AddCartesian(systemName, YGridLineType, "Default1", 0, "No");
     return new GridSystemRepresentation(systemName, 0, 0, gridRotation);
   }
 


### PR DESCRIPTION
## Description & motivation

`grids` not working as desired. Raised multiple times in forum. Problem related mainly to grid rotations when going from ETABS to Speckle.

The issue is not in the `GridLineToNative()`, but rather in the `gridLinesToSpeckle()`. Below image shows that the columns between Revit and ETABS remain the same, but the grid changes when sent from ETABS back to Speckle (after being received from Revit).

![image](https://github.com/user-attachments/assets/6ce3bced-a9a6-41fd-8e0c-9e9b0d2e062b)
![image](https://github.com/user-attachments/assets/fb46f590-63af-43e6-b3ce-88e23fd2b4ee)

## Changes

In the `gridLinesToSpeckle()`, we were not aplpying any transformations to the lines according to the rotation. Same logic applied as per `GridLineToNative()`.

See overlaid views below. More details in Testing section below🙌🎉 .

![image](https://github.com/user-attachments/assets/b3695cca-ad6d-493c-b33b-d62d3f19ffe4)
![image](https://github.com/user-attachments/assets/9acfa4af-778b-4fd0-a882-013198129902)

## Validation of changes

- [x] Case 01 - Revit -> Speckle -> ETABS
- [x] Case 02 - ETABS -> Speckle -> ETABS
- [x] Case 03 - ETABS -> Speckle -> Revit

### Case 01
![image](https://github.com/user-attachments/assets/6355886d-3b97-4387-b3bb-e17d07dccf47)
### Case 02
![image](https://github.com/user-attachments/assets/7a30ad13-7d0c-41b0-a91a-cddd4a96ed0d)
![image](https://github.com/user-attachments/assets/a9cdd7ae-ec6f-4dec-82d0-52e5c99f0560)
### Case 03
![image](https://github.com/user-attachments/assets/0e2aeb23-dd6e-4a20-83c8-12f496318db8)
## Checklist

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

https://speckle.community/t/grasshopper-etabs-problems/8212/3
https://speckle.community/t/etabs-speckle-revit-grid-system-data/11121
https://speckle.community/t/revit-speckle-etabs-mappings-and-levels-and-grids/5430/15

