### PR TITLE
Updated version inputs

### DIFF
--- a/Core/Core/Api/GraphQL/Inputs/VersionInputs.cs
+++ b/Core/Core/Api/GraphQL/Inputs/VersionInputs.cs
@@ -2,8 +2,8 @@
 
 namespace Speckle.Core.Api.GraphQL.Inputs;
 
-public sealed record UpdateVersionInput(string versionId, string? message);
+public sealed record UpdateVersionInput(string versionId, string projectId, string? message);
 
-public sealed record MoveVersionsInput(string targetModelName, IReadOnlyList<string> versionIds);
+public sealed record MoveVersionsInput(string projectId, string targetModelName, IReadOnlyList<string> versionIds);
 
-public sealed record DeleteVersionsInput(IReadOnlyList<string> versionIds);
+public sealed record DeleteVersionsInput(IReadOnlyList<string> versionIds, string projectId);

--- a/Core/Tests/Speckle.Core.Tests.Integration/Api/GraphQL/Resources/VersionResourceTests.cs
+++ b/Core/Tests/Speckle.Core.Tests.Integration/Api/GraphQL/Resources/VersionResourceTests.cs
@@ -80,7 +80,7 @@ public class VersionResourceTests
   {
     const string NEW_MESSAGE = "MY new version message";
 
-    UpdateVersionInput input = new(_version.id, NEW_MESSAGE);
+    UpdateVersionInput input = new(_version.id, _project.id, NEW_MESSAGE);
     Version updatedVersion = await Sut.Update(input);
 
     Assert.That(updatedVersion, Has.Property(nameof(Version.id)).EqualTo(_version.id));
@@ -91,7 +91,7 @@ public class VersionResourceTests
   [Test]
   public async Task VersionMoveToModel()
   {
-    MoveVersionsInput input = new(_model2.name, new[] { _version.id });
+    MoveVersionsInput input = new(_project.id, _model2.name, new[] { _version.id });
     string id = await Sut.MoveToModel(input);
     Assert.That(id, Is.EqualTo(_model2.id));
     Version movedVersion = await Sut.Get(_version.id, _model2.id, _project.id);
@@ -106,7 +106,7 @@ public class VersionResourceTests
   [Test]
   public async Task VersionDelete()
   {
-    DeleteVersionsInput input = new(new[] { _version.id });
+    DeleteVersionsInput input = new(new[] { _version.id }, _project.id);
 
     bool response = await Sut.Delete(input);
     Assert.That(response, Is.True);


### PR DESCRIPTION
A breaking change was made to our GraphQL api to require project ids on the VersionUpdate, VersionMoveToModel, and VersionDelete inputs.

This PR updates the sharp SDK with this change


see also https://github.com/specklesystems/specklepy/pull/353