### PR TITLE
fix(navis): Fixes missing element properties on coalesce from First Selected object.

### DIFF
--- a/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
@@ -275,9 +275,11 @@ public class Element
 
     var groupedProperties = properties
       .GroupBy(property => property.ConcatenatedKey)
-      .Where(group => group.Select(item => item.Value).Distinct().Count() == 1)
-      .ToDictionary(group => group.Key, group => group.First().Value);
-
+      .ToDictionary(
+        group => group.Key,
+        group => group.Select(item => item.Value).First()
+      );
+    
     var formattedProperties = groupedProperties
       .Select(
         kVp =>

--- a/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
@@ -243,9 +243,12 @@ public class Element
     if (modelItem == null || baseNode == null || converted == null)
     {
       throw new ArgumentNullException(
-        modelItem == null ? nameof(modelItem) : 
-        baseNode == null ? nameof(baseNode) : 
-        nameof(converted));
+        modelItem == null
+          ? nameof(modelItem)
+          : baseNode == null
+            ? nameof(baseNode)
+            : nameof(converted)
+      );
     }
 
     var firstObjectAncestor =
@@ -274,11 +277,8 @@ public class Element
 
     var groupedProperties = properties
       .GroupBy(property => property.ConcatenatedKey)
-      .ToDictionary(
-        group => group.Key,
-        group => group.Select(item => item.Value).First()
-      );
-    
+      .ToDictionary(group => group.Key, group => group.Select(item => item.Value).First());
+
     var formattedProperties = groupedProperties
       .Select(
         kVp =>

--- a/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
@@ -243,7 +243,10 @@ public class Element
   {
     if (modelItem == null || baseNode == null || converted == null)
     {
-      throw new ArgumentNullException("modelItem, baseNode, and converted cannot be null.");
+      throw new ArgumentNullException(
+        modelItem == null ? nameof(modelItem) : 
+        baseNode == null ? nameof(baseNode) : 
+        nameof(converted));
     }
 
     var firstObjectAncestor =

--- a/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
@@ -16,7 +16,7 @@ public class Element
   private ModelItem _modelItem;
 
   private string _indexPath;
-
+  private const char SEPARATOR = '/';
   const char SEPARATOR = '/';
 
   public string IndexPath

--- a/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
+++ b/ConnectorNavisworks/ConnectorNavisworks/Other/Elements.cs
@@ -17,7 +17,6 @@ public class Element
 
   private string _indexPath;
   private const char SEPARATOR = '/';
-  const char SEPARATOR = '/';
 
   public string IndexPath
   {


### PR DESCRIPTION
# Property Grouping Logic Change

## What Changed
Modified the LINQ query for property grouping to retain all groups regardless of value uniqueness, rather than filtering out groups with different values. Now takes the first value encountered for each key instead of requiring all values to be identical.

## Before
```csharp
.Where(
    group => group.Select(
        item => item.Value
    ).Distinct().Count() == 1
)
```
Previously filtered out any groups where values differed, only keeping groups with identical values.

## After

```csharp
// Simplified to just take first value for each key
.ToDictionary(
    group => group.Key,
    group => group.Select(item => item.Value).First()
)
```

## Why
The previous logic was too restrictive, discarding valid property groups just because they had different values. The new approach preserves all property groups while maintaining deterministic value selection.

