### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.2.+   | :white_check_mark: |
-| < 2.2   | :x:                |
+| versions 2.20 or greater   | :white_check_mark: |
+| versions before 2.20   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Already marked nuget packages more than 9 months old as deprecated (no longer maintained)
Updating our security policy to reflect this.

https://www.nuget.org/packages/Speckle.Core

Support versions of 2.x will tighten as v3 becomes default