### PR TITLE
chore: Renamed command in Rhino and Autocad toolbars

### DIFF
--- a/All.sln
+++ b/All.sln
@@ -100,6 +100,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Grasshopper", "Grasshopper", "{9461B162-AD2F-4F60-BCE4-E72DCEFD4608}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rhino", "Rhino", "{E94E7327-5A9B-48EE-93CC-E9E9A5B980F1}"
+	ProjectSection(SolutionItems) = preProject
+		ConnectorRhino\ConnectorRhino\Toolbars\SpeckleConnectorRhino.rui = ConnectorRhino\ConnectorRhino\Toolbars\SpeckleConnectorRhino.rui
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConnectorRhino6", "ConnectorRhino\ConnectorRhino6\ConnectorRhino6.csproj", "{D648BB69-B992-4D34-906E-7A547374B86C}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/App.cs
@@ -136,12 +136,19 @@ public class App : IExtensionApplication
     }
 
     RibbonToolTip speckleTip = CreateToolTip("Speckle", "Speckle Connector for " + Utils.AppName);
-    RibbonToolTip oneClickTip = CreateToolTip(
-      "Send",
-      "Sends your selected objects to your account's document stream. If nothing is selected, sends everything in the document."
+    RibbonButton button = CreateButton(
+      "Connector " + Utils.AppName,
+      SpeckleAutocadCommand.SPECKLE_COMMAND_NAME,
+      panel,
+      null,
+      speckleTip,
+      "logo"
     );
-    RibbonButton button = CreateButton("Connector " + Utils.AppName, "Speckle", panel, null, speckleTip, "logo");
-    RibbonButton oneClickSendButton = CreateButton("Send", "SpeckleSend", panel, null, oneClickTip, "send");
+    // RibbonToolTip oneClickTip = CreateToolTip(
+    //   "Send",
+    //   "Sends your selected objects to your account's document stream. If nothing is selected, sends everything in the document."
+    // );
+    // RibbonButton oneClickSendButton = CreateButton("Send", "SpeckleSend", panel, null, oneClickTip, "send");
 
     // help and resources buttons
     RibbonSplitButton helpButton =
@@ -166,9 +173,30 @@ public class App : IExtensionApplication
       "Check out our tutorials! Opens a page in your web browser"
     );
     RibbonToolTip docsTip = CreateToolTip("Docs", "Check out our documentation! Opens a page in your web browser");
-    RibbonButton community = CreateButton("Community", "SpeckleCommunity", null, helpButton, communityTip, "forum");
-    RibbonButton tutorials = CreateButton("Tutorials", "SpeckleTutorials", null, helpButton, tutorialsTip, "tutorials");
-    RibbonButton docs = CreateButton("Docs", "SpeckleDocs", null, helpButton, docsTip, "docs");
+    RibbonButton community = CreateButton(
+      "Community",
+      SpeckleAutocadCommand.SPECKLE_COMMUNITY_COMMAND_NAME,
+      null,
+      helpButton,
+      communityTip,
+      "forum"
+    );
+    RibbonButton tutorials = CreateButton(
+      "Tutorials",
+      SpeckleAutocadCommand.SPECKLE_TUTORIALS_COMMAND_NAME,
+      null,
+      helpButton,
+      tutorialsTip,
+      "tutorials"
+    );
+    RibbonButton docs = CreateButton(
+      "Docs",
+      SpeckleAutocadCommand.SPECKLE_DOCS_COMMAND_NAME,
+      null,
+      helpButton,
+      docsTip,
+      "docs"
+    );
   }
 
   public void Terminate() { }
@@ -325,16 +353,16 @@ public class App : IExtensionApplication
       {
         switch (commandParameter)
         {
-          case "Speckle":
+          case SpeckleAutocadCommand.SPECKLE_COMMAND_NAME:
             SpeckleAutocadCommand.SpeckleCommand();
             break;
-          case "SpeckleCommunity":
+          case SpeckleAutocadCommand.SPECKLE_COMMUNITY_COMMAND_NAME:
             SpeckleAutocadCommand.SpeckleCommunity();
             break;
-          case "SpeckleTutorials":
+          case SpeckleAutocadCommand.SPECKLE_TUTORIALS_COMMAND_NAME:
             SpeckleAutocadCommand.SpeckleTutorials();
             break;
-          case "SpeckleDocs":
+          case SpeckleAutocadCommand.SPECKLE_DOCS_COMMAND_NAME:
             SpeckleAutocadCommand.SpeckleDocs();
             break;
           default:

--- a/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/SpeckleAutocadCommand.cs
+++ b/ConnectorAutocadCivil/ConnectorAutocadCivil/Entry/SpeckleAutocadCommand.cs
@@ -34,6 +34,11 @@ public class SpeckleAutocadCommand
 
   const int GWL_HWNDPARENT = -8;
   #endregion
+
+  public const string SPECKLE_COMMAND_NAME = "SpeckleLegacy";
+  public const string SPECKLE_COMMUNITY_COMMAND_NAME = "SpeckleCommunity";
+  public const string SPECKLE_TUTORIALS_COMMAND_NAME = "SpeckleTutorials";
+  public const string SPECKLE_DOCS_COMMAND_NAME = "SpeckleDocs";
   private static Avalonia.Application AvaloniaApp { get; set; }
   public static Window MainWindow { get; private set; }
   private static CancellationTokenSource Lifetime = null;
@@ -51,7 +56,7 @@ public class SpeckleAutocadCommand
   /// <summary>
   /// Main command to initialize Speckle Connector
   /// </summary>
-  [CommandMethod("SpeckleLegacy", CommandFlags.Modal)]
+  [CommandMethod(SPECKLE_COMMAND_NAME, CommandFlags.Modal)]
   public static void SpeckleCommand()
   {
     CreateOrFocusSpeckle();
@@ -109,7 +114,7 @@ public class SpeckleAutocadCommand
     AvaloniaApp = app;
   }
 
-  [CommandMethod("SpeckleCommunity", CommandFlags.ActionMacro)]
+  [CommandMethod(SPECKLE_COMMUNITY_COMMAND_NAME, CommandFlags.ActionMacro)]
   public static void SpeckleCommunity()
   {
     try
@@ -127,7 +132,7 @@ public class SpeckleAutocadCommand
     }
   }
 
-  [CommandMethod("SpeckleTutorials", CommandFlags.ActionMacro)]
+  [CommandMethod(SPECKLE_TUTORIALS_COMMAND_NAME, CommandFlags.ActionMacro)]
   public static void SpeckleTutorials()
   {
     try
@@ -145,7 +150,7 @@ public class SpeckleAutocadCommand
     }
   }
 
-  [CommandMethod("SpeckleDocs", CommandFlags.ActionMacro)]
+  [CommandMethod(SPECKLE_DOCS_COMMAND_NAME, CommandFlags.ActionMacro)]
   public static void SpeckleDocs()
   {
     try


### PR DESCRIPTION
Rhino and AutoCAD toolbars also need updating to the changed command name

![image](https://github.com/user-attachments/assets/2c1b0eda-75b2-4721-9d19-3cde65131c30)
