### PR TITLE
feat(dui2): Use permission check for receive

### DIFF
--- a/Core/Core/Api/GraphQL/Models/ModelExtensions.cs
+++ b/Core/Core/Api/GraphQL/Models/ModelExtensions.cs
@@ -9,6 +9,12 @@ public static class ModelExtensions
   public static bool CanReceive(this Stream project) =>
     project.role is StreamRoles.STREAM_OWNER or StreamRoles.STREAM_CONTRIBUTOR;
 
+  /// <remarks>
+  /// You should prefer using <see cref="Speckle.Core.Api.GraphQL.Resources.ProjectResource.GetPermissions"/>
+  /// since this server should be the source of truth for permission checks,
+  /// and the logic on the serer takes into account workspace admins who should be able to receive
+  /// despite not having an explicit role on a project
+  /// </remarks>
   /// <param name="project"></param>
   /// <returns><see langword="True"/> if the <see cref="Stream.role"/> allows for receive</returns>
   public static bool CanReceive(this Project project) =>

--- a/Core/Core/Models/ProjectPermissionChecks.cs
+++ b/Core/Core/Models/ProjectPermissionChecks.cs
@@ -1,4 +1,4 @@
-﻿using Speckle.Core.Api.GraphQL.Models;
+﻿namespace Speckle.Core.Api.GraphQL.Models;
 
 public class ProjectPermissionChecks
 {

--- a/Core/Core/Models/ProjectPermissionChecks.cs
+++ b/Core/Core/Models/ProjectPermissionChecks.cs
@@ -1,0 +1,9 @@
+﻿using Speckle.Core.Api.GraphQL.Models;
+
+public class ProjectPermissionChecks
+{
+  public PermissionCheckResult canCreateModel { get; init; }
+  public PermissionCheckResult canDelete { get; init; }
+  public PermissionCheckResult canLoad { get; init; }
+  public PermissionCheckResult canPublish { get; init; }
+}

--- a/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/HomeViewModel.cs
@@ -22,7 +22,6 @@ using Material.Styles.Themes;
 using Material.Styles.Themes.Base;
 using ReactiveUI;
 using Speckle.Core.Api;
-using Speckle.Core.Api.GraphQL;
 using Speckle.Core.Api.GraphQL.Enums;
 using Speckle.Core.Api.GraphQL.Inputs;
 using Speckle.Core.Api.GraphQL.Models;
@@ -725,11 +724,8 @@ public class HomeViewModel : ReactiveObject, IRoutableViewModel
         var account = await sw.GetAccount().ConfigureAwait(true);
         using var client = new Client(account);
         var stream = await client.StreamGet(sw.StreamId).ConfigureAwait(true);
-
-        if (!stream.CanReceive())
-        {
-          throw new SpeckleException("You do not have permission to receive model this model");
-        }
+        var permissionCheck = await client.Project.GetPermissions(stream.id).ConfigureAwait(true);
+        permissionCheck?.canLoad.EnsureAuthorised();
 
         var streamState = new StreamState(account, stream);
         streamState.BranchName = sw.BranchName;

--- a/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/StreamViewModel.cs
@@ -223,7 +223,13 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
   {
     try
     {
+      var projectPermission = await Client.Project.GetPermissions(StreamState.StreamId).ConfigureAwait(true);
+      CanLoad = projectPermission?.canLoad.authorized ?? true;
+      CanLoadErrorMessage =
+        $"You do not have permission to receive model this model:\n{projectPermission?.canLoad.message}";
+
       Stream = await Client.StreamGet(StreamState.StreamId, 25).ConfigureAwait(true);
+
       if (Stream.role == "stream:owner")
       {
         var streamPendingCollaborators = await Client
@@ -613,6 +619,20 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
   }
 
+  private bool _canLoad;
+  public bool CanLoad
+  {
+    get => _canLoad;
+    internal set => this.RaiseAndSetIfChanged(ref _canLoad, value);
+  }
+
+  private string _canLoadErrorMessage;
+  public string CanLoadErrorMessage
+  {
+    get => _canLoadErrorMessage;
+    internal set => this.RaiseAndSetIfChanged(ref _canLoadErrorMessage, value);
+  }
+
   private Stream _stream;
 
   public Stream Stream
@@ -677,7 +697,7 @@ public class StreamViewModel : ReactiveObject, IRoutableViewModel, IDisposable
     }
   }
 
-  public bool StreamEnabled => !IsRemovingStream && !NoAccess && _stream.CanReceive();
+  public bool StreamEnabled => !IsRemovingStream && !NoAccess;
 
   private bool _isExpanded;
 

--- a/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Receive.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Controls/StreamEditControls/Receive.xaml
@@ -99,7 +99,7 @@
             VerticalAlignment="Center"
             IsEnabled="{Binding Commits.Count}"
             Items="{Binding Commits}"
-            PlaceholderText="Select a commit"
+            PlaceholderText="Select a model version"
             SelectedIndex="0"
             SelectedItem="{Binding SelectedCommit}">
             <ComboBox.ItemTemplate>

--- a/DesktopUI2/DesktopUI2/Views/Pages/StreamEditView.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/StreamEditView.xaml
@@ -25,8 +25,6 @@
 
   <UserControl.Resources>
     <conv:RoleCanSendValueConverter x:Key="RoleCanSendValueConverter" />
-    <conv:RoleCanReceiveValueConverter x:Key="RoleCanReceiveValueConverter" />
-    <conv:RoleCanNotReceiveValueConverter x:Key="RoleCanNotReceiveValueConverter" />
     <conv:RoleValueConverter x:Key="RoleValueConverter" />
     <conv:StringOpacityValueConverter x:Key="StringOpacityValueConverter" />
     <conv:StreamEditHeightConverter x:Key="StreamEditHeightConverter" />
@@ -154,7 +152,7 @@
             </TabItem>
 
             <!--  RECEIVE  -->
-            <TabItem IsVisible="{Binding CanReceive}" IsEnabled="{Binding Stream.role, Converter={StaticResource RoleCanReceiveValueConverter}}" ToolTip.Tip="Receive">
+            <TabItem IsVisible="{Binding CanReceive}" IsEnabled="{Binding CanLoad}" ToolTip.Tip="Receive">
               <TabItem.Header>
                 <StackPanel Orientation="Horizontal">
                   <icons:MaterialIcon
@@ -176,11 +174,13 @@
               </TabItem.Header>
               <ScrollViewer>
                 <Panel>
-                  <uc:Receive IsVisible="{Binding Stream.role, Converter={StaticResource RoleCanReceiveValueConverter}}" ToolTip.Tip="Receive"/>
-                  <Label
-                    HorizontalContentAlignment="Center"
+                  <uc:Receive IsVisible="{Binding CanLoad}" ToolTip.Tip="Receive"/>
+                  <TextBlock
+                    HorizontalAlignment="Center"
                     Margin="25"
-                    IsVisible="{Binding Stream.role, Converter={StaticResource RoleCanNotReceiveValueConverter}}">You do not have permission to receive model this model</Label>
+                    IsVisible="{Binding CanLoad, Converter={x:Static BoolConverters.Not}}"
+                    Text="{Binding CanLoadErrorMessage}"
+                    TextWrapping="Wrap"/>
                 </Panel>
               </ScrollViewer>
             </TabItem>
@@ -258,7 +258,7 @@
       <!-- </TabItem> -->
 
       <!--  REPORT  -->
-      <TabItem ToolTip.Tip="Report" IsEnabled="{Binding Stream.role, Converter={StaticResource RoleCanReceiveValueConverter}}">
+      <TabItem ToolTip.Tip="Report" IsEnabled="{Binding CanLoad}">
         <TabItem.Header>
           <StackPanel Orientation="Horizontal">
             <icons:MaterialIcon


### PR DESCRIPTION
The logic in DUI2 to check the user can receive a model was implemented using a simple check for the user's project role.
This was implemented before the server implemented the permission checks into the graphql api.

This update replaces the main checks that the DUI2 connectors do with the server permission check, and should allow workspace admins to paste by url and receive.

However, non-explicit projects still won't appear in the DUI2 UI, since there is no include implicit role filter option for the `Streams` query like there is with `activeUser.projects`