### PR TITLE
Removed favourite stream count from DUI2 stream view

### DIFF
--- a/Core/Core/Api/GraphQL/Legacy/Client.GraphqlCleintOperations/Client.StreamOperations.cs
+++ b/Core/Core/Api/GraphQL/Legacy/Client.GraphqlCleintOperations/Client.StreamOperations.cs
@@ -112,42 +112,31 @@ public partial class Client
   {
     var request = new GraphQLRequest
     {
-      Query =
-        $@"query User {{
-                      activeUser{{
-                        id,
-                        email,
-                        name,
-                        bio,
-                        company,
-                        avatar,
-                        verified,
-                        profiles,
-                        role,
-                        streams(limit:{limit}) {{
-                          totalCount,
-                          cursor,
-                          items {{
-                            id,
-                            name,
-                            description,
-                            isPublic,
-                            role,
-                            createdAt,
-                            updatedAt,
-                            favoritedDate,
-                            commentCount
-                            favoritesCount
-                            collaborators {{
-                              id,
-                              name,
-                              role,
-                              avatar
-                            }}
-                          }}
-                        }}
-                      }}
-                    }}"
+      Query = """
+        query User($limit: Int!) {
+          activeUser{
+            streams(limit:$limit) {
+              items {
+                id,
+                name,
+                description,
+                isPublic,
+                role,
+                createdAt,
+                updatedAt,
+                favoritedDate,
+                commentCount,
+                collaborators {
+                  id,
+                  name,
+                  role,
+                }
+              }
+            }
+          }
+        }
+        """,
+      Variables = new { limit }
     };
 
     var res = await ExecuteGraphQLRequest<ActiveUserResponse>(request, cancellationToken).ConfigureAwait(false);

--- a/DesktopUI2/DesktopUI2/Views/Controls/StreamDetails.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Controls/StreamDetails.xaml
@@ -37,32 +37,33 @@
       Grid.Column="3"
       Classes="Overline"
       Text="{Binding Stream.commentCount}" />
-    <icons:MaterialIcon
+    <!-- FAVOURITE STREAMS IS NO LONGER A FEATURE! -->
+    <!-- <icons:MaterialIcon -->
+    <!--   Grid.Column="4" -->
+    <!--   Margin="3,0" -->
+    <!--   VerticalAlignment="Center" -->
+    <!--   Classes="StreamCard" -->
+    <!--   Kind="Hearts" -->
+    <!--   ToolTip.Tip="Number of people who favorited" /> -->
+    <!-- <TextBlock -->
+    <!--   Grid.Column="5" -->
+    <!--   Classes="Overline" -->
+    <!--   Text="{Binding Stream.favoritesCount}" /> -->
+    <TextBlock
       Grid.Column="4"
-      Margin="3,0"
-      VerticalAlignment="Center"
-      Classes="StreamCard"
-      Kind="Hearts"
-      ToolTip.Tip="Number of people who favorited" />
+      Classes="Overline"
+      Text=" - " />
     <TextBlock
       Grid.Column="5"
       Classes="Overline"
-      Text="{Binding Stream.favoritesCount}" />
+      Text="{Binding Stream.role, Converter={StaticResource RoleValueConverter}}"
+      TextTrimming="CharacterEllipsis" />
     <TextBlock
       Grid.Column="6"
       Classes="Overline"
       Text=" - " />
     <TextBlock
       Grid.Column="7"
-      Classes="Overline"
-      Text="{Binding Stream.role, Converter={StaticResource RoleValueConverter}}"
-      TextTrimming="CharacterEllipsis" />
-    <TextBlock
-      Grid.Column="8"
-      Classes="Overline"
-      Text=" - " />
-    <TextBlock
-      Grid.Column="9"
       Classes="Overline"
       Text="{Binding Stream.id}"
       TextTrimming="CharacterEllipsis" />


### PR DESCRIPTION
This is done for two reasons:
1. Favourited streams was a feature of FE1, thus its visual noise in the UI
2. The query that populates the `HomeView` with stream info is very heavy, and @fabis94 was seeing this lead to hundreds of SQL queries. This was an easy win for us to remove a bit of complexity from that query.

Before:
![image](https://github.com/user-attachments/assets/3d4f46cd-bde3-47de-bf37-b359a4bb89d1)


After:
![image](https://github.com/user-attachments/assets/2e277a7f-c8c5-4382-b9a8-2e373d4d3f47)
