### PR TITLE
Revert deploy step to use .NET 6 SDK for Manager Feed

### DIFF
--- a/.circleci/scripts/config-template.yml
+++ b/.circleci/scripts/config-template.yml
@@ -254,7 +254,7 @@ jobs: # Each project will have individual jobs for each specific task it has to 
 
   deploy-connector-new:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:8.0
+      - image: mcr.microsoft.com/dotnet/sdk:6.0 #Needs to say on .NET 6 so long as Speckle.Manager.Feed is .NET 6
     parameters:
       slug:
         type: string


### PR DESCRIPTION
Deploy is failing because Manager.Feed is still expecting .NET6 SDK