### PR TITLE
fix: etabs frame loads on receive

### DIFF
--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/PartialClasses/Geometry/ConvertFrame.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/PartialClasses/Geometry/ConvertFrame.cs
@@ -116,7 +116,9 @@ public partial class ConverterCSI
       end2node = element1D.end2Node.basePoint;
     }
 
-    CreateFrame(end1node, end2node, out var newFrame, out _, appObj);
+    // We need to actually do something with the name
+    // If name is null this is still safe since CreateFrame has a null check before ChangeName method
+    CreateFrame(end1node, end2node, out var newFrame, out _, appObj, nameOverride: element1D.name);
     SetFrameElementProperties(element1D, newFrame, appObj.Log);
   }
 

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/PartialClasses/Loading/Loading1DElements.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/PartialClasses/Loading/Loading1DElements.cs
@@ -126,10 +126,26 @@ public partial class ConverterCSI
         continue;
       }
 
+      // 💩 Fallback to id (below) won't work. ETABS is all name-based.
+      // If name is null (and we use id) load won't be set to instance of object
+      // But we're in maintenance mode, so I won't dive deeper here, just noting it 🤷
+      // If user sets name, this will work
+      // Best would be to get name of frame element after creating but this would require strict order of operations
       int success;
-      string name = element.name ?? element.id;
+      string name = element.name ?? element.id; // <-- 💩
 
       if (loadBeam.loadType == BeamLoadType.Point)
+      {
+        success = Model.FrameObj.SetLoadPoint(
+          name,
+          loadBeam.loadCase.name,
+          myType,
+          direction,
+          loadBeam.positions[0],
+          loadBeam.values[0]
+        );
+      }
+      else
       {
         success = Model.FrameObj.SetLoadDistributed(
           name,
@@ -140,17 +156,6 @@ public partial class ConverterCSI
           loadBeam.positions[1],
           loadBeam.values[0],
           loadBeam.values[1]
-        );
-      }
-      else
-      {
-        success = Model.FrameObj.SetLoadPoint(
-          name,
-          loadBeam.loadCase.name,
-          myType,
-          direction,
-          loadBeam.positions[0],
-          loadBeam.values[0]
         );
       }
 


### PR DESCRIPTION
## Description & motivation

`Grasshopper` to `ETABS` workflow was broken when it came to assigning of frame loads. Reported in [Grasshopper to Etabs Import- Loads fail to load](https://speckle.community/t/grasshopper-to-etabs-import-loads-fail-to-load/17687/1) .

There were some pretty concerning issues:
- Attempt to assign the wrong load type (`if` statement is just wrong):
```
      if (loadBeam.loadType == BeamLoadType.Point)
      {
        success = Model.FrameObj.SetLoadDistributed(
```` 
- Discarding `name` completely, which is for ETABS' sake very important

## Changes:

- Use the `name` in `FrameToNative`
- Assign the correct load type in `LoadFrameToNative`

## Screenshots:

### Before

![Screenshot 2025-04-25 224943](https://github.com/user-attachments/assets/e4735562-356a-4b18-86eb-70b90e1de6ef)

### After

![Screenshot 2025-04-25 230201](https://github.com/user-attachments/assets/a7265f18-6acc-4cef-94b6-ada14a42b430)

## Validation of changes:

https://github.com/user-attachments/assets/999cbd04-a762-497f-a637-0e9ff576a83c

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

[Grasshopper to Etabs Import- Loads fail to load](https://speckle.community/t/grasshopper-to-etabs-import-loads-fail-to-load/17687/1)