### PR TITLE
Added workspace Id tracking

### DIFF
--- a/Core/Core/Api/GraphQL/Models/Project.cs
+++ b/Core/Core/Api/GraphQL/Models/Project.cs
@@ -27,4 +27,5 @@ public sealed class Project
   public Model model { get; init; }
   public List<ModelsTreeItem> modelChildrenTree { get; init; }
   public ResourceCollection<ModelsTreeItem> modelsTree { get; init; }
+  public string workspaceId { get; init; }
 }

--- a/Core/Tests/Speckle.Core.Tests.Integration/Speckle.Core.Tests.Integration.csproj
+++ b/Core/Tests/Speckle.Core.Tests.Integration/Speckle.Core.Tests.Integration.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/Tests/Speckle.Core.Tests.Unit/Speckle.Core.Tests.Unit.csproj
+++ b/Core/Tests/Speckle.Core.Tests.Unit/Speckle.Core.Tests.Unit.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   
   <ItemGroup>

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -1409,6 +1409,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       LastUsedTime = DateTime.UtcNow;
       var view = MainViewModel.RouterInstance.NavigationStack.Last() is StreamViewModel ? "Stream" : "Home";
 
+      string? workspaceId = await Client.GetWorkspaceId(StreamState.StreamId).ConfigureAwait(false);
+
       Analytics.TrackEvent(
         Client.Account,
         Analytics.Events.Send,
@@ -1420,7 +1422,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
           { "isMain", SelectedBranch.Branch.name == "main" ? true : false },
           { "branches", Stream.branches?.totalCount },
           { "commits", Stream.commits?.totalCount },
-          { "savedStreams", HomeViewModel.Instance.SavedStreams?.Count }
+          { "savedStreams", HomeViewModel.Instance.SavedStreams?.Count },
+          { "workspaceId", workspaceId }
         }
       );
 
@@ -1548,6 +1551,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       var view = MainViewModel.RouterInstance.NavigationStack.Last() is StreamViewModel ? "Stream" : "Home";
       LastUsedTime = DateTime.UtcNow;
 
+      string? workspaceId = await Client.GetWorkspaceId(StreamState.StreamId).ConfigureAwait(false);
+
       Analytics.TrackEvent(
         StreamState.Client.Account,
         Analytics.Events.Receive,
@@ -1563,7 +1568,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
           { "branches", Stream.branches?.totalCount },
           { "commits", Stream.commits?.totalCount },
           { "savedStreams", HomeViewModel.Instance.SavedStreams?.Count },
-          { "isMultiplayer", state.LastCommit != null ? state.LastCommit.authorId != state.UserId : false }
+          { "isMultiplayer", state.LastCommit != null ? state.LastCommit.authorId != state.UserId : false },
+          { "workspaceId", workspaceId },
         }
       );
 

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -1423,7 +1423,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
           { "branches", Stream.branches?.totalCount },
           { "commits", Stream.commits?.totalCount },
           { "savedStreams", HomeViewModel.Instance.SavedStreams?.Count },
-          { "workspaceId", workspaceId }
+          { "workspace_id", workspaceId },
         }
       );
 
@@ -1569,7 +1569,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
           { "commits", Stream.commits?.totalCount },
           { "savedStreams", HomeViewModel.Instance.SavedStreams?.Count },
           { "isMultiplayer", state.LastCommit != null ? state.LastCommit.authorId != state.UserId : false },
-          { "workspaceId", workspaceId },
+          { "workspace_id", workspaceId },
         }
       );
 


### PR DESCRIPTION
This PR adds `workspace_id` tracking for Receive and Send events.

---

I was going to add support for fetching the workspace id to all of the `ProjectResource` queries, like I've done for the v3 sdk https://github.com/specklesystems/speckle-sharp-sdk/pull/134

But, since its important that the v2 SDK is compatible with older self hosted servers, I thought it would be easiest simply to
add a helper function just for this query. This avoids having to add  a version check in each of the Project resources (which, at least right now in their current form don't have direct access to the underlying `GqlClient`.

---

Needs through testing:

- Test with app.speckle.systems:
    - [x]  project on a workspace, does it track send and receives in mixpanel
    - [x] project not on a workspace, should track `null`
  
- Test with testing1
    - [x] project not on a workspace, should track `null`, nothing should throw!