### PR TITLE
Jrm/fixed bug with non workspaces

### DIFF
--- a/Core/Core/Api/GraphQL/Inputs/ProjectInputs.cs
+++ b/Core/Core/Api/GraphQL/Inputs/ProjectInputs.cs
@@ -43,4 +43,4 @@ public sealed record ProjectUpdateInput(
 
 public sealed record ProjectUpdateRoleInput(string userId, string projectId, string? role);
 
-public sealed record UserProjectsFilter(string search, IReadOnlyList<string>? onlyWithRoles = null);
+public sealed record UserProjectsFilter(string? search, IReadOnlyList<string>? onlyWithRoles = null);

--- a/Core/Core/Api/GraphQL/Legacy/Client.GraphqlCleintOperations/Client.StreamOperations.cs
+++ b/Core/Core/Api/GraphQL/Legacy/Client.GraphqlCleintOperations/Client.StreamOperations.cs
@@ -251,7 +251,7 @@ public partial class Client
       Variables = new { query, limit }
     };
 
-    var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false); //WARN: Why do we do this?
+    // var res = await GQLClient.SendMutationAsync<StreamsData>(request, cancellationToken).ConfigureAwait(false); //WARN: Why do we do this?
     return (await ExecuteGraphQLRequest<StreamsData>(request, cancellationToken).ConfigureAwait(false)).streams.items;
   }
 
@@ -400,7 +400,7 @@ public partial class Client
                     }",
       Variables = new { id = streamId }
     };
-    var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false); //WARN: Why do we do this?
+    // var res = await GQLClient.SendMutationAsync<StreamData>(request, cancellationToken).ConfigureAwait(false); //WARN: Why do we do this?
     return (await ExecuteGraphQLRequest<StreamData>(request, cancellationToken).ConfigureAwait(false)).stream;
   }
 

--- a/Core/Core/Api/GraphQL/Resources/ActiveUserResource.cs
+++ b/Core/Core/Api/GraphQL/Resources/ActiveUserResource.cs
@@ -75,11 +75,16 @@ public sealed class ActiveUserResource
     var request = new GraphQLRequest { Query = QUERY, };
 
     var response = await _client
-      .ExecuteGraphQLRequest<RequiredResponse<RequiredResponse<RequiredResponse<PermissionCheckResult>>>>(
+      .ExecuteGraphQLRequest<OptionalResponse<RequiredResponse<RequiredResponse<PermissionCheckResult>>>>(
         request,
         cancellationToken
       )
       .ConfigureAwait(false);
+
+    if (response.data is null)
+    {
+      throw new SpeckleGraphQLException("GraphQL response indicated that the ActiveUser could not be found");
+    }
 
     return response.data.data.data;
   }
@@ -133,11 +138,16 @@ public sealed class ActiveUserResource
     };
 
     var response = await _client
-      .ExecuteGraphQLRequest<RequiredResponse<RequiredResponse<ResourceCollection<Workspace>>>>(
+      .ExecuteGraphQLRequest<OptionalResponse<RequiredResponse<ResourceCollection<Workspace>>>>(
         request,
         cancellationToken
       )
       .ConfigureAwait(false);
+
+    if (response.data is null)
+    {
+      throw new SpeckleGraphQLException("GraphQL response indicated that the ActiveUser could not be found");
+    }
 
     return response.data.data;
   }

--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml.cs
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml.cs
@@ -87,7 +87,7 @@ public sealed class NewStreamDialog : DialogUserControl
       return;
     }
 
-    const string READY_MESSAGE = "Ready";
+    const string READY_MESSAGE = " ";
     PermissionCheckResult result;
 
     if (selectedWorkspace.Workspace is null)


### PR DESCRIPTION
While testing, I managed to get a state where `testing1.speckle.dev` returned a `null` active user during the `GetWorkspaces` query. This then caused the response to fail to deserailize, which prevented the "real" grahql error of "WORKSPACES_MODULE_DISABLED_ERROR" from surfacing and be correctly handled by the `NewProjectDialogue`