### PR TITLE
fix(gh): Use external getter for `Value` property

### DIFF
--- a/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
+++ b/ConnectorGrasshopper/ConnectorGrasshopperShared/Extras/Utilities.cs
@@ -484,12 +484,11 @@ public static class Utilities
     }
 
     value = UnwrapRhino8Object(value);
-
     if (value is IGH_Goo)
     {
       var valuePropInfo = value
         .GetType()
-        .GetField("m_value", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        .GetProperty("Value", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
       if (valuePropInfo != null)
       {
         var tempValue = valuePropInfo.GetValue(value);


### PR DESCRIPTION
Do not assume internal storage `m_value` will exist in all GH_Goo's, some have varying implementation, but `Value` is usually consistent on all pre-rhino8 GH types
