### PR TITLE
CNX-573 CSIOpening

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/PartialClasses/Geometry/ConvertArea.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/PartialClasses/Geometry/ConvertArea.cs
@@ -372,10 +372,13 @@ public partial class ConverterCSI
       {
         Model.AreaObj.SetSpringAssignment(name, csiArea.CSIAreaSpring.name);
       }
-
       if (csiArea.DiaphragmAssignment != null)
       {
         Model.AreaObj.SetDiaphragm(name, csiArea.DiaphragmAssignment);
+      }
+      if (csiArea.CSIOpening != null)
+      {
+        Model.AreaObj.SetOpening(name, csiArea.CSIOpening.isOpening);
       }
     }
   }
@@ -399,9 +402,9 @@ public partial class ConverterCSI
 
     bool isOpening = false;
     Model.AreaObj.GetOpening(name, ref isOpening);
-    if (isOpening == true)
+    if (isOpening)
     {
-      speckleStructArea.property = new CSIOpening(true);
+      speckleStructArea.CSIOpening = new CSIOpening(true);
     }
     else
     {

--- a/Objects/Objects/Structural/CSI/Geometry/CSIElement2D.cs
+++ b/Objects/Objects/Structural/CSI/Geometry/CSIElement2D.cs
@@ -84,6 +84,7 @@ public class CSIElement2D : Element2D
   }
   public List<double>? StiffnessModifiers { get; set; }
   public bool Opening { get; set; }
+  public CSIOpening? CSIOpening { get; set; }
 
   [DetachProperty]
   public AnalyticalResults? AnalysisResults { get; set; }


### PR DESCRIPTION
## Ticket

Please refer here for more information: [CNX-573](https://linear.app/speckle/issue/CNX-573/csiopening)

## Description & Motivation

In creating content for Revit & Grasshopper to ETABS, I noticed that the `CSIOpening` component is essentially useless. We write and append `CSIOpening` information to the `AreaObj`, but this information is not used when receiving in ETABS.

**Definition in Grasshopper:**

![image](https://github.com/user-attachments/assets/269de5f9-b202-48a0-b56d-8b6f873c922c)

**Receiving in ETABS:**
These `AreaObj`s should have _Yes_ for attribute _Opening_ 

![image](https://github.com/user-attachments/assets/849ef9d4-ea4f-4446-9cc0-48639c9cb139)


## Changes:

**Looking at the API docs:**

![image](https://github.com/user-attachments/assets/69b24a3b-6600-472a-98bc-8b6d60ac413f)

**We need to `SetOpening` in the same way we assign `DiaphragmAssignment` / `CSIAreaSpring`:**

![image](https://github.com/user-attachments/assets/1b9f1f61-cabc-4fb3-90c7-c50fd5dd3c06)

**For `AreaToSpeckle` we target `CSIOpening` and not `property` (otherwise ETABS ➡️ Speckle ➡️ ETABS won't be compatible).**

<img width="588" alt="image" src="https://github.com/user-attachments/assets/aa5f7fae-20a1-4907-bc58-c01f1e848a43">


## Validation of changes:

### Grasshopper ➡️ Speckle ➡️ ETABS

![image](https://github.com/user-attachments/assets/70039781-4e6c-4cc0-a5f9-0d72a99f1563)

### ETABS ➡️ Speckle ➡️ ETABS

![image](https://github.com/user-attachments/assets/d5a65510-4cfb-467e-a7f0-3d0ee1914bbd)

### Revit ➡️ Speckle ➡️ ETABS

![image](https://github.com/user-attachments/assets/369f04e1-d174-492e-8c53-7deb25f4cf84)

### ETABS ➡️ Speckle ➡️ Revit

**⚠️ NOTE:** this didn't work previously, and is still not working.

#### Previously:

![image](https://github.com/user-attachments/assets/6f40e364-bd98-4905-936d-90198629020e)

#### Now:

![image](https://github.com/user-attachments/assets/3367a0b4-5480-4233-ba97-23ac4b5ab260)


## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## Comments

This is messy. We need to revisit at a later stage.

![image](https://github.com/user-attachments/assets/0fae52a3-03c8-4c62-8d8e-0d648c005ce9)


