### PR TITLE
feat(ui): Add call to action button for project create

### DIFF
--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
@@ -107,18 +107,26 @@
       Grid.Row="5"
       Margin="15" />
     
-    <Label
-      Content=" "
+    <TextBlock
+      Text=" "
       Name="permissionMessage"
       Grid.Row="6"
       Margin="15"
-      HorizontalContentAlignment="Right"/>
+      TextWrapping="Wrap"
+      TextAlignment="Right"/>
 
     <StackPanel
       Grid.Row="7"
       Margin="15"
       HorizontalAlignment="Right"
       Orientation="Horizontal">
+      <Button
+        Name="callToAction"
+        Margin="0,0,10,0"
+        Click="CTA_Click"
+        Content="Explore Plans"
+        IsVisible="False"
+        />
       <Button
         Margin="0,0,10,0"
         Classes="Outline"


### PR DESCRIPTION
- Added call to action "Explore Plans" when trying to create a project where workspace limit is reached.
- Ensure cancellation to prevent the UI from showing the wrong servers workspaces when quickly switching between


![image](https://github.com/user-attachments/assets/9ae11fa1-968b-4974-8f23-901ff5bc0124)
