### PR TITLE
fix(revit): guard against null Zone in space send and receive

### DIFF
--- a/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertSpace.cs
+++ b/Objects/Converters/ConverterRevit/ConverterRevitShared/PartialClasses/ConvertSpace.cs
@@ -66,20 +66,25 @@ public partial class ConverterRevit
       return appObj;
     }
 
-    var revitZone = revitSpace.Zone;
-    revitZone = CreateRevitZoneIfNeeded(speckleSpace, revitZone, targetPhase, level);
-
-    // if a relevant zone exists add space to it
-    if (revitZone != null)
+    // Only attempt zone association when the incoming Speckle object has an explicit zone.
+    // A null speckleSpace.zone means the source space had no zone — skipping prevents
+    // the connector from touching the Revit document's default "No Zone" state and
+    // accidentally wiping existing spaces (fixes #3524).
+    if (speckleSpace.zone != null)
     {
-      var currentSpaces = revitZone.Spaces;
+      var revitZone = revitSpace.Zone;
+      revitZone = CreateRevitZoneIfNeeded(speckleSpace, revitZone, targetPhase, level);
 
-      // if the space is already in the zone, do nothing.
-      if (!currentSpaces.Contains(revitSpace))
+      if (revitZone != null)
       {
-        var spaceSet = new DB.SpaceSet();
-        spaceSet.Insert(revitSpace);
-        revitZone.AddSpaces(spaceSet);
+        var currentSpaces = revitZone.Spaces;
+
+        if (!currentSpaces.Contains(revitSpace))
+        {
+          var spaceSet = new DB.SpaceSet();
+          spaceSet.Insert(revitSpace);
+          revitZone.AddSpaces(spaceSet);
+        }
       }
     }
 
@@ -280,10 +285,14 @@ public partial class ConverterRevit
       speckleSpace["roomId"] = revitSpace.Room.Id.ToString();
     }
 
-    // Zones are stored as a Space prop despite being a parent object, so we need to convert it here
-    speckleSpace.zone = revitDocumentAggregateCache
-      .GetOrInitializeEmptyCacheOfType<RevitZone>(out _)
-      .GetOrAdd(revitSpace.Zone.Name, () => ZoneToSpeckle(revitSpace.Zone), out _);
+    // Zones are stored as a Space prop despite being a parent object, so we need to convert it here.
+    // Guard against null: Space.Zone is null when the space has not been assigned to any zone.
+    if (revitSpace.Zone != null)
+    {
+      speckleSpace.zone = revitDocumentAggregateCache
+        .GetOrInitializeEmptyCacheOfType<RevitZone>(out _)
+        .GetOrAdd(revitSpace.Zone.Name, () => ZoneToSpeckle(revitSpace.Zone), out _);
+    }
 
     GetAllRevitParamsAndIds(speckleSpace, revitSpace);
 


### PR DESCRIPTION

## What does this PR do?

Resolves a two-part bug that caused the Revit connector to fail when receiving spaces that have no zone assigned.

Closes #3524

## Root cause

`Space.Zone` returns `null` from the Revit API when a space is not assigned to any zone. The converter had two unguarded references to this property:

**1. On send (`SpaceToSpeckle`)**
```csharp
// Before: NullReferenceException when Space.Zone is null
speckleSpace.zone = cache.GetOrAdd(revitSpace.Zone.Name, ...);
```
If `revitSpace.Zone` is `null`, accessing `.Name` throws immediately and the whole send operation fails.

**2. On receive (`SpaceToNative`)**
The zone association block ran unconditionally. When the incoming `speckleSpace.zone` was `null` (correctly serialized after this fix, or received from another host app without zone data), `CreateRevitZoneIfNeeded` returned the Revit document's internal default zone object. The connector then attempted `AddSpaces` on it, which triggered an API error — and in the error recovery path, the existing spaces were deleted instead of updated.

## Changes

- `ConvertSpace.cs` — `SpaceToSpeckle`: wrapped the cache/serialize call in a `null` guard so spaces without a zone serialize with `zone = null` rather than throwing.
- `ConvertSpace.cs` — `SpaceToNative`: moved the entire zone-association block inside a `speckleSpace.zone != null` check. When no zone was intended, the connector leaves the space's zone state untouched.

## Testing

Manually traced through the execution path with a `Space` mock where `Zone` is `null`. The updated logic skips the zone block cleanly in both directions. No changes to the happy path (spaces with zones) — the logic is structurally identical to before for those cases.
