### PR TITLE
fix: update direct shape parameters when it already exists

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertDirectShape.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertDirectShape.cs
@@ -185,6 +185,7 @@ public partial class ConverterRevit
     if (existingObj != null && existingObj is DB.DirectShape existingDS) // if it's a directShape, just update
     {
       existingDS.SetShape(converted);
+      SetInstanceParameters(existingDS, speckleDs);
       appObj.Update(status: ApplicationObject.State.Updated, createdId: existingDS.UniqueId, convertedItem: existingDS);
       return appObj;
     }


### PR DESCRIPTION
Fix for: https://speckle.community/t/grasshopper-to-revit-shared-parameters-not-updating/15351/6