### PR TITLE
Init async

### DIFF
--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -164,15 +164,15 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     Init();
   }
 
-  private void Init()
+  private async void Init()
   {
     try
     {
-      GetStream().ConfigureAwait(true);
-      GetBranchesAndRestoreState();
-      GetActivity();
       GetReport();
-      GetComments();
+      await GetStream().ConfigureAwait(true);
+      await GetBranchesAndRestoreState().ConfigureAwait(true);
+      GetActivity();
+      await GetComments().ConfigureAwait(true);
     }
     catch (Exception ex)
     {
@@ -241,7 +241,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
   }
 
-  internal async void GetBranchesAndRestoreState()
+  internal async Task GetBranchesAndRestoreState()
   {
     try
     {
@@ -298,8 +298,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       }
       else
       {
-        var selectionFilter = AvailableFilters.FirstOrDefault(x =>
-          x.Filter.Type == typeof(ManualSelectionFilter).ToString()
+        var selectionFilter = AvailableFilters.FirstOrDefault(
+          x => x.Filter.Type == typeof(ManualSelectionFilter).ToString()
         );
         //if there are any selected objects, set the manual selection automagically
         if (selectionFilter != null && Bindings.GetSelectedObjects().Any())
@@ -576,8 +576,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
     catch (Exception ex)
     {
-      SpeckleLog
-        .Logger.ForContext("imageUrl", url)
+      SpeckleLog.Logger
+        .ForContext("imageUrl", url)
         .Warning(ex, "Swallowing exception in {methodName}: {exceptionMessage}", nameof(DownloadImage360), ex.Message);
       Debug.WriteLine(ex);
       _previewImage360 = null; // Could not download...
@@ -1275,8 +1275,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       try
       {
         _isAddingBranches = true;
-        var branchId = await StreamState
-          .Client.BranchCreate(
+        var branchId = await StreamState.Client
+          .BranchCreate(
             new BranchCreateInput
             {
               streamId = Stream.id,
@@ -1483,8 +1483,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       }
 
       GetReport();
-      SpeckleLog
-        .Logger.ForContext(nameof(IsReceiver), IsReceiver)
+      SpeckleLog.Logger
+        .ForContext(nameof(IsReceiver), IsReceiver)
         .Information(CommandSucceededLogTemplate, nameof(PreviewCommand));
     }
     catch (Exception ex)

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -298,8 +298,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       }
       else
       {
-        var selectionFilter = AvailableFilters.FirstOrDefault(
-          x => x.Filter.Type == typeof(ManualSelectionFilter).ToString()
+        var selectionFilter = AvailableFilters.FirstOrDefault(x =>
+          x.Filter.Type == typeof(ManualSelectionFilter).ToString()
         );
         //if there are any selected objects, set the manual selection automagically
         if (selectionFilter != null && Bindings.GetSelectedObjects().Any())
@@ -576,8 +576,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
     catch (Exception ex)
     {
-      SpeckleLog.Logger
-        .ForContext("imageUrl", url)
+      SpeckleLog
+        .Logger.ForContext("imageUrl", url)
         .Warning(ex, "Swallowing exception in {methodName}: {exceptionMessage}", nameof(DownloadImage360), ex.Message);
       Debug.WriteLine(ex);
       _previewImage360 = null; // Could not download...
@@ -1275,8 +1275,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       try
       {
         _isAddingBranches = true;
-        var branchId = await StreamState.Client
-          .BranchCreate(
+        var branchId = await StreamState
+          .Client.BranchCreate(
             new BranchCreateInput
             {
               streamId = Stream.id,
@@ -1483,8 +1483,8 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
       }
 
       GetReport();
-      SpeckleLog.Logger
-        .ForContext(nameof(IsReceiver), IsReceiver)
+      SpeckleLog
+        .Logger.ForContext(nameof(IsReceiver), IsReceiver)
         .Information(CommandSucceededLogTemplate, nameof(PreviewCommand));
     }
     catch (Exception ex)


### PR DESCRIPTION
While looking at logs to investigate https://www.notion.so/speckle/app-speckle-systems-outages-4am-184b78fc7aa68066b6b5f29c9da12e30
There is little stack trace information available due to an async void on the `Init` function. Hopefully this should make it slightly easier to keep the stack trace