### PR TITLE
Removed frontend headers check for FE1 servers

### DIFF
--- a/Core/Core/Api/GraphQL/Models/ServerInfo.cs
+++ b/Core/Core/Api/GraphQL/Models/ServerInfo.cs
@@ -13,10 +13,9 @@ public sealed class ServerInfo
 
   /// <remarks>
   /// This field is not returned from the GQL API,
-  /// it should be populated after construction from the response headers.
-  /// see <see cref="Speckle.Core.Credentials.AccountManager"/>
+  /// it was previously populated after construction from the response headers, but now FE1 is deprecated, so we should always assume FE2
   /// </remarks>
-  public bool frontend2 { get; set; }
+  public bool frontend2 { get; set; } = true;
 
   /// <remarks>
   /// This field is not returned from the GQL API,

--- a/Core/Core/Credentials/AccountManager.cs
+++ b/Core/Core/Credentials/AccountManager.cs
@@ -90,7 +90,6 @@ public static class AccountManager
 
     ServerInfo serverInfo = response.Data.serverInfo;
     serverInfo.url = server.ToString().TrimEnd('/');
-    serverInfo.frontend2 = await IsFrontend2Server(server).ConfigureAwait(false);
 
     return response.Data.serverInfo;
   }
@@ -198,7 +197,6 @@ public static class AccountManager
 
       ServerInfo serverInfo = response.Data.serverInfo;
       serverInfo.url = server.ToString().TrimEnd('/');
-      serverInfo.frontend2 = await IsFrontend2Server(server).ConfigureAwait(false);
 
       return response.Data;
     }
@@ -800,38 +798,6 @@ public static class AccountManager
     {
       throw new SpeckleException($"Failed to get refreshed token from {server}", ex);
     }
-  }
-
-  /// <summary>
-  /// Sends a simple get request to the <paramref name="server"/>, and checks the response headers for a <c>"x-speckle-frontend-2"</c> <see cref="Boolean"/> value
-  /// </summary>
-  /// <param name="server">Server endpoint to get header</param>
-  /// <returns><see langword="true"/> if response contains FE2 header and the value was <see langword="true"/></returns>
-  /// <exception cref="SpeckleException">response contained FE2 header, but the value was <see langword="null"/>, empty, or not parseable to a <see cref="Boolean"/></exception>
-  /// <exception cref="HttpRequestException">Request to <paramref name="server"/> failed to send or response was not successful</exception>
-  private static async Task<bool> IsFrontend2Server(Uri server)
-  {
-    using var httpClient = Http.GetHttpProxyClient();
-
-    var response = await Http.HttpPing(server).ConfigureAwait(false);
-
-    var headers = response.Headers;
-    const string HEADER = "x-speckle-frontend-2";
-    if (!headers.TryGetValues(HEADER, out IEnumerable<string> values))
-    {
-      return false;
-    }
-
-    string? headerValue = values.FirstOrDefault();
-
-    if (!bool.TryParse(headerValue, out bool value))
-    {
-      throw new SpeckleException(
-        $"Headers contained {HEADER} header, but value {headerValue} could not be parsed to a bool"
-      );
-    }
-
-    return value;
   }
 
   private static string GenerateChallenge()

--- a/Core/Tests/Speckle.Core.Tests.Integration/Credentials/UserServerInfoTests.cs
+++ b/Core/Tests/Speckle.Core.Tests.Integration/Credentials/UserServerInfoTests.cs
@@ -23,20 +23,6 @@ public class UserServerInfoTests
     Assert.That(result.frontend2, Is.True);
   }
 
-  /// <remarks>
-  /// We get ServerInfo from "http://localhost:3000/graphql",
-  /// Then we mutate the `frontend2` property of ServerInfo by trying to fetch header from "http://localhost:3000/",
-  /// This is not doable in local server because there is no end-point on this to ping.
-  /// This is a bad sign for mutation.
-  /// </remarks>
-  [Test]
-  public void GetServerInfo_ExpectFail_CantPing()
-  {
-    Uri serverUrl = new(acc.serverInfo.url);
-
-    Assert.ThrowsAsync<HttpRequestException>(async () => await AccountManager.GetServerInfo(serverUrl));
-  }
-
   [Test]
   public void GetServerInfo_ExpectFail_NoServer()
   {


### PR DESCRIPTION
 #3672 is failing on integration tests since it changes, since we change the ping URL to  `/favicon.ico`, and this doesn't return the `x-speckle-frontend-2` header.

With approval from @gjedlicska, I'm now assuming that all accounts are FE2. Since FE1 is deprecated. This only thing that this affects is:
 - DUI2 UI terminology
 - StreamWrapper `ToString()` (i.e. we'll be sending people to FE2 formatted urls even if they're on FE1)