### PR TITLE
fix: Disappearing Grasshopper components after save

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Ops/Operations.SyncReceiveComponent.cs
@@ -175,24 +175,21 @@ public class SyncReceiveComponent : SelectKitTaskCapableComponentBase<Base>
   public override bool Write(GH_IWriter writer)
   {
     writer.SetBoolean("AutoReceive", AutoReceive);
-    //writer.SetString("CurrentComponentState", CurrentComponentState);
     writer.SetString("LastInfoMessage", LastInfoMessage);
-    //writer.SetString("LastCommitDate", LastCommitDate);
     writer.SetString("ReceivedObjectId", ReceivedObjectId);
     writer.SetString("ReceivedCommitId", ReceivedCommitId);
-    writer.SetString("KitName", Kit.Name);
+    writer.SetString("KitName", Kit?.Name);
+
     var streamUrl = StreamWrapper != null ? StreamWrapper.ToString() : "";
     writer.SetString("StreamWrapper", streamUrl);
-    //writer.SetBoolean(nameof(ConvertToNative), ConvertToNative);
+
     return base.Write(writer);
   }
 
   public override bool Read(GH_IReader reader)
   {
     AutoReceive = reader.GetBoolean("AutoReceive");
-    //CurrentComponentState = reader.GetString("CurrentComponentState");
     LastInfoMessage = reader.GetString("LastInfoMessage");
-    //LastCommitDate = reader.GetString("LastCommitDate");
     ReceivedObjectId = reader.GetString("ReceivedObjectId");
     ReceivedCommitId = reader.GetString("ReceivedCommitId");
 
@@ -226,7 +223,15 @@ public class SyncReceiveComponent : SelectKitTaskCapableComponentBase<Base>
   {
     if (RunCount == 1)
     {
-      ParseInput(DA);
+      try
+      {
+        ParseInput(DA);
+      }
+      catch (Exception e)
+      {
+        Console.WriteLine(e);
+        throw;
+      }
       if (InputType == "Invalid")
       {
         return;

--- a/Core/Core/Credentials/StreamWrapper.cs
+++ b/Core/Core/Credentials/StreamWrapper.cs
@@ -436,9 +436,12 @@ public class StreamWrapper
 
     if (OriginalInput != null)
     {
-      Uri uri = new(OriginalInput);
-      var fe2Match = s_fe2UrlRegex.Match(uri.AbsolutePath);
-      return fe2Match.Success ? ToProjectUri() : ToStreamUri();
+      if (Uri.IsWellFormedUriString(OriginalInput, UriKind.Absolute))
+      {
+        Uri uri = new(OriginalInput);
+        var fe2Match = s_fe2UrlRegex.Match(OriginalInput);
+        return fe2Match.Success ? ToProjectUri() : ToStreamUri();
+      }
     }
 
     // Default to old FE1


### PR DESCRIPTION
SyncReceive would disappear upon opening a document (or while saving) due to exceptions being thrown in the Read/Write logic, which shouldn't ever throw.
